### PR TITLE
feat: add multicall3 contract configuration for iotex

### DIFF
--- a/src/chains/definitions/iotex.ts
+++ b/src/chains/definitions/iotex.ts
@@ -20,4 +20,10 @@ export const iotex = /*#__PURE__*/ defineChain({
       url: 'https://iotexscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 22163670,
+    },
+  },
 })

--- a/src/chains/definitions/iotexTestnet.ts
+++ b/src/chains/definitions/iotexTestnet.ts
@@ -20,4 +20,11 @@ export const iotexTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.iotexscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xb5cecD6894c6f473Ec726A176f1512399A2e355d',
+      blockCreated: 24347592,
+    },
+  },
+  testnet: true,
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `multicall3` contract with its address and block creation details to the `iotex` and `iotexTestnet` definitions.

### Detailed summary
- Added `multicall3` contract with address and block creation details to `iotex` definition
- Added `multicall3` contract with address, block creation details, and `testnet` flag to `iotexTestnet` definition

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->