### PR TITLE
Replace SnowTrace with SnowScan.xyz a product of Etherscan

### DIFF
--- a/.changeset/rich-chicken-behave.md
+++ b/.changeset/rich-chicken-behave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Avalanche explorer to snowscan.xyz, a product of Etherscan.

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -13,9 +13,9 @@ export const avalanche = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'SnowTrace',
-      url: 'https://snowtrace.io',
-      apiUrl: 'https://api.snowtrace.io/api',
+      name: 'SnowScan',
+      url: 'https://snowscan.xyz',
+      apiUrl: 'https://api.snowscan.xyz/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Replace SnowTrace with SnowScan.xyz a product of Etherscan. Overall a better working product to have as the default Avalanche c-chain block explorer.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Avalanche explorer to snowscan.xyz, replacing snowtrace.io.

### Detailed summary
- Updated the Avalanche explorer from SnowTrace to SnowScan with new URLs.
- Utilizes snowscan.xyz for blockchain exploration and API calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->