### PR TITLE
Add APEX Testnet

### DIFF
--- a/src/chains/definitions/apexTestnet.ts
+++ b/src/chains/definitions/apexTestnet.ts
@@ -1,0 +1,26 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const apexTestnet = /*#__PURE__*/ defineChain({
+  id: 3993,
+  name: 'APEX Testnet',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc-testnet.apexlayer.xyz'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'https://exp-testnet.apexlayer.xyz',
+      apiUrl: 'https://exp-testnet.apexlayer.xyz/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xf7642be33a6b18D16a995657adb5a68CD0438aE2',
+      blockCreated: 283775,
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -2,6 +2,7 @@ export type { Chain } from '../types/chain.js'
 
 export { acala } from './definitions/acala.js'
 export { anvil } from './definitions/anvil.js'
+export { apexTestnet } from './definitions/apexTestnet.js'
 export { arbitrum } from './definitions/arbitrum.js'
 export { arbitrumGoerli } from './definitions/arbitrumGoerli.js'
 export { arbitrumNova } from './definitions/arbitrumNova.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the APEX Testnet chain.

### Detailed summary
- Added `apexTestnet` definition in `chains/index.ts`
- Defined `apexTestnet` chain with ID 3993, RPC URLs, block explorers, contracts, and testnet status in `chains/definitions/apexTestnet.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->