### PR TITLE
fix: typo in getWithdrawalStatus docs

### DIFF
--- a/site/pages/op-stack/actions/getWithdrawalStatus.md
+++ b/site/pages/op-stack/actions/getWithdrawalStatus.md
@@ -69,7 +69,7 @@ The L2 chain.
 
 ```ts
 const status = await publicClientL1.getWithdrawalStatus({
-  l2BlockNumber,
+  receipt,
   targetChain: optimism, // [!code focus]
 })
 ```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Changed the parameter `l2BlockNumber` to `receipt` in the `getWithdrawalStatus` function.
- Updated the `targetChain` parameter to `optimism`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->