### PR TITLE
feat: add holesky ens addresses

### DIFF
--- a/.changeset/witty-snails-sniff.md
+++ b/.changeset/witty-snails-sniff.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ENS Registry and ENS Universal Resolver addresses for Holesky.

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -20,6 +20,14 @@ export const holesky = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 77,
     },
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+      blockCreated: 801613,
+    },
+    ensUniversalResolver: {
+      address: '0x2548a7E09deE955c4d97688dcB6C5b24085725f5',
+      blockCreated: 815385,
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
reference: https://github.com/ensdomains/ens-contracts/pull/317

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ENS Registry and ENS Universal Resolver addresses for Holesky.

### Detailed summary
- Added ENS Registry address for Holesky: `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`
- Added ENS Universal Resolver address for Holesky: `0x2548a7E09deE955c4d97688dcB6C5b24085725f5`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->