### PR TITLE
update to use gnosisscan

### DIFF
--- a/.changeset/giant-bobcats-cry.md
+++ b/.changeset/giant-bobcats-cry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaces the default block explorer on gnosis from blockscout to gnosisscan.

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -16,7 +16,7 @@ export const gnosis = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Gnosis Chain Explorer',
+      name: 'Gnosisscan',
       url: 'https://gnosisscan.io/',
       apiUrl: 'https://api.gnosisscan.io/api',
     },

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -17,7 +17,8 @@ export const gnosis = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Gnosis Chain Explorer',
-      url: 'https://blockscout.com/xdai/mainnet',
+      url: 'https://gnosisscan.io/',
+      apiUrl: 'https://api.gnosisscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -17,7 +17,7 @@ export const gnosis = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Gnosisscan',
-      url: 'https://gnosisscan.io/',
+      url: 'https://gnosisscan.io',
       apiUrl: 'https://api.gnosisscan.io/api',
     },
   },


### PR DESCRIPTION
idk based on what the default is chosen/if other explorers should be listed as well (networks i checked all had only listed one).
That said, at least our users frequently report that we're using "blockscout" instead of the etherscan alternative.
So this pr updates to use etherscan instead of blockscout.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the default block explorer on Gnosis from Blockscout to Gnosisscan.

### Detailed summary
- Replaces the default block explorer on Gnosis from Blockscout to Gnosisscan.
- Updates the URL and API URL for the block explorer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->