### PR TITLE
add alchemy rpc to optimism sepolia

### DIFF
--- a/src/chains/definitions/optimismSepolia.ts
+++ b/src/chains/definitions/optimismSepolia.ts
@@ -14,6 +14,10 @@ export const optimismSepolia = /*#__PURE__*/ defineChain(
       public: {
         http: ['https://sepolia.optimism.io'],
       },
+      alchemy: {  
+        http: ["https://opt-sepolia.g.alchemy.com/v2"],
+        webSocket: ["wss://opt-sepolia.g.alchemy.com/v2"],
+      }
     },
     blockExplorers: {
       blockscout: {


### PR DESCRIPTION
This is causing an issues to use Optimism Sepolia with Alchemy Account Abstraction SDK. 

The Alchemy AA SDK website stated that they supported Optimism Sepolia, I tried to add it manually in my project, and it is working fine.

linked issues: https://github.com/alchemyplatform/aa-sdk/issues/343

#### Workaround solution
```ts
import { optimismSepolia } from "viem/chains";

const opSepolia = {
  ...optimismSepolia, rpcUrls: {
    ...optimismSepolia.rpcUrls,
    alchemy: {
      http: ["https://opt-sepolia.g.alchemy.com/v2"],
      webSocket: ["wss://opt-sepolia.g.alchemy.com/v2"]
    }
  }
}

const provider = new AlchemyProvider({
      apiKey: ALCHEMY_API_KEY,
      chain: opSepolia,
    })
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding Alchemy as a new provider in the `optimismSepolia` chain definition.

### Detailed summary:
- Added Alchemy as a new provider in the `optimismSepolia` chain definition.
- Added HTTP endpoint for Alchemy provider.
- Added WebSocket endpoint for Alchemy provider.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->