### PR TITLE
Fix localhost chain ID to 31_337 from 1_337

### DIFF
--- a/src/chains/definitions/localhost.ts
+++ b/src/chains/definitions/localhost.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const localhost = /*#__PURE__*/ defineChain({
-  id: 1_337,
+  id: 31_337,
   name: 'Localhost',
   nativeCurrency: {
     decimals: 18,


### PR DESCRIPTION
Fixed localhost chain ID to match Hardhat and Foundry defaults.

Changed id: 1_337 to id: 31_337 in [viem/src/chains/definitions/localhost.ts](https://github.com/wevm/viem/blob/main/src/chains/definitions/localhost.ts)

---

Identified from seeing the following error on hardhat & anvil:
```
eth_sendRawTransaction

  Trying to send a raw transaction with an invalid chainId. The expected chainId is 31337

```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the `id` of the `localhost` chain definition from 1_337 to 31_337.

### Detailed summary
- Updated the `id` of the `localhost` chain definition from 1_337 to 31_337.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->