### PR TITLE
feat: Add debug functions for transport (`onRequest`, `onResponse`)

### DIFF
--- a/.changeset/early-toys-beam.md
+++ b/.changeset/early-toys-beam.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `onRequest`, `onResponse` helpers for transport debug

--- a/playgrounds/browser/src/components/clients/HttpPublic.tsx
+++ b/playgrounds/browser/src/components/clients/HttpPublic.tsx
@@ -14,7 +14,14 @@ const apiKey = 'PjT72qifrAFZ4WV_drrd30N5onftY5VA'
 export const clients = {
   mainnet: createPublicClient({
     chain: mainnet,
-    transport: http(`${mainnet.rpcUrls.alchemy.http[0]}/${apiKey}`),
+    transport: http(`${mainnet.rpcUrls.alchemy.http[0]}/${apiKey}`, {
+      onRequest(request) {
+        console.log('request', request)
+      },
+      onResponse(response) {
+        console.log('response', response)
+      },
+    }),
   }),
   polygon: createPublicClient({
     chain: polygon,

--- a/site/docs/clients/transports/custom.md
+++ b/site/docs/clients/transports/custom.md
@@ -43,7 +43,7 @@ import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 import { customRpc } from './rpc'
 
-const client = createWalletClient({ 
+const client = createWalletClient({
   chain: mainnet,
   transport: custom({
     async request({ method, params }) {
@@ -83,7 +83,7 @@ A key for the Transport.
 ```ts
 const transport = custom(
   window.ethereum,
-  { 
+  {
     key: 'windowProvider', // [!code focus]
   }
 )
@@ -99,7 +99,7 @@ A name for the Transport
 ```ts
 const transport = custom(
   window.ethereum,
-  { 
+  {
     name: 'Window Ethereum Provider', // [!code focus]
   }
 )
@@ -128,6 +128,32 @@ The base delay (in ms) between retries. By default, the Transport will use [expo
 ```ts
 const transport = custom(window.ethereum, {
   retryDelay: 100, // [!code focus]
+})
+```
+
+### onRequest (optional)
+
+- **Type:** `(request: RpcRequest[]) => void`
+- **Default:** `undefined`
+
+A callback that is called when a request is sent.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onRequest: (request) => console.log(request), // [!code focus]
+})
+```
+
+### onResponse (optional)
+
+- **Type:** `(response: unknown) => void`
+- **Default:** `undefined`
+
+A callback that is called when a response is received without errors.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onResponse: (response) => console.log(response), // [!code focus]
 })
 ```
 

--- a/site/docs/clients/transports/fallback.md
+++ b/site/docs/clients/transports/fallback.md
@@ -39,11 +39,11 @@ const client = createPublicClient({
 
 ### Transport Ranking
 
-Transport Ranking enables each of the Transports passed to the `fallback` Transport are automatically ranked based on their **latency** & **stability** via a weighted moving score algorithm. 
+Transport Ranking enables each of the Transports passed to the `fallback` Transport are automatically ranked based on their **latency** & **stability** via a weighted moving score algorithm.
 
-Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on. 
+Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on.
 
-The Transport that has the best latency & stability score over the sample period is prioritized first. 
+The Transport that has the best latency & stability score over the sample period is prioritized first.
 
 You can turn on automated ranking with the `rank` option:
 
@@ -180,7 +180,7 @@ const transport = fallback([alchemy, infura], {
 - **Type:** `number`
 - **Default:** `3`
 
-The max number of times to retry when a request fails. 
+The max number of times to retry when a request fails.
 
 > Note: The fallback will first try all the Transports before retrying.
 
@@ -203,3 +203,28 @@ const transport = fallback([alchemy, infura], {
 })
 ```
 
+### onRequest (optional)
+
+- **Type:** `(request: RpcRequest[]) => void`
+- **Default:** `undefined`
+
+A callback that is called when a request is sent.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onRequest: (request) => console.log(request), // [!code focus]
+})
+```
+
+### onResponse (optional)
+
+- **Type:** `(response: unknown) => void`
+- **Default:** `undefined`
+
+A callback that is called when a response is received without errors.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onResponse: (response) => console.log(response), // [!code focus]
+})
+```

--- a/site/docs/clients/transports/http.md
+++ b/site/docs/clients/transports/http.md
@@ -48,7 +48,7 @@ The Transport will batch up Actions over a given period and execute them in a si
 
 You can enable Batch JSON-RPC by setting the `batch` flag to `true`:
 
-```ts 
+```ts
 const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
   batch: true // [!code focus]
 })
@@ -85,7 +85,7 @@ const transport = http('https://eth-mainnet.g.alchemy.com/v2/...')
 
 Toggle to enable Batch JSON-RPC
 
-```ts 
+```ts
 const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
   batch: true // [!code focus]
 })
@@ -98,7 +98,7 @@ const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
 
 The maximum number of JSON-RPC requests to send in a batch.
 
-```ts 
+```ts
 const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
   batch: {
     batchSize: 2_000 // [!code focus]
@@ -113,7 +113,7 @@ const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
 
 The maximum number of milliseconds to wait before sending a batch.
 
-```ts 
+```ts
 const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
   batch: {
     wait: 16 // [!code focus]
@@ -202,3 +202,28 @@ const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
 })
 ```
 
+### onRequest (optional)
+
+- **Type:** `(request: RpcRequest[]) => void`
+- **Default:** `undefined`
+
+A callback that is called when a request is sent.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onRequest: (request) => console.log(request), // [!code focus]
+})
+```
+
+### onResponse (optional)
+
+- **Type:** `(response: unknown) => void`
+- **Default:** `undefined`
+
+A callback that is called when a response is received without errors.
+
+```ts
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  onResponse: (response) => console.log(response), // [!code focus]
+})
+```

--- a/src/clients/transports/createTransport.test.ts
+++ b/src/clients/transports/createTransport.test.ts
@@ -63,3 +63,40 @@ test('value', () => {
     }
   `)
 })
+
+test('onRequest is called', async () => {
+  const mockOnRequest = vi.fn()
+
+  const transport = createTransport({
+    key: 'mock',
+    name: 'Mock Transport',
+    request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
+    type: 'mock',
+    onRequest: mockOnRequest,
+  })
+
+  await transport.request({ method: 'mockMethod', params: [] })
+
+  expect(mockOnRequest).toHaveBeenCalledTimes(1)
+  expect(mockOnRequest).toHaveBeenCalledWith({
+    method: 'mockMethod',
+    params: [],
+  })
+})
+
+test('onResponse is called', async () => {
+  const mockOnResponse = vi.fn()
+
+  const transport = createTransport({
+    key: 'mock',
+    name: 'Mock Transport',
+    request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
+    type: 'mock',
+    onResponse: mockOnResponse,
+  })
+
+  await transport.request({ method: 'mockMethod', params: [] })
+
+  expect(mockOnResponse).toHaveBeenCalledTimes(1)
+  expect(mockOnResponse).toHaveBeenCalledWith(null)
+})

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -17,7 +17,7 @@ export type TransportConfig<
   /** On request */
   onRequest?: (request: RpcRequest[]) => void
   /** On response */
-  onResponse?: (response: any) => void
+  onResponse?: (response: unknown) => void
   /** The base delay (in ms) between retries. */
   retryDelay?: number
   /** The max number of times to retry. */

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -1,6 +1,7 @@
 import type { Chain } from '../../types/chain.js'
 import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import { buildRequest } from '../../utils/buildRequest.js'
+import type { RpcRequest } from '../../utils/index.js'
 import type { ClientConfig } from '../createClient.js'
 
 export type TransportConfig<
@@ -13,6 +14,10 @@ export type TransportConfig<
   key: string
   /** The JSON-RPC request function that matches the EIP-1193 request spec. */
   request: TEIP1193RequestFn
+  /** On request */
+  onRequest?: (request: RpcRequest[]) => void
+  /** On response */
+  onResponse?: (response: any) => void
   /** The base delay (in ms) between retries. */
   retryDelay?: number
   /** The max number of times to retry. */
@@ -51,6 +56,8 @@ export function createTransport<
     key,
     name,
     request,
+    onRequest,
+    onResponse,
     retryCount = 3,
     retryDelay = 150,
     timeout,
@@ -60,7 +67,12 @@ export function createTransport<
 ): ReturnType<Transport<TType, TRpcAttributes>> {
   return {
     config: { key, name, request, retryCount, retryDelay, timeout, type },
-    request: buildRequest(request, { retryCount, retryDelay }),
+    request: buildRequest(request, {
+      retryCount,
+      retryDelay,
+      onRequest,
+      onResponse,
+    }),
     value,
   }
 }

--- a/src/clients/transports/custom.ts
+++ b/src/clients/transports/custom.ts
@@ -15,6 +15,10 @@ export type CustomTransportConfig = {
   retryCount?: TransportConfig['retryCount']
   /** The base delay (in ms) between retries. */
   retryDelay?: TransportConfig['retryDelay']
+  /** On request debug helper */
+  onRequest?: TransportConfig['onRequest']
+  /** On response */
+  onResponse?: TransportConfig['onResponse']
 }
 
 export type CustomTransport = Transport<
@@ -30,7 +34,13 @@ export function custom<TProvider extends EthereumProvider>(
   provider: TProvider,
   config: CustomTransportConfig = {},
 ): CustomTransport {
-  const { key = 'custom', name = 'Custom Provider', retryDelay } = config
+  const {
+    key = 'custom',
+    name = 'Custom Provider',
+    retryDelay,
+    onRequest,
+    onResponse,
+  } = config
   return ({ retryCount: defaultRetryCount }) =>
     createTransport({
       key,
@@ -38,6 +48,8 @@ export function custom<TProvider extends EthereumProvider>(
       request: provider.request.bind(provider),
       retryCount: config.retryCount ?? defaultRetryCount,
       retryDelay,
+      onRequest,
+      onResponse,
       type: 'custom',
     })
 }

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -71,6 +71,10 @@ export type FallbackTransportConfig = {
   retryCount?: TransportConfig['retryCount']
   /** The base delay (in ms) between retries. */
   retryDelay?: TransportConfig['retryDelay']
+  /** On request debug helper */
+  onRequest?: TransportConfig['onRequest']
+  /** On response */
+  onResponse?: TransportConfig['onResponse']
 }
 
 export type FallbackTransport = Transport<
@@ -91,6 +95,8 @@ export function fallback(
     rank = false,
     retryCount,
     retryDelay,
+    onRequest,
+    onResponse: onResponse_,
   } = config
   return ({ chain, pollingInterval = 4_000, timeout }) => {
     let transports = transports_
@@ -143,6 +149,8 @@ export function fallback(
         },
         retryCount,
         retryDelay,
+        onRequest,
+        onResponse: onResponse_,
         type: 'fallback',
       },
       {

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -37,6 +37,10 @@ export type HttpTransportConfig = {
   retryDelay?: TransportConfig['retryDelay']
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
   timeout?: TransportConfig['timeout']
+  /** On request debug helper */
+  onRequest?: (request: RpcRequest[]) => void
+  /** On response */
+  onResponse?: (response: any) => void
 }
 
 export type HttpTransport = Transport<
@@ -60,6 +64,8 @@ export function http(
     key = 'http',
     name = 'HTTP JSON-RPC',
     retryDelay,
+    onRequest,
+    onResponse,
   } = config
   return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
     const { batchSize = 1000, wait = 0 } =
@@ -105,6 +111,8 @@ export function http(
         },
         retryCount,
         retryDelay,
+        onRequest,
+        onResponse,
         timeout,
         type: 'http',
       },

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -38,9 +38,9 @@ export type HttpTransportConfig = {
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
   timeout?: TransportConfig['timeout']
   /** On request debug helper */
-  onRequest?: (request: RpcRequest[]) => void
+  onRequest?: TransportConfig['onRequest']
   /** On response */
-  onResponse?: (response: any) => void
+  onResponse?: TransportConfig['onResponse']
 }
 
 export type HttpTransport = Transport<

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -67,7 +67,6 @@ export function buildRequest<TRequest extends (args: any) => Promise<any>>(
     onRequest?: TransportConfig['onRequest']
     // Response debugger helper
     onResponse?: TransportConfig['onResponse']
-
   } = {},
 ) {
   return (async (args: any) =>


### PR DESCRIPTION
<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Add `onRequest` and `onResponse` helpers for transport debug.

### Detailed summary:
- Added `onRequest` and `onResponse` helpers for transport debug in `playgrounds/browser/src/components/clients/HttpPublic.tsx`, `src/clients/transports/fallback.ts`, `src/clients/transports/http.ts`, `src/clients/transports/custom.ts`, `src/utils/buildRequest.ts`, `src/clients/transports/createTransport.test.ts`, `site/docs/clients/transports/custom.md`, `site/docs/clients/transports/http.md`, and `site/docs/clients/transports/fallback.md`.

> The following files were skipped due to too many changes: `site/docs/clients/transports/fallback.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->