### PR TITLE
feat: add `ripemd160` & `sha256`

### DIFF
--- a/.changeset/odd-eagles-call.md
+++ b/.changeset/odd-eagles-call.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `ripemd160` and `sha256` hashing functions (re-exported from `@noble/hashes`).

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -741,6 +741,14 @@ export const sidebar: DefaultTheme.Sidebar = {
               text: 'keccak256',
               link: '/docs/utilities/keccak256',
             },
+            {
+              text: 'ripemd160',
+              link: '/docs/utilities/ripemd160',
+            },
+            {
+              text: 'sha256',
+              link: '/docs/utilities/sha256',
+            },
           ],
         },
         {

--- a/site/docs/utilities/ripemd160.md
+++ b/site/docs/utilities/ripemd160.md
@@ -1,0 +1,68 @@
+---
+head:
+  - - meta
+    - property: og:title
+      content: ripemd160
+  - - meta
+    - name: description
+      content: Calculates the Ripemd160 hash of a byte array.
+  - - meta
+    - property: og:description
+      content: Calculates the Ripemd160 hash of a byte array.
+
+---
+
+# ripemd160
+
+Calculates the [Ripemd160](https://en.wikipedia.org/wiki/RIPEMD) hash of a byte array or hex value.
+
+This function is a re-export of `ripemd160` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) – an audited & minimal JS hashing library.
+
+## Install
+
+```ts
+import { ripemd160 } from 'viem'
+```
+
+## Usage
+
+```ts
+import { ripemd160 } from 'viem'
+
+ripemd160(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+// 0x8476ee4631b9b30ac2754b0ee0c47e161d3f724c
+
+ripemd160('0xdeadbeef')
+// 0x226821c2f5423e11fe9af68bd285c249db2e4b5a
+```
+
+## Returns
+
+`Hex | ByteArray`
+
+The hashed value.
+
+## Parameters
+
+### value
+
+- **Type:** `Hex | ByteArray`
+
+The hex value or byte array to hash.
+
+### to
+
+- **Type:** `"bytes" | "hex"`
+- **Default:** `"hex"`
+
+The output type.
+
+```ts
+import { ripemd160 } from 'viem'
+
+ripemd160(
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33],
+  'bytes' // [!code focus]
+)
+// Uint8Array [132, 118, 238, 70, 49, 185, 179, 10, 194, 117, 75, 14, 224, 196, 126, 22, 29, 63, 114, 76] // [!code focus]
+```

--- a/site/docs/utilities/sha256.md
+++ b/site/docs/utilities/sha256.md
@@ -1,0 +1,68 @@
+---
+head:
+  - - meta
+    - property: og:title
+      content: sha256
+  - - meta
+    - name: description
+      content: Calculates the Sha256 hash of a byte array.
+  - - meta
+    - property: og:description
+      content: Calculates the Sha256 hash of a byte array.
+
+---
+
+# sha256
+
+Calculates the [Sha256](https://en.wikipedia.org/wiki/SHA-256) hash of a byte array or hex value.
+
+This function is a re-export of `sha256` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) – an audited & minimal JS hashing library.
+
+## Install
+
+```ts
+import { sha256 } from 'viem'
+```
+
+## Usage
+
+```ts
+import { sha256 } from 'viem'
+
+sha256(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+// 0x7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069
+
+sha256('0xdeadbeef')
+// 0x5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953
+```
+
+## Returns
+
+`Hex | ByteArray`
+
+The hashed value.
+
+## Parameters
+
+### value
+
+- **Type:** `Hex | ByteArray`
+
+The hex value or byte array to hash.
+
+### to
+
+- **Type:** `"bytes" | "hex"`
+- **Default:** `"hex"`
+
+The output type.
+
+```ts
+import { sha256 } from 'viem'
+
+sha256(
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33],
+  'bytes' // [!code focus]
+)
+// Uint8Array [95, 120, 195, 50, 116, 228, 63, 169, 222, 86, 89, 38, 92, 29, 145, 126, 37, 192, 55, 34, 220, 176, 184, 210, 125, 184, 213, 254, 170, 129, 57, 83] // [!code focus]
+```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -346,6 +346,8 @@ test('exports', () => {
       "isHash",
       "isHex",
       "keccak256",
+      "sha256",
+      "ripemd160",
       "pad",
       "padBytes",
       "padHex",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1323,6 +1323,8 @@ export { type IsBytesErrorType, isBytes } from './utils/data/isBytes.js'
 export { type IsHashErrorType, isHash } from './utils/hash/isHash.js'
 export { type IsHexErrorType, isHex } from './utils/data/isHex.js'
 export { type Keccak256ErrorType, keccak256 } from './utils/hash/keccak256.js'
+export { type Sha256ErrorType, sha256 } from './utils/hash/sha256.js'
+export { type Ripemd160ErrorType, ripemd160 } from './utils/hash/ripemd160.js'
 export {
   type PadBytesErrorType,
   type PadErrorType,

--- a/src/utils/hash/ripemd160.test.ts
+++ b/src/utils/hash/ripemd160.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from 'vitest'
+
+import { ripemd160 } from './ripemd160.js'
+
+test('to hex', () => {
+  expect(ripemd160('0xdeadbeef')).toMatchInlineSnapshot(
+    `"0x226821c2f5423e11fe9af68bd285c249db2e4b5a"`,
+  )
+
+  expect(
+    ripemd160(
+      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+    ),
+  ).toMatchInlineSnapshot(`"0x8476ee4631b9b30ac2754b0ee0c47e161d3f724c"`)
+})
+
+test('to bytes', () => {
+  expect(ripemd160('0xdeadbeef', 'bytes')).toMatchInlineSnapshot(
+    `
+    Uint8Array [
+      34,
+      104,
+      33,
+      194,
+      245,
+      66,
+      62,
+      17,
+      254,
+      154,
+      246,
+      139,
+      210,
+      133,
+      194,
+      73,
+      219,
+      46,
+      75,
+      90,
+    ]
+  `,
+  )
+
+  expect(
+    ripemd160(
+      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+      'bytes',
+    ),
+  ).toMatchInlineSnapshot(
+    `
+    Uint8Array [
+      132,
+      118,
+      238,
+      70,
+      49,
+      185,
+      179,
+      10,
+      194,
+      117,
+      75,
+      14,
+      224,
+      196,
+      126,
+      22,
+      29,
+      63,
+      114,
+      76,
+    ]
+  `,
+  )
+})

--- a/src/utils/hash/ripemd160.ts
+++ b/src/utils/hash/ripemd160.ts
@@ -1,0 +1,31 @@
+import { ripemd160 as noble_ripemd160 } from '@noble/hashes/ripemd160'
+
+import type { ErrorType } from '../../errors/utils.js'
+import type { ByteArray, Hex } from '../../types/misc.js'
+import { type IsHexErrorType, isHex } from '../data/isHex.js'
+import { type ToBytesErrorType, toBytes } from '../encoding/toBytes.js'
+import { type ToHexErrorType, toHex } from '../encoding/toHex.js'
+
+type To = 'hex' | 'bytes'
+
+export type Ripemd160Hash<TTo extends To> =
+  | (TTo extends 'bytes' ? ByteArray : never)
+  | (TTo extends 'hex' ? Hex : never)
+
+export type Ripemd160ErrorType =
+  | IsHexErrorType
+  | ToBytesErrorType
+  | ToHexErrorType
+  | ErrorType
+
+export function ripemd160<TTo extends To = 'hex'>(
+  value: Hex | ByteArray,
+  to_?: TTo,
+): Ripemd160Hash<TTo> {
+  const to = to_ || 'hex'
+  const bytes = noble_ripemd160(
+    isHex(value, { strict: false }) ? toBytes(value) : value,
+  )
+  if (to === 'bytes') return bytes as Ripemd160Hash<TTo>
+  return toHex(bytes) as Ripemd160Hash<TTo>
+}

--- a/src/utils/hash/sha256.test.ts
+++ b/src/utils/hash/sha256.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from 'vitest'
+
+import { sha256 } from './sha256.js'
+
+test('to hex', () => {
+  expect(sha256('0xdeadbeef')).toMatchInlineSnapshot(
+    `"0x5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953"`,
+  )
+
+  expect(
+    sha256(
+      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+    ),
+  ).toMatchInlineSnapshot(
+    `"0x7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"`,
+  )
+})
+
+test('to bytes', () => {
+  expect(sha256('0xdeadbeef', 'bytes')).toMatchInlineSnapshot(
+    `
+    Uint8Array [
+      95,
+      120,
+      195,
+      50,
+      116,
+      228,
+      63,
+      169,
+      222,
+      86,
+      89,
+      38,
+      92,
+      29,
+      145,
+      126,
+      37,
+      192,
+      55,
+      34,
+      220,
+      176,
+      184,
+      210,
+      125,
+      184,
+      213,
+      254,
+      170,
+      129,
+      57,
+      83,
+    ]
+  `,
+  )
+
+  expect(
+    sha256(
+      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+      'bytes',
+    ),
+  ).toMatchInlineSnapshot(
+    `
+    Uint8Array [
+      127,
+      131,
+      177,
+      101,
+      127,
+      241,
+      252,
+      83,
+      185,
+      45,
+      193,
+      129,
+      72,
+      161,
+      214,
+      93,
+      252,
+      45,
+      75,
+      31,
+      163,
+      214,
+      119,
+      40,
+      74,
+      221,
+      210,
+      0,
+      18,
+      109,
+      144,
+      105,
+    ]
+  `,
+  )
+})

--- a/src/utils/hash/sha256.ts
+++ b/src/utils/hash/sha256.ts
@@ -1,0 +1,31 @@
+import { sha256 as noble_sha256 } from '@noble/hashes/sha256'
+
+import type { ErrorType } from '../../errors/utils.js'
+import type { ByteArray, Hex } from '../../types/misc.js'
+import { type IsHexErrorType, isHex } from '../data/isHex.js'
+import { type ToBytesErrorType, toBytes } from '../encoding/toBytes.js'
+import { type ToHexErrorType, toHex } from '../encoding/toHex.js'
+
+type To = 'hex' | 'bytes'
+
+export type Sha256Hash<TTo extends To> =
+  | (TTo extends 'bytes' ? ByteArray : never)
+  | (TTo extends 'hex' ? Hex : never)
+
+export type Sha256ErrorType =
+  | IsHexErrorType
+  | ToBytesErrorType
+  | ToHexErrorType
+  | ErrorType
+
+export function sha256<TTo extends To = 'hex'>(
+  value: Hex | ByteArray,
+  to_?: TTo,
+): Sha256Hash<TTo> {
+  const to = to_ || 'hex'
+  const bytes = noble_sha256(
+    isHex(value, { strict: false }) ? toBytes(value) : value,
+  )
+  if (to === 'bytes') return bytes as Sha256Hash<TTo>
+  return toHex(bytes) as Sha256Hash<TTo>
+}

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -142,6 +142,7 @@ test('exports utils', () => {
       "recoverMessageAddress": [Function],
       "recoverPublicKey": [Function],
       "recoverTypedDataAddress": [Function],
+      "ripemd160": [Function],
       "rpc": {
         "http": [Function],
         "webSocket": [Function],
@@ -149,6 +150,7 @@ test('exports utils', () => {
       },
       "serializeAccessList": [Function],
       "serializeTransaction": [Function],
+      "sha256": [Function],
       "size": [Function],
       "slice": [Function],
       "sliceBytes": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -358,6 +358,8 @@ export {
 } from './hash/getFunctionSelector.js'
 export { type IsHashErrorType, isHash } from './hash/isHash.js'
 export { type Keccak256ErrorType, keccak256 } from './hash/keccak256.js'
+export { type Sha256ErrorType, sha256 } from './hash/sha256.js'
+export { type Ripemd160ErrorType, ripemd160 } from './hash/ripemd160.js'
 export {
   type HashDomainErrorType,
   type HashTypedDataParameters,


### PR DESCRIPTION
Fixes #1581

<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR adds the `sha256` and `ripemd160` hashing functions to the codebase and updates the documentation and tests accordingly.

### Detailed summary:
- Added `sha256` and `ripemd160` hashing functions to the codebase.
- Updated documentation for `ripemd160` and `sha256` functions.
- Added tests for `sha256` and `ripemd160` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->