### PR TITLE
fix: getAddress

### DIFF
--- a/src/utils/address/getAddress.test.ts
+++ b/src/utils/address/getAddress.test.ts
@@ -57,3 +57,16 @@ describe('errors', () => {
     `)
   })
 })
+
+test('multiple addresses', () => {
+  const addresses = [
+    '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+    '0xd2135cfb216b74109775236e36d4b433f1DF507b',
+  ].map(getAddress)
+  const addresses2 = [
+    '0xd2135cfb216b74109775236e36d4b433f1DF507b',
+    '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  ].map(getAddress)
+
+  expect(addresses).toEqual(addresses2)
+})


### PR DESCRIPTION
Calling `getAddress` on multiple addresses (e.g. `['0x...', '0x...'].map(getAddress)`) in different orders doesn't return consistent results.

Minimal reproduction: https://stackblitz.com/edit/viem-getting-started-vn6ea3?file=index.ts

Related https://github.com/wevm/wagmi/issues/3507

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new test case for handling multiple addresses in the `getAddress` utility function.
- Created two arrays of addresses and mapped them using the `getAddress` function.
- Asserted that the two arrays of addresses are equal using the `toEqual` matcher.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->