### PR TITLE
fix: abi decode recursive array

### DIFF
--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -95,6 +95,19 @@ export class AbiDecodingDataSizeTooSmallError extends BaseError {
   }
 }
 
+export type AbiDecodingOffsetOutOfBoundsErrorType =
+  AbiDecodingOffsetOutOfBoundsError & {
+    name: 'AbiDecodingOffsetOutOfBoundsError'
+  }
+export class AbiDecodingOffsetOutOfBoundsError extends BaseError {
+  override name = 'AbiDecodingOffsetOutOfBoundsError'
+  constructor({ offset, position }: { offset: number; position: number }) {
+    super(
+      `Offset at "${offset}" is out-of-bounds (current position: "${position}").`,
+    )
+  }
+}
+
 export type AbiDecodingZeroDataErrorType = AbiDecodingZeroDataError & {
   name: 'AbiDecodingZeroDataError'
 }

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -2044,3 +2044,19 @@ test('error: zero data', () => {
     Version: viem@1.0.2]
   `)
 })
+
+test('error: recursive decode array', () => {
+  const payload = `0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a${'0000000000000000000000000000000000000000000000000000000000000020'.repeat(
+    64,
+  )}`
+  expect(() =>
+    decodeAbiParameters(
+      [{ type: 'uint256[][][][][][][][][][]' }],
+      `0x${payload}`,
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [AbiDecodingOffsetOutOfBoundsError: Offset at "32" is out-of-bounds (current position: "64").
+
+    Version: viem@1.0.2]
+  `)
+})

--- a/src/utils/abi/decodeAbiParameters.ts
+++ b/src/utils/abi/decodeAbiParameters.ts
@@ -7,6 +7,7 @@ import type {
 import {
   AbiDecodingDataSizeTooSmallError,
   type AbiDecodingDataSizeTooSmallErrorType,
+  AbiDecodingOffsetOutOfBoundsError,
   AbiDecodingZeroDataError,
   type AbiDecodingZeroDataErrorType,
   InvalidAbiDecodingTypeError,
@@ -185,6 +186,9 @@ function decodeArray<const TParam extends AbiParameter>(
     const offset = hexToNumber(
       slice(data, position, position + 32, { strict: true }),
     )
+    if (offset < position)
+      throw new AbiDecodingOffsetOutOfBoundsError({ offset, position })
+
     // Get the length of the array from the offset.
     const length = hexToNumber(
       slice(data, offset, offset + 32, { strict: true }),


### PR DESCRIPTION
Fixes extreme edge-case where decoding a malformed payload against a nested array type could cause `decodeAbiParameters` to enter an infinite loop.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new error type `AbiDecodingOffsetOutOfBoundsError` and handling it in the `decodeArray` function in the `decodeAbiParameters` module.

### Detailed summary:
- Added a new error type `AbiDecodingOffsetOutOfBoundsError`
- Modified the `decodeArray` function to throw `AbiDecodingOffsetOutOfBoundsError` if the offset is out-of-bounds

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->