### PR TITLE
feat: update zksync explorer

### DIFF
--- a/.changeset/metal-plums-protect.md
+++ b/.changeset/metal-plums-protect.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated zkSync explorer

--- a/src/chains/definitions/zkSync.ts
+++ b/src/chains/definitions/zkSync.ts
@@ -19,6 +19,11 @@ export const zkSync = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
+      name: 'Etherscan',
+      url: 'https://era.zksync.network/',
+      apiUrl: 'https://api-era.zksync.network/api',
+    },
+    zkExplorer: {
       name: 'zkExplorer',
       url: 'https://explorer.zksync.io',
     },

--- a/src/chains/definitions/zkSync.ts
+++ b/src/chains/definitions/zkSync.ts
@@ -22,11 +22,7 @@ export const zkSync = /*#__PURE__*/ defineChain({
       name: 'Etherscan',
       url: 'https://era.zksync.network/',
       apiUrl: 'https://api-era.zksync.network/api',
-    },
-    zkExplorer: {
-      name: 'zkExplorer',
-      url: 'https://explorer.zksync.io',
-    },
+    }
   },
   contracts: {
     multicall3: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the zkSync explorer and changing the block explorer to Etherscan.

### Detailed summary:
- Updated the zkSync explorer.
- Changed the block explorer to Etherscan.
- Updated the URL to 'https://era.zksync.network/'.
- Added an API URL 'https://api-era.zksync.network/api'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->