### PR TITLE
test(accounts): add better test case for generating private keys

### DIFF
--- a/src/accounts/generatePrivateKey.test.ts
+++ b/src/accounts/generatePrivateKey.test.ts
@@ -1,7 +1,22 @@
-import { expect, test } from 'vitest'
+import { secp256k1 } from '@noble/curves/secp256k1'
+import { expect } from 'chai'
+import { it, vi } from 'vitest'
 
+import type { Hex } from '~viem/index.js'
 import { generatePrivateKey } from './generatePrivateKey.js'
 
-test('default', () => {
-  expect(generatePrivateKey()).toBeDefined()
+it('should generate random private key', () => {
+  const hex: Hex =
+    '0xb4eb3c48376e1dc6e236c2004aea6f70d598de97825d15b7e97eaf89057ff9b9'
+
+  vi.spyOn(secp256k1.utils, 'randomPrivateKey').mockImplementationOnce(() =>
+    Uint8Array.from(
+      Buffer.from(
+        hex.slice(2), // skip 0x
+        'hex',
+      ),
+    ),
+  )
+
+  expect(generatePrivateKey()).to.be.eq(hex)
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a test case for the `generatePrivateKey` function.

### Detailed summary:
- Added imports for `secp256k1`, `expect`, `it`, and `vi`.
- Imported type `Hex` from `~viem/index.js`.
- Updated the test case to use the `it` function instead of `test`.
- Added a new test case to check if the `generatePrivateKey` function generates a random private key correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->