### PR TITLE
Update CONTRIBUTING.md / fix for mismatching commands

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -133,8 +133,6 @@ When adding new features or fixing bugs, it's important to add test cases to cov
 
 Documentation is crucial to helping developers of all experience levels use viem. viem uses [Vocs](https://vocs.dev) and Markdown for the documentation site (located at [`site`](../site)). To start the site in dev mode, run:
 
-![image](https://github.com/wevm/viem/assets/56932084/4602dbd6-519f-4fb6-8f00-3115cb131316)
-
 ```bash
 bun run docs:dev 
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -133,8 +133,10 @@ When adding new features or fixing bugs, it's important to add test cases to cov
 
 Documentation is crucial to helping developers of all experience levels use viem. viem uses [Vocs](https://vocs.dev) and Markdown for the documentation site (located at [`site`](../site)). To start the site in dev mode, run:
 
+![image](https://github.com/wevm/viem/assets/56932084/4602dbd6-519f-4fb6-8f00-3115cb131316)
+
 ```bash
-bun run dev:docs
+bun run docs:dev 
 ```
 
 Try to keep documentation brief and use plain language so folks of all experience levels can understand. If you think something is unclear or could be explained better, you are welcome to open a pull request.


### PR DESCRIPTION
fixed instruction in docs to match command in package.json 

Changed: 
```bun run dev:docs ```
to:  
```bun run docs:dev```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating a command in the `.github/CONTRIBUTING.md` file. 

### Detailed summary:
- Updated the command from `bun run dev:docs` to `bun run docs:dev`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->