### PR TITLE
Fix op-stack link in the sidebar

### DIFF
--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -474,7 +474,7 @@ export const sidebar: DefaultTheme.Sidebar = {
             },
             {
               text: 'OP Stack',
-              link: '/docs/op-stack',
+              link: '/op-stack',
             },
             {
               text: 'zkSync',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the link for the "OP Stack" in the sidebar of the Vitepress site. 

### Detailed summary
- Updated the link for "OP Stack" in the sidebar from '/docs/op-stack' to '/op-stack'
- No other notable changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->