### PR TITLE
fix: writeContract args type inference

### DIFF
--- a/.changeset/serious-drinks-hammer.md
+++ b/.changeset/serious-drinks-hammer.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `writeContract` `args` type inference.

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -180,6 +180,7 @@ test('w/ simulateContract', async () => {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
+    args: [],
   })
   expect(await writeContract(walletClient, request)).toBeDefined()
 
@@ -232,6 +233,7 @@ test('w/ simulateContract (args chain mismatch)', async () => {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
+    args: [],
     chain: optimism,
   })
   await expect(() =>
@@ -261,6 +263,7 @@ test('w/ simulateContract (client chain mismatch)', async () => {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
+    args: [],
   })
   await expect(() =>
     writeContract(walletClient, request),

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -136,7 +136,11 @@ export async function writeContract<
   account extends Account | undefined,
   const abi extends Abi | readonly unknown[],
   functionName extends ContractFunctionName<abi, 'nonpayable' | 'payable'>,
-  args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+  args extends ContractFunctionArgs<
+    abi,
+    'nonpayable' | 'payable',
+    functionName
+  >,
   chainOverride extends Chain | undefined,
 >(
   client: Client<Transport, chain, account>,

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -140,6 +140,9 @@ test('ExtractAbiFunctionForArgs', () => {
     ExtractAbiFunctionForArgs<typeof abi, 'pure' | 'view', 'foo', []>
   >().toEqualTypeOf<(typeof abi)[0]>()
   expectTypeOf<
+    ExtractAbiFunctionForArgs<typeof abi, 'pure' | 'view', 'foo', readonly []>
+  >().toEqualTypeOf<(typeof abi)[0]>()
+  expectTypeOf<
     ExtractAbiFunctionForArgs<typeof abi, 'pure' | 'view', 'foo', ['0x']>
   >().toEqualTypeOf<(typeof abi)[1]>()
   expectTypeOf<


### PR DESCRIPTION
Closes #1655

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing type inference for the `args` parameter in the `writeContract` function.

### Detailed summary:
- Fixed type inference for the `args` parameter in the `writeContract` function.
- Added type checks for `args` in the `CheckArgs` type.
- Added test cases for `WriteContractParameters` and overloads.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->