### PR TITLE
feat: strict + gatewayUrls param for ens funcs

### DIFF
--- a/.changeset/ninety-rivers-remember.md
+++ b/.changeset/ninety-rivers-remember.md
@@ -1,5 +1,5 @@
 ---
-"viem": patch
+"viem": minor
 ---
 
 Added `gatewayUrls` and `strict` properties to ENS Actions.

--- a/.changeset/ninety-rivers-remember.md
+++ b/.changeset/ninety-rivers-remember.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `gatewayUrls` and `strict` properties to ENS Actions.

--- a/site/pages/docs/ens/actions/getEnsAddress.md
+++ b/site/pages/docs/ens/actions/getEnsAddress.md
@@ -55,7 +55,7 @@ Returns `null` if ENS name does not resolve to address.
 Name to get the address for.
 
 ```ts
-const ensName = await publicClient.getEnsAddress({
+const ensAddress = await publicClient.getEnsAddress({
   name: normalize('wevm.eth'), // [!code focus]
 })
 ```
@@ -67,7 +67,7 @@ const ensName = await publicClient.getEnsAddress({
 The block number to perform the read against.
 
 ```ts
-const ensName = await publicClient.getEnsAddress({
+const ensAddress = await publicClient.getEnsAddress({
   name: normalize('wevm.eth'),
   blockNumber: 15121123n, // [!code focus]
 })
@@ -81,7 +81,7 @@ const ensName = await publicClient.getEnsAddress({
 The block tag to perform the read against.
 
 ```ts
-const ensName = await publicClient.getEnsAddress({
+const ensAddress = await publicClient.getEnsAddress({
   name: normalize('wevm.eth'),
   blockTag: 'safe', // [!code focus]
 })
@@ -94,9 +94,36 @@ const ensName = await publicClient.getEnsAddress({
 The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multichain-address-resolution) coin type to fetch the address for
 
 ```ts
-const ensName = await publicClient.getEnsAddress({
+const ensAddress = await publicClient.getEnsAddress({
   name: normalize('wevm.eth'), 
   coinType: 60, // [!code focus]
+})
+```
+
+### gatewayUrls (optional)
+
+- **Type:** `string[]`
+
+A set of Universal Resolver gateways, used for resolving CCIP-Read requests made through the ENS Universal Resolver Contract.
+
+```ts
+const ensAddress = await publicClient.getEnsAddress({
+  name: normalize('wevm.eth'), 
+  gatewayUrls: ["https://ccip.ens.xyz"], // [!code focus]
+})
+```
+
+### strict (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+A boolean value that when set to true will strictly propagate all ENS Universal Resolver Contract errors.
+
+```ts
+const ensAddress = await publicClient.getEnsAddress({
+  name: normalize('wevm.eth'), 
+  strict: true, // [!code focus]
 })
 ```
 
@@ -108,7 +135,7 @@ const ensName = await publicClient.getEnsAddress({
 Address of ENS Universal Resolver Contract.
 
 ```ts
-const ensName = await publicClient.getEnsAddress({
+const ensAddress = await publicClient.getEnsAddress({
   name: normalize('wevm.eth'),
   universalResolverAddress: '0x74E20Bd2A1fE0cdbe45b9A1d89cb7e0a45b36376', // [!code focus]
 })

--- a/site/pages/docs/ens/actions/getEnsAvatar.md
+++ b/site/pages/docs/ens/actions/getEnsAvatar.md
@@ -61,6 +61,21 @@ const ensText = await publicClient.getEnsAvatar({
 })
 ```
 
+### assetGatewayUrls (optional)
+
+- **Type:** `{ ipfs?: string; arweave?: string }`
+
+Gateway urls to resolve IPFS and/or Arweave assets.
+
+```ts
+const ensText = await publicClient.getEnsAvatar({
+  name: normalize('wevm.eth'),
+  assetGatewayUrls: { // [!code focus:3]
+    ipfs: 'https://cloudflare-ipfs.com'
+  }
+})
+```
+
 ### blockNumber (optional)
 
 - **Type:** `number`
@@ -88,18 +103,30 @@ const ensText = await publicClient.getEnsAvatar({
 })
 ```
 
-### gatewayUrls
+### gatewayUrls (optional)
 
-- **Type:** `{ ipfs?: string; arweave?: string }`
+- **Type:** `string[]`
 
-Gateway urls to resolve IPFS and/or Arweave assets.
+A set of Universal Resolver gateways, used for resolving CCIP-Read requests made through the ENS Universal Resolver Contract.
 
 ```ts
 const ensText = await publicClient.getEnsAvatar({
-  name: normalize('wevm.eth'),
-  gatewayUrls: { // [!code focus:3]
-    ipfs: 'https://cloudflare-ipfs.com'
-  }
+  name: normalize('wevm.eth'), 
+  gatewayUrls: ["https://ccip.ens.xyz"], // [!code focus]
+})
+```
+
+### strict (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+A boolean value that when set to true will strictly propagate all ENS Universal Resolver Contract errors.
+
+```ts
+const ensText = await publicClient.getEnsAvatar({
+  name: normalize('wevm.eth'), 
+  strict: true, // [!code focus]
 })
 ```
 

--- a/site/pages/docs/ens/actions/getEnsName.md
+++ b/site/pages/docs/ens/actions/getEnsName.md
@@ -82,6 +82,33 @@ const ensName = await publicClient.getEnsName({
 })
 ```
 
+### gatewayUrls (optional)
+
+- **Type:** `string[]`
+
+A set of Universal Resolver gateways, used for resolving CCIP-Read requests made through the ENS Universal Resolver Contract.
+
+```ts
+const ensName = await publicClient.getEnsName({
+  address: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  gatewayUrls: ["https://ccip.ens.xyz"], // [!code focus]
+})
+```
+
+### strict (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+A boolean value that when set to true will strictly propagate all ENS Universal Resolver Contract errors.
+
+```ts
+const ensName = await publicClient.getEnsName({
+  address: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+  strict: true, // [!code focus]
+})
+```
+
 ### universalResolverAddress (optional)
 
 - **Type:** [`Address`](/docs/glossary/types#address)

--- a/site/pages/docs/ens/actions/getEnsText.md
+++ b/site/pages/docs/ens/actions/getEnsText.md
@@ -105,6 +105,36 @@ const ensText = await publicClient.getEnsText({
 })
 ```
 
+### gatewayUrls (optional)
+
+- **Type:** `string[]`
+
+A set of Universal Resolver gateways, used for resolving CCIP-Read requests made through the ENS Universal Resolver Contract.
+
+```ts
+const ensText = await publicClient.getEnsText({
+  name: normalize('wevm.eth'),
+  key: 'com.twitter',
+  gatewayUrls: ["https://ccip.ens.xyz"], // [!code focus]
+})
+```
+
+### strict (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+A boolean value that when set to true will strictly propagate all ENS Universal Resolver Contract errors.
+
+```ts
+const ensText = await publicClient.getEnsText({
+  name: normalize('wevm.eth'),
+  key: 'com.twitter',
+  strict: true, // [!code focus]
+})
+```
+
+
 ### universalResolverAddress (optional)
 
 - **Type:** [`Address`](/docs/glossary/types#address)

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from 'vitest'
 
 import { localHttpUrl } from '~test/src/constants.js'
 import {
+  createHttpServer,
   publicClient,
   setBlockNumber,
   setVitalikResolver,
@@ -13,7 +14,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsAddress } from './getEnsAddress.js'
 
 beforeAll(async () => {
-  await setBlockNumber(17431812n)
+  await setBlockNumber(18958931n)
   await setVitalikResolver()
 })
 
@@ -23,6 +24,22 @@ test('gets address for name', async () => {
   ).resolves.toMatchInlineSnapshot(
     '"0xA0Cf798816D4b9b9866b5330EEa46a18382f251e"',
   )
+})
+
+test('gatewayUrls provided', async () => {
+  let called = false
+
+  const server = await createHttpServer((_, res) => {
+    called = true
+    res.end()
+  })
+
+  await getEnsAddress(publicClient, {
+    name: '1.offchainexample.eth',
+    gatewayUrls: [server.url],
+  }).catch(() => {})
+
+  expect(called).toBe(true)
 })
 
 test('gets address that starts with 0s for name', async () => {
@@ -57,6 +74,25 @@ test('name with resolver that does not support addr', async () => {
   await expect(
     getEnsAddress(publicClient, { name: 'vitalik.eth' }),
   ).resolves.toBeNull()
+})
+
+test('name with resolver that does not support addr - strict', async () => {
+  await expect(
+    getEnsAddress(publicClient, { name: 'vitalik.eth', strict: true }),
+  ).rejects.toMatchInlineSnapshot(`
+    [ContractFunctionExecutionError: The contract function "resolve" reverted.
+
+    Error: ResolverError(bytes returnData)
+                        (0x)
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  resolve(bytes name, bytes data)
+      args:             (0x07766974616c696b0365746800, 0x3b3b57deee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835)
+
+    Docs: https://viem.sh/docs/contract/readContract.html
+    Version: viem@1.0.2]
+  `)
 })
 
 test('name that looks like a hex', async () => {

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -10,29 +10,29 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { Prettify } from '../../types/utils.js'
 import {
-  type DecodeFunctionResultErrorType,
   decodeFunctionResult,
+  type DecodeFunctionResultErrorType,
 } from '../../utils/abi/decodeFunctionResult.js'
 import {
-  type EncodeFunctionDataErrorType,
   encodeFunctionData,
+  type EncodeFunctionDataErrorType,
 } from '../../utils/abi/encodeFunctionData.js'
 import {
-  type GetChainContractAddressErrorType,
   getChainContractAddress,
+  type GetChainContractAddressErrorType,
 } from '../../utils/chain/getChainContractAddress.js'
-import { type TrimErrorType, trim } from '../../utils/data/trim.js'
-import { type ToHexErrorType, toHex } from '../../utils/encoding/toHex.js'
+import { trim, type TrimErrorType } from '../../utils/data/trim.js'
+import { toHex, type ToHexErrorType } from '../../utils/encoding/toHex.js'
 import { isNullUniversalResolverError } from '../../utils/ens/errors.js'
-import { type NamehashErrorType, namehash } from '../../utils/ens/namehash.js'
+import { namehash, type NamehashErrorType } from '../../utils/ens/namehash.js'
 import {
-  type PacketToBytesErrorType,
   packetToBytes,
+  type PacketToBytesErrorType,
 } from '../../utils/ens/packetToBytes.js'
 import { getAction } from '../../utils/getAction.js'
 import {
-  type ReadContractParameters,
   readContract,
+  type ReadContractParameters,
 } from '../public/readContract.js'
 
 export type GetEnsAddressParameters = Prettify<
@@ -144,8 +144,6 @@ export async function getEnsAddress<TChain extends Chain | undefined>(
       : await readContractAction(readContractParameters)
 
     if (res[0] === '0x') return null
-
-    console.log(res[0])
 
     const address = decodeFunctionResult({
       abi: addressResolverAbi,

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -39,14 +39,14 @@ export type GetEnsAddressParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** ENSIP-9 compliant coinType used to resolve addresses for other chains */
     coinType?: number
+    /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
+    gatewayUrls?: string[]
     /** Name to get the address for. */
     name: string
-    /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
-    /** Batch gateway URLs to use for resolving CCIP-read requests. */
-    gatewayUrls?: string[]
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
     strict?: boolean
+    /** Address of ENS Universal Resolver Contract. */
+    universalResolverAddress?: Address
   }
 >
 

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -10,29 +10,29 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { Prettify } from '../../types/utils.js'
 import {
-  decodeFunctionResult,
   type DecodeFunctionResultErrorType,
+  decodeFunctionResult,
 } from '../../utils/abi/decodeFunctionResult.js'
 import {
-  encodeFunctionData,
   type EncodeFunctionDataErrorType,
+  encodeFunctionData,
 } from '../../utils/abi/encodeFunctionData.js'
 import {
-  getChainContractAddress,
   type GetChainContractAddressErrorType,
+  getChainContractAddress,
 } from '../../utils/chain/getChainContractAddress.js'
-import { trim, type TrimErrorType } from '../../utils/data/trim.js'
-import { toHex, type ToHexErrorType } from '../../utils/encoding/toHex.js'
+import { type TrimErrorType, trim } from '../../utils/data/trim.js'
+import { type ToHexErrorType, toHex } from '../../utils/encoding/toHex.js'
 import { isNullUniversalResolverError } from '../../utils/ens/errors.js'
-import { namehash, type NamehashErrorType } from '../../utils/ens/namehash.js'
+import { type NamehashErrorType, namehash } from '../../utils/ens/namehash.js'
 import {
-  packetToBytes,
   type PacketToBytesErrorType,
+  packetToBytes,
 } from '../../utils/ens/packetToBytes.js'
 import { getAction } from '../../utils/getAction.js'
 import {
-  readContract,
   type ReadContractParameters,
+  readContract,
 } from '../public/readContract.js'
 
 export type GetEnsAddressParameters = Prettify<

--- a/src/actions/ens/getEnsAvatar.test.ts
+++ b/src/actions/ens/getEnsAvatar.test.ts
@@ -181,7 +181,7 @@ describe('args: gateways', async () => {
     await expect(
       getEnsAvatar(publicClient, {
         name: 'vitalik.eth',
-        gatewayUrls: { ipfs: 'https://cloudflare-ipfs.com' },
+        assetGatewayUrls: { ipfs: 'https://cloudflare-ipfs.com' },
       }),
     ).resolves.toEqual(expected)
   })

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -19,7 +19,7 @@ import {
 export type GetEnsAvatarParameters = Prettify<
   Omit<GetEnsTextParameters, 'key'> & {
     /** Gateway urls to resolve IPFS and/or Arweave assets. */
-    gatewayUrls?: AssetGatewayUrls
+    assetGatewayUrls?: AssetGatewayUrls
   }
 >
 
@@ -63,8 +63,10 @@ export async function getEnsAvatar<TChain extends Chain | undefined>(
   {
     blockNumber,
     blockTag,
-    gatewayUrls,
+    assetGatewayUrls,
     name,
+    gatewayUrls,
+    strict,
     universalResolverAddress,
   }: GetEnsAvatarParameters,
 ): Promise<GetEnsAvatarReturnType> {
@@ -78,10 +80,15 @@ export async function getEnsAvatar<TChain extends Chain | undefined>(
     key: 'avatar',
     name,
     universalResolverAddress,
+    gatewayUrls,
+    strict,
   })
   if (!record) return null
   try {
-    return await parseAvatarRecord(client, { record, gatewayUrls })
+    return await parseAvatarRecord(client, {
+      record,
+      gatewayUrls: assetGatewayUrls,
+    })
   } catch {
     return null
   }

--- a/src/actions/ens/getEnsName.test.ts
+++ b/src/actions/ens/getEnsName.test.ts
@@ -1,15 +1,24 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
 import { address, localHttpUrl } from '~test/src/constants.js'
-import { publicClient, setBlockNumber } from '~test/src/utils.js'
+import {
+  createHttpServer,
+  publicClient,
+  setBlockNumber,
+  setVitalikName,
+  setVitalikResolver,
+} from '~test/src/utils.js'
 import { optimism } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
 
+import { parseAbi } from 'abitype'
+import { encodeErrorResult, encodeFunctionResult } from '~viem/index.js'
 import { getEnsName } from './getEnsName.js'
 
 beforeAll(async () => {
-  await setBlockNumber(17680470n)
+  await setBlockNumber(18958931n)
+  await setVitalikResolver()
 })
 
 test('gets primary name for address', async () => {
@@ -18,6 +27,23 @@ test('gets primary name for address', async () => {
       address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
     }),
   ).resolves.toMatchInlineSnapshot('"awkweb.eth"')
+})
+
+test('gatewayUrls provided', async () => {
+  await setVitalikName('1.offchainexample.eth')
+  let called = false
+
+  const server = await createHttpServer((_, res) => {
+    called = true
+    res.end()
+  })
+
+  await getEnsName(publicClient, {
+    address: address.vitalik,
+    gatewayUrls: [server.url],
+  }).catch(() => {})
+
+  expect(called).toBe(true)
 })
 
 test('address with no primary name', async () => {
@@ -36,6 +62,148 @@ test('address with primary name that has no resolver', async () => {
   ).resolves.toMatchInlineSnapshot('null')
 })
 
+test('address with primary name that has no resolver - strict', async () => {
+  await expect(
+    getEnsName(publicClient, {
+      address: '0x00000000000061aD8EE190710508A818aE5325C3',
+      strict: true,
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [ContractFunctionExecutionError: The contract function "reverse" reverted.
+
+    Error: ResolverWildcardNotSupported()
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  reverse(bytes reverseName)
+      args:             (0x28303030303030303030303030363161643865653139303731303530386138313861653533323563330461646472077265766572736500)
+
+    Docs: https://viem.sh/docs/contract/readContract.html
+    Version: viem@1.0.2]
+  `)
+})
+
+describe('primary name with resolver that does not support text()', () => {
+  beforeAll(async () => {
+    await setVitalikName('vitalik.eth')
+  })
+  test('non-strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+      }),
+    ).resolves.toMatchInlineSnapshot('null')
+  })
+  test('strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+        strict: true,
+      }),
+    ).rejects.toMatchInlineSnapshot(`
+      [ContractFunctionExecutionError: The contract function "reverse" reverted.
+
+      Error: ResolverError(bytes returnData)
+                          (0x)
+       
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  reverse(bytes reverseName)
+        args:             (0x28643864613662663236393634616639643765656439653033653533343135643337616139363034350461646472077265766572736500)
+
+      Docs: https://viem.sh/docs/contract/readContract.html
+      Version: viem@1.0.2]
+    `)
+  })
+})
+
+describe('primary name with non-contract resolver', () => {
+  beforeAll(async () => {
+    await setVitalikName('vbuterin.eth')
+  })
+  test('non-strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+      }),
+    ).resolves.toMatchInlineSnapshot('null')
+  })
+  test('strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+        strict: true,
+      }),
+    ).rejects.toMatchInlineSnapshot(`
+      [ContractFunctionExecutionError: The contract function "reverse" reverted.
+
+      Error: ResolverNotContract()
+       
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  reverse(bytes reverseName)
+        args:             (0x28643864613662663236393634616639643765656439653033653533343135643337616139363034350461646472077265766572736500)
+
+      Docs: https://viem.sh/docs/contract/readContract.html
+      Version: viem@1.0.2]
+    `)
+  })
+})
+
+describe('http error', () => {
+  let server: Awaited<ReturnType<typeof createHttpServer>> | undefined
+  beforeAll(async () => {
+    await setVitalikName('1.offchainexample.eth')
+    server = await createHttpServer((_, res) => {
+      const parsed = parseAbi([
+        'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
+        'error HttpError((uint16,string)[])',
+      ])
+
+      const encoded = encodeFunctionResult({
+        abi: parsed,
+        functionName: 'query',
+        result: [
+          [true],
+          [
+            encodeErrorResult({
+              abi: parsed,
+              errorName: 'HttpError',
+              args: [[[404, 'Not Found']]],
+            }),
+          ],
+        ],
+      })
+
+      const response = JSON.stringify({ data: encoded })
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.write(response)
+      res.end()
+    })
+  })
+  test('non-strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+        gatewayUrls: [server!.url],
+      }),
+    ).resolves.toBeNull()
+  })
+  test('strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: address.vitalik,
+        gatewayUrls: [server!.url],
+        strict: true,
+      }),
+    ).rejects.toThrowError(`The contract function "reverse" reverted.
+
+Error: ResolverError(bytes returnData)
+                    (0xca7a4e75`)
+  })
+})
+
 test('custom universal resolver address', async () => {
   await expect(
     getEnsName(publicClient, {
@@ -45,22 +213,34 @@ test('custom universal resolver address', async () => {
   ).resolves.toMatchInlineSnapshot('"awkweb.eth"')
 })
 
-describe('universal resolver with custom errors', () => {
-  test('address with no primary name', async () => {
-    await expect(
-      getEnsName(publicClient, {
-        address: address.burn,
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
-      }),
-    ).resolves.toMatchInlineSnapshot('null')
-  })
+describe('universal resolver with generic errors', () => {
   test('address with primary name that has no resolver', async () => {
     await expect(
       getEnsName(publicClient, {
         address: '0x00000000000061aD8EE190710508A818aE5325C3',
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
+        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
       }),
     ).resolves.toMatchInlineSnapshot('null')
+  })
+  test('address with primary name that has no resolver - strict', async () => {
+    await expect(
+      getEnsName(publicClient, {
+        address: '0x00000000000061aD8EE190710508A818aE5325C3',
+        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
+        strict: true,
+      }),
+    ).rejects.toMatchInlineSnapshot(`
+      [ContractFunctionExecutionError: The contract function "reverse" reverted with the following reason:
+      UniversalResolver: Wildcard on non-extended resolvers is not supported
+
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  reverse(bytes reverseName)
+        args:             (0x28303030303030303030303030363161643865653139303731303530386138313861653533323563330461646472077265766572736500)
+
+      Docs: https://viem.sh/docs/contract/readContract.html
+      Version: viem@1.0.2]
+    `)
   })
 })
 
@@ -108,7 +288,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Localhost" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 16966585 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 18958930 (current block 14353601).
 
     Version: viem@1.0.2]
   `)
@@ -134,7 +314,6 @@ test('invalid universal resolver address', async () => {
 })
 
 test('resolved address mismatch', async () => {
-  await setBlockNumber(18753647n)
   expect(
     await getEnsName(publicClient, {
       address: '0xe756236ef7FD64Ebbb360465C621c7dB5a336F4d',

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -29,6 +29,10 @@ export type GetEnsNameParameters = Prettify<
     address: Address
     /** Address of ENS Universal Resolver Contract. */
     universalResolverAddress?: Address
+    /** Batch gateway URLs to use for resolving CCIP-read requests. */
+    gatewayUrls?: string[]
+    /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
+    strict?: boolean
   }
 >
 
@@ -73,6 +77,8 @@ export async function getEnsName<TChain extends Chain | undefined>(
     address,
     blockNumber,
     blockTag,
+    gatewayUrls,
+    strict,
     universalResolverAddress: universalResolverAddress_,
   }: GetEnsNameParameters,
 ): Promise<GetEnsNameReturnType> {
@@ -92,21 +98,28 @@ export async function getEnsName<TChain extends Chain | undefined>(
 
   const reverseNode = `${address.toLowerCase().substring(2)}.addr.reverse`
   try {
-    const [name, resolvedAddress] = await getAction(
-      client,
-      readContract,
-      'readContract',
-    )({
+    const readContractParameters = {
       address: universalResolverAddress,
       abi: universalResolverReverseAbi,
       functionName: 'reverse',
       args: [toHex(packetToBytes(reverseNode))],
       blockNumber,
       blockTag,
-    })
+    } as const
+
+    const readContractAction = getAction(client, readContract, 'readContract')
+
+    const [name, resolvedAddress] = gatewayUrls
+      ? await readContractAction({
+          ...readContractParameters,
+          args: [...readContractParameters.args, gatewayUrls],
+        })
+      : await readContractAction(readContractParameters)
+
     if (address.toLowerCase() !== resolvedAddress.toLowerCase()) return null
     return name
   } catch (err) {
+    if (strict) throw err
     if (isNullUniversalResolverError(err, 'reverse')) return null
     throw err
   }

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -27,12 +27,12 @@ export type GetEnsNameParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** Address to get ENS name for. */
     address: Address
-    /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
-    /** Batch gateway URLs to use for resolving CCIP-read requests. */
+    /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
     strict?: boolean
+    /** Address of ENS Universal Resolver Contract. */
+    universalResolverAddress?: Address
   }
 >
 

--- a/src/actions/ens/getEnsResolver.test.ts
+++ b/src/actions/ens/getEnsResolver.test.ts
@@ -9,7 +9,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsResolver } from './getEnsResolver.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16966590n)
+  await setBlockNumber(18958931n)
 })
 
 test('default', async () => {
@@ -80,7 +80,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Localhost" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 16966585 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 18958930 (current block 14353601).
 
     Version: viem@1.0.2]
   `)

--- a/src/actions/ens/getEnsText.test.ts
+++ b/src/actions/ens/getEnsText.test.ts
@@ -10,10 +10,16 @@ import { optimism } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
 
+import { createHttpServer } from '~test/src/utils.js'
+import {
+  encodeErrorResult,
+  encodeFunctionResult,
+  parseAbi,
+} from '~viem/index.js'
 import { getEnsText } from './getEnsText.js'
 
 beforeAll(async () => {
-  await setBlockNumber(17431812n)
+  await setBlockNumber(18958931n)
   await setVitalikResolver()
 })
 
@@ -21,6 +27,23 @@ test('gets text record for name', async () => {
   await expect(
     getEnsText(publicClient, { name: 'wagmi-dev.eth', key: 'com.twitter' }),
   ).resolves.toMatchInlineSnapshot('"wagmi_sh"')
+})
+
+test('gatewayUrls provided', async () => {
+  let called = false
+
+  const server = await createHttpServer((_, res) => {
+    called = true
+    res.end()
+  })
+
+  await getEnsText(publicClient, {
+    name: '1.offchainexample.eth',
+    key: 'email',
+    gatewayUrls: [server.url],
+  }).catch(() => {})
+
+  expect(called).toBe(true)
 })
 
 test('name without text record', async () => {
@@ -41,6 +64,29 @@ test('name with resolver that does not support text()', async () => {
   ).resolves.toBeNull()
 })
 
+test('name with resolver that does not support text() - strict', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'vitalik.eth',
+      key: 'com.twitter',
+      strict: true,
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [ContractFunctionExecutionError: The contract function "resolve" reverted.
+
+    Error: ResolverError(bytes returnData)
+                        (0x)
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  resolve(bytes name, bytes data)
+      args:             (0x07766974616c696b0365746800, 0x59d1d43cee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a534758350000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b636f6d2e74776974746572000000000000000000000000000000000000000000)
+
+    Docs: https://viem.sh/docs/contract/readContract.html
+    Version: viem@1.0.2]
+  `)
+})
+
 test('name without resolver', async () => {
   await expect(
     getEnsText(publicClient, {
@@ -48,6 +94,113 @@ test('name without resolver', async () => {
       key: 'com.twitter',
     }),
   ).resolves.toBeNull()
+})
+
+test('name without resolver - strict', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'random1223232222.eth',
+      key: 'com.twitter',
+      strict: true,
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [ContractFunctionExecutionError: The contract function "resolve" reverted.
+
+    Error: ResolverWildcardNotSupported()
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  resolve(bytes name, bytes data)
+      args:             (0x1072616e646f6d313232333233323232320365746800, 0x59d1d43c08e69c7f3b86ec46d8fb6fcebf6b6512306f0171375c6309b751a585ab24864b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b636f6d2e74776974746572000000000000000000000000000000000000000000)
+
+    Docs: https://viem.sh/docs/contract/readContract.html
+    Version: viem@1.0.2]
+  `)
+})
+
+test('name with non-contract resolver', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'vbuterin.eth',
+      key: 'com.twitter',
+    }),
+  ).resolves.toBeNull()
+})
+test('name with non-contract resolver - strict', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'vbuterin.eth',
+      key: 'com.twitter',
+      strict: true,
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [ContractFunctionExecutionError: The contract function "resolve" reverted.
+
+    Error: ResolverNotContract()
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  resolve(bytes name, bytes data)
+      args:             (0x08766275746572696e0365746800, 0x59d1d43c133a0d6e787307c1bdb6a3cde083ac5096ad9d67298908427642512fa2f6aa4f0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b636f6d2e74776974746572000000000000000000000000000000000000000000)
+
+    Docs: https://viem.sh/docs/contract/readContract.html
+    Version: viem@1.0.2]
+  `)
+})
+
+describe('http error', () => {
+  let server: Awaited<ReturnType<typeof createHttpServer>> | undefined
+  beforeAll(async () => {
+    server = await createHttpServer((_, res) => {
+      const parsed = parseAbi([
+        'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
+        'error HttpError((uint16,string)[])',
+      ])
+
+      const encoded = encodeFunctionResult({
+        abi: parsed,
+        functionName: 'query',
+        result: [
+          [true],
+          [
+            encodeErrorResult({
+              abi: parsed,
+              errorName: 'HttpError',
+              args: [[[404, 'Not Found']]],
+            }),
+          ],
+        ],
+      })
+
+      const response = JSON.stringify({ data: encoded })
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.write(response)
+      res.end()
+    })
+  })
+  test('non-strict', async () => {
+    await expect(
+      getEnsText(publicClient, {
+        name: '1.offchainexample.eth',
+        key: 'email',
+        gatewayUrls: [server!.url],
+      }),
+    ).resolves.toBeNull()
+  })
+  test('strict', async () => {
+    await expect(
+      getEnsText(publicClient, {
+        name: '1.offchainexample.eth',
+        key: 'email',
+        gatewayUrls: [server!.url],
+        strict: true,
+      }),
+    ).rejects.toThrowError(`The contract function "resolve" reverted.
+
+Error: HttpError((uint16 status, string message)[])
+                ([{"status":404,"message":"Not Found"}])`)
+  })
 })
 
 test('custom universal resolver address', async () => {
@@ -60,24 +213,36 @@ test('custom universal resolver address', async () => {
   ).resolves.toMatchInlineSnapshot('"wagmi_sh"')
 })
 
-describe('universal resolver with custom errors', () => {
-  test('name without resolver', async () => {
-    await expect(
-      getEnsText(publicClient, {
-        name: 'random123.zzz',
-        key: 'com.twitter',
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
-      }),
-    ).resolves.toBeNull()
-  })
-  test('name with invalid wildcard resolver', async () => {
+describe('universal resolver with generic errors', () => {
+  test('wildcard error', async () => {
     await expect(
       getEnsText(publicClient, {
         name: 'random1223232222.eth',
         key: 'com.twitter',
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
+        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
       }),
     ).resolves.toBeNull()
+  })
+  test('wildcard error - strict', async () => {
+    await expect(
+      getEnsText(publicClient, {
+        name: 'random1223232222.eth',
+        key: 'com.twitter',
+        strict: true,
+        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [ContractFunctionExecutionError: The contract function "resolve" reverted with the following reason:
+      UniversalResolver: Wildcard on non-extended resolvers is not supported
+
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  resolve(bytes name, bytes data)
+        args:             (0x1072616e646f6d313232333233323232320365746800, 0x59d1d43c08e69c7f3b86ec46d8fb6fcebf6b6512306f0171375c6309b751a585ab24864b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b636f6d2e74776974746572000000000000000000000000000000000000000000)
+
+      Docs: https://viem.sh/docs/contract/readContract.html
+      Version: viem@1.0.2]
+    `)
   })
 })
 
@@ -130,7 +295,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Localhost" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 16966585 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 18958930 (current block 14353601).
 
     Version: viem@1.0.2]
   `)

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -42,6 +42,10 @@ export type GetEnsTextParameters = Prettify<
     key: string
     /** Address of ENS Universal Resolver Contract. */
     universalResolverAddress?: Address
+    /** Batch gateway URLs to use for resolving CCIP-read requests. */
+    gatewayUrls?: string[]
+    /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
+    strict?: boolean
   }
 >
 
@@ -92,6 +96,8 @@ export async function getEnsText<TChain extends Chain | undefined>(
     blockTag,
     name,
     key,
+    gatewayUrls,
+    strict,
     universalResolverAddress: universalResolverAddress_,
   }: GetEnsTextParameters,
 ): Promise<GetEnsTextReturnType> {
@@ -110,11 +116,7 @@ export async function getEnsText<TChain extends Chain | undefined>(
   }
 
   try {
-    const res = await getAction(
-      client,
-      readContract,
-      'readContract',
-    )({
+    const readContractParameters = {
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,
       functionName: 'resolve',
@@ -128,7 +130,16 @@ export async function getEnsText<TChain extends Chain | undefined>(
       ],
       blockNumber,
       blockTag,
-    })
+    } as const
+
+    const readContractAction = getAction(client, readContract, 'readContract')
+
+    const res = gatewayUrls
+      ? await readContractAction({
+          ...readContractParameters,
+          args: [...readContractParameters.args, gatewayUrls],
+        })
+      : await readContractAction(readContractParameters)
 
     if (res[0] === '0x') return null
 
@@ -140,6 +151,7 @@ export async function getEnsText<TChain extends Chain | undefined>(
 
     return record === '' ? null : record
   } catch (err) {
+    if (strict) throw err
     if (isNullUniversalResolverError(err, 'resolve')) return null
     throw err
   }

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -38,14 +38,14 @@ export type GetEnsTextParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** ENS name to get Text for. */
     name: string
+    /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
+    gatewayUrls?: string[]
     /** Text record to retrieve. */
     key: string
-    /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
-    /** Batch gateway URLs to use for resolving CCIP-read requests. */
-    gatewayUrls?: string[]
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
     strict?: boolean
+    /** Address of ENS Universal Resolver Contract. */
+    universalResolverAddress?: Address
   }
 >
 

--- a/src/chains/definitions/goerli.ts
+++ b/src/chains/definitions/goerli.ts
@@ -21,8 +21,8 @@ export const goerli = /*#__PURE__*/ defineChain({
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0x56522D00C410a43BFfDF00a9A569489297385790',
-      blockCreated: 8765204,
+      address: '0xfc4AC75C46C914aF5892d6d3eFFcebD7917293F1',
+      blockCreated: 10_339_206,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -21,8 +21,8 @@ export const mainnet = /*#__PURE__*/ defineChain({
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
-      blockCreated: 16_966_585,
+      address: '0x8cab227b1162f03b8338331adaad7aadc83b895e',
+      blockCreated: 18_958_930,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -23,8 +23,8 @@ export const sepolia = /*#__PURE__*/ defineChain({
     },
     ensRegistry: { address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' },
     ensUniversalResolver: {
-      address: '0x21B000Fd62a880b2125A61e36a284BB757b76025',
-      blockCreated: 3914906,
+      address: '0xBaBC7678D7A63104f1658c11D6AE9A21cdA09725',
+      blockCreated: 5_043_334,
     },
   },
   testnet: true,

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -54,6 +54,41 @@ const universalResolverErrors = [
     name: 'ResolverWildcardNotSupported',
     type: 'error',
   },
+  {
+    inputs: [],
+    name: 'ResolverNotContract',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        name: 'returnData',
+        type: 'bytes',
+      },
+    ],
+    name: 'ResolverError',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            name: 'status',
+            type: 'uint16',
+          },
+          {
+            name: 'message',
+            type: 'string',
+          },
+        ],
+        name: 'errors',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'HttpError',
+    type: 'error',
+  },
 ] as const
 
 export const universalResolverResolveAbi = [
@@ -71,6 +106,20 @@ export const universalResolverResolveAbi = [
       { name: 'address', type: 'address' },
     ],
   },
+  {
+    name: 'resolve',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'name', type: 'bytes' },
+      { name: 'data', type: 'bytes' },
+      { name: 'gateways', type: 'string[]' },
+    ],
+    outputs: [
+      { name: '', type: 'bytes' },
+      { name: 'address', type: 'address' },
+    ],
+  },
 ] as const
 
 export const universalResolverReverseAbi = [
@@ -80,6 +129,21 @@ export const universalResolverReverseAbi = [
     type: 'function',
     stateMutability: 'view',
     inputs: [{ type: 'bytes', name: 'reverseName' }],
+    outputs: [
+      { type: 'string', name: 'resolvedName' },
+      { type: 'address', name: 'resolvedAddress' },
+      { type: 'address', name: 'reverseResolver' },
+      { type: 'address', name: 'resolver' },
+    ],
+  },
+  {
+    name: 'reverse',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'bytes', name: 'reverseName' },
+      { type: 'string[]', name: 'gateways' },
+    ],
     outputs: [
       { type: 'string', name: 'resolvedName' },
       { type: 'address', name: 'resolvedAddress' },

--- a/src/utils/ens/errors.ts
+++ b/src/utils/ens/errors.ts
@@ -17,6 +17,9 @@ export function isNullUniversalResolverError(
   if (!(cause instanceof ContractFunctionRevertedError)) return false
   if (cause.data?.errorName === 'ResolverNotFound') return true
   if (cause.data?.errorName === 'ResolverWildcardNotSupported') return true
+  if (cause.data?.errorName === 'ResolverNotContract') return true
+  if (cause.data?.errorName === 'ResolverError') return true
+  if (cause.data?.errorName === 'HttpError') return true
   // Backwards compatibility for older UniversalResolver contracts
   if (
     cause.reason?.includes(

--- a/test/src/abis.ts
+++ b/test/src/abis.ts
@@ -4413,6 +4413,71 @@ export const ensRegistryConfig = {
   ],
 } as const
 
+export const ensReverseRegistrarConfig = {
+  address: '0x9062c0a6dbd6108336bcbe4593a3d1ce05512069',
+  abi: [
+    {
+      constant: false,
+      inputs: [
+        { name: 'owner', type: 'address' },
+        { name: 'resolver', type: 'address' },
+      ],
+      name: 'claimWithResolver',
+      outputs: [{ name: 'node', type: 'bytes32' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      constant: false,
+      inputs: [{ name: 'owner', type: 'address' }],
+      name: 'claim',
+      outputs: [{ name: 'node', type: 'bytes32' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'ens',
+      outputs: [{ name: '', type: 'address' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'defaultResolver',
+      outputs: [{ name: '', type: 'address' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      constant: true,
+      inputs: [{ name: 'addr', type: 'address' }],
+      name: 'node',
+      outputs: [{ name: 'ret', type: 'bytes32' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      constant: false,
+      inputs: [{ name: 'name', type: 'string' }],
+      name: 'setName',
+      outputs: [{ name: 'node', type: 'bytes32' }],
+      payable: false,
+      type: 'function',
+    },
+    {
+      inputs: [
+        { name: 'ensAddr', type: 'address' },
+        { name: 'resolverAddr', type: 'address' },
+      ],
+      payable: false,
+      type: 'constructor',
+    },
+  ],
+} as const
+
 export const smartAccountConfig = {
   address: '0x3FCf42e10CC70Fe75A62EB3aDD6D305Aa840d145',
   abi: smartAccountAbi,

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -33,7 +33,11 @@ import {
   OffchainLookupExample,
   Payable,
 } from '../contracts/generated.js'
-import { baycContractConfig, ensRegistryConfig } from './abis.js'
+import {
+  baycContractConfig,
+  ensRegistryConfig,
+  ensReverseRegistrarConfig,
+} from './abis.js'
 import {
   accounts,
   address,
@@ -271,6 +275,32 @@ export async function setVitalikResolver() {
     functionName: 'setResolver',
     args: [namehash('vitalik.eth'), ensRegistryConfig.address],
   })
+
+  await writeContract(walletClient, {
+    ...ensRegistryConfig,
+    account: address.vitalik,
+    functionName: 'setResolver',
+    args: [namehash('vbuterin.eth'), address.vitalik],
+  })
+
+  await mine(testClient, { blocks: 1 })
+  await stopImpersonatingAccount(testClient, {
+    address: address.vitalik,
+  })
+}
+
+export async function setVitalikName(name: string) {
+  await impersonateAccount(testClient, {
+    address: address.vitalik,
+  })
+
+  await writeContract(walletClient, {
+    ...ensReverseRegistrarConfig,
+    account: address.vitalik,
+    functionName: 'setName',
+    args: [name],
+  })
+
   await mine(testClient, { blocks: 1 })
   await stopImpersonatingAccount(testClient, {
     address: address.vitalik,


### PR DESCRIPTION
changes:
- added `strict` param to ens resolver funcs (not `getEnsResolver`, since that doesn't actually access the resolver)
- added `gatewayUrls` to ens resolver funcs, which is the batch ccip gateway endpoint (code for said gateway be found [here](https://github.com/ensdomains/universal-offchain-unwrapper))
- `gatewayUrls` => `assetGatewayUrls` in `getEnsAvatar` parameters
- updated `ensUniversalResolver` on mainnet/goerli/sepolia to the latest deployment (v2)
- updated `UniversalResolver` ABI + `isNullUniversalResolverError` check

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `gatewayUrls` and `strict` properties to ENS Actions.
- Updated addresses and block numbers in chain definitions.
- Updated error handling in ENS utils.
- Updated tests and documentation for ENS Actions.

> The following files were skipped due to too many changes: `src/actions/ens/getEnsName.ts`, `src/actions/ens/getEnsText.ts`, `src/actions/ens/getEnsAddress.ts`, `src/actions/ens/getEnsAddress.test.ts`, `site/pages/docs/ens/actions/getEnsAddress.md`, `src/utils/ens/errors.test.ts`, `src/actions/ens/getEnsText.test.ts`, `src/actions/ens/getEnsName.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->