### PR TITLE
fix: ccipFetch error handling

### DIFF
--- a/.changeset/cyan-tomatoes-joke.md
+++ b/.changeset/cyan-tomatoes-joke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where if a CCIP-Read request returned with an undefined body, body.error would still attempt to be read causing an `Cannot read properties of undefined` error, instead of the status text.

--- a/src/utils/ccip.test.ts
+++ b/src/utils/ccip.test.ts
@@ -162,6 +162,31 @@ describe('ccipFetch', async () => {
     await server.close()
   })
 
+  test('result undefined', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.writeHead(500)
+      res.end()
+    })
+
+    await expect(() =>
+      ccipFetch({
+        data: '0xdeadbeef',
+        sender: accounts[0].address,
+        urls: [`${server.url}/{sender}/{data}`],
+      }),
+    ).rejects.toMatchInlineSnapshot(`
+      [HttpRequestError: HTTP request failed.
+
+      Status: 500
+      URL: http://localhost
+
+      Details: Internal Server Error
+      Version: viem@1.0.2]
+    `)
+
+    await server.close()
+  })
+
   test('post method', async () => {
     let body = ''
     const server = await createHttpServer((req, res) => {

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -140,7 +140,9 @@ export async function ccipFetch({
       if (!response.ok) {
         error = new HttpRequestError({
           body,
-          details: stringify(result.error) || response.statusText,
+          details: result?.error
+            ? stringify(result.error)
+            : response.statusText,
           headers: response.headers,
           status: response.status,
           url,


### PR DESCRIPTION
Fixed an issue where if a CCIP-Read request returned with an undefined body, body.error would still attempt to be read causing an `Cannot read properties of undefined` error, instead of the status text.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing an issue related to handling undefined body in CCIP-Read requests.

### Detailed summary:
- In `ccip.ts`, the `details` property of `HttpRequestError` is updated to handle undefined `result.error`.
- In `ccip.test.ts`, a new test case is added to check for the rejection of a request with an undefined result.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->