### PR TITLE
Update Lightlink RPC urls

### DIFF
--- a/.changeset/smooth-onions-invite.md
+++ b/.changeset/smooth-onions-invite.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Lightlink RPC urls

--- a/src/chains/definitions/lightlinkPegasus.ts
+++ b/src/chains/definitions/lightlinkPegasus.ts
@@ -11,10 +11,7 @@ export const lightlinkPegasus = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: [
-        'https://replicator-01.pegasus.lightlink.io/rpc/v1',
-        'https://replicator-02.pegasus.lightlink.io/rpc/v1',
-      ],
+      http: ['https://replicator.pegasus.lightlink.io/rpc/v1'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/lightlinkPhoenix.ts
+++ b/src/chains/definitions/lightlinkPhoenix.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const lightlinkPhoenix = /*#__PURE__*/ defineChain({
   id: 1_890,
-  name: 'LightLink Phoenix',
+  name: 'LightLink Phoenix Mainnet',
   network: 'lightlink-phoenix',
   nativeCurrency: {
     decimals: 18,
@@ -11,10 +11,7 @@ export const lightlinkPhoenix = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: [
-        'https://replicator-01.phoenix.lightlink.io/rpc/v1',
-        'https://replicator-02.phoenix.lightlink.io/rpc/v1',
-      ],
+      http: ['https://replicator.phoenix.lightlink.io/rpc/v1'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Update Lightlink RPC urls to match the new ones from https://chainlist.org/?search=lightlink&testnets=true

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the LightLink RPC URLs and the name of the LightLink Phoenix chain.

### Detailed summary
- Updated LightLink RPC URLs to use a single URL for both chains
- Changed the name of the LightLink Phoenix chain to "LightLink Phoenix Mainnet"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->