### PR TITLE
Add Multicall3 contract to xdc mainnet and testnet definitions

### DIFF
--- a/.changeset/silly-keys-peel.md
+++ b/.changeset/silly-keys-peel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall to XDC mainnet and testnet

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -21,4 +21,10 @@ export const xdc = /*#__PURE__*/ defineChain({
       url: 'https://xdc.blocksscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 71542788,
+    },
+  },
 })

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -17,4 +17,10 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
       url: 'https://apothem.blocksscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 59765389,
+    },
+  },
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding multicall support to the XDC mainnet and testnet. 

### Detailed summary
- Added multicall contract `multicall3`
- Added address and block creation details for `multicall3` in the XDC mainnet and testnet definitions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->