### PR TITLE
Fix Wallet Action Write Contract Type

### DIFF
--- a/.changeset/fair-clocks-rescue.md
+++ b/.changeset/fair-clocks-rescue.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fix typings for writeContract args in walletActions
+Fixed wallet actions types

--- a/.changeset/fair-clocks-rescue.md
+++ b/.changeset/fair-clocks-rescue.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix typings for writeContract args in walletActions

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -663,7 +663,11 @@ export type WalletActions<
   writeContract: <
     const abi extends Abi | readonly unknown[],
     functionName extends ContractFunctionName<abi, 'payable' | 'nonpayable'>,
-    args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+    args extends ContractFunctionArgs<
+      abi,
+      'payable' | 'nonpayable',
+      functionName
+    >,
     TChainOverride extends Chain | undefined = undefined,
   >(
     args: WriteContractParameters<


### PR DESCRIPTION
I think this is a typo from the parameters inside the wallet actions types.

This results in type error when using `writeContract` from wallet actions.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Fixed wallet actions types in `src/clients/decorators/wallet.ts`
- Updated the `args` parameter in the `WriteContractParameters` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->