### PR TITLE
Fix Minor Typo in Documentation

### DIFF
--- a/site/pages/docs/actions/public/createEventFilter.md
+++ b/site/pages/docs/actions/public/createEventFilter.md
@@ -209,7 +209,7 @@ const filter = await publicClient.createEventFilter({
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),
   strict: true
 })
-const logs = await publicClient.getFilterLogs({ logs })
+const logs = await publicClient.getFilterLogs({ filter })
 
 logs[0].args
 //      ^? { address: Address, to: Address, value: bigint }


### PR DESCRIPTION
The code snippet uses `logs` variable incorrectly, it should be `filter`.

Great library. Thanks for your hard work.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- In `createEventFilter.md`, the `getFilterLogs` method is updated to use the `filter` parameter instead of `logs` in the `publicClient.getFilterLogs` function call.
- The `logs[0].args` object now has additional properties: `address`, `to`, and `value` of type `Address` and `bigint` respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->