### PR TITLE
feat: rename optimism sepolia chain

### DIFF
--- a/.changeset/chatty-ducks-brake.md
+++ b/.changeset/chatty-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Renamed Optimism Sepolia chain

--- a/src/chains/definitions/optimismSepolia.ts
+++ b/src/chains/definitions/optimismSepolia.ts
@@ -6,7 +6,7 @@ const sourceId = 11_155_111 // sepolia
 export const optimismSepolia = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 11155420,
-  name: 'Optimism Sepolia',
+  name: 'OP Sepolia',
   nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {


### PR DESCRIPTION
# Description

The chain Optimism Sepolia is officially referred to as `OP Sepolia`, as documented in their official guidelines available at: https://docs.optimism.io/chain/networks#op-sepolia.

address: franm.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the Optimism Sepolia chain to OP Sepolia. 

### Detailed summary
- Renamed the chain name from 'Optimism Sepolia' to 'OP Sepolia' in the chain definition file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->