### PR TITLE
Added optional alchemy rpcUrls for arbitrumSepolia

### DIFF
--- a/.changeset/chatty-falcons-provide.md
+++ b/.changeset/chatty-falcons-provide.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
 Added optional alchemy rpcUrls for arbitrumSepolia

--- a/.changeset/chatty-falcons-provide.md
+++ b/.changeset/chatty-falcons-provide.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added optional alchemy rpcUrls for arbitrumSepolia

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -10,6 +10,10 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
     decimals: 18,
   },
   rpcUrls: {
+    alchemy: {
+      http: ["https://arb-sepolia.g.alchemy.com/v2"],
+      webSocket: ["wss://arb-sepolia.g.alchemy.com/v2"],
+    },
     default: {
       http: ['https://sepolia-rollup.arbitrum.io/rpc'],
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding optional alchemy rpcUrls for arbitrumSepolia. 

### Detailed summary
- Added `alchemy` rpcUrls for `arbitrumSepolia`
- Added `http` and `webSocket` endpoints for alchemy rpcUrls

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->