### PR TITLE
Feat: export getProof from root and from actions

### DIFF
--- a/.changeset/dry-bananas-smile.md
+++ b/.changeset/dry-bananas-smile.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `getProof`.

--- a/src/actions/index.test.ts
+++ b/src/actions/index.test.ts
@@ -34,6 +34,7 @@ test('exports actions', () => {
       "getGasPrice": [Function],
       "getLogs": [Function],
       "getPermissions": [Function],
+      "getProof": [Function],
       "getStorageAt": [Function],
       "getTransaction": [Function],
       "getTransactionConfirmations": [Function],

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -243,6 +243,12 @@ export {
   getPermissions,
 } from './wallet/getPermissions.js'
 export {
+  type GetProofErrorType,
+  type GetProofParameters,
+  type GetProofReturnType,
+  getProof,
+} from './public/getProof.js'
+export {
   type ReplacementReason,
   type ReplacementReturnType,
   type WaitForTransactionReceiptErrorType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,11 @@ export type {
   GetPermissionsReturnType,
 } from './actions/wallet/getPermissions.js'
 export type {
+  GetProofErrorType,
+  GetProofParameters,
+  GetProofReturnType,
+} from './actions/public/getProof.js'
+export type {
   GetStorageAtErrorType,
   GetStorageAtParameters,
   GetStorageAtReturnType,


### PR DESCRIPTION
Exports [getProof](https://beta.viem.sh/docs/actions/public/getProof.html) from root and from actions.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update the code to export the `getProof` function and its related types.

### Detailed summary:
- Exported the `getProof` function in `index.test.ts`.
- Exported `GetProofErrorType`, `GetProofParameters`, and `GetProofReturnType` types in `index.ts`.
- Updated the exports in `index.ts` to include `getProof` and its related types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->