### PR TITLE
fix: ambiguity in abi item extraction

### DIFF
--- a/.changeset/cool-cars-deny.md
+++ b/.changeset/cool-cars-deny.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where Viem could extract the wrong ABI item if ambiguity is detected within overload ABI items. Now, if ambiguity is detected, an error will be thrown.

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -1,4 +1,4 @@
-import type { AbiEvent, AbiParameter } from 'abitype'
+import type { Abi, AbiEvent, AbiParameter } from 'abitype'
 
 import type { Hex } from '../types/misc.js'
 import { formatAbiItem, formatAbiParams } from '../utils/abi/formatAbiItem.js'
@@ -328,6 +328,27 @@ export class AbiFunctionSignatureNotFoundError extends BaseError {
         docsPath,
       },
     )
+  }
+}
+
+export type AbiItemAmbiguityErrorType = AbiItemAmbiguityError & {
+  name: 'AbiItemAmbiguityError'
+}
+export class AbiItemAmbiguityError extends BaseError {
+  override name = 'AbiItemAmbiguityError'
+  constructor(
+    x: { abiItem: Abi[number]; type: string },
+    y: { abiItem: Abi[number]; type: string },
+  ) {
+    super('Found ambiguous types in overloaded ABI items.', {
+      metaMessages: [
+        `\`${x.type}\` in \`${formatAbiItem(x.abiItem)}\`, and`,
+        `\`${y.type}\` in \`${formatAbiItem(y.abiItem)}\``,
+        '',
+        'These types encode differently and cannot be distinguished at runtime.',
+        'Remove one of the ambiguous items in the ABI.',
+      ],
+    })
   }
 }
 

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -195,29 +195,18 @@ export function getAmbiguousTypes(
         (args as any)[parameterIndex],
       )
 
+    const types = [sourceParameter.type, targetParameter.type]
+
     const ambiguous = (() => {
-      if (
-        [sourceParameter.type, targetParameter.type].includes('address') &&
-        [sourceParameter.type, targetParameter.type].includes('bytes20')
-      )
-        return true
-
-      if (
-        [sourceParameter.type, targetParameter.type].includes('address') &&
-        [sourceParameter.type, targetParameter.type].includes('string')
-      )
+      if (types.includes('address') && types.includes('bytes20')) return true
+      if (types.includes('address') && types.includes('string'))
         return isAddress(args[parameterIndex] as Address)
-
-      if (
-        [sourceParameter.type, targetParameter.type].includes('address') &&
-        [sourceParameter.type, targetParameter.type].includes('bytes')
-      )
+      if (types.includes('address') && types.includes('bytes'))
         return isAddress(args[parameterIndex] as Address)
-
       return false
     })()
 
-    if (ambiguous) return [sourceParameter.type, targetParameter.type]
+    if (ambiguous) return types
   }
 
   return

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -66,7 +66,7 @@ export function getAbiItem<
   if (abiItems.length === 0) return undefined as any
   if (abiItems.length === 1) return abiItems[0] as any
 
-  let matchedOverload: AbiItem | undefined = undefined
+  let matchedAbiItem: AbiItem | undefined = undefined
   for (const abiItem of abiItems) {
     if (!('inputs' in abiItem)) continue
     if (!args || args.length === 0) {
@@ -84,13 +84,13 @@ export function getAbiItem<
     if (matched) {
       // Check for ambiguity against already matched parameters (e.g. `address` vs `bytes20`).
       if (
-        matchedOverload &&
-        'inputs' in matchedOverload &&
-        matchedOverload.inputs
+        matchedAbiItem &&
+        'inputs' in matchedAbiItem &&
+        matchedAbiItem.inputs
       ) {
         const ambiguousTypes = getAmbiguousTypes(
           abiItem.inputs,
-          matchedOverload.inputs,
+          matchedAbiItem.inputs,
           args as readonly unknown[],
         )
         if (ambiguousTypes)
@@ -100,18 +100,18 @@ export function getAbiItem<
               type: ambiguousTypes[0],
             },
             {
-              abiItem: matchedOverload,
+              abiItem: matchedAbiItem,
               type: ambiguousTypes[1],
             },
           )
       }
 
-      matchedOverload = abiItem
+      matchedAbiItem = abiItem
     }
   }
 
-  if (matchedOverload)
-    return matchedOverload as GetAbiItemReturnType<TAbi, TItemName>
+  if (matchedAbiItem)
+    return matchedAbiItem as GetAbiItemReturnType<TAbi, TItemName>
   return abiItems[0] as GetAbiItemReturnType<TAbi, TItemName>
 }
 


### PR DESCRIPTION
Fixed an issue where Viem could extract the wrong ABI item if ambiguity is detected within overload ABI items. Now, if ambiguity is detected, an error will be thrown.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on fixing an issue in the Viem code where the wrong ABI item could be extracted if there was ambiguity within overloaded ABI items.

### Detailed summary:
- Fixed the issue where Viem could extract the wrong ABI item if ambiguity is detected within overload ABI items.
- Added an error to be thrown if ambiguity is detected.
- Provided clear instructions on how to resolve the ambiguity by removing one of the ambiguous items in the ABI.

> The following files were skipped due to too many changes: `src/utils/abi/getAbiItem.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->