### PR TITLE
chore: add `nix` setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake;

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _types
 .DS_Store
 .eslintcache
 .next
+.direnv
 bench
 cache
 coverage
@@ -17,7 +18,6 @@ tsconfig*.tsbuildinfo
 .env.development.local
 .env.test.local
 .env.production.local
-.envrc
 
 # @wagmi/cli
 generated.ts

--- a/biome.json
+++ b/biome.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "ignore": [
+      ".direnv",
       "_cjs",
       "_esm",
       "_types",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1691140388,
+        "narHash": "sha256-AH3fx2VFGPRSOjnuakab4T4AdUstwTnFTbnkoU4df8Q=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "6089aad0ef615ac8c7b0c948d6052fa848c99523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "ref": "monthly",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1694760568,
+        "narHash": "sha256-3G07BiXrp2YQKxdcdms22MUx6spc6A++MSePtatCYuI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "46688f8eb5cd6f1298d873d4d2b9cf245e09e88e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "foundry": "foundry",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -21,16 +21,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1691140388,
-        "narHash": "sha256-AH3fx2VFGPRSOjnuakab4T4AdUstwTnFTbnkoU4df8Q=",
-        "owner": "shazow",
+        "lastModified": 1695025364,
+        "narHash": "sha256-tpL5fyWfXJKzniAvtB+kY7GE1TMiAozDA3JdewBnzDc=",
+        "owner": "fubhy",
         "repo": "foundry.nix",
-        "rev": "6089aad0ef615ac8c7b0c948d6052fa848c99523",
+        "rev": "3750d6d79cd55641bcce9307fe96a982dc830b54",
         "type": "github"
       },
       "original": {
-        "owner": "shazow",
-        "ref": "monthly",
+        "owner": "fubhy",
         "repo": "foundry.nix",
         "type": "github"
       }
@@ -51,11 +50,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694760568,
-        "narHash": "sha256-3G07BiXrp2YQKxdcdms22MUx6spc6A++MSePtatCYuI=",
+        "lastModified": 1694948089,
+        "narHash": "sha256-d2B282GmQ9o8klc22/Rbbbj6r99EnELQpOQjWMyv0rU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46688f8eb5cd6f1298d873d4d2b9cf245e09e88e",
+        "rev": "5148520bfab61f99fd25fb9ff7bfbb50dad3c9db",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1695025364,
+        "lastModified": 1695052823,
         "narHash": "sha256-tpL5fyWfXJKzniAvtB+kY7GE1TMiAozDA3JdewBnzDc=",
         "owner": "fubhy",
         "repo": "foundry.nix",
-        "rev": "3750d6d79cd55641bcce9307fe96a982dc830b54",
+        "rev": "a13e1de2e3d72bbf500c03eb57634cfdaf02ce0e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,32 +1,27 @@
 {
   inputs = {
-    nixpkgs = {
-      url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    };
-
-    utils = {
-      url = "github:numtide/flake-utils";
-    };
-
-    foundry = {
-      url = "github:shazow/foundry.nix/monthly";
-    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+    foundry.url = "github:fubhy/foundry.nix";
   };
 
-  outputs = { self, nixpkgs, utils, foundry }:
-    utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [foundry.overlay];
-        };
-      in {
-        devShell = with pkgs; mkShell {
-          buildInputs = [
-            foundry-bin
+  outputs = { self, nixpkgs, utils, foundry, ... }:
+    utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ foundry.overlay ];
+      };
+    in {
+      formatter = pkgs.alejandra;
+
+      devShells = {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
             bun
+            foundry-bin
             nodejs_20
           ];
         };
-      });
+      };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    };
+
+    utils = {
+      url = "github:numtide/flake-utils";
+    };
+
+    foundry = {
+      url = "github:shazow/foundry.nix/monthly";
+    };
+  };
+
+  outputs = { self, nixpkgs, utils, foundry }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [foundry.overlay];
+        };
+      in {
+        devShell = with pkgs; mkShell {
+          buildInputs = [
+            foundry-bin
+            bun
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           buildInputs = [
             foundry-bin
             bun
+            nodejs_20
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           buildInputs = with pkgs; [
             bun
             foundry-bin
-            nodejs_20
+            nodejs
           ];
         };
       };


### PR DESCRIPTION
Uses `nix`, `flakes` and `direnv` for a carefree dev stack around viem

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the dependencies and configuration files. 

### Detailed summary
- Added `.direnv` to the ignore list in `biome.json`
- Added `flake.nix` file with inputs and outputs configuration
- Added `flake.lock` file with locked dependencies versions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->