### PR TITLE
fix: Passing gas in proveTransaction

### DIFF
--- a/.changeset/tame-mirrors-tan.md
+++ b/.changeset/tame-mirrors-tan.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `gas` derivation in OP Stack's `proveWithdrawal`.

--- a/src/chains/opStack/actions/proveWithdrawal.ts
+++ b/src/chains/opStack/actions/proveWithdrawal.ts
@@ -134,7 +134,7 @@ export async function proveWithdrawal<
           client,
           parameters as EstimateProveWithdrawalGasParameters,
         )
-      : undefined
+      : (gas ?? undefined)
 
   return writeContract(client, {
     account,


### PR DESCRIPTION
Was reading the code for unrelated reason and thought this might have been a bug. Seemed like we weren't passing the gas parameter if it was defined

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing the `gas` derivation in the `proveWithdrawal` function of the OP Stack.

### Detailed summary:
- Fixed the `gas` derivation in the `proveWithdrawal` function of the OP Stack's `actions/proveWithdrawal.ts` file.
- Replaced the `undefined` value with `(gas ?? undefined)` in the function's parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->