### PR TITLE
export getAction

### DIFF
--- a/.changeset/tender-windows-exercise.md
+++ b/.changeset/tender-windows-exercise.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `getAction`.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -348,6 +348,7 @@ export {
   type GetTransactionErrorReturnType,
   getTransactionError,
 } from './errors/getTransactionError.js'
+export { getAction } from './getAction.js'
 export {
   type DefineFormatterErrorType,
   defineFormatter,


### PR DESCRIPTION
I want to be able to use this from within an extended client to "hook" the original behavior

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting the `getAction` function. 

### Detailed summary
- Exported `getAction` function from `src/utils/getAction.js` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->