### PR TITLE
docs: add account kit to the third party section

### DIFF
--- a/site/docs/third-party/account-abstraction.md
+++ b/site/docs/third-party/account-abstraction.md
@@ -1,4 +1,5 @@
 ---
+outline: deep
 head:
   - - meta
     - property: og:title
@@ -13,11 +14,111 @@ head:
 
 # Account Abstraction
 
-While Account Abstraction is not built into the core `viem` library, you can use a third-party library like [permissionless.js](https://docs.pimlico.io/permissionless/reference) to integrate with ERC-4337.
+While Account Abstraction is not built into the core `viem` library, you can use a third-party library like [Account Kit](https://accountkit.alchemy.com) and [permissionless.js](https://docs.pimlico.io/permissionless/reference) to integrate with ERC-4337.
 
 **Libraries:**
-
+- [account-kit](#account-kit)
 - [permissionless.js](#permissionless-js)
+
+
+## Account Kit
+
+**Account Kit** is a framework to embed smart accounts in your web3 app, unlocking [powerful features](https://accountkit.alchemy.com/getting-started) like email/social login, gas sponsorship, batched transactions, and more. The [`aa-sdk`](https://github.com/alchemyplatform/aa-sdk) makes it easy to integrate and deploy smart accounts, send user operations, and sponsor gas with just a few lines of code.
+
+### What is included in the Account Kit stack?
+
+Account Kit is a complete solution for [account abstraction](https://www.alchemy.com/overviews/what-is-account-abstraction). It includes five components:
+
+- **AA-SDK**: A simple, powerful interface to integrate, deploy, and use smart accounts. The [`aa-sdk`](https://github.com/alchemyplatform/aa-sdk) orchestrates everything under the hood to make development easy.
+- **LightAccount:** Secure, audited smart contract accounts. Easy to deploy, just when your users need them.
+- **Signer:** Integrations with the most popular wallet providers. Secure your accounts with email, social login, passkeys, or a self-custodial wallet signer.
+- **Gas Manager API:** A programmable API to sponsor gas for UserOps that meet your criteria.
+- **Bundler API:** The most reliable ERC-4337 Bundler. Land your UserOps onchain, batch operations, and sponsor gas at massive scale.
+
+### Getting Started
+
+Below is a quick example that will show you how to create a Provider, connect it to a Light Account which will be owned by an EOA private key, and send a User Operation with that account.
+
+#### 1. Install the aa-sdk
+
+::: code-group
+
+```bash [npm]
+npm install @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
+```
+
+```bash [yarn]
+yarn add @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
+```
+
+:::
+
+#### 2. Create a Provider and Connect to Light Account
+
+```ts
+// importing required dependencies
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import {
+  LightSmartContractAccount,
+  getDefaultLightAccountFactory,
+} from "@alchemy/aa-accounts";
+import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
+import { sepolia } from "viem/chains";
+
+const chain = sepolia;
+const PRIVATE_KEY = "0xYourEOAPrivateKey"; // Replace with the private key of your EOA that will be the owner of Light Account
+
+const eoaSigner: SmartAccountSigner =
+  LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // Create a signer for your EOA
+
+// Create a provider with your EOA as the smart account owner, this provider is used to send user operations from your smart account and interact with the blockchain
+const provider = new AlchemyProvider({
+  apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
+  chain,
+  entryPointAddress: "0x...",
+}).connect(
+  (rpcClient) =>
+    new LightSmartContractAccount({
+      entryPointAddress: "0x...",
+      chain: rpcClient.chain,
+      owner: eoaSigner,
+      factoryAddress: getDefaultLightAccountFactory(rpcClient.chain), // Default address for Light Account on Sepolia, you can replace it with your own.
+      rpcClient,
+    })
+); // Log the user operation hash
+
+
+// Logging the smart account address -- please fund this address with some SepoliaETH in order for the user operations to be executed successfully
+provider.getAddress().then((address: string) => console.log(address));
+
+```
+
+::: tip Note
+Remember to:
+
+1. Replace `"0xYourEOAPrivateKey"` with your actual EOA private key.
+2. Set `"ALCHEMY_API_KEY"` with your unique Alchemy API key.
+3. Fund your smart account address with some SepoliaETH in order for the user operation to go through. This address is logged to the console when you run the script.
+4. Adjust the `target` and `data` fields in the `sendUserOperation` function to match your requirements.
+:::
+
+#### 3. Send a User Operation
+
+```ts
+// provider from previous steps
+
+// Send a user operation from your smart contract account
+const { hash } = await provider.sendUserOperation({
+  target: "0xTargetAddress", // Replace with the desired target address
+  data: "0xCallData", // Replace with the desired call data
+  value: 0n, // value: bigint or undefined
+});
+
+console.log(hash);
+```
+
+### Next Steps
+For a more, in depth, guide on how to build your own 4337 dApp, check out our [guide](https://accountkit.alchemy.com/smart-accounts/overview.html). The guide will take you through all the steps necessary to Deploy an Account, Select a Signer, Sponsor Gas, Send Transactions (including batched transactions), and Managing Account Ownership.
 
 ## permissionless.js
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added information about the Account Kit framework for account abstraction
- Included instructions for installing the aa-sdk
- Provided an example code snippet for creating a Provider and connecting to a Light Account
- Added information about sending a User Operation using the Provider
- Mentioned the permissionless.js library for interacting with ERC-4337 bundlers and paymasters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->