### PR TITLE
docs(ethers-migration): update `parseBytes32String` section

### DIFF
--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -1399,13 +1399,20 @@ utils.parseBytes32String('0x48656c6c6f20776f726c642e0000000000000000000000000000
 
 #### viem
 
-```ts {3-6}
-import { hexToString } from 'viem'
+```ts {3-11}
+import { hexToString, zeroHash, type Hex } from 'viem'
 
-hexToString(
-  '0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000', 
-  { size: 32 }
-)
+function parseBytes32String(hex: Hex) {
+  // When the hex is zero, `viem.hexToString` returns `\u0000`,
+  // which differs from `ethers.utils.parseBytes32String` that returns an empty string
+  if (zeroHash.toLowerCase() === hex.toLowerCase()) {
+    return ''
+  } else {
+    return hexToString(hex, { size: 32 })
+  }
+}
+
+parseBytes32String('0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000')
 // "Hello world"
 ```
 


### PR DESCRIPTION
When the hex is zero, `viem.hexToString` returns `\u0000`, which differs from `ethers.utils.parseBytes32String` that returns an empty string.

Here is a live demonstration: https://stackblitz.com/edit/nestjs-typescript-starter-jhhogg?file=src%2Fmain.ts&terminal=start

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new function `parseBytes32String` to the `viem` library. 

### Detailed summary
- Added import for `zeroHash` and `Hex` from `viem`
- Added `parseBytes32String` function that handles zero hash case
- Replaced direct call to `hexToString` with `parseBytes32String`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->