### PR TITLE
docs: link types to glossary

### DIFF
--- a/site/docs/abi/decodeAbiParameters.md
+++ b/site/docs/abi/decodeAbiParameters.md
@@ -82,7 +82,7 @@ const values = decodeAbiParameters(
 
 ### data
 
-- **Type**: `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The ABI encoded data.
 

--- a/site/docs/abi/encodeAbiParameters.md
+++ b/site/docs/abi/encodeAbiParameters.md
@@ -62,7 +62,7 @@ const encodedData = encodeAbiParameters(
 
 ## Returns
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The ABI encoded data.
 

--- a/site/docs/abi/encodePacked.md
+++ b/site/docs/abi/encodePacked.md
@@ -38,7 +38,7 @@ encodePacked(
 
 ## Returns
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The encoded packed data.
 

--- a/site/docs/abi/parseAbi.md
+++ b/site/docs/abi/parseAbi.md
@@ -34,7 +34,7 @@ const abi = parseAbi([
 
 ## Returns
 
-`Abi`
+[`Abi`](/docs/glossary/types#abi)
 
 The JSON ABI.
 

--- a/site/docs/abi/parseAbiItem.md
+++ b/site/docs/abi/parseAbiItem.md
@@ -33,7 +33,7 @@ const abiItem = parseAbiItem(
 
 ## Returns
 
-`Abi`
+[`Abi`](/docs/glossary/types#abi)
 
 Parsed ABI item.
 

--- a/site/docs/abi/parseAbiParameter.md
+++ b/site/docs/abi/parseAbiParameter.md
@@ -31,7 +31,7 @@ const abiParameter = parseAbiParameter('address from')
 
 ## Returns
 
-`Abi`
+[`Abi`](/docs/glossary/types#abi)
 
 Parsed ABI parameter.
 

--- a/site/docs/abi/parseAbiParameters.md
+++ b/site/docs/abi/parseAbiParameters.md
@@ -33,7 +33,7 @@ const abiParameters = parseAbiParameters(
 
 ## Returns
 
-`Abi`
+[`Abi`](/docs/glossary/types#abi)
 
 Parsed ABI parameters.
 

--- a/site/docs/actions/public/call.md
+++ b/site/docs/actions/public/call.md
@@ -71,7 +71,7 @@ const data = await publicClient.call({
 
 ### to
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address or recipient.
 
@@ -85,7 +85,7 @@ const data = await publicClient.call({
 
 ### accessList (optional)
 
-- **Type:** `AccessList`
+- **Type:** [`AccessList`](/docs/glossary/types#accesslist)
 
 The access list.
 

--- a/site/docs/actions/public/estimateGas.md
+++ b/site/docs/actions/public/estimateGas.md
@@ -56,7 +56,7 @@ const gasEstimate = await publicClient.estimateGas({
 
 ### from (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 Transaction sender.
 
@@ -124,7 +124,7 @@ const gasEstimate = await publicClient.estimateGas({
 
 ### to (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 Transaction recipient.
 

--- a/site/docs/actions/public/getBalance.md
+++ b/site/docs/actions/public/getBalance.md
@@ -37,7 +37,7 @@ The balance of the address in wei.
 
 ### address
 
-- **Type:** `'0x${string}'`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the account.
 

--- a/site/docs/actions/public/getBlock.md
+++ b/site/docs/actions/public/getBlock.md
@@ -42,7 +42,7 @@ Information about the block.
 
 ### blockHash (optional)
 
-- **Type:** `'0x${string}'`
+- **Type:** [`Hash`](/docs/glossary/types#hash)
 
 Information at a given block hash.
 

--- a/site/docs/actions/public/getBlockTransactionCount.md
+++ b/site/docs/actions/public/getBlockTransactionCount.md
@@ -35,7 +35,7 @@ The block transaction count.
 
 ### blockHash (optional)
 
-- **Type:** `'0x${string}'`
+- **Type:** [`Hash`](/docs/glossary/types#hash)
 
 Count at a given block hash.
 

--- a/site/docs/actions/public/getTransactionConfirmations.md
+++ b/site/docs/actions/public/getTransactionConfirmations.md
@@ -61,7 +61,7 @@ const balance = await publicClient.getTransactionConfirmations({
 
 ### hash
 
-- **Type:** `0x${string}`
+- **Type:** [`Hash`](/docs/glossary/types#hash)
 
 The hash of the transaction.
 

--- a/site/docs/actions/public/getTransactionCount.md
+++ b/site/docs/actions/public/getTransactionCount.md
@@ -37,7 +37,7 @@ The number of transactions an account has sent.
 
 ### address
 
-- **Type:** `'0x${string}'`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the account.
 

--- a/site/docs/actions/test/impersonateAccount.md
+++ b/site/docs/actions/test/impersonateAccount.md
@@ -30,7 +30,7 @@ await testClient.impersonateAccount({ // [!code focus:4]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the target account.
 

--- a/site/docs/actions/test/sendUnsignedTransaction.md
+++ b/site/docs/actions/test/sendUnsignedTransaction.md
@@ -39,7 +39,7 @@ The transaction hash.
 
 ### from
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The Transaction sender.
 
@@ -68,7 +68,7 @@ const hash = await testClient.sendUnsignedTransaction({
 
 ### accessList (optional)
 
-- **Type:** `AccessList`
+- **Type:** [`AccessList`](/docs/glossary/types#accesslist)
 
 The access list.
 

--- a/site/docs/actions/test/setBalance.md
+++ b/site/docs/actions/test/setBalance.md
@@ -32,7 +32,7 @@ await testClient.setBalance({ // [!code focus:4]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the target account.
 

--- a/site/docs/actions/test/setCode.md
+++ b/site/docs/actions/test/setCode.md
@@ -31,7 +31,7 @@ await testClient.setCode({ // [!code focus:4]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The account address.
 
@@ -44,7 +44,7 @@ await testClient.setCode({
 
 ### bytecode
 
-- **Type:** `Address`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The stored bytecode.
 

--- a/site/docs/actions/test/setCoinbase.md
+++ b/site/docs/actions/test/setCoinbase.md
@@ -30,7 +30,7 @@ await testClient.setCoinbase({ // [!code focus:99]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The coinbase address.
 

--- a/site/docs/actions/test/setNonce.md
+++ b/site/docs/actions/test/setNonce.md
@@ -31,7 +31,7 @@ await testClient.setNonce({ // [!code focus:4]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the target account.
 

--- a/site/docs/actions/test/setStorageAt.md
+++ b/site/docs/actions/test/setStorageAt.md
@@ -32,7 +32,7 @@ await testClient.setStorageAt({ // [!code focus:99]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The account address.
 

--- a/site/docs/actions/test/stopImpersonatingAccount.md
+++ b/site/docs/actions/test/stopImpersonatingAccount.md
@@ -30,7 +30,7 @@ await testClient.stopImpersonatingAccount({ // [!code focus:4]
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the target account.
 

--- a/site/docs/actions/wallet/sendTransaction.md
+++ b/site/docs/actions/wallet/sendTransaction.md
@@ -71,7 +71,7 @@ const hash = await walletClient.sendTransaction({
 
 ### accessList (optional)
 
-- **Type:** `AccessList`
+- **Type:** [`AccessList`](/docs/glossary/types#accesslist)
 
 The access list.
 

--- a/site/docs/actions/wallet/signMessage.md
+++ b/site/docs/actions/wallet/signMessage.md
@@ -40,7 +40,7 @@ The signed message.
 
 ### account
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 Account to use for signing. [Read more](/docs/clients/wallet).
 

--- a/site/docs/actions/wallet/watchAsset.md
+++ b/site/docs/actions/wallet/watchAsset.md
@@ -59,7 +59,7 @@ await walletClient.watchAsset({
 
 ### options.address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address of the token contract.
 

--- a/site/docs/contract/decodeDeployData.md
+++ b/site/docs/contract/decodeDeployData.md
@@ -98,7 +98,7 @@ const { args } = decodeFunctionData({
 
 ### bytecode
 
-- **Type:** `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 Contract bytecode.
 
@@ -112,7 +112,7 @@ const { args } = decodeFunctionData({
 
 ### data
 
-- **Type:** `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The encoded calldata.
 

--- a/site/docs/contract/decodeErrorResult.md
+++ b/site/docs/contract/decodeErrorResult.md
@@ -86,7 +86,7 @@ const value = decodeErrorResult({
 
 ### data
 
-- **Type**: `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The calldata.
 

--- a/site/docs/contract/decodeFunctionData.md
+++ b/site/docs/contract/decodeFunctionData.md
@@ -150,7 +150,7 @@ const { functionName } = decodeFunctionData({
 
 ### data
 
-- **Type:** `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The encoded calldata.
 

--- a/site/docs/contract/decodeFunctionResult.md
+++ b/site/docs/contract/decodeFunctionResult.md
@@ -184,7 +184,7 @@ const value = decodeFunctionResult({
 
 ### data
 
-- **Type**: `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 The calldata.
 

--- a/site/docs/contract/encodeDeployData.md
+++ b/site/docs/contract/encodeDeployData.md
@@ -111,7 +111,7 @@ export const publicClient = createPublicClient({
 
 ## Return Value
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 ABI encoded data (bytecode & constructor arguments).
 
@@ -133,7 +133,7 @@ const data = encodeFunctionData({
 
 ### bytecode
 
-- **Type:** `Hex`
+- **Type:** [`Hex`](/docs/glossary/types#hex)
 
 Contract bytecode.
 

--- a/site/docs/contract/encodeErrorResult.md
+++ b/site/docs/contract/encodeErrorResult.md
@@ -67,7 +67,7 @@ export const publicClient = createPublicClient({
 
 ## Return Value
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The encoded error.
 

--- a/site/docs/contract/encodeFunctionData.md
+++ b/site/docs/contract/encodeFunctionData.md
@@ -113,7 +113,7 @@ export const publicClient = createPublicClient({
 
 ## Return Value
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 ABI encoded data (4byte function selector & arguments).
 

--- a/site/docs/contract/encodeFunctionResult.md
+++ b/site/docs/contract/encodeFunctionResult.md
@@ -185,7 +185,7 @@ const data = encodeFunctionResult({
 
 ### values
 
-- **Type**: `Hex`
+- **Type**: [`Hex`](/docs/glossary/types#hex)
 
 Return values to encode.
 

--- a/site/docs/contract/estimateContractGas.md
+++ b/site/docs/contract/estimateContractGas.md
@@ -127,7 +127,7 @@ The gas estimate.
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 

--- a/site/docs/contract/getBytecode.md
+++ b/site/docs/contract/getBytecode.md
@@ -42,7 +42,7 @@ export const publicClient = createPublicClient({
 
 ## Return Value
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The contract's bytecode.
 
@@ -50,7 +50,7 @@ The contract's bytecode.
 
 ### address
 
-- **Type**: `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 

--- a/site/docs/contract/getStorageAt.md
+++ b/site/docs/contract/getStorageAt.md
@@ -45,7 +45,7 @@ export const publicClient = createPublicClient({
 
 ## Return Value
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The value of the storage slot.
 
@@ -53,7 +53,7 @@ The value of the storage slot.
 
 ### address
 
-- **Type**: `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 
@@ -66,7 +66,7 @@ const data = await publicClient.getStorageAt({
 
 ### slot
 
-- **Type**: `Hex`
+- **Type**: [`Hex`](/docs/glossary/types#hex)
 
 The storage position (as a hex encoded value).
 

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -105,7 +105,7 @@ An array of results with accompanying status.
 
 ### contracts.address
 
-- **Type**: `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 
@@ -124,7 +124,7 @@ const results = await publicClient.multicall({
 
 ### contracts.abi
 
-- **Type**: `Abi`
+- **Type:** [`Abi`](/docs/glossary/types#abi)
 
 The contract ABI.
 

--- a/site/docs/contract/readContract.md
+++ b/site/docs/contract/readContract.md
@@ -120,7 +120,7 @@ The response from the contract. Type is inferred.
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 

--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -178,7 +178,7 @@ The response from the contract. Type is inferred.
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 

--- a/site/docs/contract/watchContractEvent.md
+++ b/site/docs/contract/watchContractEvent.md
@@ -211,7 +211,7 @@ const unwatch = await publicClient.watchContractEvent({
 
 ### address (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address. If no address is provided, then it will emit all events matching the event signatures on the ABI.
 

--- a/site/docs/contract/writeContract.md
+++ b/site/docs/contract/writeContract.md
@@ -167,7 +167,7 @@ export const walletClient = createWalletClient({
 
 ## Return Value
 
-`Hash`
+[`Hash`](/docs/glossary/types#hash)
 
 A [Transaction Hash](/docs/glossary/terms#hash).
 
@@ -177,7 +177,7 @@ Unlike [`readContract`](/docs/contract/readContract), `writeContract` only retur
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The contract address.
 
@@ -222,7 +222,7 @@ await walletClient.writeContract({
 
 ### account
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The Account sender. [Read more](/docs/clients/wallet).
 

--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -50,7 +50,7 @@ Since ENS names prohibit certain forbidden characters (e.g. underscore) and have
 
 ## Returns
 
-`Address`
+[`Address`](/docs/glossary/types#address)
 
 The address that resolves to provided ENS name.
 
@@ -60,7 +60,7 @@ Returns `0x0000000000000000000000000000000000000000` if ENS name does not resolv
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 Address to get primary ENS name for.
 
@@ -99,7 +99,7 @@ const ensName = await publicClient.getEnsAddress({
 
 ### universalResolverAddress (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 - **Default:** `client.chain.contracts.ensUniversalResolver.address`
 
 Address of ENS Universal Resolver Contract.

--- a/site/docs/ens/actions/getEnsName.md
+++ b/site/docs/ens/actions/getEnsName.md
@@ -55,7 +55,7 @@ Returns `null` if address does not have primary name assigned.
 
 ### address
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 Address to get primary ENS name for.
 
@@ -94,7 +94,7 @@ const ensName = await publicClient.getEnsName({
 
 ### universalResolverAddress (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 - **Default:** `client.chain.contracts.ensUniversalResolver.address`
 
 Address of ENS Universal Resolver Contract.

--- a/site/docs/utilities/getAddress.md
+++ b/site/docs/utilities/getAddress.md
@@ -33,7 +33,7 @@ getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac') // [!code focus:2]
 
 ## Returns
 
-`Address`
+[`Address`](/docs/glossary/types#address)
 
 The checksummed address.
 

--- a/site/docs/utilities/getContractAddress.md
+++ b/site/docs/utilities/getContractAddress.md
@@ -36,7 +36,7 @@ getContractAddress({ // [!code focus:99]
 
 ## Returns
 
-`Address`
+[`Address`](/docs/glossary/types#address)
 
 The contract address.
 
@@ -44,7 +44,7 @@ The contract address.
 
 ### from (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The address the contract was deployed from.
 
@@ -57,7 +57,7 @@ getContractAddress({
 
 ### nonce (optional)
 
-- **Type:** `Address`
+- **Type:** [`Address`](/docs/glossary/types#address)
 
 The nonce of the transaction which deployed the contract.
 
@@ -88,7 +88,7 @@ getContractAddress({
 
 ### bytecode (optional)
 
-- **Type:** `ByteArray` | `Hex` 
+- **Type:** `ByteArray` | [`Hex`](/docs/glossary/types#hex)
 - **Only applicable for `opcode: 'CREATE2'` deployments**
 
 The to-be-deployed contract’s bytecode
@@ -104,7 +104,7 @@ getContractAddress({
 
 ### salt (optional)
 
-- **Type:** `ByteArray` | `Hex` 
+- **Type:** `ByteArray` | [`Hex`](/docs/glossary/types#hex)
 - **Only applicable for `opcode: 'CREATE2'` deployments**
 
 An arbitrary value provided by the sender.

--- a/site/docs/utilities/getEventSelector.md
+++ b/site/docs/utilities/getEventSelector.md
@@ -36,7 +36,7 @@ const selector = getEventSelector('Transfer(address indexed from, address indexe
 
 ## Returns
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The selector as a hex value.
 

--- a/site/docs/utilities/getFunctionSelector.md
+++ b/site/docs/utilities/getFunctionSelector.md
@@ -36,7 +36,7 @@ const selector = getFunctionSelector('ownerOf(uint256)')
 
 ## Returns
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The selector as a hex value.
 

--- a/site/docs/utilities/size.md
+++ b/site/docs/utilities/size.md
@@ -42,7 +42,7 @@ The size of the value (in bytes).
 
 ### value
 
-- **Type:** `Hex` | `ByteArray`
+- **Type:** [`Hex`](/docs/glossary/types#hex) | `ByteArray`
 
 The value (hex or byte array) to retrieve the size of.
 

--- a/site/docs/utilities/toHex.md
+++ b/site/docs/utilities/toHex.md
@@ -44,7 +44,7 @@ toHex(true)
 
 ## Returns
 
-`Hex`
+[`Hex`](/docs/glossary/types#hex)
 
 The hex value.
 


### PR DESCRIPTION
Add glossary links for _most_ of the remaining types.