### PR TITLE
refactor: convert `blockNumber` to `bigint`

### DIFF
--- a/packages/core/src/actions/account/fetchBalance.test.ts
+++ b/packages/core/src/actions/account/fetchBalance.test.ts
@@ -72,19 +72,19 @@ test('fetches balance at block number', async () => {
   expect(
     await fetchBalance(publicClient, {
       address: targetAccount.address,
-      blockNumber: currentBlockNumber - 1,
+      blockNumber: currentBlockNumber - 1n,
     }),
   ).toMatchInlineSnapshot('10003000000000000000000n')
   expect(
     await fetchBalance(publicClient, {
       address: targetAccount.address,
-      blockNumber: currentBlockNumber - 2,
+      blockNumber: currentBlockNumber - 2n,
     }),
   ).toMatchInlineSnapshot('10001000000000000000000n')
   expect(
     await fetchBalance(publicClient, {
       address: targetAccount.address,
-      blockNumber: currentBlockNumber - 3,
+      blockNumber: currentBlockNumber - 3n,
     }),
   ).toMatchInlineSnapshot('10000000000000000000000n')
 })

--- a/packages/core/src/actions/account/fetchBalance.ts
+++ b/packages/core/src/actions/account/fetchBalance.ts
@@ -6,7 +6,7 @@ export type FetchBalanceArgs = {
   address: Address
 } & (
   | {
-      blockNumber?: number
+      blockNumber?: bigint
       blockTag?: never
     }
   | {

--- a/packages/core/src/actions/block/fetchBlock.test.ts
+++ b/packages/core/src/actions/block/fetchBlock.test.ts
@@ -37,7 +37,7 @@ test('fetches latest block', async () => {
 describe('args: blockNumber', () => {
   test('fetches block by block number', async () => {
     const block = await fetchBlock(publicClient, {
-      blockNumber: initialBlockNumber - 1,
+      blockNumber: initialBlockNumber - 1n,
     })
     expect(block).toMatchInlineSnapshot(`
       {
@@ -464,7 +464,7 @@ describe('args: includeTransactions', () => {
 test('non-existent block: throws if block number does not exist', async () => {
   await expect(
     fetchBlock(publicClient, {
-      blockNumber: 69420694206942,
+      blockNumber: 69420694206942n,
       includeTransactions: true,
     }),
   ).rejects.toMatchInlineSnapshot(`
@@ -491,7 +491,8 @@ test('non-existent block: throws if block hash does not exist', async () => {
 })
 
 test('BlockNotFoundError', () => {
-  expect(new BlockNotFoundError({ blockNumber: 69420 })).toMatchInlineSnapshot(`
+  expect(new BlockNotFoundError({ blockNumber: 69420n }))
+    .toMatchInlineSnapshot(`
     [BlockNotFoundError: Block at number "69420" could not be found.
 
     Details: block not found at given hash or number

--- a/packages/core/src/actions/block/fetchBlock.ts
+++ b/packages/core/src/actions/block/fetchBlock.ts
@@ -15,7 +15,7 @@ export type FetchBlockArgs = {
   | {
       blockHash?: never
       /** The block number. */
-      blockNumber?: number
+      blockNumber?: bigint
       blockTag?: never
     }
   | {
@@ -68,7 +68,7 @@ export class BlockNotFoundError extends BaseError {
     blockNumber,
   }: {
     blockHash?: Data
-    blockNumber?: number
+    blockNumber?: bigint
   }) {
     let identifier = 'Block'
     if (blockHash) identifier = `Block at hash "${blockHash}"`

--- a/packages/core/src/actions/block/fetchBlockNumber.ts
+++ b/packages/core/src/actions/block/fetchBlockNumber.ts
@@ -1,6 +1,6 @@
 import type { PublicClient } from '../../clients'
 
-export type FetchBlockNumberResponse = number
+export type FetchBlockNumberResponse = bigint
 
 export async function fetchBlockNumber(
   rpc: PublicClient,
@@ -8,5 +8,5 @@ export async function fetchBlockNumber(
   const blockNumber = await rpc.request({
     method: 'eth_blockNumber',
   })
-  return Number(BigInt(blockNumber))
+  return BigInt(blockNumber)
 }

--- a/packages/core/src/actions/test/mine.test.ts
+++ b/packages/core/src/actions/test/mine.test.ts
@@ -9,12 +9,12 @@ test('mines 1 block', async () => {
   const currentBlockNumber = await fetchBlockNumber(publicClient)
   await mine(testClient, { blocks: 1 })
   const nextBlockNumber = await fetchBlockNumber(publicClient)
-  expect(nextBlockNumber).toEqual(currentBlockNumber + 1)
+  expect(nextBlockNumber).toEqual(currentBlockNumber + 1n)
 })
 
 test('mines 5 blocks', async () => {
   const currentBlockNumber = await fetchBlockNumber(publicClient)
   await mine(testClient, { blocks: 5 })
   const nextBlockNumber = await fetchBlockNumber(publicClient)
-  expect(nextBlockNumber).toEqual(currentBlockNumber + 5)
+  expect(nextBlockNumber).toEqual(currentBlockNumber + 5n)
 })

--- a/packages/core/src/actions/transaction/fetchTransaction.test.ts
+++ b/packages/core/src/actions/transaction/fetchTransaction.test.ts
@@ -221,7 +221,7 @@ describe('args: hash', () => {
 describe('args: blockHash', () => {
   test('blockHash: fetches transaction by block hash & index', async () => {
     const { hash: blockHash } = await fetchBlock(publicClient, {
-      blockNumber: initialBlockNumber - 69,
+      blockNumber: initialBlockNumber - 69n,
     })
 
     if (!blockHash) throw new Error('no block hash found')
@@ -242,7 +242,7 @@ describe('args: blockHash', () => {
 
   test('blockHash: throws if transaction not found', async () => {
     const { hash: blockHash } = await fetchBlock(publicClient, {
-      blockNumber: initialBlockNumber - 69,
+      blockNumber: initialBlockNumber - 69n,
     })
     if (!blockHash) throw new Error('no block hash found')
 
@@ -258,7 +258,7 @@ describe('args: blockHash', () => {
 describe('args: blockNumber', () => {
   test('fetches transaction by block number & index', async () => {
     const transaction = await fetchTransaction(publicClient, {
-      blockNumber: initialBlockNumber - 420,
+      blockNumber: initialBlockNumber - 420n,
       index: 5,
     })
     expect(transaction.from).toMatchInlineSnapshot(
@@ -275,7 +275,7 @@ describe('args: blockNumber', () => {
   test('throws if transaction not found', async () => {
     await expect(
       fetchTransaction(publicClient, {
-        blockNumber: initialBlockNumber - 420,
+        blockNumber: initialBlockNumber - 420n,
         index: 420,
       }),
     ).rejects.toThrowError(
@@ -315,7 +315,7 @@ describe('TransactionNotFoundError', () => {
   })
 
   test('blockNumber', async () => {
-    expect(new TransactionNotFoundError({ blockNumber: 42069, index: 420 }))
+    expect(new TransactionNotFoundError({ blockNumber: 42069n, index: 420 }))
       .toMatchInlineSnapshot(`
         [TransactionNotFoundError: Transaction at block number "42069" at index "420" could not be found.
 

--- a/packages/core/src/actions/transaction/fetchTransaction.ts
+++ b/packages/core/src/actions/transaction/fetchTransaction.ts
@@ -21,7 +21,7 @@ export type FetchTransactionArgs =
     }
   | {
       blockHash?: never
-      blockNumber: number
+      blockNumber: bigint
       blockTag?: never
       hash?: never
       index: number
@@ -99,7 +99,7 @@ export class TransactionNotFoundError extends BaseError {
     index,
   }: {
     blockHash?: Data
-    blockNumber?: number
+    blockNumber?: bigint
     blockTag?: BlockTag
     hash?: Data
     index?: number

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -57,7 +57,9 @@ export const accounts = [
   },
 ] as const
 
-export const initialBlockNumber = Number(process.env.VITE_ANVIL_BLOCK_NUMBER)
+export const initialBlockNumber = BigInt(
+  Number(process.env.VITE_ANVIL_BLOCK_NUMBER),
+)
 
 export const localWsUrl = 'ws://127.0.0.1:8545'
 

--- a/playgrounds/benchmark/suite.ts
+++ b/playgrounds/benchmark/suite.ts
@@ -41,7 +41,7 @@ export const getSuite = ({ url }: { url: string }): Suite => {
       key: 'blockByNumber',
       fns: {
         viem: async () => {
-          await fetchBlock(viemClient, { blockNumber: 69420 })
+          await fetchBlock(viemClient, { blockNumber: 69420n })
         },
         ethers: async () => {
           await ethersProvider.getBlock(69420)
@@ -54,7 +54,7 @@ export const getSuite = ({ url }: { url: string }): Suite => {
       fns: {
         viem: async () => {
           await fetchBlock(viemClient, {
-            blockNumber: 69420,
+            blockNumber: 69420n,
             includeTransactions: true,
           })
         },

--- a/playgrounds/dev/components/actions/FetchBlock.tsx
+++ b/playgrounds/dev/components/actions/FetchBlock.tsx
@@ -10,7 +10,7 @@ export function FetchBlock({ client }: { client: PublicClient }) {
   useEffect(() => {
     ;(async () => {
       setLatestBlock(await fetchBlock(client, { blockTag: 'latest' }))
-      setBlock(await fetchBlock(client, { blockNumber: 42069 }))
+      setBlock(await fetchBlock(client, { blockNumber: 42069n }))
     })()
   }, [client])
 

--- a/playgrounds/dev/components/actions/FetchBlockNumber.tsx
+++ b/playgrounds/dev/components/actions/FetchBlockNumber.tsx
@@ -10,5 +10,5 @@ export function FetchBlockNumber({ client }: { client: PublicClient }) {
       setBlockNumber(await fetchBlockNumber(client))
     })()
   }, [client])
-  return <div>{blockNumber}</div>
+  return <div>{blockNumber?.toString()}</div>
 }

--- a/playgrounds/dev/components/actions/FetchTransaction.tsx
+++ b/playgrounds/dev/components/actions/FetchTransaction.tsx
@@ -116,7 +116,7 @@ function FetchTransactionByNumberAndIndex({
     if (blockNumber && index) {
       setTransaction(
         await fetchTransaction(client, {
-          blockNumber: parseInt(blockNumber),
+          blockNumber: BigInt(blockNumber),
           index: parseInt(index),
         }),
       )

--- a/playgrounds/dev/components/actions/WatchBlockNumber.tsx
+++ b/playgrounds/dev/components/actions/WatchBlockNumber.tsx
@@ -11,5 +11,5 @@ export function WatchBlockNumber({ client }: { client: PublicClient }) {
     })
     return unwatch
   }, [client])
-  return <div>{blockNumber}</div>
+  return <div>{blockNumber?.toString()}</div>
 }


### PR DESCRIPTION
Refactoring `blockNumber` to be a `bigint` instead of a `number`. Could be possible for an L2 to overflow.