### PR TITLE
Fix broken link

### DIFF
--- a/site/pages/docs/glossary/types.md
+++ b/site/pages/docs/glossary/types.md
@@ -2,7 +2,7 @@
 
 ## `Abi`
 
-Type matching the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec#json)
+Type matching the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html#json)
 
 Re-exported from [ABIType](https://abitype.dev/api/types#abi).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates a link in the `types.md` file related to the Contract ABI Specification. 

### Detailed summary
- Updated the link from `.org` to `.html` for the Contract ABI Specification.
- Re-exported `Abi` from [ABIType](https://abitype.dev/api/types#abi).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->