### PR TITLE
Fix docs: blockTag type in getTransactionCount action

### DIFF
--- a/site/pages/docs/actions/public/getTransactionCount.md
+++ b/site/pages/docs/actions/public/getTransactionCount.md
@@ -64,7 +64,7 @@ const transactionCount = await publicClient.getTransactionCount({
 
 ### blockTag
 
-- **Type:** `bigint`
+- **Type:** `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'`
 
 Get the count at a block tag.
 


### PR DESCRIPTION
https://viem.sh/docs/actions/public/getTransactionCount#blocktag

Now: bigint
Correct: 'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `blockTag` type in the `getTransactionCount` documentation from `bigint` to `string` with specific allowed values.

### Detailed summary
- Updated `blockTag` type from `bigint` to `'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'` in `getTransactionCount` documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->