### PR TITLE
docs: fix index type

### DIFF
--- a/site/docs/actions/test/setStorageAt.md
+++ b/site/docs/actions/test/setStorageAt.md
@@ -46,7 +46,7 @@ await testClient.setStorageAt({
 
 ### index
 
-- **Type:** ``number | `0x${string}` ``
+- **Type:** `number | Hash`
 
 The storage slot (index). Can either be a number or hash value.
 


### PR DESCRIPTION
The `index` parameter type for `setStorageAt` isn't rendering properly in the docs. Using double backticks resolves this.