### PR TITLE
Fix klaytn rpcUrls

### DIFF
--- a/.changeset/silver-shoes-roll.md
+++ b/.changeset/silver-shoes-roll.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Klaytn RPC URLs.

--- a/src/chains/definitions/klaytn.ts
+++ b/src/chains/definitions/klaytn.ts
@@ -10,8 +10,8 @@ export const klaytn = /*#__PURE__*/ defineChain({
     symbol: 'KLAY',
   },
   rpcUrls: {
-    default: { http: ['https://klaytn.drpc.org'] },
-    public: { http: ['https://klaytn.drpc.org'] },
+    default: { http: ['https://public-en-cypress.klaytn.net'] },
+    public: { http: ['https://public-en-cypress.klaytn.net'] },
   },
   blockExplorers: {
     etherscan: { name: 'KlaytnScope', url: 'https://scope.klaytn.com' },


### PR DESCRIPTION
Fixed Fix klaytn rpcUrls according to official Klaytn documentation.
Explained details [here](https://github.com/wevm/viem/discussions/1630).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the Klaytn RPC URLs. 

### Detailed summary
- Updated the `default` and `public` RPC URLs for Klaytn from `'https://klaytn.drpc.org'` to `'https://public-en-cypress.klaytn.net'`.
- No other notable changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->