### PR TITLE
Allow passing a custom RPC schema type for clients

### DIFF
--- a/.changeset/late-turtles-fry.md
+++ b/.changeset/late-turtles-fry.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Allow passing a custom RPC schema type for clients

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -2,6 +2,7 @@ import { expectTypeOf, test } from 'vitest'
 
 import type { JsonRpcAccount } from '../accounts/types.js'
 import { localhost } from '../chains/index.js'
+import { type EIP1193RequestFn } from '../types/eip1193.js'
 import { type Client, createClient } from './createClient.js'
 import { http } from './transports/http.js'
 
@@ -60,4 +61,26 @@ test('extend', () => {
   expectTypeOf(extended.bar).toEqualTypeOf<'barbaz'>()
   expectTypeOf(extended.foo).toEqualTypeOf<'bar'>()
   expectTypeOf(extended.getChainId).toEqualTypeOf<() => 1337>()
+})
+
+test('with custom rpc schema', () => {
+  type MockRpcSchema = [
+    {
+      Method: 'wallet_wagmi'
+      Parameters: [string]
+      ReturnType: string
+    },
+  ]
+
+  const client = createClient<
+    ReturnType<typeof http>,
+    undefined,
+    undefined,
+    MockRpcSchema
+  >({
+    transport: http(),
+  })
+
+  expectTypeOf(client).toMatchTypeOf<Client>()
+  expectTypeOf(client.request).toEqualTypeOf<EIP1193RequestFn<MockRpcSchema>>()
 })

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -127,6 +127,7 @@ export function createClient<
   transport extends Transport,
   chain extends Chain | undefined = undefined,
   accountOrAddress extends Account | Address | undefined = undefined,
+  rpcSchema extends RpcSchema | undefined = undefined,
 >(
   parameters: ClientConfig<transport, chain, accountOrAddress>,
 ): Prettify<
@@ -135,7 +136,8 @@ export function createClient<
     chain,
     accountOrAddress extends Address
       ? Prettify<JsonRpcAccount<accountOrAddress>>
-      : accountOrAddress
+      : accountOrAddress,
+    rpcSchema
   >
 >
 

--- a/src/clients/createPublicClient.test-d.ts
+++ b/src/clients/createPublicClient.test-d.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf, test } from 'vitest'
 
 import { localhost } from '../chains/index.js'
+import { type EIP1193RequestFn } from '../types/eip1193.js'
 import { type PublicClient, createPublicClient } from './createPublicClient.js'
 import { http } from './transports/http.js'
 
@@ -17,4 +18,25 @@ test('without chain', () => {
   const client = createPublicClient({ transport: http() })
   expectTypeOf(client).toMatchTypeOf<PublicClient>()
   expectTypeOf(client.chain).toEqualTypeOf(undefined)
+})
+
+test('with custom rpc schema', () => {
+  type MockRpcSchema = [
+    {
+      Method: 'eth_wagmi'
+      Parameters: [string]
+      ReturnType: string
+    },
+  ]
+
+  const client = createPublicClient<
+    ReturnType<typeof http>,
+    undefined,
+    MockRpcSchema
+  >({
+    transport: http(),
+  })
+
+  expectTypeOf(client).toMatchTypeOf<PublicClient>()
+  expectTypeOf(client.request).toEqualTypeOf<EIP1193RequestFn<MockRpcSchema>>()
 })

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -1,5 +1,5 @@
 import type { Chain } from '../types/chain.js'
-import type { PublicRpcSchema } from '../types/eip1193.js'
+import type { PublicRpcSchema, RpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import { type Client, type ClientConfig, createClient } from './createClient.js'
 import { type PublicActions, publicActions } from './decorators/public.js'
@@ -24,12 +24,13 @@ export type PublicClientConfig<
 export type PublicClient<
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
+  rpcSchema extends RpcSchema | undefined = PublicRpcSchema,
 > = Prettify<
   Client<
     transport,
     chain,
     undefined,
-    PublicRpcSchema,
+    rpcSchema,
     PublicActions<transport, chain>
   >
 >
@@ -56,9 +57,10 @@ export type PublicClient<
 export function createPublicClient<
   transport extends Transport,
   chain extends Chain | undefined = undefined,
+  rpcSchema extends RpcSchema | undefined = PublicRpcSchema,
 >(
   parameters: PublicClientConfig<transport, chain>,
-): PublicClient<transport, chain>
+): PublicClient<transport, chain, rpcSchema>
 
 export function createPublicClient(
   parameters: PublicClientConfig,

--- a/src/clients/createWalletClient.test-d.ts
+++ b/src/clients/createWalletClient.test-d.ts
@@ -2,6 +2,7 @@ import { expectTypeOf, test } from 'vitest'
 
 import type { JsonRpcAccount } from '../accounts/types.js'
 import { localhost } from '../chains/index.js'
+import { type EIP1193RequestFn } from '../types/eip1193.js'
 import { type WalletClient, createWalletClient } from './createWalletClient.js'
 import { http } from './transports/http.js'
 
@@ -40,4 +41,26 @@ test('without account', () => {
   })
   expectTypeOf(client).toMatchTypeOf<WalletClient>()
   expectTypeOf(client.account).toEqualTypeOf(undefined)
+})
+
+test('with custom rpc schema', () => {
+  type MockRpcSchema = [
+    {
+      Method: 'wallet_wagmi'
+      Parameters: [string]
+      ReturnType: string
+    },
+  ]
+
+  const client = createWalletClient<
+    ReturnType<typeof http>,
+    undefined,
+    undefined,
+    MockRpcSchema
+  >({
+    transport: http(),
+  })
+
+  expectTypeOf(client).toMatchTypeOf<WalletClient>()
+  expectTypeOf(client.request).toEqualTypeOf<EIP1193RequestFn<MockRpcSchema>>()
 })

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -3,7 +3,7 @@ import type { Address } from 'abitype'
 import type { Account } from '../accounts/types.js'
 import type { ParseAccount } from '../types/account.js'
 import type { Chain } from '../types/chain.js'
-import type { WalletRpcSchema } from '../types/eip1193.js'
+import type { RpcSchema, WalletRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import { type Client, type ClientConfig, createClient } from './createClient.js'
 import { type WalletActions, walletActions } from './decorators/wallet.js'
@@ -33,14 +33,9 @@ export type WalletClient<
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
+  rpcSchema extends RpcSchema | undefined = WalletRpcSchema,
 > = Prettify<
-  Client<
-    transport,
-    chain,
-    account,
-    WalletRpcSchema,
-    WalletActions<chain, account>
-  >
+  Client<transport, chain, account, rpcSchema, WalletActions<chain, account>>
 >
 
 /**
@@ -83,9 +78,10 @@ export function createWalletClient<
   transport extends Transport,
   chain extends Chain | undefined = undefined,
   accountOrAddress extends Account | Address | undefined = undefined,
+  rpcSchema extends RpcSchema | undefined = WalletRpcSchema,
 >(
   parameters: WalletClientConfig<transport, chain, accountOrAddress>,
-): WalletClient<transport, chain, ParseAccount<accountOrAddress>>
+): WalletClient<transport, chain, ParseAccount<accountOrAddress>, rpcSchema>
 
 export function createWalletClient(
   parameters: WalletClientConfig,


### PR DESCRIPTION
This pull request results from an issue I encountered while developing an application that uses the wallet provider as a public RPC provider. I have explained the problem here: https://github.com/wagmi-dev/wagmi/discussions/2957.

As a first step to fix this, it would be great if Viem clients could accept custom RPC schema types - this PR tackles exactly this 

This pull request significantly improves the developer experience as there are many custom RPC methods chains/wallets may implement, and keeping them all in Viem's types would be overkill.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR allows passing a custom RPC schema type for clients.
- It adds support for custom RPC schema in `createClient`, `createPublicClient`, and `createWalletClient` functions.
- The `rpcSchema` parameter is added to the function signatures.
- The `RpcSchema` type is introduced in the `eip1193.js` file.
- Tests are added to ensure the correct behaviour of clients with custom RPC schema.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->