### PR TITLE
Update outdated testing instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,7 +108,7 @@ VITE_NETWORK_TRANSPORT_MODE=http
 
 - `pnpm test` — runs tests in watch mode
 
-Sometimes the tests are *brittle* and will fail (as they are run on multiple threads). You can press `f` to rerun them and they should pass. 
+Sometimes there may be some tests which fail unexpectedly – you can press `f` to rerun them and they should pass. 
 
 When adding new features or fixing bugs, it's important to add test cases to cover the new/updated behavior.
 


### PR DESCRIPTION
In this PR, the section **Running the test suite** is updated:
- `ANVIL_FORK_URL` is changed to `VITE_ANVIL_FORK_URL` to match above
- clarity the the RPC service provider should be mainnet
- Remove `pnpm anvil` step. It doesn't seem to be required
- Add instructions to re-run with `f` in case it fails the first time. 

Still waiting for https://github.com/wagmi-dev/viem/discussions/996 to be concluded tho.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the variable name `ANVIL_FORK_URL` to `VITE_ANVIL_FORK_URL` in `.github/CONTRIBUTING.md`.
- Added a note about running tests in watch mode using `pnpm test`.
- Added a note about rerunning failed tests by pressing `f`.
- Added a note about the importance of adding test cases for new features or bug fixes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->