### PR TITLE
Fix doc about viem/op-stack

### DIFF
--- a/site/op-stack/actions/buildProveWithdrawal.md
+++ b/site/op-stack/actions/buildProveWithdrawal.md
@@ -23,7 +23,7 @@ Builds the transaction that proves a withdrawal was initiated on an L2. Used in 
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 

--- a/site/op-stack/actions/finalizeWithdrawal.md
+++ b/site/op-stack/actions/finalizeWithdrawal.md
@@ -25,7 +25,7 @@ Internally performs a contract write to the [`finalizeWithdrawalTransaction` fun
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 
@@ -73,7 +73,7 @@ If you do not wish to pass an `account` to every `finalizeWithdrawal`, you can a
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 

--- a/site/op-stack/actions/proveWithdrawal.md
+++ b/site/op-stack/actions/proveWithdrawal.md
@@ -25,7 +25,7 @@ Internally performs a contract write to the [`proveWithdrawalTransaction` functi
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 
@@ -86,7 +86,7 @@ We can use the resulting `args` to prove the withdrawal transaction on the L1.
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 
@@ -143,7 +143,7 @@ If you do not wish to pass an `account` to every `proveWithdrawal`, you can also
 ```ts [example.ts]
 import { account, publicClientL2, walletClientL1 } from './config'
 
-const receipt = await getTransactionReceipt(publicClientL2, {
+const receipt = await publicClientL2.getTransactionReceipt({
   hash: '0xbbdd0957a82a057a76b5f093de251635ac4ddc6e2d0c4aa7fbf82d73e4e11039',
 })
 

--- a/site/op-stack/utilities/extractTransactionDepositedLogs.md
+++ b/site/op-stack/utilities/extractTransactionDepositedLogs.md
@@ -18,13 +18,13 @@ Extracts `TransactionDeposited` logs from an opaque array of logs.
 
 ## Import
 ```ts
-import { extractTransactionDepositedLogs } from 'viem'
+import { extractTransactionDepositedLogs } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { extractTransactionDepositedLogs } from 'viem'
+import { extractTransactionDepositedLogs } from 'viem/op-stack'
 
 const receipt = await client.getTransactionReceipt({
   hash: '0xc9c0361bc3da9cd3560e48b469d0d6aac0e633e4897895edfd26a287f7c578ec',

--- a/site/op-stack/utilities/extractWithdrawalMessageLogs.md
+++ b/site/op-stack/utilities/extractWithdrawalMessageLogs.md
@@ -18,13 +18,13 @@ Extracts [`MessagePassed` logs](https://github.com/ethereum-optimism/optimism/bl
 
 ## Import
 ```ts
-import { extractWithdrawalMessageLogs } from 'viem'
+import { extractWithdrawalMessageLogs } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { extractWithdrawalMessageLogs } from 'viem'
+import { extractWithdrawalMessageLogs } from 'viem/op-stack'
 
 const receipt = await client.getTransactionReceipt({
   hash: '0xc9c0361bc3da9cd3560e48b469d0d6aac0e633e4897895edfd26a287f7c578ec',

--- a/site/op-stack/utilities/fromOpaqueData.md
+++ b/site/op-stack/utilities/fromOpaqueData.md
@@ -18,13 +18,13 @@ Decodes opaque deposit data found in the `TransactionDeposited` event log data.
 
 ## Import
 ```ts
-import { opaqueDataToDepositData } from 'viem'
+import { opaqueDataToDepositData } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { opaqueDataToDepositData } from 'viem'
+import { opaqueDataToDepositData } from 'viem/op-stack'
 
 const data = opaqueDataToDepositData('0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045000000000000526c01deadbeef')
 ```

--- a/site/op-stack/utilities/getL2TransactionHash.md
+++ b/site/op-stack/utilities/getL2TransactionHash.md
@@ -24,13 +24,13 @@ For the general case of retrieving an L2 transaction hash from an L1 transaction
 
 ## Import
 ```ts
-import { getL2TransactionHash } from 'viem'
+import { getL2TransactionHash } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { extractTransactionDepositedLogs, getL2TransactionHash } from 'viem'
+import { extractTransactionDepositedLogs, getL2TransactionHash } from 'viem/op-stack'
 
 const receipt = await client.getTransactionReceipt({
   hash: '0xa08acae48f12243bccd7153c88d892673d5578cce4ee9988c0332e8bba47436b',

--- a/site/op-stack/utilities/getL2TransactionHashes.md
+++ b/site/op-stack/utilities/getL2TransactionHashes.md
@@ -20,13 +20,13 @@ Useful for extracting L2 hashes from an **L1 Transaction Receipt**.
 
 ## Import
 ```ts
-import { getL2TransactionHashes } from 'viem'
+import { getL2TransactionHashes } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { extractTransactionDepositedLogs, getL2TransactionHashes } from 'viem'
+import { extractTransactionDepositedLogs, getL2TransactionHashes } from 'viem/op-stack'
 
 const receipt = await client.getTransactionReceipt({
   hash: '0xa08acae48f12243bccd7153c88d892673d5578cce4ee9988c0332e8bba47436b',

--- a/site/op-stack/utilities/getSourceHash.md
+++ b/site/op-stack/utilities/getSourceHash.md
@@ -18,13 +18,13 @@ Computes the [source hash](https://github.com/ethereum-optimism/optimism/blob/de
 
 ## Import
 ```ts
-import { getSourceHash } from 'viem'
+import { getSourceHash } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { getSourceHash } from 'viem'
+import { getSourceHash } from 'viem/op-stack'
 
 // User Deposit
 const sourceHash = getSourceHash({

--- a/site/op-stack/utilities/getWithdrawalHashStorageSlot.md
+++ b/site/op-stack/utilities/getWithdrawalHashStorageSlot.md
@@ -19,13 +19,13 @@ Computes the withdrawal hash storage slot to be used when proving a withdrawal.
 ## Import
 
 ```ts
-import { getWithdrawalHashStorageSlot } from 'viem'
+import { getWithdrawalHashStorageSlot } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { getWithdrawalHashStorageSlot } from 'viem'
+import { getWithdrawalHashStorageSlot } from 'viem/op-stack'
 
 const slot = getWithdrawalHashStorageSlot({ // [!code hl]
   withdrawalHash: '0xB1C3824DEF40047847145E069BF467AA67E906611B9F5EF31515338DB0AABFA2' // [!code hl]

--- a/site/op-stack/utilities/getWithdrawals.md
+++ b/site/op-stack/utilities/getWithdrawals.md
@@ -19,13 +19,13 @@ Gets withdrawal messages emitted from the [`MessagePassed` log](https://github.c
 ## Import
 
 ```ts
-import { getWithdrawals } from 'viem'
+import { getWithdrawals } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { extractTransactionDepositedLogs, getWithdrawals } from 'viem'
+import { extractTransactionDepositedLogs, getWithdrawals } from 'viem/op-stack'
 
 const receipt = await client.getTransactionReceipt({
   hash: '0xa08acae48f12243bccd7153c88d892673d5578cce4ee9988c0332e8bba47436b',

--- a/site/op-stack/utilities/parseTransaction.md
+++ b/site/op-stack/utilities/parseTransaction.md
@@ -18,13 +18,13 @@ Parses a serialized RLP-encoded transaction. Supports signed & unsigned Deposit,
 
 ## Import
 ```ts
-import { parseTransaction } from 'viem'
+import { parseTransaction } from 'viem/op-stack'
 ```
 
 ## Usage
 
 ```ts
-import { parseTransaction } from 'viem'
+import { parseTransaction } from 'viem/op-stack'
 
 const transaction = parseTransaction('0x02ef0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0')
 ```
@@ -34,7 +34,7 @@ const transaction = parseTransaction('0x02ef018203118477359400847735940080947099
 The `parseTransaction` module from `viem/op-stack` also supports parsing deposit transactions (`0x7e`-prefixed):
 
 ```ts
-import { parseTransaction } from 'viem'
+import { parseTransaction } from 'viem/op-stack'
 
 const transaction = parseTransaction('0x7ef83ca018040f35752170c3339ddcd850f185c9cc46bdef4d6e1f2ab323f4d3d710431994977f82a600a1414e583f7f13623f1ac5d58b1c0b808080808080')
 ```

--- a/src/chains/opStack/actions/getTimeToFinalize.ts
+++ b/src/chains/opStack/actions/getTimeToFinalize.ts
@@ -59,7 +59,7 @@ const buffer = 10
  *   transport: http(),
  * })
  *
- * const receipt = await getTransactionReceipt(publicClientL2, {
+ * const receipt = await publicClientL2.getTransactionReceipt({
  *   hash: '0x9a2f4283636ddeb9ac32382961b22c177c9e86dd3b283735c154f897b1a7ff4a',
  * })
  *

--- a/src/chains/opStack/actions/getTimeToProve.ts
+++ b/src/chains/opStack/actions/getTimeToProve.ts
@@ -56,7 +56,7 @@ export type GetTimeToProveErrorType = GetTimeToNextL2OutputErrorType | ErrorType
  *   transport: http(),
  * })
  *
- * const receipt = await getTransactionReceipt(publicClientL2, { hash: '0x...' })
+ * const receipt = await publicClientL2.getTransactionReceipt({ hash: '0x...' })
  * const { period, seconds, timestamp } = await getTimeToProve(publicClientL1, {
  *   receipt,
  *   targetChain: optimism

--- a/src/chains/opStack/actions/getWithdrawalStatus.ts
+++ b/src/chains/opStack/actions/getWithdrawalStatus.ts
@@ -71,7 +71,7 @@ export type GetWithdrawalStatusErrorType =
  *   transport: http(),
  * })
  *
- * const receipt = await getTransactionReceipt(publicClientL2, { hash: '0x...' })
+ * const receipt = await publicClientL2.getTransactionReceipt({ hash: '0x...' })
  * const status = await getWithdrawalStatus(publicClientL1, {
  *   receipt,
  *   targetChain: optimism

--- a/src/chains/opStack/actions/waitToFinalize.ts
+++ b/src/chains/opStack/actions/waitToFinalize.ts
@@ -40,7 +40,7 @@ export type WaitToFinalizeErrorType = GetTimeToFinalizeErrorType | ErrorType
  *   transport: http(),
  * })
  *
- * const receipt = await getTransactionReceipt(publicClientL2, {
+ * const receipt = await publicClientL2.getTransactionReceipt({
  *   hash: '0x9a2f4283636ddeb9ac32382961b22c177c9e86dd3b283735c154f897b1a7ff4a',
  * })
  *

--- a/src/chains/opStack/actions/waitToProve.ts
+++ b/src/chains/opStack/actions/waitToProve.ts
@@ -67,7 +67,7 @@ export type WaitToProveErrorType =
  *   transport: http(),
  * })
  *
- * const receipt = await getTransactionReceipt(publicClientL2, { hash: '0x...' })
+ * const receipt = await publicClientL2.getTransactionReceipt({ hash: '0x...' })
  * await waitToProve(publicClientL1, {
  *   receipt,
  *   targetChain: optimism

--- a/src/chains/opStack/decorators/publicL1.ts
+++ b/src/chains/opStack/decorators/publicL1.ts
@@ -436,7 +436,7 @@ export type PublicActionsL1<
    *   transport: http(),
    * })
    *
-   * const receipt = await getTransactionReceipt(publicClientL2, {
+   * const receipt = await publicClientL2.getTransactionReceipt({
    *   hash: '0x9a2f4283636ddeb9ac32382961b22c177c9e86dd3b283735c154f897b1a7ff4a',
    * })
    *


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Refactored code to use `publicClientL2.getTransactionReceipt()` instead of `getTransactionReceipt(publicClientL2, ...)`
- Updated imports in various files to use `viem/op-stack` instead of `viem`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->