### PR TITLE
Add multicall3 contract to Neon EVM MainNet

### DIFF
--- a/.changeset/fluffy-rocks-arrive.md
+++ b/.changeset/fluffy-rocks-arrive.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add multicall3 contract to Neon EVM MainNet

--- a/src/chains/definitions/neonMainnet.ts
+++ b/src/chains/definitions/neonMainnet.ts
@@ -16,6 +16,11 @@ export const neonMainnet = /*#__PURE__*/ defineChain({
       url: 'https://neonscan.org',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 206545524,
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
Add multicall3 contract to Neon EVM MainNet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the multicall3 contract to the Neon EVM MainNet.

### Detailed summary
- Added multicall3 contract to Neon EVM MainNet
- Updated the `neonMainnet.ts` file to include the multicall3 contract with its address and blockCreated information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->