### PR TITLE
chore: use node as the module resolution option

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "target": "ESNext",
     "types": ["bun-types"],
     "baseUrl": ".",


### PR DESCRIPTION
Without the change the IDE (and typescript) will complain with the error below: 

![image](https://github.com/wevm/viem/assets/72753578/b307a4b9-5707-4a36-b1b3-09e6ed896da8)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the TypeScript configuration to use `nodenext` for `module` and `moduleResolution`.

### Detailed summary
- Updated `module` to `nodenext`
- Updated `moduleResolution` to `nodenext`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->