### PR TITLE
chore: deprecate foundry in favor of anvil

### DIFF
--- a/.changeset/nasty-geese-leave.md
+++ b/.changeset/nasty-geese-leave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Anvil chain (deprecate `foundry`).

--- a/src/chains/definitions/anvil.ts
+++ b/src/chains/definitions/anvil.ts
@@ -1,0 +1,17 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const anvil = /*#__PURE__*/ defineChain({
+  id: 31_337,
+  name: 'Anvil',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: {
+      http: ['http://127.0.0.1:8545'],
+      webSocket: ['ws://127.0.0.1:8545'],
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,6 +1,7 @@
 export type { Chain } from '../types/chain.js'
 
 export { acala } from './definitions/acala.js'
+export { anvil } from './definitions/anvil.js'
 export { arbitrum } from './definitions/arbitrum.js'
 export { arbitrumGoerli } from './definitions/arbitrumGoerli.js'
 export { arbitrumNova } from './definitions/arbitrumNova.js'
@@ -61,6 +62,9 @@ export { filecoinCalibration } from './definitions/filecoinCalibration.js'
 export { filecoinHyperspace } from './definitions/filecoinHyperspace.js'
 export { flare } from './definitions/flare.js'
 export { flareTestnet } from './definitions/flareTestnet.js'
+/** 
+ * @deprecated Use `anvil` instead.
+ */
 export { foundry } from './definitions/foundry.js'
 export { fuse } from './definitions/fuse.js'
 export { fuseSparknet } from './definitions/fuseSparknet.js'

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -62,9 +62,7 @@ export { filecoinCalibration } from './definitions/filecoinCalibration.js'
 export { filecoinHyperspace } from './definitions/filecoinHyperspace.js'
 export { flare } from './definitions/flare.js'
 export { flareTestnet } from './definitions/flareTestnet.js'
-/** 
- * @deprecated Use `anvil` instead.
- */
+/** @deprecated Use `anvil` instead. */
 export { foundry } from './definitions/foundry.js'
 export { fuse } from './definitions/fuse.js'
 export { fuseSparknet } from './definitions/fuseSparknet.js'


### PR DESCRIPTION
This PR addresses the request to deprecate the foundry chain in favor of anvil naming convention. Changes made are as follows:

**Deprecation:** Added a JSDoc deprecation notice to `src/chains/definitions/index.ts`, advising the use of the anvil chain instead of foundry. This marks foundry for removal in the next major version to avoid a breaking change.
**New Chain Addition:** Created `src/chains/definitions/anvil.ts` to introduce the anvil chain as the recommended alternative to foundry.
**Index Update:** Updated `src/chains/index.ts` to include the export of the anvil chain, ensuring it's available for use throughout the project.

These changes are in line with the directive to smoothly transition from foundry to anvil, providing a clear path forward for users of the library while maintaining backward compatibility until the next major release.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `Anvil` chain and deprecates the `foundry` chain.

### Detailed summary
- Added `Anvil` chain, replacing `foundry`
- Deprecated `foundry` chain
- Updated chain index to export `anvil` instead of `foundry`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->