### PR TITLE
chore: removed non-default chain properties.

### DIFF
--- a/.changeset/twelve-terms-notice.md
+++ b/.changeset/twelve-terms-notice.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed non-default chain properties.

--- a/src/chains/definitions/arbitrumGoerli.ts
+++ b/src/chains/definitions/arbitrumGoerli.ts
@@ -14,10 +14,6 @@ export const arbitrumGoerli = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Arbiscan',
-      url: 'https://goerli.arbiscan.io',
-    },
     default: {
       name: 'Arbiscan',
       url: 'https://goerli.arbiscan.io',

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -9,20 +9,11 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
     decimals: 18,
   },
   rpcUrls: {
-    alchemy: {
-      http: ['https://arb-sepolia.g.alchemy.com/v2'],
-      webSocket: ['wss://arb-sepolia.g.alchemy.com/v2'],
-    },
     default: {
       http: ['https://sepolia-rollup.arbitrum.io/rpc'],
     },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Arbiscan',
-      url: 'https://sepolia.arbiscan.io',
-      apiUrl: 'https://sepolia.arbiscan.io/api',
-    },
     default: {
       name: 'Arbiscan',
       url: 'https://sepolia.arbiscan.io',

--- a/src/chains/definitions/astarZkatana.ts
+++ b/src/chains/definitions/astarZkatana.ts
@@ -14,11 +14,6 @@ export const astarZkatana = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    blockscout: {
-      name: 'Blockscout zKatana chain explorer',
-      url: 'https://zkatana.blockscout.com',
-      apiUrl: 'https://zkatana.blockscout.com/api',
-    },
     default: {
       name: 'zKatana Explorer',
       url: 'https://zkatana.explorer.startale.com',

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -15,11 +15,6 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    blockscout: {
-      name: 'Blockscout',
-      url: 'https://base-sepolia.blockscout.com',
-      apiUrl: 'https://base-sepolia.blockscout.com/api',
-    },
     default: {
       name: 'Blockscout',
       url: 'https://base-sepolia.blockscout.com',

--- a/src/chains/definitions/bitTorrent.ts
+++ b/src/chains/definitions/bitTorrent.ts
@@ -10,11 +10,6 @@ export const bitTorrent = /*#__PURE__*/ defineChain({
     public: { http: ['https://rpc.bittorrentchain.io'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Bttcscan',
-      url: 'https://bttcscan.com',
-      apiUrl: 'https://api.bttcscan.com/api',
-    },
     default: {
       name: 'Bttcscan',
       url: 'https://bttcscan.com',

--- a/src/chains/definitions/bitTorrentTestnet.ts
+++ b/src/chains/definitions/bitTorrentTestnet.ts
@@ -10,11 +10,6 @@ export const bitTorrentTestnet = /*#__PURE__*/ defineChain({
     public: { http: ['https://testrpc.bittorrentchain.io'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Bttcscan',
-      url: 'https://testnet.bttcscan.com',
-      apiUrl: 'https://testnet.bttcscan.com/api',
-    },
     default: {
       name: 'Bttcscan',
       url: 'https://testnet.bttcscan.com',

--- a/src/chains/definitions/defichainEvm.ts
+++ b/src/chains/definitions/defichainEvm.ts
@@ -22,11 +22,6 @@ export const defichainEvm = /*#__PURE__*/ defineChain({
       name: 'DeFiScan',
       url: 'https://meta.defiscan.live',
     },
-    blockscout: {
-      name: 'Blockscout',
-      url: 'https://blockscout.mainnet.ocean.jellyfishsdk.com',
-      apiUrl: 'https://blockscout.mainnet.ocean.jellyfishsdk.com/api',
-    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/defichainEvmTestnet.ts
+++ b/src/chains/definitions/defichainEvmTestnet.ts
@@ -22,11 +22,6 @@ export const defichainEvmTestnet = /*#__PURE__*/ defineChain({
       name: 'DeFiScan',
       url: 'https://meta.defiscan.live/?network=TestNet',
     },
-    blockscout: {
-      name: 'Blockscout',
-      url: 'https://blockscout.testnet.ocean.jellyfishsdk.com',
-      apiUrl: 'https://blockscout.testnet.ocean.jellyfishsdk.com/api',
-    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/klaytnBaobab.ts
+++ b/src/chains/definitions/klaytnBaobab.ts
@@ -13,10 +13,6 @@ export const klaytnBaobab = /*#__PURE__*/ defineChain({
     default: { http: ['https://public-en-baobab.klaytn.net'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'KlaytnScope',
-      url: 'https://baobab.klaytnscope.com',
-    },
     default: {
       name: 'KlaytnScope',
       url: 'https://baobab.klaytnscope.com',

--- a/src/chains/definitions/manta.ts
+++ b/src/chains/definitions/manta.ts
@@ -13,11 +13,6 @@ export const manta = /*#__PURE__*/ defineChain({
     default: { http: ['https://pacific-rpc.manta.network/http'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Manta Explorer',
-      url: 'https://pacific-explorer.manta.network',
-      apiUrl: 'https://pacific-explorer.manta.network/api',
-    },
     default: {
       name: 'Manta Explorer',
       url: 'https://pacific-explorer.manta.network',

--- a/src/chains/definitions/mantaTestnet.ts
+++ b/src/chains/definitions/mantaTestnet.ts
@@ -13,11 +13,6 @@ export const mantaTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://manta-testnet.calderachain.xyz/http'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Manta Testnet Explorer',
-      url: 'https://pacific-explorer.testnet.manta.network',
-      apiUrl: 'https://pacific-explorer.testnet.manta.network/api',
-    },
     default: {
       name: 'Manta Testnet Explorer',
       url: 'https://pacific-explorer.testnet.manta.network',

--- a/src/chains/definitions/rootstock.ts
+++ b/src/chains/definitions/rootstock.ts
@@ -13,11 +13,6 @@ export const rootstock = /*#__PURE__*/ defineChain({
     default: { http: ['https://public-node.rsk.co'] },
   },
   blockExplorers: {
-    blockscout: {
-      name: 'Blockscout',
-      url: 'https://rootstock.blockscout.com',
-      apiUrl: 'https://rootstock.blockscout.com/api',
-    },
     default: {
       name: 'RSK Explorer',
       url: 'https://explorer.rsk.co',

--- a/src/chains/definitions/shibarium.ts
+++ b/src/chains/definitions/shibarium.ts
@@ -11,10 +11,6 @@ export const shibarium = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'Blockscout',
-      url: 'https://shibariumscan.io',
-    },
     default: {
       name: 'Blockscout',
       url: 'https://shibariumscan.io',

--- a/src/chains/definitions/wemix.ts
+++ b/src/chains/definitions/wemix.ts
@@ -10,10 +10,6 @@ export const wemix = /*#__PURE__*/ defineChain({
     public: { http: ['https://api.wemix.com'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'wemixExplorer',
-      url: 'https://explorer.wemix.com',
-    },
     default: {
       name: 'wemixExplorer',
       url: 'https://explorer.wemix.com',

--- a/src/chains/definitions/wemixTestnet.ts
+++ b/src/chains/definitions/wemixTestnet.ts
@@ -10,11 +10,6 @@ export const wemixTestnet = /*#__PURE__*/ defineChain({
     public: { http: ['https://api.test.wemix.com'] },
   },
   blockExplorers: {
-    etherscan: {
-      name: 'wemixExplorer',
-      url: 'https://testnet.wemixscan.com',
-      apiUrl: 'https://testnet.wemixscan.com/api',
-    },
     default: {
       name: 'wemixExplorer',
       url: 'https://testnet.wemixscan.com',

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -12,10 +12,6 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
     default: { http: ['https://erpc.apothem.network'] },
   },
   blockExplorers: {
-    xinfin: {
-      name: 'XinFin',
-      url: 'https://explorer.apothem.network',
-    },
     default: {
       name: 'Blocksscan',
       url: 'https://apothem.blocksscan.io',


### PR DESCRIPTION
Removed non-default chain properties.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing non-default chain properties. 

### Detailed summary
- Removed non-default chain properties for Shibarium, Arbitrum Goerli, Wemix, XinFin, Klaytn Baobab, BitTorrent, BitTorrent Testnet, Rootstock, Wemix Testnet, Base Sepolia, Manta, Astar Zkatana, Defichain EVM, Defichain EVM Testnet, and Arbitrum Sepolia.
- Updated block explorer URLs for Shibarium, Arbitrum Goerli, Wemix, XinFin, Klaytn Baobab, BitTorrent, BitTorrent Testnet, Rootstock, Wemix Testnet, Base Sepolia, Manta, Astar Zkatana, Defichain EVM, Defichain EVM Testnet, and Arbitrum Sepolia.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->