### PR TITLE
Fix typo in revert message

### DIFF
--- a/src/actions/public/estimateContractGas.test.ts
+++ b/src/actions/public/estimateContractGas.test.ts
@@ -275,7 +275,7 @@ describe('contract errors', () => {
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "overflowWrite" reverted with the following reason:
-      Arithmic operation resulted in underflow or overflow.
+      Arithmetic operation resulted in underflow or overflow.
 
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -349,7 +349,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomWrite()
@@ -375,7 +375,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomWrite()

--- a/src/actions/public/estimateContractGas.test.ts
+++ b/src/actions/public/estimateContractGas.test.ts
@@ -349,7 +349,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomWrite()
@@ -375,7 +375,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomWrite()

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -310,7 +310,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomRead()
@@ -333,7 +333,7 @@ describe('contract errors', () => {
       [ContractFunctionExecutionError: The contract function "simpleCustomReadNoArgs" reverted.
 
       Error: SimpleErrorNoArgs()
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomReadNoArgs()
@@ -357,7 +357,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomRead()
@@ -387,7 +387,7 @@ describe('contract errors', () => {
       Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
       You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomRead()
@@ -412,7 +412,7 @@ test('fake contract address', async () => {
       - The contract does not have the function "totalSupply",
       - The parameters passed to the contract function may be invalid, or
       - The address is not a contract.
-
+     
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
       function:  totalSupply()

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -242,7 +242,7 @@ describe('contract errors', () => {
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "overflowRead" reverted with the following reason:
-      Arithmic operation resulted in underflow or overflow.
+      Arithmetic operation resulted in underflow or overflow.
 
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -310,7 +310,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomRead()
@@ -333,7 +333,7 @@ describe('contract errors', () => {
       [ContractFunctionExecutionError: The contract function "simpleCustomReadNoArgs" reverted.
 
       Error: SimpleErrorNoArgs()
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomReadNoArgs()
@@ -357,7 +357,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomRead()
@@ -387,7 +387,7 @@ describe('contract errors', () => {
       Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
       You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomRead()
@@ -412,7 +412,7 @@ test('fake contract address', async () => {
       - The contract does not have the function "totalSupply",
       - The parameters passed to the contract function may be invalid, or
       - The address is not a contract.
-     
+
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
       function:  totalSupply()

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -386,7 +386,7 @@ describe('contract errors', () => {
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "overflowWrite" reverted with the following reason:
-      Arithmic operation resulted in underflow or overflow.
+      Arithmetic operation resulted in underflow or overflow.
 
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -460,7 +460,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomWrite()
@@ -486,7 +486,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomWrite()
@@ -521,7 +521,7 @@ test('fake contract address', async () => {
       - The contract does not have the function "mint",
       - The parameters passed to the contract function may be invalid, or
       - The address is not a contract.
-     
+
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
       function:  mint()
@@ -550,7 +550,7 @@ describe('node errors', () => {
         to:            0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:          0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         maxFeePerGas:  115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -581,7 +581,7 @@ describe('node errors', () => {
         to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:  0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         gas:   100
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -660,7 +660,7 @@ describe('node errors', () => {
         to:     0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:   0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         nonce:  0
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -689,18 +689,18 @@ describe('node errors', () => {
       This error could arise when the account does not have enough funds to:
        - pay for the total gas fee,
        - pay for the value to send.
-       
+
       The cost of the transaction is calculated as \`gas * gas fee + value\`, where:
        - \`gas\` is the amount of gas needed for transaction to execute,
        - \`gas fee\` is the gas fee,
        - \`value\` is the amount of ether to send to the recipient.
-       
+
       Raw Call Arguments:
         from:   0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC
         to:     0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         value:  100000 ETH
         data:   0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -743,7 +743,7 @@ describe('node errors', () => {
         data:                  0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         maxFeePerGas:          20 gwei
         maxPriorityFeePerGas:  22 gwei
-       
+
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -460,7 +460,7 @@ describe('contract errors', () => {
 
       Error: SimpleError(string message)
                         (bugger)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  simpleCustomWrite()
@@ -486,7 +486,7 @@ describe('contract errors', () => {
 
       Error: ComplexError((address sender, uint256 bar), string message, uint256 number)
                          ({"sender":"0x0000000000000000000000000000000000000000","bar":"69"}, bugger, 69)
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  complexCustomWrite()
@@ -521,7 +521,7 @@ test('fake contract address', async () => {
       - The contract does not have the function "mint",
       - The parameters passed to the contract function may be invalid, or
       - The address is not a contract.
-
+     
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
       function:  mint()
@@ -550,7 +550,7 @@ describe('node errors', () => {
         to:            0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:          0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         maxFeePerGas:  115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -581,7 +581,7 @@ describe('node errors', () => {
         to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:  0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         gas:   100
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -660,7 +660,7 @@ describe('node errors', () => {
         to:     0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         data:   0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         nonce:  0
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -689,18 +689,18 @@ describe('node errors', () => {
       This error could arise when the account does not have enough funds to:
        - pay for the total gas fee,
        - pay for the value to send.
-
+       
       The cost of the transaction is calculated as \`gas * gas fee + value\`, where:
        - \`gas\` is the amount of gas needed for transaction to execute,
        - \`gas fee\` is the gas fee,
        - \`value\` is the amount of ether to send to the recipient.
-
+       
       Raw Call Arguments:
         from:   0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC
         to:     0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
         value:  100000 ETH
         data:   0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)
@@ -743,7 +743,7 @@ describe('node errors', () => {
         data:                  0xa0712d680000000000000000000000000000000000000000000000000000000000010f2c
         maxFeePerGas:          20 gwei
         maxPriorityFeePerGas:  22 gwei
-
+       
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
         function:  mint(uint256 tokenId)

--- a/src/constants/solidity.test.ts
+++ b/src/constants/solidity.test.ts
@@ -7,7 +7,7 @@ test('exports solidity constants', () => {
     {
       "panicReasons": {
         "1": "An \`assert\` condition failed.",
-        "17": "Arithmic operation resulted in underflow or overflow.",
+        "17": "Arithmetic operation resulted in underflow or overflow.",
         "18": "Division or modulo by zero (e.g. \`5 / 0\` or \`23 % 0\`).",
         "33": "Attempted to convert to an invalid type.",
         "34": "Attempted to access a storage byte array that is incorrectly encoded.",

--- a/src/constants/solidity.ts
+++ b/src/constants/solidity.ts
@@ -3,7 +3,7 @@ import type { AbiError } from 'abitype'
 // https://docs.soliditylang.org/en/v0.8.16/control-structures.html#panic-via-assert-and-error-via-require
 export const panicReasons = {
   1: 'An `assert` condition failed.',
-  17: 'Arithmic operation resulted in underflow or overflow.',
+  17: 'Arithmetic operation resulted in underflow or overflow.',
   18: 'Division or modulo by zero (e.g. `5 / 0` or `23 % 0`).',
   33: 'Attempted to convert to an invalid type.',
   34: 'Attempted to access a storage byte array that is incorrectly encoded.',


### PR DESCRIPTION
Yeah I'm "that guy"...

There was a typo in revert message for underflows etc that was annoying me - this PR corrects it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates error messages related to arithmetic operations in contract functions and constants. It corrects the spelling of "Arithmic" to "Arithmetic".

### Detailed summary
- Updated error messages for arithmetic operations in contract functions
- Corrected spelling from "Arithmic" to "Arithmetic" in constants

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->