### PR TITLE
Update base sepolia explorer url

### DIFF
--- a/.changeset/chilled-cheetahs-push.md
+++ b/.changeset/chilled-cheetahs-push.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Base Sepolia explorer URL.

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -16,7 +16,7 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Blockscout',
+      name: 'Basescan',
       url: 'https://sepolia.basescan.org',
       apiUrl: 'https://api-sepolia.basescan.org/api',
     },

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -17,8 +17,8 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://base-sepolia.blockscout.com',
-      apiUrl: 'https://base-sepolia.blockscout.com/api',
+      url: 'https://sepolia.basescan.org',
+      apiUrl: 'https://api-sepolia.basescan.org/api',
     },
   },
   contracts: {


### PR DESCRIPTION
It looks like Base may be migrating from a Blockscout explorer (https://base-sepolia.blockscout.com) to Etherscan (https://sepolia.basescan.org).

EDIT: 

@tmm I saw that you recently removed non-default explorer URLs. FWIW, this may be a case where it would be best if both were included - Jesse from Base says both explorers will be around long term (https://warpcast.com/jessepollak/0x067ed15a).

Also, let me know if you'd rather Ponder not use `viem/chains` as a ~registry for explorer URLs in this way!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Base Sepolia explorer URL. 

### Detailed summary
- Updated the name of the default block explorer to "Basescan".
- Updated the URL of the default block explorer to "https://sepolia.basescan.org".
- Updated the API URL of the default block explorer to "https://api-sepolia.basescan.org/api".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->