### PR TITLE
feat: Add eth_blobGasPrice to client.request

### DIFF
--- a/.changeset/tough-bulldogs-kick.md
+++ b/.changeset/tough-bulldogs-kick.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added typescript type for eth_blobGasFee request

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -192,6 +192,18 @@ export type PublicRpcSchema = [
     ReturnType: Quantity
   },
   /**
+   * @description Returns the current blob price of gas expressed in wei
+   *
+   * @example
+   * provider.request({ method: 'eth_blobGasPrice' })
+   * // => '0x09184e72a000'
+   */
+  {
+    Method: 'eth_blobGasPrice'
+    Parameters?: undefined
+    ReturnType: Quantity
+  },
+  /**
    * @description Returns the number of the most recent block seen by this client
    *
    * @example


### PR DESCRIPTION
Add eth_blobGasPrice method for eip-4844 

https://eips.ethereum.org/EIPS/eip-4844

https://www.eip4844.com/

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a TypeScript type for the `eth_blobGasFee` request.
- Added a new method `eth_blobGasPrice` that returns the current blob price of gas expressed in wei.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->