### PR TITLE
Docs: Update link to publicClient.verifyMessage Action

### DIFF
--- a/site/pages/docs/utilities/verifyMessage.md
+++ b/site/pages/docs/utilities/verifyMessage.md
@@ -8,7 +8,7 @@ Verify that a message was signed by the provided address.
 
 :::warning[Warning]
 This utility can only verify a message that was signed by an Externally Owned Account (EOA).
-To verify messages from Contract Accounts (& EOA), use the [`publicClient.verifyMessage` Action](../actions/public/verifyMessage.md) instead.
+To verify messages from Contract Accounts (& EOA), use the [`publicClient.verifyMessage` Action](/docs/actions/public/verifyMessage) instead.
 :::
 
 ## Usage

--- a/site/pages/docs/utilities/verifyTypedData.md
+++ b/site/pages/docs/utilities/verifyTypedData.md
@@ -8,7 +8,7 @@ Verify that typed data was signed by the provided address.
 
 :::warning[Warning]
 This utility can only verify typed data that was signed by an Externally Owned Account (EOA).
-To verify messages from Contract Accounts (& EOA), use the [`publicClient.verifyMessage` Action](../actions/public/verifyMessage.md) instead.
+To verify messages from Contract Accounts (& EOA), use the [`publicClient.verifyMessage` Action](/docs/actions/public/verifyMessage) instead.
 :::
 
 ## Usage


### PR DESCRIPTION
## Description
In the [utilities/verifyMessage](https://viem.sh/docs/utilities/verifyMessage) and [utilities/verifyTypedData](https://viem.sh/docs/utilities/verifyTypedData) sections, you reference  publicClient.verifyMessage Action

Previous link: https://viem.sh/vercel/path0/site/pages/docs/actions/public/verifyMessage (Not found)
Correct placement: https://viem.sh/docs/actions/public/verifyMessage

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the file paths in the warning messages for the `verifyMessage` utility. 

### Detailed summary
- Updated the file path in the warning message in `verifyMessage.md` from `../actions/public/verifyMessage.md` to `/docs/actions/public/verifyMessage`.
- Updated the file path in the warning message in `verifyTypedData.md` from `../actions/public/verifyMessage.md` to `/docs/actions/public/verifyMessage`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->