### PR TITLE
Add State overrides to eth_call

### DIFF
--- a/.changeset/real-roses-cross.md
+++ b/.changeset/real-roses-cross.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `stateOverride` property to `call`, `simulateContract`, `readContract`, and `multicall`.

--- a/site/pages/docs/actions/public/call.md
+++ b/site/pages/docs/actions/public/call.md
@@ -239,11 +239,19 @@ const data = await publicClient.call({
   account,
   data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-  stateOverride: { // [!code focus:5]
-    '0x70997970c51812dc3a010c7d01b50e0d17dc79c8': {
-      balance: parseEther('100'),
-    },
-  },
+  stateOverride: [ // [!code focus:13]
+    {
+      address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      balance: parseEther('1'),
+      code: '0x0',
+      stateDiff: [
+        {
+          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+        },
+      ],
+    }
+  ],
 })
 ```
 

--- a/site/pages/docs/actions/public/call.md
+++ b/site/pages/docs/actions/public/call.md
@@ -8,7 +8,7 @@ Executes a new message call immediately without submitting a transaction to the 
 
 ```ts [example.ts]
 import { account, publicClient } from './config'
- 
+
 const data = await publicClient.call({ // [!code focus:7]
   account,
   data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
@@ -225,6 +225,25 @@ const data = await publicClient.call({
   account,
   data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+})
+```
+
+### stateOverride (optional)
+
+- **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
+
+The state override set is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call.
+
+```ts
+const data = await publicClient.call({
+  account,
+  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  stateOverride: { // [!code focus:5]
+    '0x70997970c51812dc3a010c7d01b50e0d17dc79c8': {
+      balance: parseEther('100'),
+    },
+  },
 })
 ```
 

--- a/site/pages/docs/actions/public/call.md
+++ b/site/pages/docs/actions/public/call.md
@@ -106,6 +106,37 @@ const data = await publicClient.call({
 })
 ```
 
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the call against.
+
+```ts
+const data = await publicClient.call({
+  blockNumber: 15121123n, // [!code focus]
+  account,
+  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+})
+```
+
+### blockTag (optional)
+
+- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
+- **Default:** `'latest'`
+
+The block tag to perform the call against.
+
+```ts
+const data = await publicClient.call({
+  blockTag: 'safe', // [!code focus]
+  account,
+  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+})
+```
+
 ### gas (optional)
 
 - **Type:** `bigint`
@@ -182,6 +213,32 @@ const data = await publicClient.call({
 })
 ```
 
+### stateOverride (optional)
+
+- **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
+
+The state override set is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call.
+
+```ts
+const data = await publicClient.call({
+  account,
+  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  stateOverride: [ // [!code focus]
+    { // [!code focus]
+      address: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // [!code focus]
+      balance: parseEther('1'), // [!code focus]
+      stateDiff: [ // [!code focus]
+        { // [!code focus]
+          slot: '0x3ea2f1d0abf3fc66cf29eebb70cbd4e7fe762ef8a09bcc06c8edf641230afec0', // [!code focus]
+          value: '0x00000000000000000000000000000000000000000000000000000000000001a4', // [!code focus]
+        }, // [!code focus]
+      ], // [!code focus]
+    } // [!code focus]
+  ], // [!code focus]
+})
+```
+
 ### value (optional)
 
 - **Type:** `bigint`
@@ -194,64 +251,6 @@ const data = await publicClient.call({
   data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1'), // [!code focus]
-})
-```
-
-### blockNumber (optional)
-
-- **Type:** `number`
-
-The block number to perform the call against.
-
-```ts
-const data = await publicClient.call({
-  blockNumber: 15121123n, // [!code focus]
-  account,
-  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-})
-```
-
-### blockTag (optional)
-
-- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
-- **Default:** `'latest'`
-
-The block tag to perform the call against.
-
-```ts
-const data = await publicClient.call({
-  blockTag: 'safe', // [!code focus]
-  account,
-  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-})
-```
-
-### stateOverride (optional)
-
-- **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
-
-The state override set is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call.
-
-```ts
-const data = await publicClient.call({
-  account,
-  data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-  stateOverride: [ // [!code focus:13]
-    {
-      address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      balance: parseEther('1'),
-      code: '0x0',
-      stateDiff: [
-        {
-          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-        },
-      ],
-    }
-  ],
 })
 ```
 

--- a/site/pages/docs/contract/multicall.md
+++ b/site/pages/docs/contract/multicall.md
@@ -277,6 +277,38 @@ const results = await publicClient.multicall({
 })
 ```
 
+### stateOverride (optional)
+
+- **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
+
+The state override set is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call.
+
+```ts
+const data = await publicClient.multicall({
+  contracts: [
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: wagmiAbi,
+      functionName: 'totalSupply',
+    },
+    ...
+  ],
+  stateOverride: [ // [!code focus:13]
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      balance: parseEther('1'),
+      code: '0x0',
+      stateDiff: [
+        {
+          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+        },
+      ],
+    }
+  ],
+})
+```
+
 ## Live Example
 
 Check out the usage of `multicall` in the live [Multicall Example](https://stackblitz.com/github/wevm/viem/tree/main/examples/contracts_multicall) below.

--- a/site/pages/docs/contract/multicall.md
+++ b/site/pages/docs/contract/multicall.md
@@ -293,19 +293,18 @@ const data = await publicClient.multicall({
     },
     ...
   ],
-  stateOverride: [ // [!code focus:13]
-    {
-      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      balance: parseEther('1'),
-      code: '0x0',
-      stateDiff: [
-        {
-          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-        },
-      ],
-    }
-  ],
+  stateOverride: [ // [!code focus]
+    { // [!code focus]
+      address: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // [!code focus]
+      balance: parseEther('1'), // [!code focus]
+      stateDiff: [ // [!code focus]
+        { // [!code focus]
+          slot: '0x3ea2f1d0abf3fc66cf29eebb70cbd4e7fe762ef8a09bcc06c8edf641230afec0', // [!code focus]
+          value: '0x00000000000000000000000000000000000000000000000000000000000001a4', // [!code focus]
+        }, // [!code focus]
+      ], // [!code focus]
+    } // [!code focus]
+  ], // [!code focus]
 })
 ```
 

--- a/site/pages/docs/contract/readContract.md
+++ b/site/pages/docs/contract/readContract.md
@@ -224,19 +224,18 @@ const data = await publicClient.readContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'totalSupply',
-  stateOverride: [ // [!code focus:13]
-    {
-      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      balance: parseEther('1'),
-      code: '0x0',
-      stateDiff: [
-        {
-          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-        },
-      ],
-    }
-  ],
+  stateOverride: [ // [!code focus]
+    { // [!code focus]
+      address: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // [!code focus]
+      balance: parseEther('1'), // [!code focus]
+      stateDiff: [ // [!code focus]
+        { // [!code focus]
+          slot: '0x3ea2f1d0abf3fc66cf29eebb70cbd4e7fe762ef8a09bcc06c8edf641230afec0', // [!code focus]
+          value: '0x00000000000000000000000000000000000000000000000000000000000001a4', // [!code focus]
+        }, // [!code focus]
+      ], // [!code focus]
+    } // [!code focus]
+  ], // [!code focus]
 })
 ```
 

--- a/site/pages/docs/contract/readContract.md
+++ b/site/pages/docs/contract/readContract.md
@@ -213,6 +213,33 @@ const data = await publicClient.readContract({
 })
 ```
 
+### stateOverride (optional)
+
+- **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
+
+The state override set is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call.
+
+```ts
+const data = await publicClient.readContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'totalSupply',
+  stateOverride: [ // [!code focus:13]
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      balance: parseEther('1'),
+      code: '0x0',
+      stateDiff: [
+        {
+          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
+        },
+      ],
+    }
+  ],
+})
+```
+
 ## Live Example
 
 Check out the usage of `readContract` in the live [Reading Contracts Example](https://stackblitz.com/github/wevm/viem/tree/main/examples/contracts_reading-contracts) below.

--- a/site/pages/docs/contract/simulateContract.md
+++ b/site/pages/docs/contract/simulateContract.md
@@ -262,104 +262,54 @@ export const publicClient = createPublicClient({
 
 :::
 
-### Simulate an approve and execute
+### State Overrides
 
 When using `simulateContract`, there sometimes needs to be an initial state change to make the transaction pass. A common use case would be an approval. For that, there are [state overrides](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth#eth-call). In the example below, we are simulating sending a token on behalf of another user. To do this, we need to modify the state of the token contract to have maximum approve from the token owner.
 
 :::code-group
 
 ```ts twoslash [example.ts]
-// @filename: config.ts
-
-import { createPublicClient, custom, http } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
-import { mainnet } from 'viem/chains'
-const PRIVATE_KEY = '0x0' as `0x${string}`
-export const account = privateKeyToAccount(PRIVATE_KEY)
- 
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-
-// @filename: constants.ts
-export const token: `0x${string}` = '0x0'
-export const otherUser: `0x${string}` = '0x0'
-export const allowanceSlot: `0x${string}` = '0x0'
-export const maxAllowance: `0x${string}` = '0x0'
-
-// @filename: abi.ts
-export const erc20abi = [
-  {
-    type: 'function',
-    name: 'transferFrom',
-    stateMutability: 'nonpayable',
-    inputs: [
-      {
-        name: 'sender',
-        type: 'address',
-      },
-      {
-        name: 'recipient',
-        type: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-      },
-    ],
-    outputs: [
-      {
-        type: 'bool',
-      },
-    ],
-  },
-] as const;
-
-// @filename: example.ts
-// ---cut---
 import { account, publicClient } from './config'
-import { erc20abi } from './abi'
-import { token, otherUser, allowanceSlot, maxAllowance } from './constants'
+import { abi, address } from './contract'
+
+// Allowance slot: A 32 bytes hex string representing the allowance slot of the sender.
+const allowanceSlot = '0x....'
+
+// Max allowance: A 32 bytes hex string representing the maximum allowance (2^256 - 1)
+const maxAllowance = numberToHex(maxUint256)
 
 const { result } = await publicClient.simulateContract({
-//      ^?
-  address: token,
-  abi: erc20abi,
-  functionName: 'transferFrom',
-  args: [otherUser, account.address, 69420n],
-  stateOverride: [
-    {
-      // modifying the state of the token contract
-      address: token,
-      stateDiff: [
-        {
-          slot: allowanceSlot,
-          value: maxAllowance,
-        },
-      ],
-    },
-  ],
+  abi,
+  address,
   account,
+  functionName: 'transferFrom',
+  args: [
+    '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', 
+    account.address, 
+    69420n
+  ],
+  stateOverride: [ // [!code hl]
+    { // [!code hl]
+      // modifying the state of the token contract // [!code hl]
+      address, // [!code hl]
+      stateDiff: [ // [!code hl]
+        { // [!code hl]
+          slot: allowanceSlot, // [!code hl]
+          value: maxAllowance, // [!code hl]
+        }, // [!code hl]
+      ], // [!code hl]
+    }, // [!code hl]
+  ], // [!code hl]
 })
 
 console.log(result)
-// @log: true
+// @log: Output: true
 ```
 
-```ts twoslash [constants.ts]
-// The address of the token contract
-export const token = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-// The address of the user we are sending the token on behalf of
-export const otherUser = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-// Allowance slot: A 32 bytes hex string representing the allowance slot of `otherUser`
-export const allowanceSlot = '0x....'
-// Max allowance: A 32 bytes hex string representing the maximum allowance (2^256 - 1)
-export const maxAllowance = '0xFFFF....'
-```
+```ts twoslash [contract.ts] filename="contract.ts"
+export const address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 
-```ts twoslash [abi.ts]
-export const erc20abi = [
+export const abi = [
   {
     type: 'function',
     name: 'transferFrom',
@@ -384,17 +334,15 @@ export const erc20abi = [
       },
     ],
   },
-] as const;
+] as const
 ```
 
-```ts twoslash [config.ts]
-const PRIVATE_KEY = '0x0' as `0x${string}`
-// ---cut---
+```ts twoslash [config.ts] filename="config.ts"
 import { createPublicClient, custom, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 
-export const account = privateKeyToAccount(PRIVATE_KEY)
+export const account = privateKeyToAccount('0x...')
  
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -509,7 +457,40 @@ const { result } = await publicClient.simulateContract({
 })
 ```
 
-### dataSuffix
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the read against.
+
+```ts
+const { result } = await publicClient.simulateContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+  blockNumber: 15121123n, // [!code focus]
+})
+```
+
+### blockTag (optional)
+
+- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
+- **Default:** `'latest'`
+
+The block tag to perform the read against.
+
+```ts
+const { result } = await publicClient.simulateContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+  blockTag: 'safe', // [!code focus]
+})
+```
+
+### dataSuffix (optional)
 
 - **Type:** `Hex`
 
@@ -610,58 +591,6 @@ const { result } = await publicClient.simulateContract({
 })
 ```
 
-### value (optional)
-
-- **Type:** `number`
-
-Value in wei sent with this transaction.
-
-```ts
-const { result } = await publicClient.simulateContract({
-  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-  abi: wagmiAbi,
-  functionName: 'mint',
-  args: [69420],
-  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-  value: parseEther('1') // [!code focus]
-})
-```
-
-
-
-### blockNumber (optional)
-
-- **Type:** `number`
-
-The block number to perform the read against.
-
-```ts
-const { result } = await publicClient.simulateContract({
-  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-  abi: wagmiAbi,
-  functionName: 'mint',
-  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-  blockNumber: 15121123n, // [!code focus]
-})
-```
-
-### blockTag (optional)
-
-- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
-- **Default:** `'latest'`
-
-The block tag to perform the read against.
-
-```ts
-const { result } = await publicClient.simulateContract({
-  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-  abi: wagmiAbi,
-  functionName: 'mint',
-  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-  blockTag: 'safe', // [!code focus]
-})
-```
-
 ### stateOverride (optional)
 
 - **Type:** [`StateOverride`](/docs/glossary/types#stateoverride)
@@ -676,19 +605,35 @@ const data = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-  stateOverride: [ // [!code focus:13]
-    {
-      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      balance: parseEther('1'),
-      code: '0x0',
-      stateDiff: [
-        {
-          slot: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-          value: "0x00000000000000000000000000000000000000000000000000000000000001a4",
-        },
-      ],
-    }
-  ],
+  stateOverride: [ // [!code focus]
+    { // [!code focus]
+      address: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // [!code focus]
+      balance: parseEther('1'), // [!code focus]
+      stateDiff: [ // [!code focus]
+        { // [!code focus]
+          slot: '0x3ea2f1d0abf3fc66cf29eebb70cbd4e7fe762ef8a09bcc06c8edf641230afec0', // [!code focus]
+          value: '0x00000000000000000000000000000000000000000000000000000000000001a4', // [!code focus]
+        }, // [!code focus]
+      ], // [!code focus]
+    } // [!code focus]
+  ], // [!code focus]
+})
+```
+
+### value (optional)
+
+- **Type:** `number`
+
+Value in wei sent with this transaction.
+
+```ts
+const { result } = await publicClient.simulateContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  args: [69420],
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+  value: parseEther('1') // [!code focus]
 })
 ```
 

--- a/site/pages/docs/glossary/types.md
+++ b/site/pages/docs/glossary/types.md
@@ -153,3 +153,7 @@ All types of transactions. `"eip1559" | "eip2930" | "eip4844" | "legacy"`
 A type for all transaction requests.
 
 [See Type](https://github.com/wevm/viem/blob/main/src/types/transaction.ts).
+
+## `StateOverride`
+
+A type defining state overrides for `eth_call` method. [See more](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth#eth-call)

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -313,12 +313,12 @@ describe('errors', () => {
       This error could arise when the account does not have enough funds to:
        - pay for the total gas fee,
        - pay for the value to send.
-
+       
       The cost of the transaction is calculated as \`gas * gas fee + value\`, where:
        - \`gas\` is the amount of gas needed for transaction to execute,
        - \`gas fee\` is the gas fee,
        - \`value\` is the amount of ether to send to the recipient.
-
+       
       Raw Call Arguments:
         from:   0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
         to:     0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
@@ -504,19 +504,19 @@ describe('errors', () => {
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [CallExecutionError: \`state\` and \`stateDiff\` are set on the same account.
+        [CallExecutionError: state and stateDiff are set on the same account.
 
-      Raw Call Arguments:
-        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
-        data:  0x06fdde03
-        State Override:
-          0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2:
-            state:
-              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
-            stateDiff:
-              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+        Raw Call Arguments:
+          to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+          data:  0x06fdde03
+          State Override:
+            0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2:
+              state:
+                0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+              stateDiff:
+                0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
 
-      Version: viem@1.0.2]
+        Version: viem@1.0.2]
       `)
     })
   })

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -389,6 +389,96 @@ describe('errors', () => {
       Version: viem@1.0.2]
     `)
   })
+
+  describe('state overrides error', () => {
+    test('wrong address', async () => {
+      await expect(
+        call(publicClient, {
+          data: name4bytes,
+          to: wagmiContractAddress,
+          stateOverride: [
+            {
+              address: '0x1',
+              stateDiff: [
+                {
+                  slot: `0x${fourTwenty}`,
+                  value: `0x${fourTwenty}`,
+                },
+              ],
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [InvalidAddressError: Address "0x1" is invalid.
+
+        Version: viem@1.0.2]
+      `)
+    })
+
+    test('duplicate address', async () => {
+      await expect(
+        call(publicClient, {
+          data: name4bytes,
+          to: wagmiContractAddress,
+          stateOverride: [
+            {
+              address: wagmiContractAddress,
+              stateDiff: [
+                {
+                  slot: `0x${fourTwenty}`,
+                  value: `0x${fourTwenty}`,
+                },
+              ],
+            },
+            {
+              address: wagmiContractAddress,
+              stateDiff: [
+                {
+                  slot: `0x${fourTwenty}`,
+                  value: `0x${fourTwenty}`,
+                },
+              ],
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [AccountStateConflictError: State for account "${wagmiContractAddress}" is set multiple times.
+
+        Version: viem@1.0.2]
+      `)
+    })
+
+    test('pass state and stateDiff', async () => {
+      await expect(
+        call(publicClient, {
+          data: name4bytes,
+          to: wagmiContractAddress,
+          stateOverride: [
+            // @ts-expect-error Cannot pass `state` and `stateDiff` at the same time
+            {
+              address: wagmiContractAddress,
+              stateDiff: [
+                {
+                  slot: `0x${fourTwenty}`,
+                  value: `0x${fourTwenty}`,
+                },
+              ],
+              state: [
+                {
+                  slot: `0x${fourTwenty}`,
+                  value: `0x${fourTwenty}`,
+                },
+              ],
+            },
+          ],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [StateAssignmentConflictError: \`state\` and \`stateDiff\` are set on the same account.
+
+        Version: viem@1.0.2]
+      `)
+    })
+  })
 })
 
 describe('batch call', () => {

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -119,7 +119,7 @@ test('args: override', async () => {
   // we don't divide by 2 because length must be length * 2 if word is strictly less than 32 bytes
   const bytesLen = fakeNameHex.length - 2
 
-  if (bytesLen > 31) throw new Error('name too long')
+  expect(bytesLen).toBeLessThanOrEqual(62)
 
   const slotValue = `${pad(fakeNameHex, { dir: 'right', size: 31 })}${toHex(
     bytesLen,

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -20,8 +20,7 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { wait } from '../../utils/wait.js'
 
-import { encodeAbiParameters, pad, toHex } from '~viem/index.js'
-import type { StateMapping } from '~viem/types/misc.js'
+import { type Hex, encodeAbiParameters, pad, toHex } from '~viem/index.js'
 import { call, getRevertErrorData } from './call.js'
 
 const wagmiContractAddress = '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2'
@@ -125,16 +124,19 @@ test('args: override', async () => {
   const slotValue = `${pad(fakeNameHex, { dir: 'right', size: 31 })}${toHex(
     bytesLen,
     { size: 1 },
-  ).slice(2)}`
+  ).slice(2)}` as Hex
 
   const { data } = await call(publicClient, {
     data: name4bytes,
     to: wagmiContractAddress,
     stateOverride: {
       [wagmiContractAddress]: {
-        stateDiff: {
-          [nameSlot]: slotValue,
-        } as StateMapping,
+        stateDiff: [
+          {
+            slot: nameSlot,
+            value: slotValue,
+          },
+        ],
       },
     },
   })

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -409,9 +409,17 @@ describe('errors', () => {
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [InvalidAddressError: Address "0x1" is invalid.
+      [CallExecutionError: Address "0x1" is invalid.
 
-        Version: viem@1.0.2]
+      Raw Call Arguments:
+        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+        data:  0x06fdde03
+        State Override:
+          0x1:
+            stateDiff:
+              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+
+      Version: viem@1.0.2]
       `)
     })
 
@@ -442,9 +450,20 @@ describe('errors', () => {
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AccountStateConflictError: State for account "${wagmiContractAddress}" is set multiple times.
+      [CallExecutionError: State for account "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2" is set multiple times.
 
-        Version: viem@1.0.2]
+      Raw Call Arguments:
+        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+        data:  0x06fdde03
+        State Override:
+          0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2:
+            stateDiff:
+              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+          0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2:
+            stateDiff:
+              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+
+      Version: viem@1.0.2]
       `)
     })
 
@@ -473,9 +492,19 @@ describe('errors', () => {
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [StateAssignmentConflictError: \`state\` and \`stateDiff\` are set on the same account.
+      [CallExecutionError: \`state\` and \`stateDiff\` are set on the same account.
 
-        Version: viem@1.0.2]
+      Raw Call Arguments:
+        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+        data:  0x06fdde03
+        State Override:
+          0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2:
+            state:
+              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+            stateDiff:
+              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+
+      Version: viem@1.0.2]
       `)
     })
   })

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -20,7 +20,7 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { wait } from '../../utils/wait.js'
 
-import { type Hex, encodeAbiParameters, pad, toHex } from '~viem/index.js'
+import { type Hex, encodeAbiParameters, pad, toHex } from '../../index.js'
 import { call, getRevertErrorData } from './call.js'
 
 const wagmiContractAddress = '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2'
@@ -129,8 +129,9 @@ test('args: override', async () => {
   const { data } = await call(publicClient, {
     data: name4bytes,
     to: wagmiContractAddress,
-    stateOverride: {
-      [wagmiContractAddress]: {
+    stateOverride: [
+      {
+        address: wagmiContractAddress,
         stateDiff: [
           {
             slot: nameSlot,
@@ -138,7 +139,7 @@ test('args: override', async () => {
           },
         ],
       },
-    },
+    ],
   })
 
   expect(data).toMatchInlineSnapshot(

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -21,7 +21,12 @@ import {
 import type { ErrorType } from '../../errors/utils.js'
 import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
-import type { Hex, RawAccountStateOverride, RawStateOverride, StateMapping } from '../../types/misc.js'
+import type {
+  Hex,
+  RawAccountStateOverride,
+  RawStateOverride,
+  StateMapping,
+} from '../../types/misc.js'
 import type { RpcTransactionRequest } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
@@ -70,15 +75,18 @@ export type AccountStateOverride = {
   balance?: bigint
   nonce?: number
   code?: Hex
-} & ({
-  /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-  state?: StateMapping,
-  stateDiff?: never,
-} | {
-  /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-  stateDiff?: StateMapping,
-  state?: never,
-})
+} & (
+  | {
+      /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+      state?: StateMapping
+      stateDiff?: never
+    }
+  | {
+      /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+      stateDiff?: StateMapping
+      state?: never
+    }
+)
 
 export type StateOverride = {
   [account: Address]: AccountStateOverride
@@ -91,18 +99,18 @@ export type CallParameters<
   batch?: boolean
 } & (
     | {
-      /** The balance of the account at a block number. */
-      blockNumber?: bigint
-      blockTag?: never
-    }
+        /** The balance of the account at a block number. */
+        blockNumber?: bigint
+        blockTag?: never
+      }
     | {
-      blockNumber?: never
-      /**
-       * The balance of the account at a block tag.
-       * @default 'latest'
-       */
-      blockTag?: BlockTag
-    }
+        blockNumber?: never
+        /**
+         * The balance of the account at a block tag.
+         * @default 'latest'
+         */
+        blockTag?: BlockTag
+      }
   ) & {
     stateOverride?: StateOverride
   }
@@ -355,14 +363,12 @@ export function getRevertErrorData(err: unknown) {
   return typeof error.data === 'object' ? error.data.data : error.data
 }
 
-export function parseAccountStateOverride(args: AccountStateOverride): RawAccountStateOverride {
-  const {
-    balance,
-    nonce,
-    ...rest
-  } = args;
+export function parseAccountStateOverride(
+  args: AccountStateOverride,
+): RawAccountStateOverride {
+  const { balance, nonce, ...rest } = args
   const rawAccountStateOverride: RawAccountStateOverride = {
-    ...rest
+    ...rest,
   }
   if (balance !== undefined) {
     rawAccountStateOverride.balance = numberToHex(balance, { size: 32 })
@@ -370,14 +376,18 @@ export function parseAccountStateOverride(args: AccountStateOverride): RawAccoun
   if (nonce !== undefined) {
     rawAccountStateOverride.nonce = numberToHex(nonce, { size: 8 })
   }
-  return rawAccountStateOverride;
+  return rawAccountStateOverride
 }
 
-export function parseStateOverride(args?: StateOverride): RawStateOverride | undefined {
+export function parseStateOverride(
+  args?: StateOverride,
+): RawStateOverride | undefined {
   if (!args) return undefined
   const rawStateOverride: RawStateOverride = {}
   for (const account in args) {
-    rawStateOverride[account as Address] = parseAccountStateOverride(args[account as Address])
+    rawStateOverride[account as Address] = parseAccountStateOverride(
+      args[account as Address],
+    )
   }
   return rawStateOverride
 }

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,14 +160,13 @@ export async function call<TChain extends Chain | undefined>(
     ...rest
   } = args
   const account = account_ ? parseAccount(account_) : undefined
+  const rpcStateOverride = parseStateOverride(stateOverride)
 
   try {
     assertRequest(args as AssertRequestParameters)
 
     const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
     const block = blockNumberHex || blockTag
-
-    const rpcStateOverride = parseStateOverride(stateOverride)
 
     const chainFormat = client.chain?.formatters?.transactionRequest?.format
     const format = chainFormat || formatTransactionRequest

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -83,18 +83,18 @@ export type CallParameters<
   batch?: boolean
 } & (
     | {
-      /** The balance of the account at a block number. */
-      blockNumber?: bigint
-      blockTag?: never
-    }
+        /** The balance of the account at a block number. */
+        blockNumber?: bigint
+        blockTag?: never
+      }
     | {
-      blockNumber?: never
-      /**
-       * The balance of the account at a block tag.
-       * @default 'latest'
-       */
-      blockTag?: BlockTag
-    }
+        blockNumber?: never
+        /**
+         * The balance of the account at a block tag.
+         * @default 'latest'
+         */
+        blockTag?: BlockTag
+      }
   ) & {
     stateOverride?: StateOverride
   }

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,13 +160,14 @@ export async function call<TChain extends Chain | undefined>(
     ...rest
   } = args
   const account = account_ ? parseAccount(account_) : undefined
-  const rpcStateOverride = parseStateOverride(stateOverride)
 
   try {
     assertRequest(args as AssertRequestParameters)
 
     const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
     const block = blockNumberHex || blockTag
+
+    const rpcStateOverride = parseStateOverride(stateOverride)
 
     const chainFormat = client.chain?.formatters?.transactionRequest?.format
     const format = chainFormat || formatTransactionRequest

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -83,18 +83,18 @@ export type CallParameters<
   batch?: boolean
 } & (
     | {
-        /** The balance of the account at a block number. */
-        blockNumber?: bigint
-        blockTag?: never
-      }
+      /** The balance of the account at a block number. */
+      blockNumber?: bigint
+      blockTag?: never
+    }
     | {
-        blockNumber?: never
-        /**
-         * The balance of the account at a block tag.
-         * @default 'latest'
-         */
-        blockTag?: BlockTag
-      }
+      blockNumber?: never
+      /**
+       * The balance of the account at a block tag.
+       * @default 'latest'
+       */
+      blockTag?: BlockTag
+    }
   ) & {
     stateOverride?: StateOverride
   }
@@ -361,22 +361,22 @@ export function parseAccountStateOverride(
   args: AccountStateOverride,
 ): RpcAccountStateOverride {
   const { balance, nonce, state, stateDiff, ...rest } = args
-  const rawAccountStateOverride: RpcAccountStateOverride = {
+  const rpcAccountStateOverride: RpcAccountStateOverride = {
     ...rest,
   }
   if (balance !== undefined) {
-    rawAccountStateOverride.balance = numberToHex(balance, { size: 32 })
+    rpcAccountStateOverride.balance = numberToHex(balance, { size: 32 })
   }
   if (nonce !== undefined) {
-    rawAccountStateOverride.nonce = numberToHex(nonce, { size: 8 })
+    rpcAccountStateOverride.nonce = numberToHex(nonce, { size: 8 })
   }
   if (state !== undefined) {
-    rawAccountStateOverride.state = parseStateMapping(state)
+    rpcAccountStateOverride.state = parseStateMapping(state)
   }
   if (stateDiff !== undefined) {
-    rawAccountStateOverride.stateDiff = parseStateMapping(stateDiff)
+    rpcAccountStateOverride.stateDiff = parseStateMapping(stateDiff)
   }
-  return rawAccountStateOverride
+  return rpcAccountStateOverride
 }
 
 export function parseStateOverride(

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -26,7 +26,9 @@ import {
 import { mainnet } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
-
+import type { Hex } from '../../types/misc.js'
+import { pad } from '../../utils/data/pad.js'
+import { toHex } from '../../utils/encoding/toHex.js'
 import { multicall } from './multicall.js'
 import * as readContract from './readContract.js'
 
@@ -276,6 +278,69 @@ test('args: multicallAddress', async () => {
       },
       {
         "result": 10000n,
+        "status": "success",
+      },
+    ]
+  `)
+})
+
+test('args: stateOverride', async () => {
+  const fakeName = 'NotWagmi'
+
+  // layout of strings in storage
+  const nameSlot = toHex(0, { size: 32 })
+  const fakeNameHex = toHex(fakeName)
+  // we don't divide by 2 because length must be length * 2 if word is strictly less than 32 bytes
+  const bytesLen = fakeNameHex.length - 2
+
+  expect(bytesLen).toBeLessThanOrEqual(62)
+
+  const slotValue = `${pad(fakeNameHex, { dir: 'right', size: 31 })}${toHex(
+    bytesLen,
+    { size: 1 },
+  ).slice(2)}` as Hex
+
+  expect(
+    await multicall(publicClient, {
+      batchSize: 2,
+      contracts: [
+        {
+          ...wagmiContractConfig,
+          functionName: 'name',
+        },
+        {
+          ...wagmiContractConfig,
+          functionName: 'name',
+        },
+        {
+          ...wagmiContractConfig,
+          functionName: 'name',
+        },
+      ],
+      stateOverride: [
+        {
+          address: wagmiContractConfig.address,
+          stateDiff: [
+            {
+              slot: nameSlot,
+              value: slotValue,
+            },
+          ],
+        },
+      ],
+    }),
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "result": "${fakeName}",
+        "status": "success",
+      },
+      {
+        "result": "${fakeName}",
+        "status": "success",
+      },
+      {
+        "result": "${fakeName}",
         "status": "success",
       },
     ]

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -42,7 +42,7 @@ export type MulticallParameters<
     optional?: boolean
     properties?: Record<string, any>
   } = {},
-> = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
+> = Pick<CallParameters, 'blockNumber' | 'blockTag' | 'stateOverride'> & {
   allowFailure?: allowFailure | boolean | undefined
   batchSize?: number | undefined
   contracts: MulticallContracts<
@@ -125,6 +125,7 @@ export async function multicall<
     blockNumber,
     blockTag,
     multicallAddress: multicallAddress_,
+    stateOverride,
   } = parameters
   const contracts = parameters.contracts as ContractFunctionParameters[]
 
@@ -218,6 +219,7 @@ export async function multicall<
         blockNumber,
         blockTag,
         functionName: 'aggregate3',
+        stateOverride,
       }),
     ),
   )

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -11,6 +11,9 @@ import { baycContractConfig, wagmiContractConfig } from '~test/src/abis.js'
 import { address, forkBlockNumber } from '~test/src/constants.js'
 import { deployErrorExample, publicClient } from '~test/src/utils.js'
 
+import type { Hex } from '../../types/misc.js'
+import { pad } from '../../utils/data/pad.js'
+import { toHex } from '../../utils/encoding/toHex.js'
 import { readContract } from './readContract.js'
 
 describe('wagmi', () => {
@@ -101,6 +104,41 @@ describe('wagmi', () => {
         args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
       }),
     ).toEqual(3n)
+  })
+
+  test('state override', async () => {
+    const fakeName = 'NotWagmi'
+
+    // layout of strings in storage
+    const nameSlot = toHex(0, { size: 32 })
+    const fakeNameHex = toHex(fakeName)
+    // we don't divide by 2 because length must be length * 2 if word is strictly less than 32 bytes
+    const bytesLen = fakeNameHex.length - 2
+
+    expect(bytesLen).toBeLessThanOrEqual(62)
+
+    const slotValue = `${pad(fakeNameHex, { dir: 'right', size: 31 })}${toHex(
+      bytesLen,
+      { size: 1 },
+    ).slice(2)}` as Hex
+
+    expect(
+      await readContract(publicClient, {
+        ...wagmiContractConfig,
+        functionName: 'name',
+        stateOverride: [
+          {
+            address: wagmiContractConfig.address,
+            stateDiff: [
+              {
+                slot: nameSlot,
+                value: slotValue,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual(fakeName)
   })
 })
 

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -106,7 +106,7 @@ describe('wagmi', () => {
     ).toEqual(3n)
   })
 
-  test('state override', async () => {
+  test('args: stateOverride', async () => {
     const fakeName = 'NotWagmi'
 
     // layout of strings in storage

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -40,7 +40,7 @@ export type ReadContractParameters<
     functionName
   > = ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
 > = UnionEvaluate<
-  Pick<CallParameters, 'account' | 'blockNumber' | 'blockTag'>
+  Pick<CallParameters, 'account' | 'blockNumber' | 'blockTag' | 'stateOverride'>
 > &
   ContractFunctionParameters<abi, 'pure' | 'view', functionName, args>
 

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -17,6 +17,7 @@ import { formatGwei } from '../utils/unit/formatGwei.js'
 
 import { AbiErrorSignatureNotFoundError } from './abi.js'
 import { BaseError } from './base.js'
+import { prettyStateOverride } from './stateOverride.js'
 import { prettyPrint } from './transaction.js'
 import { getContractAddress } from './utils.js'
 
@@ -42,10 +43,11 @@ export class CallExecutionError extends BaseError {
       nonce,
       to,
       value,
+      stateOverride,
     }: CallParameters & { chain?: Chain; docsPath?: string },
   ) {
     const account = account_ ? parseAccount(account_) : undefined
-    const prettyArgs = prettyPrint({
+    let prettyArgs = prettyPrint({
       from: account?.address,
       to,
       value:
@@ -63,6 +65,10 @@ export class CallExecutionError extends BaseError {
         `${formatGwei(maxPriorityFeePerGas)} gwei`,
       nonce,
     })
+
+    if (stateOverride) {
+      prettyArgs += `\n${prettyStateOverride(stateOverride)}`
+    }
 
     super(cause.shortMessage, {
       cause,

--- a/src/errors/data.ts
+++ b/src/errors/data.ts
@@ -57,7 +57,7 @@ export class InvalidBytesLengthError extends BaseError {
     super(
       `${type.charAt(0).toUpperCase()}${type
         .slice(1)
-        .toLowerCase()} if expected to be ${targetSize} bytes long, but is ${size} bytes long.`,
+        .toLowerCase()} is expected to be ${targetSize} ${type} long, but is ${size} ${type} long.`,
     )
   }
 }

--- a/src/errors/data.ts
+++ b/src/errors/data.ts
@@ -39,3 +39,25 @@ export class SizeExceedsPaddingSizeError extends BaseError {
     )
   }
 }
+
+export type InvalidBytesLengthErrorType = InvalidBytesLengthError & {
+  name: 'InvalidBytesLengthError'
+}
+export class InvalidBytesLengthError extends BaseError {
+  override name = 'InvalidBytesLengthError'
+  constructor({
+    size,
+    targetSize,
+    type,
+  }: {
+    size: number
+    targetSize: number
+    type: 'hex' | 'bytes'
+  }) {
+    super(
+      `${type.charAt(0).toUpperCase()}${type
+        .slice(1)
+        .toLowerCase()} if expected to be ${targetSize} bytes long, but is ${size} bytes long.`,
+    )
+  }
+}

--- a/src/errors/stateOverride.test.ts
+++ b/src/errors/stateOverride.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+
+import {
+  AccountStateConflictError,
+  StateAssignmentConflictError,
+} from './stateOverride.js'
+
+test('AccountStateConflictError', () => {
+  expect(
+    new AccountStateConflictError({
+      address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+    }),
+  ).toMatchInlineSnapshot(`
+    [AccountStateConflictError: State for account "0xd8da6bf26964af9d7eed9e03e53415d37aa96045" is set multiple times.
+
+    Version: viem@1.0.2]
+  `)
+})
+
+test('StateAssignmentConflictError', () => {
+  expect(new StateAssignmentConflictError()).toMatchInlineSnapshot(`
+    [StateAssignmentConflictError: \`state\` and \`stateDiff\` are set on the same account.
+
+    Version: viem@1.0.2]
+  `)
+})

--- a/src/errors/stateOverride.ts
+++ b/src/errors/stateOverride.ts
@@ -1,0 +1,23 @@
+import { BaseError } from './base.js'
+
+export type AccountStateConflictErrorType = AccountStateConflictError & {
+  name: 'AccountStateConflictError'
+}
+
+export class AccountStateConflictError extends BaseError {
+  override name = 'AccountStateConflictError'
+  constructor({ address }: { address: string }) {
+    super(`State for account "${address}" is set multiple times.`)
+  }
+}
+
+export type StateAssignmentConflictErrorType = StateAssignmentConflictError & {
+  name: 'StateAssignmentConflictError'
+}
+
+export class StateAssignmentConflictError extends BaseError {
+  override name = 'StateAssignmentConflictError'
+  constructor() {
+    super('`state` and `stateDiff` are set on the same account.')
+  }
+}

--- a/src/errors/stateOverride.ts
+++ b/src/errors/stateOverride.ts
@@ -1,3 +1,4 @@
+import type { StateMapping, StateOverride } from '../types/stateOverride.js'
 import { BaseError } from './base.js'
 
 export type AccountStateConflictErrorType = AccountStateConflictError & {
@@ -20,4 +21,30 @@ export class StateAssignmentConflictError extends BaseError {
   constructor() {
     super('`state` and `stateDiff` are set on the same account.')
   }
+}
+
+export function prettyStateMapping(stateMapping: StateMapping) {
+  return stateMapping.reduce((pretty, { slot, value }) => {
+    return `${pretty}        ${slot}: ${value}\n`
+  }, '')
+}
+
+export function prettyStateOverride(stateOverride: StateOverride) {
+  return stateOverride
+    .reduce((pretty, { address, ...state }) => {
+      let val = `${pretty}    ${address}:\n`
+      if (state.nonce) val += `      nonce: ${state.nonce}\n`
+      if (state.balance) val += `      balance: ${state.balance}\n`
+      if (state.code) val += `      code: ${state.code}\n`
+      if (state.state) {
+        val += '      state:\n'
+        val += prettyStateMapping(state.state)
+      }
+      if (state.stateDiff) {
+        val += '      stateDiff:\n'
+        val += prettyStateMapping(state.stateDiff)
+      }
+      return val
+    }, '  State Override:\n')
+    .slice(0, -1)
 }

--- a/src/errors/stateOverride.ts
+++ b/src/errors/stateOverride.ts
@@ -19,7 +19,7 @@ export type StateAssignmentConflictErrorType = StateAssignmentConflictError & {
 export class StateAssignmentConflictError extends BaseError {
   override name = 'StateAssignmentConflictError'
   constructor() {
-    super('`state` and `stateDiff` are set on the same account.')
+    super('state and stateDiff are set on the same account.')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -852,6 +852,12 @@ export {
   UrlRequiredError,
   type UrlRequiredErrorType,
 } from './errors/transport.js'
+export {
+  AccountStateConflictError,
+  type AccountStateConflictErrorType,
+  StateAssignmentConflictError,
+  type StateAssignmentConflictErrorType,
+} from './errors/stateOverride.js'
 export type {
   AbiItem,
   ExtractAbiFunctionForArgs,
@@ -973,8 +979,15 @@ export type {
   RpcUncle,
   Status,
   RpcProof,
+  RpcAccountStateOverride,
+  RpcStateOverride,
+  RpcStateMapping,
 } from './types/rpc.js'
 export type { Withdrawal } from './types/withdrawal.js'
+export type {
+  StateMapping,
+  StateOverride,
+} from './types/stateOverride.js'
 export { labelhash, type LabelhashErrorType } from './utils/ens/labelhash.js'
 export { namehash, type NamehashErrorType } from './utils/ens/namehash.js'
 export {

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -227,16 +227,16 @@ export type PublicRpcSchema = [
   {
     Method: 'eth_call'
     Parameters:
-    | [transaction: Partial<TransactionRequest>]
-    | [
-      transaction: Partial<TransactionRequest>,
-      block: BlockNumber | BlockTag | BlockIdentifier,
-    ]
-    | [
-      transaction: Partial<TransactionRequest>,
-      block: BlockNumber | BlockTag | BlockIdentifier,
-      stateOverrideSet: RawStateOverride,
-    ]
+      | [transaction: Partial<TransactionRequest>]
+      | [
+          transaction: Partial<TransactionRequest>,
+          block: BlockNumber | BlockTag | BlockIdentifier,
+        ]
+      | [
+          transaction: Partial<TransactionRequest>,
+          block: BlockNumber | BlockTag | BlockIdentifier,
+          stateOverrideSet: RawStateOverride,
+        ]
     ReturnType: Hex
   },
   /**
@@ -274,8 +274,8 @@ export type PublicRpcSchema = [
   {
     Method: 'eth_estimateGas'
     Parameters:
-    | [transaction: TransactionRequest]
-    | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+      | [transaction: TransactionRequest]
+      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
     ReturnType: Quantity
   },
   /**
@@ -454,15 +454,15 @@ export type PublicRpcSchema = [
         topics?: LogTopic[]
       } & (
         | {
-          fromBlock?: BlockNumber | BlockTag
-          toBlock?: BlockNumber | BlockTag
-          blockHash?: never
-        }
+            fromBlock?: BlockNumber | BlockTag
+            toBlock?: BlockNumber | BlockTag
+            blockHash?: never
+          }
         | {
-          fromBlock?: never
-          toBlock?: never
-          blockHash?: Hash
-        }
+            fromBlock?: never
+            toBlock?: never
+            blockHash?: Hash
+          }
       ),
     ]
     ReturnType: Log[]
@@ -1138,8 +1138,8 @@ export type WalletRpcSchema = [
   {
     Method: 'eth_estimateGas'
     Parameters:
-    | [transaction: TransactionRequest]
-    | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+      | [transaction: TransactionRequest]
+      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
     ReturnType: Quantity
   },
   /**
@@ -1330,22 +1330,22 @@ export type EIP1193Parameters<
   TRpcSchema extends RpcSchema | undefined = undefined,
 > = TRpcSchema extends RpcSchema
   ? {
-    [K in keyof TRpcSchema]: Prettify<
-      {
-        method: TRpcSchema[K] extends TRpcSchema[number]
-        ? TRpcSchema[K]['Method']
-        : never
-      } & (TRpcSchema[K] extends TRpcSchema[number]
-        ? TRpcSchema[K]['Parameters'] extends undefined
-        ? { params?: never }
-        : { params: TRpcSchema[K]['Parameters'] }
-        : never)
-    >
-  }[number]
+      [K in keyof TRpcSchema]: Prettify<
+        {
+          method: TRpcSchema[K] extends TRpcSchema[number]
+            ? TRpcSchema[K]['Method']
+            : never
+        } & (TRpcSchema[K] extends TRpcSchema[number]
+          ? TRpcSchema[K]['Parameters'] extends undefined
+            ? { params?: never }
+            : { params: TRpcSchema[K]['Parameters'] }
+          : never)
+      >
+    }[number]
   : {
-    method: string
-    params?: unknown
-  }
+      method: string
+      params?: unknown
+    }
 
 export type EIP1193RequestOptions = {
   // The base delay (in ms) between retries.
@@ -1372,11 +1372,11 @@ export type EIP1193RequestFn<
     TRpcSchema,
     TRpcSchemaOverride
   > extends RpcSchema
-  ? Extract<
-    DerivedRpcSchema<TRpcSchema, TRpcSchemaOverride>[number],
-    { Method: TParameters['method'] }
-  >['ReturnType']
-  : unknown,
+    ? Extract<
+        DerivedRpcSchema<TRpcSchema, TRpcSchemaOverride>[number],
+        { Method: TParameters['method'] }
+      >['ReturnType']
+    : unknown,
 >(
   args: TParameters,
   options?: EIP1193RequestOptions,

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'abitype'
 
 import type { BlockTag } from './block.js'
-import type { Hash, Hex, LogTopic } from './misc.js'
+import type { Hash, Hex, LogTopic, StateOverrideSet } from './misc.js'
 import type {
   Quantity,
   RpcBlock as Block,
@@ -231,6 +231,11 @@ export type PublicRpcSchema = [
       | [
           transaction: Partial<TransactionRequest>,
           block: BlockNumber | BlockTag | BlockIdentifier,
+        ]
+      | [
+          transaction: Partial<TransactionRequest>,
+          block: BlockNumber | BlockTag | BlockIdentifier,
+          stateOverrideSet: StateOverrideSet,
         ]
     ReturnType: Hex
   },

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'abitype'
 
 import type { BlockTag } from './block.js'
-import type { Hash, Hex, LogTopic, StateOverrideSet } from './misc.js'
+import type { Hash, Hex, LogTopic, RawStateOverride } from './misc.js'
 import type {
   Quantity,
   RpcBlock as Block,
@@ -227,16 +227,16 @@ export type PublicRpcSchema = [
   {
     Method: 'eth_call'
     Parameters:
-      | [transaction: Partial<TransactionRequest>]
-      | [
-          transaction: Partial<TransactionRequest>,
-          block: BlockNumber | BlockTag | BlockIdentifier,
-        ]
-      | [
-          transaction: Partial<TransactionRequest>,
-          block: BlockNumber | BlockTag | BlockIdentifier,
-          stateOverrideSet: StateOverrideSet,
-        ]
+    | [transaction: Partial<TransactionRequest>]
+    | [
+      transaction: Partial<TransactionRequest>,
+      block: BlockNumber | BlockTag | BlockIdentifier,
+    ]
+    | [
+      transaction: Partial<TransactionRequest>,
+      block: BlockNumber | BlockTag | BlockIdentifier,
+      stateOverrideSet: RawStateOverride,
+    ]
     ReturnType: Hex
   },
   /**
@@ -274,8 +274,8 @@ export type PublicRpcSchema = [
   {
     Method: 'eth_estimateGas'
     Parameters:
-      | [transaction: TransactionRequest]
-      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+    | [transaction: TransactionRequest]
+    | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
     ReturnType: Quantity
   },
   /**
@@ -454,15 +454,15 @@ export type PublicRpcSchema = [
         topics?: LogTopic[]
       } & (
         | {
-            fromBlock?: BlockNumber | BlockTag
-            toBlock?: BlockNumber | BlockTag
-            blockHash?: never
-          }
+          fromBlock?: BlockNumber | BlockTag
+          toBlock?: BlockNumber | BlockTag
+          blockHash?: never
+        }
         | {
-            fromBlock?: never
-            toBlock?: never
-            blockHash?: Hash
-          }
+          fromBlock?: never
+          toBlock?: never
+          blockHash?: Hash
+        }
       ),
     ]
     ReturnType: Log[]
@@ -1138,8 +1138,8 @@ export type WalletRpcSchema = [
   {
     Method: 'eth_estimateGas'
     Parameters:
-      | [transaction: TransactionRequest]
-      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+    | [transaction: TransactionRequest]
+    | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
     ReturnType: Quantity
   },
   /**
@@ -1330,22 +1330,22 @@ export type EIP1193Parameters<
   TRpcSchema extends RpcSchema | undefined = undefined,
 > = TRpcSchema extends RpcSchema
   ? {
-      [K in keyof TRpcSchema]: Prettify<
-        {
-          method: TRpcSchema[K] extends TRpcSchema[number]
-            ? TRpcSchema[K]['Method']
-            : never
-        } & (TRpcSchema[K] extends TRpcSchema[number]
-          ? TRpcSchema[K]['Parameters'] extends undefined
-            ? { params?: never }
-            : { params: TRpcSchema[K]['Parameters'] }
-          : never)
-      >
-    }[number]
+    [K in keyof TRpcSchema]: Prettify<
+      {
+        method: TRpcSchema[K] extends TRpcSchema[number]
+        ? TRpcSchema[K]['Method']
+        : never
+      } & (TRpcSchema[K] extends TRpcSchema[number]
+        ? TRpcSchema[K]['Parameters'] extends undefined
+        ? { params?: never }
+        : { params: TRpcSchema[K]['Parameters'] }
+        : never)
+    >
+  }[number]
   : {
-      method: string
-      params?: unknown
-    }
+    method: string
+    params?: unknown
+  }
 
 export type EIP1193RequestOptions = {
   // The base delay (in ms) between retries.
@@ -1372,11 +1372,11 @@ export type EIP1193RequestFn<
     TRpcSchema,
     TRpcSchemaOverride
   > extends RpcSchema
-    ? Extract<
-        DerivedRpcSchema<TRpcSchema, TRpcSchemaOverride>[number],
-        { Method: TParameters['method'] }
-      >['ReturnType']
-    : unknown,
+  ? Extract<
+    DerivedRpcSchema<TRpcSchema, TRpcSchemaOverride>[number],
+    { Method: TParameters['method'] }
+  >['ReturnType']
+  : unknown,
 >(
   args: TParameters,
   options?: EIP1193RequestOptions,

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1,7 +1,8 @@
 import type { Address } from 'abitype'
 
 import type { BlockTag } from './block.js'
-import type { Hash, Hex, LogTopic, RawStateOverride } from './misc.js'
+import type { Hash, Hex, LogTopic } from './misc.js'
+import type { RpcStateOverride } from './rpc.js'
 import type {
   Quantity,
   RpcBlock as Block,
@@ -235,7 +236,7 @@ export type PublicRpcSchema = [
       | [
           transaction: Partial<TransactionRequest>,
           block: BlockNumber | BlockTag | BlockIdentifier,
-          stateOverrideSet: RawStateOverride,
+          stateOverrideSet: RpcStateOverride,
         ]
     ReturnType: Hex
   },

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 export type ByteArray = Uint8Array
 export type Hex = `0x${string}`
 export type Hash = `0x${string}`
@@ -16,4 +17,25 @@ export type Signature = {
 export type CompactSignature = {
   r: Hex
   yParityAndS: Hex
+}
+
+export type StateOverride = {
+  [slots: Hex]: Hex
+}
+
+export type SingleAccountStateOverrideSet = {
+  /** Fake balance to set for the account before executing the call. <32 bytes */
+  balance?: Hex
+  /** Fake nonce to set for the account before executing the call. <8 bytes */
+  nonce?: Hex
+  /** Fake EVM bytecode to inject into the account before executing the call. */
+  code?: Hex
+  /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+  state?: StateOverride
+  /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+  stateDiff?: StateOverride
+}
+
+export type StateOverrideSet = {
+  [address: Address]: SingleAccountStateOverrideSet
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,4 +1,3 @@
-import type { Address } from 'abitype'
 export type ByteArray = Uint8Array
 export type Hex = `0x${string}`
 export type Hash = `0x${string}`
@@ -17,26 +16,4 @@ export type Signature = {
 export type CompactSignature = {
   r: Hex
   yParityAndS: Hex
-}
-
-/** A key-value mapping of slot and storage values (supposedly 32 bytes each) */
-export type StateMapping = {
-  [slots: Hex]: Hex
-}
-
-export type RawAccountStateOverride = Partial<{
-  /** Fake balance to set for the account before executing the call. <32 bytes */
-  balance: Hex
-  /** Fake nonce to set for the account before executing the call. <8 bytes */
-  nonce: Hex
-  /** Fake EVM bytecode to inject into the account before executing the call. */
-  code: Hex
-  /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-  state: StateMapping
-  /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-  stateDiff: StateMapping
-}>
-
-export type RawStateOverride = {
-  [address: Address]: RawAccountStateOverride
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -6,9 +6,9 @@ export type LogTopic = Hex | Hex[] | null
 export type SignableMessage =
   | string
   | {
-    /** Raw data representation of the message. */
-    raw: Hex | ByteArray
-  }
+      /** Raw data representation of the message. */
+      raw: Hex | ByteArray
+    }
 export type Signature = {
   r: Hex
   s: Hex

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -6,9 +6,9 @@ export type LogTopic = Hex | Hex[] | null
 export type SignableMessage =
   | string
   | {
-      /** Raw data representation of the message. */
-      raw: Hex | ByteArray
-    }
+    /** Raw data representation of the message. */
+    raw: Hex | ByteArray
+  }
 export type Signature = {
   r: Hex
   s: Hex
@@ -19,23 +19,24 @@ export type CompactSignature = {
   yParityAndS: Hex
 }
 
-export type StateOverride = {
+/** A key-value mapping of slot and storage values (supposedly 32 bytes each) */
+export type StateMapping = {
   [slots: Hex]: Hex
 }
 
-export type SingleAccountStateOverrideSet = {
+export type RawAccountStateOverride = Partial<{
   /** Fake balance to set for the account before executing the call. <32 bytes */
-  balance?: Hex
+  balance: Hex
   /** Fake nonce to set for the account before executing the call. <8 bytes */
-  nonce?: Hex
+  nonce: Hex
   /** Fake EVM bytecode to inject into the account before executing the call. */
-  code?: Hex
+  code: Hex
   /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-  state?: StateOverride
+  state: StateMapping
   /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-  stateDiff?: StateOverride
-}
+  stateDiff: StateMapping
+}>
 
-export type StateOverrideSet = {
-  [address: Address]: SingleAccountStateOverrideSet
+export type RawStateOverride = {
+  [address: Address]: RawAccountStateOverride
 }

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 import type {
   Block,
   BlockIdentifier,
@@ -7,6 +8,7 @@ import type {
 } from './block.js'
 import type { FeeHistory, FeeValues } from './fee.js'
 import type { Log } from './log.js'
+import type { Hex } from './misc.js'
 import type { Proof } from './proof.js'
 import type {
   TransactionEIP1559,
@@ -103,3 +105,25 @@ export type RpcResponse<TResult = any, TError = any> = {
   | ErrorResult<TError>
   | Subscription<TResult, TError>
 )
+
+/** A key-value mapping of slot and storage values (supposedly 32 bytes each) */
+export type RpcStateMapping = {
+  [slots: Hex]: Hex
+}
+
+export type RpcAccountStateOverride = {
+  /** Fake balance to set for the account before executing the call. <32 bytes */
+  balance?: Hex
+  /** Fake nonce to set for the account before executing the call. <8 bytes */
+  nonce?: Hex
+  /** Fake EVM bytecode to inject into the account before executing the call. */
+  code?: Hex
+  /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+  state?: RpcStateMapping
+  /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+  stateDiff?: RpcStateMapping
+}
+
+export type RpcStateOverride = {
+  [address: Address]: RpcAccountStateOverride
+}

--- a/src/types/stateOverride.ts
+++ b/src/types/stateOverride.ts
@@ -1,0 +1,27 @@
+import type { Address } from 'abitype'
+import type { Hex } from './misc.js'
+import type { OneOf } from './utils.js'
+
+export type StateMapping = Array<{
+  slot: Hex
+  value: Hex
+}>
+
+export type AccountStateOverride = {
+  balance?: bigint
+  nonce?: number
+  code?: Hex
+} & OneOf<
+  | {
+      /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+      state?: StateMapping
+    }
+  | {
+      /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+      stateDiff?: StateMapping
+    }
+>
+
+export type StateOverride = {
+  [account: Address]: AccountStateOverride
+}

--- a/src/types/stateOverride.ts
+++ b/src/types/stateOverride.ts
@@ -7,21 +7,18 @@ export type StateMapping = Array<{
   value: Hex
 }>
 
-export type AccountStateOverride = {
+export type StateOverride = Array<{
+  address: Address
   balance?: bigint
   nonce?: number
   code?: Hex
 } & OneOf<
   | {
-      /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-      state?: StateMapping
-    }
+    /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+    state?: StateMapping
+  }
   | {
-      /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-      stateDiff?: StateMapping
-    }
->
-
-export type StateOverride = {
-  [account: Address]: AccountStateOverride
-}
+    /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+    stateDiff?: StateMapping
+  }
+>>

--- a/src/types/stateOverride.ts
+++ b/src/types/stateOverride.ts
@@ -7,18 +7,20 @@ export type StateMapping = Array<{
   value: Hex
 }>
 
-export type StateOverride = Array<{
-  address: Address
-  balance?: bigint
-  nonce?: number
-  code?: Hex
-} & OneOf<
-  | {
-    /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-    state?: StateMapping
-  }
-  | {
-    /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-    stateDiff?: StateMapping
-  }
->>
+export type StateOverride = Array<
+  {
+    address: Address
+    balance?: bigint
+    nonce?: number
+    code?: Hex
+  } & OneOf<
+    | {
+        /** Fake key-value mapping to override all slots in the account storage before executing the call. */
+        state?: StateMapping
+      }
+    | {
+        /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
+        stateDiff?: StateMapping
+      }
+  >
+>


### PR DESCRIPTION
## What

The goal of this PR is to add state overrides to call and `eth_call` EIP1193 types. These overrides are helpful in many cases. It modifies the state of selected accounts before the transaction. It is a default feature in geth. It allows to modify:

- The balance of the account
- The code on a given account
- The state (key-value mapping representation of the storage) either on top of the account storage or completely override it.

## Why

I only added the rpc schema and changed the "low-level" call function. But the first case scenario that comes in mind is the approve and swap transaction simulation.

If you know the mapping key for the allowances, you could change the allowance to the max allowance before a `simulateContract` call. This would allow a cheap onchain simulation of the rates you could get.

```ts
const { result } = await publicClient.simulateContract({
  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
  abi: mangroveABI,
  functionName: 'marketOrderByTick',
  account,
  stateOverride: {
    // modify the state of the USDT contract
    [USDT_ADDRESS]: {
      // Allows to modify storage while keeping other storage intact
      stateDiff: {
        // modify the storage slot corresponding to allowance
        [userAllowanceSlot]: "0xffffffffff...",
      }
    }
  }
})
```

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding the `stateOverride` property to various functions (`call`, `simulateContract`, `readContract`, and `multicall`) and introducing related types and error classes.

### Detailed summary:
- Added `stateOverride` property to `call`, `simulateContract`, `readContract`, and `multicall` functions.
- Added `StateOverride` type defining state overrides for `eth_call` method.
- Added `InvalidBytesLengthErrorType` and `InvalidBytesLengthError` classes.
- Added `RpcStateOverride` and `RpcStateMapping` types.
- Added `StateMapping` and `StateOverride` types.
- Added `AccountStateConflictErrorType`, `AccountStateConflictError`, `StateAssignmentConflictErrorType`, and `StateAssignmentConflictError` classes.
- Updated various files with the new changes.

> The following files were skipped due to too many changes: `src/errors/stateOverride.ts`, `src/actions/public/multicall.test.ts`, `site/pages/docs/actions/public/call.md`, `src/actions/public/call.ts`, `site/pages/docs/contract/simulateContract.md`, `src/actions/public/call.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->