### PR TITLE
add mutilcall3 configuration for iotex

### DIFF
--- a/.changeset/chilled-panthers-battle.md
+++ b/.changeset/chilled-panthers-battle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+add multicall3 contract configuration for iotex

--- a/.changeset/chilled-panthers-battle.md
+++ b/.changeset/chilled-panthers-battle.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-add multicall3 contract configuration for iotex
+Added multicall3 contract configuration for Iotex.

--- a/src/chains/definitions/iotex.ts
+++ b/src/chains/definitions/iotex.ts
@@ -20,4 +20,10 @@ export const iotex = /*#__PURE__*/ defineChain({
       url: 'https://iotexscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 22163670,
+    },
+  },
 })

--- a/src/chains/definitions/iotexTestnet.ts
+++ b/src/chains/definitions/iotexTestnet.ts
@@ -20,11 +20,5 @@ export const iotexTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.iotexscan.io',
     },
   },
-  contracts: {
-    multicall3: {
-      address: '0xb5cecD6894c6f473Ec726A176f1512399A2e355d',
-      blockCreated: 24347592,
-    },
-  },
   testnet: true,
 })

--- a/src/chains/definitions/iotexTestnet.ts
+++ b/src/chains/definitions/iotexTestnet.ts
@@ -20,4 +20,11 @@ export const iotexTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.iotexscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xb5cecD6894c6f473Ec726A176f1512399A2e355d',
+      blockCreated: 24347592,
+    },
+  },
+  testnet: true,
 })


### PR DESCRIPTION
mainnet verify: https://iotexscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?format=io#code
testnet verify: https://testnet.iotexscan.io/address/io1kh8v66y5cm688mrjdgtk79gj8xdzud2a0wal9m#code

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding multicall3 contract configuration for Iotex testnet.

### Detailed summary
- Added `testnet: true` in `src/chains/definitions/iotexTestnet.ts`.
- Added `multicall3` contract configuration in `src/chains/definitions/iotex.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->