### PR TITLE
feat: add alchemy as rpc url for base sepolia

### DIFF
--- a/.changeset/curvy-tips-fetch.md
+++ b/.changeset/curvy-tips-fetch.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
 feat: add alchemy as rpc url for base sepolia

--- a/.changeset/curvy-tips-fetch.md
+++ b/.changeset/curvy-tips-fetch.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-feat: add alchemy as rpc url for base sepolia
+Added RPC URLs to Base Sepolia

--- a/.changeset/curvy-tips-fetch.md
+++ b/.changeset/curvy-tips-fetch.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+feat: add alchemy as rpc url for base sepolia

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -8,6 +8,10 @@ export const baseSepolia = /*#__PURE__*/ defineChain(
     name: 'Base Sepolia',
     nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
+      alchemy: {
+        http: ['https://base-sepolia.g.alchemy.com/v2'],
+        webSocket: ['wss://base-sepolia.g.alchemy.com/v2'],
+      },
       default: {
         http: ['https://sepolia.base.org'],
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding RPC URLs to the Base Sepolia chain definition.

### Detailed summary
- Added RPC URLs for Alchemy HTTP and WebSocket endpoints to the Base Sepolia chain definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->