### PR TITLE
docs: Update createEventFilter to use 'toBlock' instead of 'fromBlock'

### DIFF
--- a/site/docs/actions/public/createEventFilter.md
+++ b/site/docs/actions/public/createEventFilter.md
@@ -301,7 +301,7 @@ Block to query/listen until.
 
 ```ts
 const filter = await publicClient.createEventFilter({
-  fromBlock: 70120n // [!code focus]
+  toBlock: 70120n // [!code focus]
 })
 ```
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The focus of this PR is to fix a typo in the `createEventFilter` function call.
- The `fromBlock` parameter has been changed to `toBlock` in the function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->