### PR TITLE
docs: add missing block parameters to getBytecode and getStorageAt

### DIFF
--- a/site/pages/docs/contract/getBytecode.md
+++ b/site/pages/docs/contract/getBytecode.md
@@ -50,6 +50,33 @@ const bytecode = await publicClient.getBytecode({
 })
 ```
 
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the bytecode read against.
+
+```ts
+const bytecode = await publicClient.getBytecode({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  blockNumber: 15121123n, // [!code focus]
+})
+```
+
+### blockTag (optional)
+
+- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
+- **Default:** `'latest'`
+
+The block tag to perform the bytecode read against.
+
+```ts
+const bytecode = await publicClient.getBytecode({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  blockTag: 'safe', // [!code focus]
+})
+```
+
 ## JSON-RPC Method
 
 [`eth_getCode`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getcode)

--- a/site/pages/docs/contract/getStorageAt.md
+++ b/site/pages/docs/contract/getStorageAt.md
@@ -67,6 +67,35 @@ const data = await publicClient.getStorageAt({
 })
 ```
 
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the storage slot read against.
+
+```ts
+const bytecode = await publicClient.getStorageAt({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  slot: toHex(0),
+  blockNumber: 15121123n, // [!code focus]
+})
+```
+
+### blockTag (optional)
+
+- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
+- **Default:** `'latest'`
+
+The block tag to perform the storage slot read against.
+
+```ts
+const bytecode = await publicClient.getStorageAt({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  slot: toHex(0),
+  blockTag: 'safe', // [!code focus]
+})
+```
+
 ## JSON-RPC Method
 
 [`eth_getStorageAt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `blockNumber` and `blockTag` options to the `getBytecode` and `getStorageAt` methods. 

### Detailed summary
- Added `blockNumber` option to `getBytecode` method.
- Added `blockTag` option to `getBytecode` method.
- Added `blockNumber` option to `getStorageAt` method.
- Added `blockTag` option to `getStorageAt` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->