### PR TITLE
Change explorer of Arbitrum Sepolia to Arbiscan

### DIFF
--- a/.changeset/blue-keys-judge.md
+++ b/.changeset/blue-keys-judge.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Modified explorer link of Arbitrum Sepolia.

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -22,10 +22,8 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: {
-      name: 'Blockscout',
-      url: 'https://sepolia-explorer.arbitrum.io',
-    },
+    etherscan: { name: 'Arbiscan', url: 'https://sepolia.arbiscan.io' },
+    default: { name: 'Arbiscan', url: 'https://sepolia.arbiscan.io' },
   },
   contracts: {
     multicall3: {


### PR DESCRIPTION
Arbiscan explorer [https://sepolia.arbiscan.io/](https://sepolia.arbiscan.io/) has already been available for a few months on Arbitrum Sepolia, and it's more reliable than the Blockscout instance.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the explorer link of Arbitrum Sepolia. 

### Detailed summary
- Changes the default block explorer link from 'Blockscout' to 'Arbiscan'
- Adds a new block explorer link 'Arbiscan' with the same URL

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->