### PR TITLE
feat: support `args` on `createEventFilter` & `getLogs`

### DIFF
--- a/src/_test/constants.ts
+++ b/src/_test/constants.ts
@@ -45,6 +45,7 @@ export const accounts = [
 
 export const address = {
   vitalik: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+  usdcHolder: '0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
 } as const
 
 export const initialBlockNumber = BigInt(

--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -111,7 +111,7 @@ describe('buildFilterTopics', () => {
     ])
   })
 
-  test.skip('named args', () => {
+  test('named args', () => {
     expect(
       buildFilterTopics({
         event: 'Transfer(address indexed from, address indexed to)',
@@ -155,9 +155,43 @@ describe('buildFilterTopics', () => {
       '0x000000000000000000000000000000000000000000000000000000000000000c',
       '0x0000000000000000000000000000000000000000000000000000000000000001',
     ])
+
+    expect(
+      buildFilterTopics({
+        event:
+          'Transfer(string indexed baz, uint indexed foo, bool indexed bar)',
+        args: {
+          baz: 'watermelon sugar high',
+          foo: 12,
+          bar: true,
+        },
+      }),
+    ).toEqual([
+      '0xd72ffe8f642f870a4e0b389d4e008752294ecfa2a379b4a9790c067aef635088',
+      '0xdb31e24017b555ff340729aa37fadedf910b5395e13a218e76e155c39527bf02',
+      '0x000000000000000000000000000000000000000000000000000000000000000c',
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ])
+
+    expect(
+      buildFilterTopics({
+        event:
+          'Transfer(bytes indexed baz, uint indexed foo, bool indexed bar)',
+        args: {
+          baz: '0x69420',
+          foo: 12,
+          bar: true,
+        },
+      }),
+    ).toEqual([
+      '0xd0ac01db7189fe6027705e6dda462153bf4aec72630a11dcec054ac78bac314d',
+      '0xd36b1a27d526376a81ba9b34292f4103e8340cc80a493e43aa00a14ebd0df4c5',
+      '0x000000000000000000000000000000000000000000000000000000000000000c',
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ])
   })
 
-  test.skip('unnamed args', () => {
+  test('unnamed args', () => {
     expect(
       buildFilterTopics({
         event: 'Transfer(address indexed, address indexed, uint indexed)',
@@ -240,6 +274,4 @@ describe('buildFilterTopics', () => {
       ],
     ])
   })
-
-  // TODO: more arg types
 })

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -17,7 +17,7 @@ import {
   setIntervalMining,
   stopImpersonatingAccount,
 } from '../test'
-import { sendTransaction } from '../wallet'
+import { sendTransaction, writeContract } from '../wallet'
 import { parseEther } from '../../utils'
 import type { Hash, Log } from '../../types'
 import { createBlockFilter } from './createBlockFilter'
@@ -30,12 +30,18 @@ beforeAll(async () => {
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })
+  await impersonateAccount(testClient, {
+    address: address.usdcHolder,
+  })
 })
 
 afterAll(async () => {
   await setIntervalMining(testClient, { interval: 1 })
   await stopImpersonatingAccount(testClient, {
     address: address.vitalik,
+  })
+  await stopImpersonatingAccount(testClient, {
+    address: address.usdcHolder,
   })
 })
 
@@ -135,7 +141,8 @@ describe('events', () => {
 
   test('args: event', async () => {
     const filter = await createEventFilter(publicClient, {
-      event: 'Transfer(address from, address to, uint256 value)',
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
     })
 
     await sendTransaction(walletClient, {
@@ -172,7 +179,8 @@ describe('events', () => {
 
   test('args: fromBlock/toBlock', async () => {
     const filter = await createEventFilter(publicClient, {
-      event: 'Transfer(address from, address to, uint256 value)',
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
       fromBlock: initialBlockNumber - 5n,
       toBlock: initialBlockNumber,
     })
@@ -185,5 +193,191 @@ describe('events', () => {
     expect(logs.length).toBe(0)
   })
 
-  test.todo('args: args')
+  test('args: singular `from`', async () => {
+    const namedFilter = await createEventFilter(publicClient, {
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
+      args: {
+        from: address.vitalik,
+      },
+    })
+    const unnamedFilter = await createEventFilter(publicClient, {
+      event: 'Transfer(address indexed, address indexed, uint256)',
+      args: [address.vitalik],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (await getFilterChanges(publicClient, { filter: namedFilter })).length,
+    ).toBe(2)
+    expect(
+      (await getFilterChanges(publicClient, { filter: unnamedFilter })).length,
+    ).toBe(2)
+  })
+
+  test('args: multiple `from`', async () => {
+    const namedFilter = await createEventFilter(publicClient, {
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
+      args: {
+        from: [address.usdcHolder, address.vitalik],
+      },
+    })
+    const unnamedFilter = await createEventFilter(publicClient, {
+      event: 'Transfer(address indexed, address indexed, uint256)',
+      args: [[address.usdcHolder, address.vitalik]],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (await getFilterChanges(publicClient, { filter: namedFilter })).length,
+    ).toBe(3)
+    expect(
+      (await getFilterChanges(publicClient, { filter: unnamedFilter })).length,
+    ).toBe(3)
+  })
+
+  test('args: singular `to`', async () => {
+    const namedFilter = await createEventFilter(publicClient, {
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
+      args: {
+        to: accounts[0].address,
+      },
+    })
+    const unnamedFilter = await createEventFilter(publicClient, {
+      event: 'Transfer(address indexed, address indexed, uint256)',
+      args: [null, accounts[0].address],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (await getFilterChanges(publicClient, { filter: namedFilter })).length,
+    ).toBe(1)
+    expect(
+      (await getFilterChanges(publicClient, { filter: unnamedFilter })).length,
+    ).toBe(1)
+  })
+
+  test('args: multiple `to`', async () => {
+    const namedFilter = await createEventFilter(publicClient, {
+      event:
+        'Transfer(address indexed from, address indexed to, uint256 value)',
+      args: {
+        to: [accounts[0].address, accounts[1].address],
+      },
+    })
+    const unnamedFilter = await createEventFilter(publicClient, {
+      event: 'Transfer(address indexed, address indexed, uint256)',
+      args: [null, [accounts[0].address, accounts[1].address]],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (await getFilterChanges(publicClient, { filter: namedFilter })).length,
+    ).toBe(3)
+    expect(
+      (await getFilterChanges(publicClient, { filter: unnamedFilter })).length,
+    ).toBe(3)
+  })
 })

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -17,7 +17,7 @@ import {
   setIntervalMining,
   stopImpersonatingAccount,
 } from '../test'
-import { sendTransaction } from '../wallet'
+import { sendTransaction, writeContract } from '../wallet'
 import type { Log } from '../../types'
 import { getLogs } from './getLogs'
 import { getBlock } from './getBlock'
@@ -27,12 +27,18 @@ beforeAll(async () => {
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })
+  await impersonateAccount(testClient, {
+    address: address.usdcHolder,
+  })
 })
 
 afterAll(async () => {
   await setIntervalMining(testClient, { interval: 1 })
   await stopImpersonatingAccount(testClient, {
     address: address.vitalik,
+  })
+  await impersonateAccount(testClient, {
+    address: address.usdcHolder,
   })
 })
 
@@ -103,5 +109,198 @@ describe('events', () => {
     expect(logs.length).toBe(118)
   })
 
-  test.todo('args: args')
+  test('args: singular `from`', async () => {
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (
+        await getLogs(publicClient, {
+          event:
+            'Transfer(address indexed from, address indexed to, uint256 value)',
+          args: {
+            from: address.vitalik,
+          },
+        })
+      ).length,
+    ).toBe(2)
+    expect(
+      (
+        await getLogs(publicClient, {
+          event: 'Transfer(address indexed, address indexed, uint256)',
+          args: [address.vitalik],
+        })
+      ).length,
+    ).toBe(2)
+  })
+
+  test('args: multiple `from`', async () => {
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (
+        await getLogs(publicClient, {
+          event:
+            'Transfer(address indexed from, address indexed to, uint256 value)',
+          args: {
+            from: [address.usdcHolder, address.vitalik],
+          },
+        })
+      ).length,
+    ).toBe(3)
+    expect(
+      (
+        await getLogs(publicClient, {
+          event:
+            'Transfer(address indexed from, address indexed to, uint256 value)',
+          args: {
+            from: [address.usdcHolder, address.vitalik],
+          },
+        })
+      ).length,
+    ).toBe(3)
+  })
+
+  test('args: singular `to`', async () => {
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (
+        await getLogs(publicClient, {
+          event:
+            'Transfer(address indexed from, address indexed to, uint256 value)',
+          args: {
+            to: accounts[0].address,
+          },
+        })
+      ).length,
+    ).toBe(1)
+    expect(
+      (
+        await getLogs(publicClient, {
+          event: 'Transfer(address indexed, address indexed, uint256)',
+          args: [null, accounts[0].address],
+        })
+      ).length,
+    ).toBe(1)
+  })
+
+  test('args: multiple `to`', async () => {
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      from: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      (
+        await getLogs(publicClient, {
+          event:
+            'Transfer(address indexed from, address indexed to, uint256 value)',
+          args: {
+            to: [accounts[0].address, accounts[1].address],
+          },
+        })
+      ).length,
+    ).toBe(3)
+    expect(
+      (
+        await getLogs(publicClient, {
+          event: 'Transfer(address indexed, address indexed, uint256)',
+          args: [null, [accounts[0].address, accounts[1].address]],
+        })
+      ).length,
+    ).toBe(3)
+  })
 })

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
     address: address.vitalik,
   })
   await impersonateAccount(testClient, {
-    address: '0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
+    address: address.usdcHolder,
   })
 })
 
@@ -28,7 +28,7 @@ afterAll(async () => {
     address: address.vitalik,
   })
   await stopImpersonatingAccount(testClient, {
-    address: '0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
+    address: address.usdcHolder,
   })
 })
 
@@ -231,14 +231,14 @@ test('args: args', async () => {
     ...usdcContractConfig,
     eventName: 'Transfer',
     args: {
-      from: '0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
+      from: address.usdcHolder,
     },
     onLogs: (logs_) => logs.push(logs_),
   })
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    from: '0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
+    from: address.usdcHolder,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
   })


### PR DESCRIPTION
- Adds support for `args` on `createEventFilter` & `getLogs`
- Currently using a "lightweight" version of `parseAbi`. It does not support structs or arrays (which I think is okay for now – indexed args are rarely that type anyway).