### PR TITLE
feat: integrate multicall3 contract for telos testnet

### DIFF
--- a/src/chains/definitions/telosTestnet.ts
+++ b/src/chains/definitions/telosTestnet.ts
@@ -17,5 +17,11 @@ export const telosTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.teloscan.io/',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xAE96D72FE112a9eB21C5627222F9173E9FF9b285',
+      blockCreated: 278_551_551,
+    },
+  },
   testnet: true,
 })

--- a/src/chains/definitions/telosTestnet.ts
+++ b/src/chains/definitions/telosTestnet.ts
@@ -20,7 +20,7 @@ export const telosTestnet = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xAE96D72FE112a9eB21C5627222F9173E9FF9b285',
-      blockCreated: 278_551_551,
+      blockCreated: 278551551,
     },
   },
   testnet: true,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new contract called `multicall3` to the `telosTestnet` chain definition.

### Detailed summary
- Added `multicall3` contract to the `telosTestnet` chain definition.
- Set the address of the `multicall3` contract to `0xAE96D72FE112a9eB21C5627222F9173E9FF9b285`.
- Set the block created of the `multicall3` contract to `278551551`.
- Updated the `testnet` flag to `true`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->