### PR TITLE
chore: export missing actions

### DIFF
--- a/.changeset/large-bats-think.md
+++ b/.changeset/large-bats-think.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported missing `watchContractEvent` and `watchEvent` actions.

--- a/src/actions/index.test.ts
+++ b/src/actions/index.test.ts
@@ -72,6 +72,8 @@ test('exports actions', () => {
       "watchAsset": [Function],
       "watchBlockNumber": [Function],
       "watchBlocks": [Function],
+      "watchContractEvent": [Function],
+      "watchEvent": [Function],
       "watchPendingTransactions": [Function],
       "writeContract": [Function],
     }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -30,6 +30,8 @@ export {
   waitForTransactionReceipt,
   watchBlockNumber,
   watchBlocks,
+  watchContractEvent,
+  watchEvent,
   watchPendingTransactions,
 } from './public'
 export type {
@@ -79,6 +81,8 @@ export type {
   OnBlockNumber,
   OnBlockNumberResponse,
   OnBlockResponse,
+  OnLogs,
+  OnLogsResponse,
   OnTransactions,
   OnTransactionsResponse,
   ReadContractArgs,
@@ -93,6 +97,8 @@ export type {
   WaitForTransactionReceiptResponse,
   WatchBlockNumberArgs,
   WatchBlocksArgs,
+  WatchContractEventArgs,
+  WatchEventArgs,
   WatchPendingTransactionsArgs,
 } from './public'
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -249,6 +249,8 @@ test('exports actions', () => {
       "watchAsset": [Function],
       "watchBlockNumber": [Function],
       "watchBlocks": [Function],
+      "watchContractEvent": [Function],
+      "watchEvent": [Function],
       "watchPendingTransactions": [Function],
       "webSocket": [Function],
       "weiUnits": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export type {
   OnBlockNumber,
   OnBlockNumberResponse,
   OnBlockResponse,
+  OnLogs,
+  OnLogsResponse,
   OnTransactions,
   OnTransactionsResponse,
   ReadContractArgs,
@@ -87,6 +89,8 @@ export type {
   WatchBlockNumberArgs,
   WatchBlocksArgs,
   WatchPendingTransactionsArgs,
+  WatchContractEventArgs,
+  WatchEventArgs,
   WriteContractArgs,
   WriteContractResponse,
 } from './actions'
@@ -158,6 +162,8 @@ export {
   watchBlockNumber,
   watchBlocks,
   watchPendingTransactions,
+  watchContractEvent,
+  watchEvent,
   writeContract,
 } from './actions'
 


### PR DESCRIPTION
Export missing `watchContractEvent` and `watchEvent` actions.