### PR TITLE
fix(docs): update getting started op-stack links

### DIFF
--- a/.changeset/tough-radios-jam.md
+++ b/.changeset/tough-radios-jam.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-fix getting started with op-stack links

--- a/.changeset/tough-radios-jam.md
+++ b/.changeset/tough-radios-jam.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix getting started with op-stack links

--- a/site/pages/op-stack.mdx
+++ b/site/pages/op-stack.mdx
@@ -4,9 +4,9 @@ description: Getting started with the OP Stack in Viem
 
 # Getting started with OP Stack
 
-Viem provides first-class support for chains implemented on the [OP Stack](https://docs.optimism.io/getting-started-op-stack).
+Viem provides first-class support for chains implemented on the [OP Stack](https://docs.optimism.io/stack/getting-started).
 
-The OP Stack is a set of modular open-source software that enable developers to build fast, secure, and scalable Layer 2 Ethereum protocols & applications. [Read more.](https://docs.optimism.io/getting-started-op-stack)
+The OP Stack is a set of modular open-source software that enable developers to build fast, secure, and scalable Layer 2 Ethereum protocols & applications. [Read more.](https://docs.optimism.io/stack/getting-started)
 
 ## Quick Start
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the URLs in the OP Stack documentation to point to the correct location. 

### Detailed summary
- Updated the URL in the first line of the document from `https://docs.optimism.io/getting-started-op-stack` to `https://docs.optimism.io/stack/getting-started`.
- Updated the URL in the second line of the document from `https://docs.optimism.io/getting-started-op-stack` to `https://docs.optimism.io/stack/getting-started`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->