### PR TITLE
fix: don't support unprefixed addresses

### DIFF
--- a/src/utils/address/getAddress.test.ts
+++ b/src/utils/address/getAddress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { getAddress } from './getAddress'
+import type { Address } from 'abitype'
 
 test('checksums address', () => {
   expect(
@@ -39,6 +40,13 @@ describe('errors', () => {
       getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678aff'),
     ).toThrowErrorMatchingInlineSnapshot(`
       "Address \\"0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678aff\\" is invalid.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      getAddress('a5cc3c03994db5b0d9a5eEdD10Cabab0813678ac' as Address),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Address \\"a5cc3c03994db5b0d9a5eEdD10Cabab0813678ac\\" is invalid.
 
       Version: viem@1.0.2"
     `)

--- a/src/utils/address/getAddress.ts
+++ b/src/utils/address/getAddress.ts
@@ -3,7 +3,7 @@ import type { Address } from '../../types'
 import { stringToBytes } from '../encoding'
 import { keccak256 } from '../hash'
 
-const addressRegex = /^(0x)?[a-fA-F0-9]{40}$/
+const addressRegex = /^0x[a-fA-F0-9]{40}$/
 
 export function checksumAddress(address_: Address): Address {
   const hexAddress = address_.substring(2).toLowerCase()


### PR DESCRIPTION
The address regex previously allowed unprefixed addresses, which then would be parsed and checksummed at the wrong start index. This PR fails when an address is not `0x`-prefixed