### PR TITLE
feat: add explorer API URLs to viem/chains definitions

### DIFF
--- a/.changeset/nine-laws-crash.md
+++ b/.changeset/nine-laws-crash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added API URLs for block explorers in `viem/chains`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -276,6 +276,7 @@ export const mainnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://etherscan.io',
+      apiUrl: 'https://api.etherscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/acala.ts
+++ b/src/chains/definitions/acala.ts
@@ -23,6 +23,7 @@ export const acala = /*#__PURE__*/ defineChain({
     default: {
       name: 'Acala Blockscout',
       url: 'https://blockscout.acala.network',
+      apiUrl: 'https://blockscout.acala.network/api',
     },
   },
   testnet: false,

--- a/src/chains/definitions/arbitrum.ts
+++ b/src/chains/definitions/arbitrum.ts
@@ -10,7 +10,11 @@ export const arbitrum = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'Arbiscan', url: 'https://arbiscan.io' },
+    default: {
+      name: 'Arbiscan',
+      url: 'https://arbiscan.io',
+      apiUrl: 'https://api.arbiscan.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/arbitrumGoerli.ts
+++ b/src/chains/definitions/arbitrumGoerli.ts
@@ -14,8 +14,14 @@ export const arbitrumGoerli = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io' },
-    default: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io' },
+    etherscan: {
+      name: 'Arbiscan',
+      url: 'https://goerli.arbiscan.io',
+    },
+    default: {
+      name: 'Arbiscan',
+      url: 'https://goerli.arbiscan.io',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/arbitrumNova.ts
+++ b/src/chains/definitions/arbitrumNova.ts
@@ -10,7 +10,11 @@ export const arbitrumNova = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'Arbiscan', url: 'https://nova.arbiscan.io' },
+    default: {
+      name: 'Arbiscan',
+      url: 'https://nova.arbiscan.io',
+      apiUrl: 'https://api-nova.arbiscan.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -18,8 +18,16 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    etherscan: { name: 'Arbiscan', url: 'https://sepolia.arbiscan.io' },
-    default: { name: 'Arbiscan', url: 'https://sepolia.arbiscan.io' },
+    etherscan: {
+      name: 'Arbiscan',
+      url: 'https://sepolia.arbiscan.io',
+      apiUrl: 'https://sepolia.arbiscan.io/api',
+    },
+    default: {
+      name: 'Arbiscan',
+      url: 'https://sepolia.arbiscan.io',
+      apiUrl: 'https://sepolia.arbiscan.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/astar.ts
+++ b/src/chains/definitions/astar.ts
@@ -13,7 +13,10 @@ export const astar = /*#__PURE__*/ defineChain({
     default: { http: ['https://astar.api.onfinality.io/public'] },
   },
   blockExplorers: {
-    default: { name: 'Astar Subscan', url: 'https://astar.subscan.io' },
+    default: {
+      name: 'Astar Subscan',
+      url: 'https://astar.subscan.io',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/astarZkatana.ts
+++ b/src/chains/definitions/astarZkatana.ts
@@ -17,6 +17,7 @@ export const astarZkatana = /*#__PURE__*/ defineChain({
     blockscout: {
       name: 'Blockscout zKatana chain explorer',
       url: 'https://zkatana.blockscout.com',
+      apiUrl: 'https://zkatana.blockscout.com/api',
     },
     default: {
       name: 'zKatana Explorer',

--- a/src/chains/definitions/aurora.ts
+++ b/src/chains/definitions/aurora.ts
@@ -12,7 +12,11 @@ export const aurora = /*#__PURE__*/ defineChain({
     default: { http: ['https://mainnet.aurora.dev'] },
   },
   blockExplorers: {
-    default: { name: 'Aurorascan', url: 'https://aurorascan.dev' },
+    default: {
+      name: 'Aurorascan',
+      url: 'https://aurorascan.dev',
+      apiUrl: 'https://aurorascan.dev/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/auroraTestnet.ts
+++ b/src/chains/definitions/auroraTestnet.ts
@@ -12,7 +12,11 @@ export const auroraTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://testnet.aurora.dev'] },
   },
   blockExplorers: {
-    default: { name: 'Aurorascan', url: 'https://testnet.aurorascan.dev' },
+    default: {
+      name: 'Aurorascan',
+      url: 'https://testnet.aurorascan.dev',
+      apiUrl: 'https://testnet.aurorascan.dev/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -12,7 +12,11 @@ export const avalanche = /*#__PURE__*/ defineChain({
     default: { http: ['https://api.avax.network/ext/bc/C/rpc'] },
   },
   blockExplorers: {
-    default: { name: 'SnowTrace', url: 'https://snowtrace.io' },
+    default: {
+      name: 'SnowTrace',
+      url: 'https://snowtrace.io',
+      apiUrl: 'https://api.snowtrace.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -12,7 +12,11 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
     default: { http: ['https://api.avax-test.network/ext/bc/C/rpc'] },
   },
   blockExplorers: {
-    default: { name: 'SnowTrace', url: 'https://testnet.snowtrace.io' },
+    default: {
+      name: 'SnowTrace',
+      url: 'https://testnet.snowtrace.io',
+      apiUrl: 'https://api-testnet.snowtrace.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/bahamut.ts
+++ b/src/chains/definitions/bahamut.ts
@@ -35,6 +35,7 @@ export const bahamut = /*#__PURE__*/ defineChain({
     default: {
       name: 'Ftnscan',
       url: 'https://www.ftnscan.com',
+      apiUrl: 'https://www.ftnscan.com/api',
     },
   },
 })

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -17,6 +17,7 @@ export const base = /*#__PURE__*/ defineChain({
     default: {
       name: 'Basescan',
       url: 'https://basescan.org',
+      apiUrl: 'https://api.basescan.org/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/baseGoerli.ts
+++ b/src/chains/definitions/baseGoerli.ts
@@ -15,6 +15,7 @@ export const baseGoerli = /*#__PURE__*/ defineChain({
     default: {
       name: 'Basescan',
       url: 'https://goerli.basescan.org',
+      apiUrl: 'https://goerli.basescan.org/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -18,10 +18,12 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
     blockscout: {
       name: 'Blockscout',
       url: 'https://base-sepolia.blockscout.com',
+      apiUrl: 'https://base-sepolia.blockscout.com/api',
     },
     default: {
       name: 'Blockscout',
       url: 'https://base-sepolia.blockscout.com',
+      apiUrl: 'https://base-sepolia.blockscout.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/bearNetworkChainMainnet.ts
+++ b/src/chains/definitions/bearNetworkChainMainnet.ts
@@ -12,6 +12,10 @@ export const bearNetworkChainMainnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://brnkc-mainnet.bearnetwork.net'] },
   },
   blockExplorers: {
-    default: { name: 'BrnkScan', url: 'https://brnkscan.bearnetwork.net' },
+    default: {
+      name: 'BrnkScan',
+      url: 'https://brnkscan.bearnetwork.net',
+      apiUrl: 'https://brnkscan.bearnetwork.net/api',
+    },
   },
 })

--- a/src/chains/definitions/bearNetworkChainTestnet.ts
+++ b/src/chains/definitions/bearNetworkChainTestnet.ts
@@ -15,6 +15,7 @@ export const bearNetworkChainTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'BrnkTestScan',
       url: 'https://brnktest-scan.bearnetwork.net',
+      apiUrl: 'https://brnktest-scan.bearnetwork.net/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/bitTorrent.ts
+++ b/src/chains/definitions/bitTorrent.ts
@@ -10,7 +10,15 @@ export const bitTorrent = /*#__PURE__*/ defineChain({
     public: { http: ['https://rpc.bittorrentchain.io'] },
   },
   blockExplorers: {
-    etherscan: { name: 'Bttcscan', url: 'https://bttcscan.com' },
-    default: { name: 'Bttcscan', url: 'https://bttcscan.com' },
+    etherscan: {
+      name: 'Bttcscan',
+      url: 'https://bttcscan.com',
+      apiUrl: 'https://api.bttcscan.com/api',
+    },
+    default: {
+      name: 'Bttcscan',
+      url: 'https://bttcscan.com',
+      apiUrl: 'https://api.bttcscan.com/api',
+    },
   },
 })

--- a/src/chains/definitions/bitTorrentTestnet.ts
+++ b/src/chains/definitions/bitTorrentTestnet.ts
@@ -10,8 +10,16 @@ export const bitTorrentTestnet = /*#__PURE__*/ defineChain({
     public: { http: ['https://testrpc.bittorrentchain.io'] },
   },
   blockExplorers: {
-    etherscan: { name: 'Bttcscan', url: 'https://testnet.bttcscan.com' },
-    default: { name: 'Bttcscan', url: 'https://testnet.bttcscan.com' },
+    etherscan: {
+      name: 'Bttcscan',
+      url: 'https://testnet.bttcscan.com',
+      apiUrl: 'https://testnet.bttcscan.com/api',
+    },
+    default: {
+      name: 'Bttcscan',
+      url: 'https://testnet.bttcscan.com',
+      apiUrl: 'https://testnet.bttcscan.com/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/boba.ts
+++ b/src/chains/definitions/boba.ts
@@ -12,7 +12,10 @@ export const boba = /*#__PURE__*/ defineChain({
     default: { http: ['https://mainnet.boba.network'] },
   },
   blockExplorers: {
-    default: { name: 'BOBAScan', url: 'https://bobascan.com' },
+    default: {
+      name: 'BOBAScan',
+      url: 'https://bobascan.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/bronos.ts
+++ b/src/chains/definitions/bronos.ts
@@ -12,6 +12,9 @@ export const bronos = /*#__PURE__*/ defineChain({
     default: { http: ['https://evm.bronos.org'] },
   },
   blockExplorers: {
-    default: { name: 'BronoScan', url: 'https://broscan.bronos.org' },
+    default: {
+      name: 'BronoScan',
+      url: 'https://broscan.bronos.org',
+    },
   },
 })

--- a/src/chains/definitions/bronosTestnet.ts
+++ b/src/chains/definitions/bronosTestnet.ts
@@ -12,7 +12,10 @@ export const bronosTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://evm-testnet.bronos.org'] },
   },
   blockExplorers: {
-    default: { name: 'BronoScan', url: 'https://tbroscan.bronos.org' },
+    default: {
+      name: 'BronoScan',
+      url: 'https://tbroscan.bronos.org',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/bsc.ts
+++ b/src/chains/definitions/bsc.ts
@@ -12,7 +12,11 @@ export const bsc = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.ankr.com/bsc'] },
   },
   blockExplorers: {
-    default: { name: 'BscScan', url: 'https://bscscan.com' },
+    default: {
+      name: 'BscScan',
+      url: 'https://bscscan.com',
+      apiUrl: 'https://api.bscscan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/bscTestnet.ts
+++ b/src/chains/definitions/bscTestnet.ts
@@ -12,7 +12,11 @@ export const bscTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://data-seed-prebsc-1-s1.bnbchain.org:8545'] },
   },
   blockExplorers: {
-    default: { name: 'BscScan', url: 'https://testnet.bscscan.com' },
+    default: {
+      name: 'BscScan',
+      url: 'https://testnet.bscscan.com',
+      apiUrl: 'https://testnet.bscscan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/bxn.ts
+++ b/src/chains/definitions/bxn.ts
@@ -13,6 +13,7 @@ export const bxn = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://explorer.blackfort.network',
+      apiUrl: 'https://explorer.blackfort.network/api',
     },
   },
 })

--- a/src/chains/definitions/bxnTestnet.ts
+++ b/src/chains/definitions/bxnTestnet.ts
@@ -17,6 +17,7 @@ export const bxnTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://testnet-explorer.blackfort.network',
+      apiUrl: 'https://testnet-explorer.blackfort.network/api',
     },
   },
 })

--- a/src/chains/definitions/celo.ts
+++ b/src/chains/definitions/celo.ts
@@ -17,6 +17,7 @@ export const celo = /*#__PURE__*/ defineChain({
     default: {
       name: 'Celo Explorer',
       url: 'https://explorer.celo.org/mainnet',
+      apiUrl: 'https://explorer.celo.org/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -19,6 +19,7 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
     default: {
       name: 'Celo Explorer',
       url: 'https://explorer.celo.org/alfajores',
+      apiUrl: 'https://explorer.celo.org/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/chiliz.ts
+++ b/src/chains/definitions/chiliz.ts
@@ -18,6 +18,7 @@ export const chiliz = /*#__PURE__*/ defineChain({
     default: {
       name: 'Chiliz Explorer',
       url: 'https://scan.chiliz.com',
+      apiUrl: 'https://scan.chiliz.com/api',
     },
   },
 })

--- a/src/chains/definitions/coreDao.ts
+++ b/src/chains/definitions/coreDao.ts
@@ -12,7 +12,10 @@ export const coreDao = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.coredao.org'] },
   },
   blockExplorers: {
-    default: { name: 'CoreDao', url: 'https://scan.coredao.org' },
+    default: {
+      name: 'CoreDao',
+      url: 'https://scan.coredao.org',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/cronos.ts
+++ b/src/chains/definitions/cronos.ts
@@ -12,7 +12,11 @@ export const cronos = /*#__PURE__*/ defineChain({
     default: { http: ['https://evm.cronos.org'] },
   },
   blockExplorers: {
-    default: { name: 'Cronoscan', url: 'https://cronoscan.com' },
+    default: {
+      name: 'Cronoscan',
+      url: 'https://cronoscan.com',
+      apiUrl: 'https://api.cronoscan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/crossbell.ts
+++ b/src/chains/definitions/crossbell.ts
@@ -14,7 +14,11 @@ export const crossbell = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'CrossScan', url: 'https://scan.crossbell.io' },
+    default: {
+      name: 'CrossScan',
+      url: 'https://scan.crossbell.io',
+      apiUrl: 'https://scan.crossbell.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/defichainEvm.ts
+++ b/src/chains/definitions/defichainEvm.ts
@@ -25,6 +25,7 @@ export const defichainEvm = /*#__PURE__*/ defineChain({
     blockscout: {
       name: 'Blockscout',
       url: 'https://blockscout.mainnet.ocean.jellyfishsdk.com',
+      apiUrl: 'https://blockscout.mainnet.ocean.jellyfishsdk.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/defichainEvmTestnet.ts
+++ b/src/chains/definitions/defichainEvmTestnet.ts
@@ -25,6 +25,7 @@ export const defichainEvmTestnet = /*#__PURE__*/ defineChain({
     blockscout: {
       name: 'Blockscout',
       url: 'https://blockscout.testnet.ocean.jellyfishsdk.com',
+      apiUrl: 'https://blockscout.testnet.ocean.jellyfishsdk.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/dogechain.ts
+++ b/src/chains/definitions/dogechain.ts
@@ -15,6 +15,7 @@ export const dogechain = /*#__PURE__*/ defineChain({
     default: {
       name: 'DogeChainExplorer',
       url: 'https://explorer.dogechain.dog',
+      apiUrl: 'https://explorer.dogechain.dog/api',
     },
   },
 })

--- a/src/chains/definitions/edgeware.ts
+++ b/src/chains/definitions/edgeware.ts
@@ -12,7 +12,11 @@ export const edgeware = /*#__PURE__*/ defineChain({
     default: { http: ['https://edgeware-evm.jelliedowl.net'] },
   },
   blockExplorers: {
-    default: { name: 'Edgscan by Bharathcoorg', url: 'https://edgscan.live' },
+    default: {
+      name: 'Edgscan by Bharathcoorg',
+      url: 'https://edgscan.live',
+      apiUrl: 'https://edgscan.live/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/edgewareTestnet.ts
+++ b/src/chains/definitions/edgewareTestnet.ts
@@ -15,6 +15,7 @@ export const edgewareTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Edgscan by Bharathcoorg',
       url: 'https://testnet.edgscan.live',
+      apiUrl: 'https://testnet.edgscan.live/api',
     },
   },
 })

--- a/src/chains/definitions/ekta.ts
+++ b/src/chains/definitions/ekta.ts
@@ -12,6 +12,10 @@ export const ekta = /*#__PURE__*/ defineChain({
     default: { http: ['https://main.ekta.io'] },
   },
   blockExplorers: {
-    default: { name: 'Ektascan', url: 'https://ektascan.io' },
+    default: {
+      name: 'Ektascan',
+      url: 'https://ektascan.io',
+      apiUrl: 'https://ektascan.io/api',
+    },
   },
 })

--- a/src/chains/definitions/ektaTestnet.ts
+++ b/src/chains/definitions/ektaTestnet.ts
@@ -12,7 +12,11 @@ export const ektaTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://test.ekta.io:8545'] },
   },
   blockExplorers: {
-    default: { name: 'Test Ektascan', url: 'https://test.ektascan.io' },
+    default: {
+      name: 'Test Ektascan',
+      url: 'https://test.ektascan.io',
+      apiUrl: 'https://test.ektascan.io/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/eos.ts
+++ b/src/chains/definitions/eos.ts
@@ -15,6 +15,7 @@ export const eos = /*#__PURE__*/ defineChain({
     default: {
       name: 'EOS EVM Explorer',
       url: 'https://explorer.evm.eosnetwork.com',
+      apiUrl: 'https://explorer.evm.eosnetwork.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/eosTestnet.ts
+++ b/src/chains/definitions/eosTestnet.ts
@@ -15,6 +15,7 @@ export const eosTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'EOS EVM Testnet Explorer',
       url: 'https://explorer.testnet.evm.eosnetwork.com',
+      apiUrl: 'https://explorer.testnet.evm.eosnetwork.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/evmos.ts
+++ b/src/chains/definitions/evmos.ts
@@ -12,6 +12,9 @@ export const evmos = /*#__PURE__*/ defineChain({
     default: { http: ['https://eth.bd.evmos.org:8545'] },
   },
   blockExplorers: {
-    default: { name: 'Evmos Block Explorer', url: 'https://escan.live' },
+    default: {
+      name: 'Evmos Block Explorer',
+      url: 'https://escan.live',
+    },
   },
 })

--- a/src/chains/definitions/fantom.ts
+++ b/src/chains/definitions/fantom.ts
@@ -12,7 +12,11 @@ export const fantom = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.ankr.com/fantom'] },
   },
   blockExplorers: {
-    default: { name: 'FTMScan', url: 'https://ftmscan.com' },
+    default: {
+      name: 'FTMScan',
+      url: 'https://ftmscan.com',
+      apiUrl: 'https://api.ftmscan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/fantomTestnet.ts
+++ b/src/chains/definitions/fantomTestnet.ts
@@ -12,7 +12,11 @@ export const fantomTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.testnet.fantom.network'] },
   },
   blockExplorers: {
-    default: { name: 'FTMScan', url: 'https://testnet.ftmscan.com' },
+    default: {
+      name: 'FTMScan',
+      url: 'https://testnet.ftmscan.com',
+      apiUrl: 'https://testnet.ftmscan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/fibo.ts
+++ b/src/chains/definitions/fibo.ts
@@ -12,6 +12,9 @@ export const fibo = /*#__PURE__*/ defineChain({
     default: { http: ['https://network.hzroc.art'] },
   },
   blockExplorers: {
-    default: { name: 'FiboScan', url: 'https://scan.fibochain.org' },
+    default: {
+      name: 'FiboScan',
+      url: 'https://scan.fibochain.org',
+    },
   },
 })

--- a/src/chains/definitions/filecoin.ts
+++ b/src/chains/definitions/filecoin.ts
@@ -12,7 +12,10 @@ export const filecoin = /*#__PURE__*/ defineChain({
     default: { http: ['https://api.node.glif.io/rpc/v1'] },
   },
   blockExplorers: {
-    default: { name: 'Filfox', url: 'https://filfox.info/en' },
+    default: {
+      name: 'Filfox',
+      url: 'https://filfox.info/en',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/filecoinCalibration.ts
+++ b/src/chains/definitions/filecoinCalibration.ts
@@ -12,6 +12,9 @@ export const filecoinCalibration = /*#__PURE__*/ defineChain({
     default: { http: ['https://api.calibration.node.glif.io/rpc/v1'] },
   },
   blockExplorers: {
-    default: { name: 'Filscan', url: 'https://calibration.filscan.io' },
+    default: {
+      name: 'Filscan',
+      url: 'https://calibration.filscan.io',
+    },
   },
 })

--- a/src/chains/definitions/filecoinHyperspace.ts
+++ b/src/chains/definitions/filecoinHyperspace.ts
@@ -12,6 +12,9 @@ export const filecoinHyperspace = /*#__PURE__*/ defineChain({
     default: { http: ['https://api.hyperspace.node.glif.io/rpc/v1'] },
   },
   blockExplorers: {
-    default: { name: 'Filfox', url: 'https://hyperspace.filfox.info/en' },
+    default: {
+      name: 'Filfox',
+      url: 'https://hyperspace.filfox.info/en',
+    },
   },
 })

--- a/src/chains/definitions/flare.ts
+++ b/src/chains/definitions/flare.ts
@@ -15,6 +15,7 @@ export const flare = /*#__PURE__*/ defineChain({
     default: {
       name: 'Flare Explorer',
       url: 'https://flare-explorer.flare.network',
+      apiUrl: 'https://flare-explorer.flare.network/api',
     },
   },
 })

--- a/src/chains/definitions/flareTestnet.ts
+++ b/src/chains/definitions/flareTestnet.ts
@@ -15,6 +15,7 @@ export const flareTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Coston2 Explorer',
       url: 'https://coston2-explorer.flare.network',
+      apiUrl: 'https://coston2-explorer.flare.network/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/fuse.ts
+++ b/src/chains/definitions/fuse.ts
@@ -8,7 +8,11 @@ export const fuse = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.fuse.io'] },
   },
   blockExplorers: {
-    default: { name: 'Fuse Explorer', url: 'https://explorer.fuse.io' },
+    default: {
+      name: 'Fuse Explorer',
+      url: 'https://explorer.fuse.io',
+      apiUrl: 'https://explorer.fuse.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/fuseSparknet.ts
+++ b/src/chains/definitions/fuseSparknet.ts
@@ -11,6 +11,7 @@ export const fuseSparknet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Sparkent Explorer',
       url: 'https://explorer.fusespark.io',
+      apiUrl: 'https://explorer.fusespark.io/api',
     },
   },
 })

--- a/src/chains/definitions/gnosisChiado.ts
+++ b/src/chains/definitions/gnosisChiado.ts
@@ -18,6 +18,7 @@ export const gnosisChiado = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://blockscout.chiadochain.net',
+      apiUrl: 'https://blockscout.chiadochain.net/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/gobi.ts
+++ b/src/chains/definitions/gobi.ts
@@ -12,7 +12,10 @@ export const gobi = /*#__PURE__*/ defineChain({
     default: { http: ['https://gobi-testnet.horizenlabs.io/ethv1'] },
   },
   blockExplorers: {
-    default: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io' },
+    default: {
+      name: 'Gobi Explorer',
+      url: 'https://gobi-explorer.horizen.io',
+    },
   },
   contracts: {},
   testnet: true,

--- a/src/chains/definitions/goerli.ts
+++ b/src/chains/definitions/goerli.ts
@@ -13,6 +13,7 @@ export const goerli = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://goerli.etherscan.io',
+      apiUrl: 'https://api-goerli.etherscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/haqqMainnet.ts
+++ b/src/chains/definitions/haqqMainnet.ts
@@ -17,6 +17,7 @@ export const haqqMainnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'HAQQ Explorer',
       url: 'https://explorer.haqq.network',
+      apiUrl: 'https://explorer.haqq.network/api',
     },
   },
 })

--- a/src/chains/definitions/haqqTestedge2.ts
+++ b/src/chains/definitions/haqqTestedge2.ts
@@ -17,6 +17,7 @@ export const haqqTestedge2 = /*#__PURE__*/ defineChain({
     default: {
       name: 'HAQQ Explorer',
       url: 'https://explorer.testedge2.haqq.network',
+      apiUrl: 'https://explorer.testedge2.haqq.network/api',
     },
   },
 })

--- a/src/chains/definitions/harmonyOne.ts
+++ b/src/chains/definitions/harmonyOne.ts
@@ -12,7 +12,10 @@ export const harmonyOne = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.ankr.com/harmony'] },
   },
   blockExplorers: {
-    default: { name: 'Harmony Explorer', url: 'https://explorer.harmony.one' },
+    default: {
+      name: 'Harmony Explorer',
+      url: 'https://explorer.harmony.one',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/iotex.ts
+++ b/src/chains/definitions/iotex.ts
@@ -15,6 +15,9 @@ export const iotex = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'IoTeXScan', url: 'https://iotexscan.io' },
+    default: {
+      name: 'IoTeXScan',
+      url: 'https://iotexscan.io',
+    },
   },
 })

--- a/src/chains/definitions/iotexTestnet.ts
+++ b/src/chains/definitions/iotexTestnet.ts
@@ -15,6 +15,9 @@ export const iotexTestnet = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'IoTeXScan', url: 'https://testnet.iotexscan.io' },
+    default: {
+      name: 'IoTeXScan',
+      url: 'https://testnet.iotexscan.io',
+    },
   },
 })

--- a/src/chains/definitions/jbc.ts
+++ b/src/chains/definitions/jbc.ts
@@ -17,6 +17,7 @@ export const jbc = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://exp-l1.jibchain.net',
+      apiUrl: 'https://exp-l1.jibchain.net/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/karura.ts
+++ b/src/chains/definitions/karura.ts
@@ -23,6 +23,7 @@ export const karura = /*#__PURE__*/ defineChain({
     default: {
       name: 'Karura Blockscout',
       url: 'https://blockscout.karura.network',
+      apiUrl: 'https://blockscout.karura.network/api',
     },
   },
   testnet: false,

--- a/src/chains/definitions/kava.ts
+++ b/src/chains/definitions/kava.ts
@@ -13,7 +13,11 @@ export const kava = /*#__PURE__*/ defineChain({
     default: { http: ['https://evm.kava.io'] },
   },
   blockExplorers: {
-    default: { name: 'Kava EVM Explorer', url: 'https://kavascan.com' },
+    default: {
+      name: 'Kava EVM Explorer',
+      url: 'https://kavascan.com',
+      apiUrl: 'https://kavascan.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/kavaTestnet.ts
+++ b/src/chains/definitions/kavaTestnet.ts
@@ -16,6 +16,7 @@ export const kavaTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Kava EVM Testnet Explorer',
       url: 'https://testnet.kavascan.com/',
+      apiUrl: 'https://testnet.kavascan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/klaytn.ts
+++ b/src/chains/definitions/klaytn.ts
@@ -12,7 +12,10 @@ export const klaytn = /*#__PURE__*/ defineChain({
     default: { http: ['https://public-en-cypress.klaytn.net'] },
   },
   blockExplorers: {
-    default: { name: 'KlaytnScope', url: 'https://scope.klaytn.com' },
+    default: {
+      name: 'KlaytnScope',
+      url: 'https://scope.klaytn.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/klaytnBaobab.ts
+++ b/src/chains/definitions/klaytnBaobab.ts
@@ -13,8 +13,14 @@ export const klaytnBaobab = /*#__PURE__*/ defineChain({
     default: { http: ['https://public-en-baobab.klaytn.net'] },
   },
   blockExplorers: {
-    etherscan: { name: 'KlaytnScope', url: 'https://baobab.klaytnscope.com' },
-    default: { name: 'KlaytnScope', url: 'https://baobab.klaytnscope.com' },
+    etherscan: {
+      name: 'KlaytnScope',
+      url: 'https://baobab.klaytnscope.com',
+    },
+    default: {
+      name: 'KlaytnScope',
+      url: 'https://baobab.klaytnscope.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/kroma.ts
+++ b/src/chains/definitions/kroma.ts
@@ -13,6 +13,7 @@ export const kroma = /*#__PURE__*/ defineChain({
     default: {
       name: 'Kroma Explorer',
       url: 'https://blockscout.kroma.network',
+      apiUrl: 'https://blockscout.kroma.network/api',
     },
   },
   testnet: false,

--- a/src/chains/definitions/kromaSepolia.ts
+++ b/src/chains/definitions/kromaSepolia.ts
@@ -13,6 +13,7 @@ export const kromaSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Kroma Sepolia Explorer',
       url: 'https://blockscout.sepolia.kroma.network',
+      apiUrl: 'https://blockscout.sepolia.kroma.network/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/linea.ts
+++ b/src/chains/definitions/linea.ts
@@ -14,6 +14,7 @@ export const linea = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://lineascan.build',
+      apiUrl: 'https://api.lineascan.build/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/lineaTestnet.ts
+++ b/src/chains/definitions/lineaTestnet.ts
@@ -14,6 +14,7 @@ export const lineaTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://goerli.lineascan.build',
+      apiUrl: 'https://goerli.lineascan.build/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/lukso.ts
+++ b/src/chains/definitions/lukso.ts
@@ -19,6 +19,7 @@ export const lukso = /*#__PURE__*/ defineChain({
     default: {
       name: 'LUKSO Mainnet Explorer',
       url: 'https://explorer.execution.mainnet.lukso.network',
+      apiUrl: 'https://api.explorer.execution.mainnet.lukso.network/api',
     },
   },
 })

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -13,6 +13,7 @@ export const mainnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://etherscan.io',
+      apiUrl: 'https://api.etherscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/mandala.ts
+++ b/src/chains/definitions/mandala.ts
@@ -23,6 +23,7 @@ export const mandala = /*#__PURE__*/ defineChain({
     default: {
       name: 'Mandala Blockscout',
       url: 'https://blockscout.mandala.aca-staging.network',
+      apiUrl: 'https://blockscout.mandala.aca-staging.network/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/manta.ts
+++ b/src/chains/definitions/manta.ts
@@ -16,10 +16,12 @@ export const manta = /*#__PURE__*/ defineChain({
     etherscan: {
       name: 'Manta Explorer',
       url: 'https://pacific-explorer.manta.network',
+      apiUrl: 'https://pacific-explorer.manta.network/api',
     },
     default: {
       name: 'Manta Explorer',
       url: 'https://pacific-explorer.manta.network',
+      apiUrl: 'https://pacific-explorer.manta.network/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/mantaTestnet.ts
+++ b/src/chains/definitions/mantaTestnet.ts
@@ -16,10 +16,12 @@ export const mantaTestnet = /*#__PURE__*/ defineChain({
     etherscan: {
       name: 'Manta Testnet Explorer',
       url: 'https://pacific-explorer.testnet.manta.network',
+      apiUrl: 'https://pacific-explorer.testnet.manta.network/api',
     },
     default: {
       name: 'Manta Testnet Explorer',
       url: 'https://pacific-explorer.testnet.manta.network',
+      apiUrl: 'https://pacific-explorer.testnet.manta.network/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/mantle.ts
+++ b/src/chains/definitions/mantle.ts
@@ -15,6 +15,7 @@ export const mantle = /*#__PURE__*/ defineChain({
     default: {
       name: 'Mantle Explorer',
       url: 'https://explorer.mantle.xyz',
+      apiUrl: 'https://explorer.mantle.xyz/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/mantleTestnet.ts
+++ b/src/chains/definitions/mantleTestnet.ts
@@ -15,6 +15,7 @@ export const mantleTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Mantle Testnet Explorer',
       url: 'https://explorer.testnet.mantle.xyz',
+      apiUrl: 'https://explorer.testnet.mantle.xyz/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/meter.ts
+++ b/src/chains/definitions/meter.ts
@@ -12,6 +12,9 @@ export const meter = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.meter.io'] },
   },
   blockExplorers: {
-    default: { name: 'MeterScan', url: 'https://scan.meter.io' },
+    default: {
+      name: 'MeterScan',
+      url: 'https://scan.meter.io',
+    },
   },
 })

--- a/src/chains/definitions/metis.ts
+++ b/src/chains/definitions/metis.ts
@@ -15,6 +15,7 @@ export const metis = /*#__PURE__*/ defineChain({
     default: {
       name: 'Andromeda Explorer',
       url: 'https://andromeda-explorer.metis.io',
+      apiUrl: 'https://andromeda-explorer.metis.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/metisGoerli.ts
+++ b/src/chains/definitions/metisGoerli.ts
@@ -15,6 +15,7 @@ export const metisGoerli = /*#__PURE__*/ defineChain({
     default: {
       name: 'Metis Goerli Explorer',
       url: 'https://goerli.explorer.metisdevops.link',
+      apiUrl: 'https://goerli.explorer.metisdevops.link/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/modeTestnet.ts
+++ b/src/chains/definitions/modeTestnet.ts
@@ -13,6 +13,7 @@ export const modeTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://sepolia.explorer.mode.network',
+      apiUrl: 'https://sepolia.explorer.mode.network/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/moonbaseAlpha.ts
+++ b/src/chains/definitions/moonbaseAlpha.ts
@@ -18,6 +18,7 @@ export const moonbaseAlpha = /*#__PURE__*/ defineChain({
     default: {
       name: 'Moonscan',
       url: 'https://moonbase.moonscan.io',
+      apiUrl: 'https://moonbase.moonscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/moonbeam.ts
+++ b/src/chains/definitions/moonbeam.ts
@@ -18,6 +18,7 @@ export const moonbeam = /*#__PURE__*/ defineChain({
     default: {
       name: 'Moonscan',
       url: 'https://moonscan.io',
+      apiUrl: 'https://api-moonbeam.moonscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/moonriver.ts
+++ b/src/chains/definitions/moonriver.ts
@@ -18,6 +18,7 @@ export const moonriver = /*#__PURE__*/ defineChain({
     default: {
       name: 'Moonscan',
       url: 'https://moonriver.moonscan.io',
+      apiUrl: 'https://api-moonriver.moonscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/nexi.ts
+++ b/src/chains/definitions/nexi.ts
@@ -13,6 +13,7 @@ export const nexi = /*#__PURE__*/ defineChain({
     default: {
       name: 'NexiScan',
       url: 'https://www.nexiscan.com',
+      apiUrl: 'https://www.nexiscan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/nexilix.ts
+++ b/src/chains/definitions/nexilix.ts
@@ -12,7 +12,10 @@ export const nexilix = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpcurl.pos.nexilix.com'] },
   },
   blockExplorers: {
-    default: { name: 'NexilixScan', url: 'https://scan.nexilix.com' },
+    default: {
+      name: 'NexilixScan',
+      url: 'https://scan.nexilix.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/oasisTestnet.ts
+++ b/src/chains/definitions/oasisTestnet.ts
@@ -13,6 +13,7 @@ export const oasisTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Ftnscan',
       url: 'https://oasis.ftnscan.com',
+      apiUrl: 'https://oasis.ftnscan.com/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/oasys.ts
+++ b/src/chains/definitions/oasys.ts
@@ -13,6 +13,7 @@ export const oasys = /*#__PURE__*/ defineChain({
     default: {
       name: 'OasysScan',
       url: 'https://scan.oasys.games',
+      apiUrl: 'https://scan.oasys.games/api',
     },
   },
 })

--- a/src/chains/definitions/okc.ts
+++ b/src/chains/definitions/okc.ts
@@ -12,7 +12,10 @@ export const okc = /*#__PURE__*/ defineChain({
     default: { http: ['https://exchainrpc.okex.org'] },
   },
   blockExplorers: {
-    default: { name: 'oklink', url: 'https://www.oklink.com/okc' },
+    default: {
+      name: 'oklink',
+      url: 'https://www.oklink.com/okc',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/opBNB.ts
+++ b/src/chains/definitions/opBNB.ts
@@ -12,7 +12,10 @@ export const opBNB = /*#__PURE__*/ defineChain({
     default: { http: ['https://opbnb-mainnet-rpc.bnbchain.org'] },
   },
   blockExplorers: {
-    default: { name: 'opbnbscan', url: 'https://mainnet.opbnbscan.com' },
+    default: {
+      name: 'opbnbscan',
+      url: 'https://mainnet.opbnbscan.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/opBNBTestnet.ts
+++ b/src/chains/definitions/opBNBTestnet.ts
@@ -12,7 +12,10 @@ export const opBNBTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://opbnb-testnet-rpc.bnbchain.org'] },
   },
   blockExplorers: {
-    default: { name: 'opbnbscan', url: 'https://testnet.opbnbscan.com' },
+    default: {
+      name: 'opbnbscan',
+      url: 'https://testnet.opbnbscan.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -16,7 +16,7 @@ export const optimism = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Optimism Explorer',
-      url: 'https://explorer.optimism.io',
+      url: 'https://optimistic.etherscan.io',
       apiUrl: 'https://api-optimistic.etherscan.io',
     },
   },

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -17,6 +17,7 @@ export const optimism = /*#__PURE__*/ defineChain({
     default: {
       name: 'Optimism Explorer',
       url: 'https://explorer.optimism.io',
+      apiUrl: 'https://api-optimistic.etherscan.io',
     },
   },
   contracts: {

--- a/src/chains/definitions/optimismGoerli.ts
+++ b/src/chains/definitions/optimismGoerli.ts
@@ -17,6 +17,7 @@ export const optimismGoerli = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://goerli-optimism.etherscan.io',
+      apiUrl: 'https://goerli-optimism.etherscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/optimismSepolia.ts
+++ b/src/chains/definitions/optimismSepolia.ts
@@ -17,6 +17,7 @@ export const optimismSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://optimism-sepolia.blockscout.com',
+      apiUrl: 'https://optimism-sepolia.blockscout.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/pgn.ts
+++ b/src/chains/definitions/pgn.ts
@@ -17,10 +17,12 @@ export const pgn = /*#__PURE__*/ defineChain({
     default: {
       name: 'PGN Explorer',
       url: 'https://explorer.publicgoods.network',
+      apiUrl: 'https://explorer.publicgoods.network/api',
     },
     blocksout: {
       name: 'PGN Explorer',
       url: 'https://explorer.publicgoods.network',
+      apiUrl: 'https://explorer.publicgoods.network/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/pgnTestnet.ts
+++ b/src/chains/definitions/pgnTestnet.ts
@@ -17,10 +17,12 @@ export const pgnTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'PGN Testnet Explorer',
       url: 'https://explorer.sepolia.publicgoods.network',
+      apiUrl: 'https://explorer.sepolia.publicgoods.network/api',
     },
     blocksout: {
       name: 'PGN Testnet Explorer',
       url: 'https://explorer.sepolia.publicgoods.network',
+      apiUrl: 'https://explorer.sepolia.publicgoods.network/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -13,6 +13,7 @@ export const polygon = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://polygonscan.com',
+      apiUrl: 'https://api.polygonscan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/polygonMumbai.ts
+++ b/src/chains/definitions/polygonMumbai.ts
@@ -13,6 +13,7 @@ export const polygonMumbai = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://mumbai.polygonscan.com',
+      apiUrl: 'https://mumbai.polygonscan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/polygonZkEvm.ts
+++ b/src/chains/definitions/polygonZkEvm.ts
@@ -13,6 +13,7 @@ export const polygonZkEvm = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://zkevm.polygonscan.com',
+      apiUrl: 'https://api-zkevm.polygonscan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/polygonZkEvmTestnet.ts
+++ b/src/chains/definitions/polygonZkEvmTestnet.ts
@@ -13,6 +13,7 @@ export const polygonZkEvmTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://testnet-zkevm.polygonscan.com',
+      apiUrl: 'https://testnet-zkevm.polygonscan.com/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/pulsechain.ts
+++ b/src/chains/definitions/pulsechain.ts
@@ -15,6 +15,7 @@ export const pulsechain = /*#__PURE__*/ defineChain({
     default: {
       name: 'PulseScan',
       url: 'https://scan.pulsechain.com',
+      apiUrl: 'https://api.scan.pulsechain.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/pulsechainV4.ts
+++ b/src/chains/definitions/pulsechainV4.ts
@@ -15,6 +15,7 @@ export const pulsechainV4 = /*#__PURE__*/ defineChain({
     default: {
       name: 'PulseScan',
       url: 'https://scan.v4.testnet.pulsechain.com',
+      apiUrl: 'https://scan.v4.testnet.pulsechain.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/qMainnet.ts
+++ b/src/chains/definitions/qMainnet.ts
@@ -15,6 +15,7 @@ export const qMainnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Q Mainnet Explorer',
       url: 'https://explorer.q.org',
+      apiUrl: 'https://explorer.q.org/api',
     },
   },
 })

--- a/src/chains/definitions/qTestnet.ts
+++ b/src/chains/definitions/qTestnet.ts
@@ -15,6 +15,7 @@ export const qTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Q Testnet Explorer',
       url: 'https://explorer.qtestnet.org',
+      apiUrl: 'https://explorer.qtestnet.org/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/rollux.ts
+++ b/src/chains/definitions/rollux.ts
@@ -15,7 +15,11 @@ export const rollux = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'RolluxExplorer', url: 'https://explorer.rollux.com' },
+    default: {
+      name: 'RolluxExplorer',
+      url: 'https://explorer.rollux.com',
+      apiUrl: 'https://explorer.rollux.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/rolluxTestnet.ts
+++ b/src/chains/definitions/rolluxTestnet.ts
@@ -18,6 +18,7 @@ export const rolluxTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'RolluxTestnetExplorer',
       url: 'https://rollux.tanenbaum.io',
+      apiUrl: 'https://rollux.tanenbaum.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/ronin.ts
+++ b/src/chains/definitions/ronin.ts
@@ -10,7 +10,10 @@ export const ronin = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'Ronin Explorer', url: 'https://app.roninchain.com' },
+    default: {
+      name: 'Ronin Explorer',
+      url: 'https://app.roninchain.com',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/rootstock.ts
+++ b/src/chains/definitions/rootstock.ts
@@ -13,8 +13,15 @@ export const rootstock = /*#__PURE__*/ defineChain({
     default: { http: ['https://public-node.rsk.co'] },
   },
   blockExplorers: {
-    blockscout: { name: 'Blockscout', url: 'https://rootstock.blockscout.com' },
-    default: { name: 'RSK Explorer', url: 'https://explorer.rsk.co' },
+    blockscout: {
+      name: 'Blockscout',
+      url: 'https://rootstock.blockscout.com',
+      apiUrl: 'https://rootstock.blockscout.com/api',
+    },
+    default: {
+      name: 'RSK Explorer',
+      url: 'https://explorer.rsk.co',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/sapphire.ts
+++ b/src/chains/definitions/sapphire.ts
@@ -15,6 +15,7 @@ export const sapphire = /*#__PURE__*/ defineChain({
     default: {
       name: 'Oasis Sapphire Explorer',
       url: 'https://explorer.sapphire.oasis.io',
+      apiUrl: 'https://explorer.sapphire.oasis.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/sapphireTestnet.ts
+++ b/src/chains/definitions/sapphireTestnet.ts
@@ -15,6 +15,7 @@ export const sapphireTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Oasis Sapphire Testnet Explorer',
       url: 'https://testnet.explorer.sapphire.oasis.dev',
+      apiUrl: 'https://testnet.explorer.sapphire.oasis.dev/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/scroll.ts
+++ b/src/chains/definitions/scroll.ts
@@ -14,6 +14,7 @@ export const scroll = /*#__PURE__*/ defineChain({
     default: {
       name: 'Scrollscan',
       url: 'https://scrollscan.com',
+      apiUrl: 'https://api.scrollscan.com/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/scrollSepolia.ts
+++ b/src/chains/definitions/scrollSepolia.ts
@@ -13,6 +13,7 @@ export const scrollSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://sepolia-blockscout.scroll.io',
+      apiUrl: 'https://sepolia-blockscout.scroll.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/scrollTestnet.ts
+++ b/src/chains/definitions/scrollTestnet.ts
@@ -14,6 +14,7 @@ export const scrollTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://blockscout.scroll.io',
+      apiUrl: 'https://blockscout.scroll.io/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -13,6 +13,7 @@ export const sepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://sepolia.etherscan.io',
+      apiUrl: 'https://api-sepolia.etherscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/shimmer.ts
+++ b/src/chains/definitions/shimmer.ts
@@ -18,6 +18,7 @@ export const shimmer = /*#__PURE__*/ defineChain({
     default: {
       name: 'Shimmer Network Explorer',
       url: 'https://explorer.evm.shimmer.network',
+      apiUrl: 'https://explorer.evm.shimmer.network/api',
     },
   },
 })

--- a/src/chains/definitions/shimmerTestnet.ts
+++ b/src/chains/definitions/shimmerTestnet.ts
@@ -18,6 +18,7 @@ export const shimmerTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Shimmer Network Explorer',
       url: 'https://explorer.evm.testnet.shimmer.network',
+      apiUrl: 'https://explorer.evm.testnet.shimmer.network/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/songbird.ts
+++ b/src/chains/definitions/songbird.ts
@@ -15,6 +15,7 @@ export const songbird = /*#__PURE__*/ defineChain({
     default: {
       name: 'Songbird Explorer',
       url: 'https://songbird-explorer.flare.network',
+      apiUrl: 'https://songbird-explorer.flare.network/api',
     },
   },
 })

--- a/src/chains/definitions/songbirdTestnet.ts
+++ b/src/chains/definitions/songbirdTestnet.ts
@@ -15,6 +15,7 @@ export const songbirdTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Coston Explorer',
       url: 'https://coston-explorer.flare.network',
+      apiUrl: 'https://coston-explorer.flare.network/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/spicy.ts
+++ b/src/chains/definitions/spicy.ts
@@ -25,6 +25,7 @@ export const spicy = /*#__PURE__*/ defineChain({
     default: {
       name: 'Chiliz Explorer',
       url: 'http://spicy-explorer.chiliz.com',
+      apiUrl: 'http://spicy-explorer.chiliz.com/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/syscoin.ts
+++ b/src/chains/definitions/syscoin.ts
@@ -15,7 +15,11 @@ export const syscoin = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'SyscoinExplorer', url: 'https://explorer.syscoin.org' },
+    default: {
+      name: 'SyscoinExplorer',
+      url: 'https://explorer.syscoin.org',
+      apiUrl: 'https://explorer.syscoin.org/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/syscoinTestnet.ts
+++ b/src/chains/definitions/syscoinTestnet.ts
@@ -15,7 +15,10 @@ export const syscoinTestnet = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'SyscoinTestnetExplorer', url: 'https://tanenbaum.io' },
+    default: {
+      name: 'SyscoinTestnetExplorer',
+      url: 'https://tanenbaum.io',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/tenet.ts
+++ b/src/chains/definitions/tenet.ts
@@ -13,7 +13,11 @@ export const tenet = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.tenet.org'] },
   },
   blockExplorers: {
-    default: { name: 'TenetScan Mainnet', url: 'https://tenetscan.io' },
+    default: {
+      name: 'TenetScan Mainnet',
+      url: 'https://tenetscan.io',
+      apiUrl: 'https://tenetscan.io/api',
+    },
   },
   testnet: false,
 })

--- a/src/chains/definitions/wemix.ts
+++ b/src/chains/definitions/wemix.ts
@@ -10,7 +10,13 @@ export const wemix = /*#__PURE__*/ defineChain({
     public: { http: ['https://api.wemix.com'] },
   },
   blockExplorers: {
-    etherscan: { name: 'wemixExplorer', url: 'https://explorer.wemix.com' },
-    default: { name: 'wemixExplorer', url: 'https://explorer.wemix.com' },
+    etherscan: {
+      name: 'wemixExplorer',
+      url: 'https://explorer.wemix.com',
+    },
+    default: {
+      name: 'wemixExplorer',
+      url: 'https://explorer.wemix.com',
+    },
   },
 })

--- a/src/chains/definitions/wemixTestnet.ts
+++ b/src/chains/definitions/wemixTestnet.ts
@@ -10,8 +10,16 @@ export const wemixTestnet = /*#__PURE__*/ defineChain({
     public: { http: ['https://api.test.wemix.com'] },
   },
   blockExplorers: {
-    etherscan: { name: 'wemixExplorer', url: 'https://testnet.wemixscan.com' },
-    default: { name: 'wemixExplorer', url: 'https://testnet.wemixscan.com' },
+    etherscan: {
+      name: 'wemixExplorer',
+      url: 'https://testnet.wemixscan.com',
+      apiUrl: 'https://testnet.wemixscan.com/api',
+    },
+    default: {
+      name: 'wemixExplorer',
+      url: 'https://testnet.wemixscan.com',
+      apiUrl: 'https://testnet.wemixscan.com/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -12,7 +12,13 @@ export const xdc = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.xinfin.network'] },
   },
   blockExplorers: {
-    xinfin: { name: 'XinFin', url: 'https://explorer.xinfin.network' },
-    default: { name: 'Blocksscan', url: 'https://xdc.blocksscan.io' },
+    xinfin: {
+      name: 'XinFin',
+      url: 'https://explorer.xinfin.network',
+    },
+    default: {
+      name: 'Blocksscan',
+      url: 'https://xdc.blocksscan.io',
+    },
   },
 })

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -12,7 +12,13 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://erpc.apothem.network'] },
   },
   blockExplorers: {
-    xinfin: { name: 'XinFin', url: 'https://explorer.apothem.network' },
-    default: { name: 'Blocksscan', url: 'https://apothem.blocksscan.io' },
+    xinfin: {
+      name: 'XinFin',
+      url: 'https://explorer.apothem.network',
+    },
+    default: {
+      name: 'Blocksscan',
+      url: 'https://apothem.blocksscan.io',
+    },
   },
 })

--- a/src/chains/definitions/zkFair.ts
+++ b/src/chains/definitions/zkFair.ts
@@ -21,6 +21,7 @@ export const zkFair = /*#__PURE__*/ defineChain({
     default: {
       name: 'zkFair Explorer',
       url: 'https://scan.zkfair.io',
+      apiUrl: 'https://scan.zkfair.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/zkSync.ts
+++ b/src/chains/definitions/zkSync.ts
@@ -22,7 +22,6 @@ export const zkSync = /*#__PURE__*/ defineChain({
       name: 'zkExplorer',
       url: 'https://explorer.zksync.io',
     },
-    etherscan: { name: 'ZkScan', url: 'https://era.zksync.network' },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/zora.ts
+++ b/src/chains/definitions/zora.ts
@@ -19,7 +19,11 @@ export const zora = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    default: { name: 'Explorer', url: 'https://explorer.zora.energy' },
+    default: {
+      name: 'Explorer',
+      url: 'https://explorer.zora.energy',
+      apiUrl: 'https://explorer.zora.energy/api',
+    },
   },
   contracts: {
     ...chainConfig.contracts,

--- a/src/chains/definitions/zoraSepolia.ts
+++ b/src/chains/definitions/zoraSepolia.ts
@@ -23,6 +23,7 @@ export const zoraSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Zora Sepolia Explorer',
       url: 'https://sepolia.explorer.zora.energy/',
+      apiUrl: 'https://sepolia.explorer.zora.energy/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/zoraTestnet.ts
+++ b/src/chains/definitions/zoraTestnet.ts
@@ -22,6 +22,7 @@ export const zoraTestnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Explorer',
       url: 'https://testnet.explorer.zora.energy',
+      apiUrl: 'https://testnet.explorer.zora.energy/api',
     },
   },
   contracts: {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -72,6 +72,7 @@ export type Chain<
 type ChainBlockExplorer = {
   name: string
   url: string
+  apiUrl?: string | undefined
 }
 
 export type ChainContract = {

--- a/src/utils/chain/extractChain.test.ts
+++ b/src/utils/chain/extractChain.test.ts
@@ -14,6 +14,7 @@ test('default', async () => {
         "default": {
           "name": "Etherscan",
           "url": "https://etherscan.io",
+          "apiUrl": "https://api.etherscan.io/api",
         },
       },
       "contracts": {
@@ -58,7 +59,8 @@ test('default', async () => {
       "blockExplorers": {
         "default": {
           "name": "Optimism Explorer",
-          "url": "https://explorer.optimism.io",
+          "url": "https://optimistic.etherscan.io",
+          "apiUrl": "https://api-optimistic.etherscan.io",
         },
       },
       "contracts": {

--- a/test/chains/check.test.ts
+++ b/test/chains/check.test.ts
@@ -38,6 +38,16 @@ chains_.forEach((chain) => {
       },
       { timeout: defaultTimeout },
     )
+
+    const explorerApiUrl = chain.blockExplorers?.default.apiUrl
+    if (explorerApiUrl)
+      test(
+        `${chain.name}: check block explorer API`,
+        async () => {
+          await assertExplorerApiUrl(explorerApiUrl)
+        },
+        { timeout: defaultTimeout },
+      )
 })
 
 function isLocalNetwork(url: string): boolean {
@@ -88,4 +98,14 @@ async function assertWebSocketRpcUrls(
 
 async function assertExplorerUrl(explorerUrl: string): Promise<void> {
   await fetch(explorerUrl, { method: 'HEAD' })
+}
+
+async function assertExplorerApiUrl(explorerApiUrl: string): Promise<void> {
+  const url = `${explorerApiUrl}?module=block&action=getblocknobytime&closest=before&timestamp=${Math.floor(Date.now() / 1000)}`
+  const response = await fetch(url)
+  const data = await response.json()
+  expect(data).toMatchObject({
+    status: "1",
+    message: expect.stringContaining("OK"),
+  })
 }


### PR DESCRIPTION
This PR adds explorer API URLs to `viem/chains` (https://github.com/wevm/viem/discussions/1681).

I wrote [a script](https://github.com/0xOlias/explorer-urls) that guesses the API URL from the explorer URL using a list of known common patterns, and checks that the endpoint responds to an [Etherscan-style API request for the latest block](https://docs.etherscan.io/api-endpoints/blocks#get-block-number-by-timestamp). Blockscout explorers (and perhaps others) also implement this endpoint.

I attempted to add an explorer API URL test to `test/chains/check.test.ts` which uses the same verification approach.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds API URLs for block explorers in various chains.

### Detailed summary
- Added API URLs for block explorers in `viem/chains`.
- Added API URLs for block explorers in `src/chains/definitions`.
- Added API URLs for block explorers in `src/chains/definitions/contracts`.
- Added API URLs for block explorers in `src/chains/definitions/blockExplorers`.

> The following files were skipped due to too many changes: `src/chains/definitions/lukso.ts`, `src/chains/definitions/bronos.ts`, `src/chains/definitions/mandala.ts`, `src/chains/definitions/defichainEvm.ts`, `src/chains/definitions/eosTestnet.ts`, `src/chains/definitions/evmos.ts`, `src/chains/definitions/astarZkatana.ts`, `src/chains/definitions/boba.ts`, `src/chains/definitions/defichainEvmTestnet.ts`, `src/chains/definitions/iotexTestnet.ts`, `src/chains/definitions/shimmerTestnet.ts`, `src/chains/definitions/filecoin.ts`, `src/chains/definitions/okc.ts`, `src/chains/definitions/sapphireTestnet.ts`, `src/chains/definitions/coreDao.ts`, `src/chains/definitions/filecoinCalibration.ts`, `src/chains/definitions/ekta.ts`, `src/chains/definitions/optimism.ts`, `src/chains/definitions/filecoinHyperspace.ts`, `src/chains/definitions/bronosTestnet.ts`, `src/chains/definitions/klaytn.ts`, `src/chains/definitions/nexilix.ts`, `src/chains/definitions/astar.ts`, `src/chains/definitions/opBNB.ts`, `src/chains/definitions/ronin.ts`, `src/chains/definitions/opBNBTestnet.ts`, `src/chains/definitions/bsc.ts`, `src/chains/definitions/gobi.ts`, `src/chains/definitions/fantom.ts`, `src/chains/definitions/harmonyOne.ts`, `src/chains/definitions/syscoinTestnet.ts`, `src/chains/definitions/arbitrum.ts`, `src/chains/definitions/avalanche.ts`, `src/chains/definitions/cronos.ts`, `src/chains/definitions/tenet.ts`, `src/chains/definitions/aurora.ts`, `src/chains/definitions/kava.ts`, `src/chains/definitions/ektaTestnet.ts`, `src/chains/definitions/crossbell.ts`, `src/chains/definitions/fuse.ts`, `src/chains/definitions/arbitrumNova.ts`, `src/chains/definitions/bscTestnet.ts`, `src/chains/definitions/fantomTestnet.ts`, `src/chains/definitions/bearNetworkChainMainnet.ts`, `src/chains/definitions/auroraTestnet.ts`, `src/chains/definitions/edgeware.ts`, `src/chains/definitions/rollux.ts`, `src/chains/definitions/zora.ts`, `src/chains/definitions/avalancheFuji.ts`, `src/chains/definitions/syscoin.ts`, `src/chains/definitions/baseSepolia.ts`, `src/chains/definitions/pgn.ts`, `src/chains/definitions/manta.ts`, `src/chains/definitions/xdc.ts`, `src/chains/definitions/xdcTestnet.ts`, `src/chains/definitions/wemix.ts`, `src/chains/definitions/pgnTestnet.ts`, `src/chains/definitions/arbitrumGoerli.ts`, `src/chains/definitions/mantaTestnet.ts`, `src/chains/definitions/klaytnBaobab.ts`, `src/chains/definitions/bitTorrent.ts`, `src/utils/chain/extractChain.test.ts`, `src/chains/definitions/rootstock.ts`, `src/chains/definitions/bitTorrentTestnet.ts`, `src/chains/definitions/arbitrumSepolia.ts`, `src/chains/definitions/wemixTestnet.ts`, `test/chains/check.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->