### PR TITLE
Added Info how to replace getSigHash for functions when coming from ethers.

### DIFF
--- a/site/pages/docs/ethers-migration.mdx
+++ b/site/pages/docs/ethers-migration.mdx
@@ -1146,6 +1146,28 @@ const result = decodeFunctionResult({
 })
 ```
 
+### Interface.getSighash (For Function)
+
+#### Ethers
+
+```ts {3-3}
+import {Interface, FunctionFragment} from '@ethersproject/abi';
+
+const signature = Interface.getSighash(FunctionFragment.from(fragment));
+```
+
+#### viem
+
+```ts {3-7}
+import { getFunctionSignature, keccak256, toBytes } from 'viem'
+
+const hash = (value: string) => keccak256(toBytes(value))
+
+function hashFunction(def: AbiFunction) {
+  return hash(getFunctionSignature(def))
+}
+```
+
 ## Address Utilities
 
 ### getAddress


### PR DESCRIPTION
This is based on help from jxom on the discord. 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new method `getSighash` to the `Interface` class for the `ethers` library and provides an alternative implementation using the `viem` library.

### Detailed summary:
- Added a new method `getSighash` to the `Interface` class in the `ethers` library.
- The `getSighash` method is used to generate the signature hash for a given function.
- Added an alternative implementation using the `viem` library.
- Imported `Interface`, `FunctionFragment`, `getFunctionSignature`, `keccak256`, and `toBytes` from their respective libraries.
- Defined a new function `hash` that takes a string value and returns the keccak256 hash of that value.
- Defined a new function `hashFunction` that takes an `AbiFunction` definition and returns the hash of the function signature using the `getFunctionSignature` function from the `viem` library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->