### PR TITLE
Fix: remove unused params from verifyHash

### DIFF
--- a/src/actions/public/verifyHash.ts
+++ b/src/actions/public/verifyHash.ts
@@ -19,10 +19,7 @@ import { getAction } from '../../utils/getAction.js'
 import { encodeDeployData, isHex, toHex } from '../../utils/index.js'
 import { type CallErrorType, type CallParameters, call } from './call.js'
 
-export type VerifyHashParameters = Pick<
-  CallParameters,
-  'blockNumber' | 'blockTag'
-> & {
+export type VerifyHashParameters = {
   /** The address that signed the original message. */
   address: Address
   /** The hash to be verified. */


### PR DESCRIPTION
Removes the unused parameters `blockNumber` and `blockTag` from the helper function `verifyHash`, consequently removing the unused parameters from the public actions [`verifyMessage`](https://beta.viem.sh/docs/actions/public/verifyMessage.html) and [`verifyTypedData`](https://beta.viem.sh/docs/actions/public/verifyTypedData.html).

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the `VerifyHashParameters` type in the `verifyHash.ts` file.

### Detailed summary:
- The `VerifyHashParameters` type is now no longer dependent on the `CallParameters` type.
- The `VerifyHashParameters` type now includes two properties: `address` and `hash`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->