### PR TITLE
chore: modification to kakarot sepolia

### DIFF
--- a/src/chains/definitions/kakarotSepolia.ts
+++ b/src/chains/definitions/kakarotSepolia.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const kakarotSepolia = /*#__PURE__*/ defineChain({
-  id: 107107114116,
+  id: 1802203764,
   name: 'Kakarot Sepolia',
   nativeCurrency: {
     name: 'Ether',


### PR DESCRIPTION
We have decided to use another chain id, the network is yet to go live, so it is safe to change it, the PR makes this change.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `id` of the `kakarotSepolia` chain definition from `107107114116` to `1802203764`.

### Detailed summary
- Updated the `id` of the `kakarotSepolia` chain definition from `107107114116` to `1802203764`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->