### PR TITLE
Fix checksum validation on isAddress

### DIFF
--- a/.changeset/heavy-steaks-heal.md
+++ b/.changeset/heavy-steaks-heal.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Upgrade isAddress to return false for invalid checksummed addresses

--- a/src/accounts/toAccount.test.ts
+++ b/src/accounts/toAccount.test.ts
@@ -18,6 +18,9 @@ describe('toAccount', () => {
     expect(() => toAccount('0x1')).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0x1" is invalid.
 
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
       Version: viem@1.0.2]
     `)
   })
@@ -64,6 +67,9 @@ describe('toAccount', () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0x1" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `)

--- a/src/accounts/toAccount.ts
+++ b/src/accounts/toAccount.ts
@@ -35,14 +35,15 @@ export function toAccount<TAccountSource extends AccountSource>(
   source: TAccountSource,
 ): GetAccountReturnType<TAccountSource> {
   if (typeof source === 'string') {
-    if (!isAddress(source)) throw new InvalidAddressError({ address: source })
+    if (!isAddress(source, { strict: false }))
+      throw new InvalidAddressError({ address: source })
     return {
       address: source,
       type: 'json-rpc',
     } as GetAccountReturnType<TAccountSource>
   }
 
-  if (!isAddress(source.address))
+  if (!isAddress(source.address, { strict: false }))
     throw new InvalidAddressError({ address: source.address })
   return {
     address: source.address,

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -421,17 +421,20 @@ describe('errors', () => {
           ],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [CallExecutionError: Address "0x1" is invalid.
+        [CallExecutionError: Address "0x1" is invalid.
 
-      Raw Call Arguments:
-        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
-        data:  0x06fdde03
-        State Override:
-          0x1:
-            stateDiff:
-              0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
+        - Address must be a hex value of 20 bytes (40 hex characters).
+        - Address must match its checksum counterpart.
+         
+        Raw Call Arguments:
+          to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+          data:  0x06fdde03
+          State Override:
+            0x1:
+              stateDiff:
+                0x00000000000000000000000000000000000000000000000000000000000001a4: 0x00000000000000000000000000000000000000000000000000000000000001a4
 
-      Version: viem@1.0.2]
+        Version: viem@1.0.2]
       `)
     })
 

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -423,7 +423,8 @@ export function parseStateOverride(
   if (!args) return undefined
   const rpcStateOverride: RpcStateOverride = {}
   for (const { address, ...accountState } of args) {
-    if (!isAddress(address)) throw new InvalidAddressError({ address })
+    if (!isAddress(address, { strict: false }))
+      throw new InvalidAddressError({ address })
     if (rpcStateOverride[address])
       throw new AccountStateConflictError({ address: address })
     rpcStateOverride[address] = parseAccountStateOverride(accountState)

--- a/src/chains/opStack/serializers.test.ts
+++ b/src/chains/opStack/serializers.test.ts
@@ -99,6 +99,9 @@ describe('deposit', async () => {
       `
       [InvalidAddressError: Address "0xaabbccddeeff00112233445566778899aabbccd" is invalid.
 
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
       Version: viem@1.0.2]
     `,
     )
@@ -112,6 +115,9 @@ describe('deposit', async () => {
     expect(() => serializeTransaction(tx)).toThrowErrorMatchingInlineSnapshot(
       `
       [InvalidAddressError: Address "0xaabbccddeeff00112233445566778899aabbccd" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `,

--- a/src/chains/zksync/utils/assertEip712Transaction.test.ts
+++ b/src/chains/zksync/utils/assertEip712Transaction.test.ts
@@ -47,6 +47,9 @@ test('default', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 
@@ -59,6 +62,9 @@ test('default', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 
@@ -70,6 +76,9 @@ test('default', () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x" is invalid.
+
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
 
     Version: viem@1.0.2]
   `)

--- a/src/errors/address.test.ts
+++ b/src/errors/address.test.ts
@@ -10,6 +10,9 @@ test('InvalidAddressError', () => {
   ).toMatchInlineSnapshot(`
     [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 })

--- a/src/errors/address.ts
+++ b/src/errors/address.ts
@@ -6,6 +6,11 @@ export type InvalidAddressErrorType = InvalidAddressError & {
 export class InvalidAddressError extends BaseError {
   override name = 'InvalidAddressError'
   constructor({ address }: { address: string }) {
-    super(`Address "${address}" is invalid.`)
+    super(`Address "${address}" is invalid.`, {
+      metaMessages: [
+        '- Address must be a hex value of 20 bytes (40 hex characters).',
+        '- Address must match its checksum counterpart.',
+      ],
+    })
   }
 }

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1721,6 +1721,9 @@ test('invalid address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x111" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 })

--- a/src/utils/abi/encodePacked.test.ts
+++ b/src/utils/abi/encodePacked.test.ts
@@ -222,6 +222,9 @@ test('error: invalid address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0xdeadbeef" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 })

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -155,7 +155,7 @@ export function isArgOfType(arg: unknown, abiParameter: AbiParameter): boolean {
   const abiParameterType = abiParameter.type
   switch (abiParameterType) {
     case 'address':
-      return isAddress(arg as Address)
+      return isAddress(arg as Address, { strict: false })
     case 'bool':
       return argType === 'boolean'
     case 'function':
@@ -233,9 +233,9 @@ export function getAmbiguousTypes(
     const ambiguous = (() => {
       if (types.includes('address') && types.includes('bytes20')) return true
       if (types.includes('address') && types.includes('string'))
-        return isAddress(args[parameterIndex] as Address)
+        return isAddress(args[parameterIndex] as Address, { strict: false })
       if (types.includes('address') && types.includes('bytes'))
-        return isAddress(args[parameterIndex] as Address)
+        return isAddress(args[parameterIndex] as Address, { strict: false })
       return false
     })()
 

--- a/src/utils/address/getAddress.test.ts
+++ b/src/utils/address/getAddress.test.ts
@@ -4,9 +4,6 @@ import { getAddress } from './getAddress.js'
 
 test('checksums address', () => {
   expect(
-    getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac'),
-  ).toMatchInlineSnapshot('"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"')
-  expect(
     getAddress('0xa0cf798816d4b9b9866b5330eea46a18382f251e'),
   ).toMatchInlineSnapshot('"0xA0Cf798816D4b9b9866b5330EEa46a18382f251e"')
   expect(
@@ -35,9 +32,22 @@ test('checksums address', () => {
 describe('errors', () => {
   test('invalid address', () => {
     expect(() =>
+      getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
+      Version: viem@1.0.2]
+    `)
+    expect(() =>
       getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az'),
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `)
@@ -46,12 +56,18 @@ describe('errors', () => {
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678aff" is invalid.
 
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
       Version: viem@1.0.2]
     `)
     expect(() =>
       getAddress('a5cc3c03994db5b0d9a5eEdD10Cabab0813678ac'),
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "a5cc3c03994db5b0d9a5eEdD10Cabab0813678ac" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `)

--- a/src/utils/address/isAddress.test.ts
+++ b/src/utils/address/isAddress.test.ts
@@ -3,7 +3,9 @@ import { expect, test } from 'vitest'
 import { isAddress } from './isAddress.js'
 
 test('checks if address is valid', () => {
-  expect(isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac')).toBeTruthy()
+  expect(isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac')).toBeFalsy()
+  expect(isAddress('x')).toBeFalsy()
+  expect(isAddress('0xa')).toBeFalsy()
   expect(isAddress('0xa0cf798816d4b9b9866b5330eea46a18382f251e')).toBeTruthy()
   expect(isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az')).toBeFalsy()
   expect(isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678aff')).toBeFalsy()

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -1,18 +1,18 @@
 import type { Address } from 'abitype'
 import type { ErrorType } from '../../errors/utils.js'
-import { checksumAddress} from './getAddress.js'
+import { checksumAddress } from './getAddress.js'
 
 const addressRegex = /^0x[a-fA-F0-9]{40}$/
 
 export type IsAddressErrorType = ErrorType
 
 export function isAddress(address: string): address is Address {
-  if (!addressRegex.test(address) ) {
-    return false;
+  if (!addressRegex.test(address)) {
+    return false
   }
   if (address.toLowerCase() === address) {
-    return true;
+    return true
   }
   // @ts-ignore
-  return checksumAddress(address) === address;
+  return checksumAddress(address) === address
 }

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -1,10 +1,18 @@
 import type { Address } from 'abitype'
 import type { ErrorType } from '../../errors/utils.js'
+import { checksumAddress} from './getAddress.js'
 
 const addressRegex = /^0x[a-fA-F0-9]{40}$/
 
 export type IsAddressErrorType = ErrorType
 
 export function isAddress(address: string): address is Address {
-  return addressRegex.test(address)
+  if (!addressRegex.test(address) ) {
+    return false;
+  }
+  if (address.toLowerCase() === address) {
+    return true;
+  }
+  // @ts-ignore
+  return checksumAddress(address) === address;
 }

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -9,7 +9,7 @@ const isAddressCache = /*#__PURE__*/ new LruMap<boolean>(8192)
 
 export type IsAddressOptions = {
   /**
-   * Enables strict mode. Whether or not to compare the address against it's checksum.
+   * Enables strict mode. Whether or not to compare the address against its checksum.
    *
    * @default true
    */

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -1,18 +1,35 @@
 import type { Address } from 'abitype'
 import type { ErrorType } from '../../errors/utils.js'
+import { LruMap } from '../lru.js'
 import { checksumAddress } from './getAddress.js'
 
 const addressRegex = /^0x[a-fA-F0-9]{40}$/
 
+const isAddressCache = /*#__PURE__*/ new LruMap<boolean>(8192)
+
+export type IsAddressOptions = {
+  /**
+   * Enables strict mode. Whether or not to compare the address against it's checksum.
+   *
+   * @default true
+   */
+  strict?: boolean
+}
+
 export type IsAddressErrorType = ErrorType
 
-export function isAddress(address: string): address is Address {
-  if (!addressRegex.test(address)) {
-    return false
-  }
-  if (address.toLowerCase() === address) {
+export function isAddress(
+  address: string,
+  { strict = true }: IsAddressOptions = {},
+): address is Address {
+  if (isAddressCache.has(address)) return isAddressCache.get(address)!
+
+  const result = (() => {
+    if (!addressRegex.test(address)) return false
+    if (address.toLowerCase() === address) return true
+    if (strict) return checksumAddress(address as Address) === address
     return true
-  }
-  // @ts-ignore
-  return checksumAddress(address) === address
+  })()
+  isAddressCache.set(address, result)
+  return result
 }

--- a/src/utils/address/isAddressEqual.test.ts
+++ b/src/utils/address/isAddressEqual.test.ts
@@ -39,6 +39,9 @@ describe('errors', () => {
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az" is invalid.
 
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
       Version: viem@1.0.2]
     `)
     expect(() =>
@@ -48,6 +51,9 @@ describe('errors', () => {
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678aff" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `)

--- a/src/utils/address/isAddressEqual.ts
+++ b/src/utils/address/isAddressEqual.ts
@@ -11,7 +11,9 @@ export type IsAddressEqualReturnType = boolean
 export type IsAddressEqualErrorType = InvalidAddressErrorType | ErrorType
 
 export function isAddressEqual(a: Address, b: Address) {
-  if (!isAddress(a)) throw new InvalidAddressError({ address: a })
-  if (!isAddress(b)) throw new InvalidAddressError({ address: b })
+  if (!isAddress(a, { strict: false }))
+    throw new InvalidAddressError({ address: a })
+  if (!isAddress(b, { strict: false }))
+    throw new InvalidAddressError({ address: b })
   return a.toLowerCase() === b.toLowerCase()
 }

--- a/src/utils/lru.test.ts
+++ b/src/utils/lru.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { LruMap } from './lru.js'
+
+test('default', () => {
+  const cache = new LruMap(5)
+  cache.set('a', 1)
+  cache.set('b', 2)
+  cache.set('c', 3)
+  cache.set('d', 4)
+  cache.set('e', 5)
+  cache.set('f', 6)
+  cache.set('g', 7)
+  expect(cache.size).toBe(5)
+  expect(cache.has('a')).toBe(false)
+  expect(cache.has('b')).toBe(false)
+  expect(cache.get('c')).toBe(3)
+  expect(cache.get('d')).toBe(4)
+  expect(cache.get('e')).toBe(5)
+  expect(cache.get('f')).toBe(6)
+  expect(cache.get('g')).toBe(7)
+})

--- a/src/utils/lru.ts
+++ b/src/utils/lru.ts
@@ -1,0 +1,20 @@
+/**
+ * Map with a LRU (Least recently used) policy.
+ *
+ * @link https://en.wikipedia.org/wiki/Cache_replacement_policies#LRU
+ */
+export class LruMap<value = unknown> extends Map<string, value> {
+  maxSize: number
+
+  constructor(size: number) {
+    super()
+    this.maxSize = size
+  }
+
+  override set(key: string, value: value) {
+    super.set(key, value)
+    if (this.maxSize && this.size > this.maxSize)
+      this.delete(this.keys().next().value)
+    return this
+  }
+}

--- a/src/utils/transaction/assertRequest.test.ts
+++ b/src/utils/transaction/assertRequest.test.ts
@@ -10,6 +10,9 @@ test('invalid address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x1" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 })
@@ -30,6 +33,9 @@ test('invalid from address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x123" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 })
@@ -39,6 +45,9 @@ test('invalid to address', () => {
     assertRequest({ to: '0x123' }),
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x123" is invalid.
+
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
 
     Version: viem@1.0.2]
   `)

--- a/src/utils/transaction/assertTransaction.test.ts
+++ b/src/utils/transaction/assertTransaction.test.ts
@@ -89,6 +89,9 @@ test('invalid address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x123" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 
@@ -97,6 +100,9 @@ test('invalid address', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x123" is invalid.
 
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+
     Version: viem@1.0.2]
   `)
 
@@ -104,6 +110,9 @@ test('invalid address', () => {
     assertTransactionLegacy({ to: '0x123', chainId: 1 }),
   ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x123" is invalid.
+
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
 
     Version: viem@1.0.2]
   `)

--- a/src/utils/transaction/parseTransaction.test.ts
+++ b/src/utils/transaction/parseTransaction.test.ts
@@ -220,6 +220,9 @@ describe('eip1559', () => {
       ).toThrowErrorMatchingInlineSnapshot(`
         [InvalidAddressError: Address "0x" is invalid.
 
+        - Address must be a hex value of 20 bytes (40 hex characters).
+        - Address must match its checksum counterpart.
+
         Version: viem@1.0.2]
       `)
 
@@ -239,6 +242,9 @@ describe('eip1559', () => {
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [InvalidAddressError: Address "0x123456" is invalid.
+
+        - Address must be a hex value of 20 bytes (40 hex characters).
+        - Address must match its checksum counterpart.
 
         Version: viem@1.0.2]
       `)

--- a/src/utils/transaction/parseTransaction.ts
+++ b/src/utils/transaction/parseTransaction.ts
@@ -326,7 +326,8 @@ export function parseAccessList(accessList_: RecursiveArray<Hex>): AccessList {
   for (let i = 0; i < accessList_.length; i++) {
     const [address, storageKeys] = accessList_[i] as [Hex, Hex[]]
 
-    if (!isAddress(address)) throw new InvalidAddressError({ address })
+    if (!isAddress(address, { strict: false }))
+      throw new InvalidAddressError({ address })
 
     accessList.push({
       address: address,

--- a/src/utils/transaction/serializeAccessList.ts
+++ b/src/utils/transaction/serializeAccessList.ts
@@ -42,7 +42,7 @@ export function serializeAccessList(
       }
     }
 
-    if (!isAddress(address)) {
+    if (!isAddress(address, { strict: false })) {
       throw new InvalidAddressError({ address })
     }
 

--- a/src/utils/transaction/serializeTransaction.test.ts
+++ b/src/utils/transaction/serializeTransaction.test.ts
@@ -220,6 +220,9 @@ describe('eip1559', () => {
       ).toThrowErrorMatchingInlineSnapshot(`
         [InvalidAddressError: Address "0x0000000000000000000000000000000000000000000000000000000000000001" is invalid.
 
+        - Address must be a hex value of 20 bytes (40 hex characters).
+        - Address must match its checksum counterpart.
+
         Version: viem@1.0.2]
       `)
     })
@@ -439,6 +442,9 @@ describe('eip2930', () => {
         }),
       ).toThrowErrorMatchingInlineSnapshot(`
         [InvalidAddressError: Address "0x0" is invalid.
+
+        - Address must be a hex value of 20 bytes (40 hex characters).
+        - Address must match its checksum counterpart.
 
         Version: viem@1.0.2]
       `)

--- a/src/utils/typedData.test.ts
+++ b/src/utils/typedData.test.ts
@@ -172,6 +172,9 @@ describe('validateTypedData', () => {
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0x000000000000000000000000000000000000z" is invalid.
 
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
       Version: viem@1.0.2]
     `)
   })
@@ -296,6 +299,9 @@ describe('validateTypedData', () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
       [InvalidAddressError: Address "0xCczCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
 
       Version: viem@1.0.2]
     `)

--- a/src/utils/typedData.test.ts
+++ b/src/utils/typedData.test.ts
@@ -307,7 +307,7 @@ describe('validateTypedData', () => {
         name: 'Ether!',
         version: '1',
         chainId: 1n,
-        verifyingContract: '0xCccCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
       },
       primaryType: 'EIP712Domain',
       types: {


### PR DESCRIPTION
I doubt I'm doing the proper code-style, but this is a POC for closing #1803

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Upgrade the `isAddress` function to return `false` for invalid checksummed addresses.

### Detailed summary:
- Modified the `isAddress` function to include an optional `strict` parameter.
- Updated multiple files to use the new `isAddress` function with `strict: false` parameter.
- Added error messages for invalid addresses, including requirements for valid addresses.
- Added tests to ensure the validity of addresses and error handling.
- Added a new `LruMap` class for caching with a LRU policy.

> The following files were skipped due to too many changes: `src/actions/public/call.test.ts`, `src/utils/address/isAddress.ts`, `src/utils/address/getAddress.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->