### PR TITLE
add getL1BaseFee action for op-stack

### DIFF
--- a/.changeset/lazy-games-teach.md
+++ b/.changeset/lazy-games-teach.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-add getL1BaseFee action for op-stack
+Added `getL1BaseFee` action for OP Stack.

--- a/.changeset/lazy-games-teach.md
+++ b/.changeset/lazy-games-teach.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+add getL1BaseFee action for op-stack

--- a/src/chains/opStack/actions/getL1BaseFee.test.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import {
+  optimismClient,
+  optimismClientWithAccount,
+  optimismClientWithoutChain,
+} from '~test/src/opStack.js'
+
+import { getL1BaseFee } from './getL1BaseFee.js'
+
+
+test('default', async () => {
+  const baseFee = await getL1BaseFee(optimismClient)
+  expect(baseFee >= 0).toBeTruthy()
+})
+
+test('withAccount', async () => {
+  const baseFee = await getL1BaseFee(optimismClientWithAccount, {})
+  expect(baseFee >= 0).toBeTruthy()
+})
+
+test('args: gasPriceOracleAddress', async () => {
+  const baseFee = await getL1BaseFee(optimismClient, {
+    gasPriceOracleAddress: '0x420000000000000000000000000000000000000F',
+  })
+  expect(baseFee >= 0).toBeTruthy()
+})
+
+test('args: nonce', async () => {
+  const baseFee = await getL1BaseFee(optimismClient)
+  expect(baseFee >= 0).toBeTruthy()
+})
+
+test('args: nullish chain', async () => {
+  const baseFee = await getL1BaseFee(optimismClientWithoutChain, {
+    chain: null,
+  })
+  expect(baseFee >= 0).toBeTruthy()
+})

--- a/src/chains/opStack/actions/getL1BaseFee.test.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.test.ts
@@ -8,7 +8,6 @@ import {
 
 import { getL1BaseFee } from './getL1BaseFee.js'
 
-
 test('default', async () => {
   const baseFee = await getL1BaseFee(optimismClient)
   expect(baseFee >= 0).toBeTruthy()

--- a/src/chains/opStack/actions/getL1BaseFee.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.ts
@@ -4,9 +4,7 @@ import {
   type ReadContractErrorType,
   readContract,
 } from '../../../actions/public/readContract.js'
-import {
-  type PrepareTransactionRequestErrorType
-} from '../../../actions/wallet/prepareTransactionRequest.js'
+import { type PrepareTransactionRequestErrorType } from '../../../actions/wallet/prepareTransactionRequest.js'
 import type { Client } from '../../../clients/createClient.js'
 import type { Transport } from '../../../clients/transports/createTransport.js'
 import type { ErrorType } from '../../../errors/utils.js'
@@ -21,10 +19,10 @@ import { contracts } from '../contracts.js'
 export type GetL1BaseFeeParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TChainOverride extends Chain | undefined = undefined,
-> =  GetChainParameter<TChain, TChainOverride> & {
-    /** Gas price oracle address. */
-    gasPriceOracleAddress?: Address
-  }
+> = GetChainParameter<TChain, TChainOverride> & {
+  /** Gas price oracle address. */
+  gasPriceOracleAddress?: Address
+}
 
 export type GetL1BaseFeeReturnType = bigint
 
@@ -34,7 +32,6 @@ export type GetL1BaseFeeErrorType =
   | HexToNumberErrorType
   | ReadContractErrorType
   | ErrorType
-
 
 /**
  * get the L1 base fee
@@ -79,6 +76,6 @@ export async function getL1BaseFee<
   return readContract(client, {
     abi: gasPriceOracleAbi,
     address: gasPriceOracleAddress,
-    functionName: 'baseFee'
+    functionName: 'baseFee',
   })
 }

--- a/src/chains/opStack/actions/getL1BaseFee.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.ts
@@ -76,6 +76,6 @@ export async function getL1BaseFee<
   return readContract(client, {
     abi: gasPriceOracleAbi,
     address: gasPriceOracleAddress,
-    functionName: 'baseFee',
+    functionName: 'l1BaseFee',
   })
 }

--- a/src/chains/opStack/actions/getL1BaseFee.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.ts
@@ -1,0 +1,84 @@
+import type { Address } from 'abitype'
+
+import {
+  type ReadContractErrorType,
+  readContract,
+} from '../../../actions/public/readContract.js'
+import {
+  type PrepareTransactionRequestErrorType
+} from '../../../actions/wallet/prepareTransactionRequest.js'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { ErrorType } from '../../../errors/utils.js'
+import { type Chain, type GetChainParameter } from '../../../types/chain.js'
+import type { RequestErrorType } from '../../../utils/buildRequest.js'
+import { getChainContractAddress } from '../../../utils/chain/getChainContractAddress.js'
+import { type HexToNumberErrorType } from '../../../utils/encoding/fromHex.js'
+
+import { gasPriceOracleAbi } from '../abis.js'
+import { contracts } from '../contracts.js'
+
+export type GetL1BaseFeeParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+  TChainOverride extends Chain | undefined = undefined,
+> =  GetChainParameter<TChain, TChainOverride> & {
+    /** Gas price oracle address. */
+    gasPriceOracleAddress?: Address
+  }
+
+export type GetL1BaseFeeReturnType = bigint
+
+export type GetL1BaseFeeErrorType =
+  | RequestErrorType
+  | PrepareTransactionRequestErrorType
+  | HexToNumberErrorType
+  | ReadContractErrorType
+  | ErrorType
+
+
+/**
+ * get the L1 base fee
+ *
+ * @param client - Client to use
+ * @param parameters - {@link GetL1BaseFeeParameters}
+ * @returns The basefee (in wei). {@link GetL1BaseFeeReturnType}
+ *
+ * @example
+ * import { createPublicClient, http, parseEther } from 'viem'
+ * import { optimism } from 'viem/chains'
+ * import { getL1BaseFee } from 'viem/chains/optimism'
+ *
+ * const client = createPublicClient({
+ *   chain: optimism,
+ *   transport: http(),
+ * })
+ * const l1BaseFee = await getL1BaseFee(client)
+ */
+export async function getL1BaseFee<
+  TChain extends Chain | undefined,
+  TChainOverride extends Chain | undefined = undefined,
+>(
+  client: Client<Transport, TChain>,
+  args?: GetL1BaseFeeParameters<TChain, TChainOverride>,
+): Promise<GetL1BaseFeeReturnType> {
+  const {
+    chain = client.chain,
+    gasPriceOracleAddress: gasPriceOracleAddress_,
+  } = args || {}
+
+  const gasPriceOracleAddress = (() => {
+    if (gasPriceOracleAddress_) return gasPriceOracleAddress_
+    if (chain)
+      return getChainContractAddress({
+        chain,
+        contract: 'gasPriceOracle',
+      })
+    return contracts.gasPriceOracle.address
+  })()
+
+  return readContract(client, {
+    abi: gasPriceOracleAbi,
+    address: gasPriceOracleAddress,
+    functionName: 'baseFee'
+  })
+}

--- a/src/chains/opStack/decorators/publicL2.test.ts
+++ b/src/chains/opStack/decorators/publicL2.test.ts
@@ -18,6 +18,7 @@ test('default', async () => {
       "estimateContractTotalGas": [Function],
       "estimateInitiateWithdrawalGas": [Function],
       "estimateL1Fee": [Function],
+      "getL1BaseFee": [Function],
       "estimateL1Gas": [Function],
       "estimateTotalFee": [Function],
       "estimateTotalGas": [Function],
@@ -99,6 +100,11 @@ describe('smoke test', () => {
     const fee = await opStackClient.estimateL1Fee({
       account: accounts[0].address,
     })
+    expect(fee).toBeDefined()
+  })
+
+  test('getL1BaseFee', async () => {
+    const fee = await opStackClient.getL1BaseFee()
     expect(fee).toBeDefined()
   })
 

--- a/src/chains/opStack/decorators/publicL2.ts
+++ b/src/chains/opStack/decorators/publicL2.ts
@@ -48,6 +48,11 @@ import {
   estimateL1Fee,
 } from '../actions/estimateL1Fee.js'
 import {
+  type GetL1BaseFeeParameters,
+  type GetL1BaseFeeReturnType,
+  getL1BaseFee,
+} from '../actions/getL1BaseFee.js'
+import {
   type EstimateL1GasParameters,
   type EstimateL1GasReturnType,
   estimateL1Gas,
@@ -364,6 +369,29 @@ export type PublicActionsL2<
   estimateL1Fee: <chainOverride extends Chain | undefined = undefined>(
     parameters: EstimateL1FeeParameters<chain, account, chainOverride>,
   ) => Promise<EstimateL1FeeReturnType>
+
+   /**
+   * Get the L1 basefee
+   *
+   * @param client - Client to use
+   * @param parameters - {@link GetL1BaseFeeParameters}
+   * @returns The fee (in wei). {@link GetL1BaseFeeReturnType}
+   *
+   * @example
+   * import { createPublicClient, http, parseEther } from 'viem'
+   * import { optimism } from 'viem/chains'
+   * import { publicActionsL2 } from 'viem/op-stack'
+   *
+   * const client = createPublicClient({
+   *   chain: optimism,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const l1BaseFee = await client.getL1BaseFee()
+   */
+   getL1BaseFee: <chainOverride extends Chain | undefined = undefined>(
+    parameters?: GetL1BaseFeeParameters<chain, chainOverride>,
+  ) => Promise<GetL1BaseFeeReturnType>
   /**
    * Estimates the amount of L1 data gas required to execute an L2 transaction.
    *
@@ -479,6 +507,7 @@ export function publicActionsL2() {
       estimateInitiateWithdrawalGas: (args) =>
         estimateInitiateWithdrawalGas(client, args),
       estimateL1Fee: (args) => estimateL1Fee(client, args),
+      getL1BaseFee: (args) => getL1BaseFee(client, args),
       estimateL1Gas: (args) => estimateL1Gas(client, args),
       estimateTotalFee: (args) => estimateTotalFee(client, args),
       estimateTotalGas: (args) => estimateTotalGas(client, args),

--- a/src/chains/opStack/decorators/publicL2.ts
+++ b/src/chains/opStack/decorators/publicL2.ts
@@ -48,11 +48,6 @@ import {
   estimateL1Fee,
 } from '../actions/estimateL1Fee.js'
 import {
-  type GetL1BaseFeeParameters,
-  type GetL1BaseFeeReturnType,
-  getL1BaseFee,
-} from '../actions/getL1BaseFee.js'
-import {
   type EstimateL1GasParameters,
   type EstimateL1GasReturnType,
   estimateL1Gas,
@@ -67,6 +62,11 @@ import {
   type EstimateTotalGasReturnType,
   estimateTotalGas,
 } from '../actions/estimateTotalGas.js'
+import {
+  type GetL1BaseFeeParameters,
+  type GetL1BaseFeeReturnType,
+  getL1BaseFee,
+} from '../actions/getL1BaseFee.js'
 
 export type PublicActionsL2<
   chain extends Chain | undefined = Chain | undefined,
@@ -370,7 +370,7 @@ export type PublicActionsL2<
     parameters: EstimateL1FeeParameters<chain, account, chainOverride>,
   ) => Promise<EstimateL1FeeReturnType>
 
-   /**
+  /**
    * Get the L1 basefee
    *
    * @param client - Client to use
@@ -389,7 +389,7 @@ export type PublicActionsL2<
    *
    * const l1BaseFee = await client.getL1BaseFee()
    */
-   getL1BaseFee: <chainOverride extends Chain | undefined = undefined>(
+  getL1BaseFee: <chainOverride extends Chain | undefined = undefined>(
     parameters?: GetL1BaseFeeParameters<chain, chainOverride>,
   ) => Promise<GetL1BaseFeeReturnType>
   /**

--- a/src/chains/opStack/index.ts
+++ b/src/chains/opStack/index.ts
@@ -53,6 +53,12 @@ export {
   type EstimateL1FeeReturnType,
 } from './actions/estimateL1Fee.js'
 export {
+  getL1BaseFee,
+  type GetL1BaseFeeErrorType,
+  type GetL1BaseFeeParameters,
+  type GetL1BaseFeeReturnType,
+} from './actions/getL1BaseFee.js'
+export {
   estimateL1Gas,
   type EstimateL1GasErrorType,
   type EstimateL1GasParameters,


### PR DESCRIPTION
add getL1BaseFee action for op-stack

Useful to get the current L1BaseFee on op-stack chains

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `getL1BaseFee` action for OP Stack and includes related tests and documentation updates.

### Detailed summary
- Added `getL1BaseFee` action for OP Stack
- Updated tests for `getL1BaseFee`
- Updated documentation for `getL1BaseFee`
- Added `getL1BaseFee` function in `getL1BaseFee.ts`
- Updated `publicActionsL2` to include `getL1BaseFee` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->