### PR TITLE
Add blast network

### DIFF
--- a/.changeset/slimy-mayflies-smile.md
+++ b/.changeset/slimy-mayflies-smile.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added blast network
+Added Blast chain.

--- a/.changeset/slimy-mayflies-smile.md
+++ b/.changeset/slimy-mayflies-smile.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added blast network

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -5,7 +5,6 @@ const sourceId = 1 // mainnet
 export const blast = /*#__PURE__*/ defineChain({
     id: 81457,
     name: 'Blast',
-    network: 'blast',
     nativeCurrency: {
       decimals: 18,
       name: 'Ether',

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const blast = /*#__PURE__*/ defineChain({
+    id: 81457,
+    name: 'Blast',
+    network: 'blast',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'Ether',
+      symbol: 'ETH',
+    },
+    rpcUrls: {
+      public: { http: ['https://rpc.blast.io'] },
+      default: { http: ['https://rpc.blast.io'] },
+    },
+    blockExplorers: {
+      default: { name: 'Blastscan', url: 'https://blastscan.io' },
+    }
+  })

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -15,5 +15,11 @@ export const blast = /*#__PURE__*/ defineChain({
     },
     blockExplorers: {
       default: { name: 'Blastscan', url: 'https://blastscan.io' },
-    }
+    },
+    contracts: {
+        multicall3: {
+          address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+          blockCreated: 212929,
+        },
+      },
   })

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -11,7 +11,6 @@ export const blast = /*#__PURE__*/ defineChain({
       symbol: 'ETH',
     },
     rpcUrls: {
-      public: { http: ['https://rpc.blast.io'] },
       default: { http: ['https://rpc.blast.io'] },
     },
     blockExplorers: {

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -1,5 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+const sourceId = 1 // mainnet
+
 export const blast = /*#__PURE__*/ defineChain({
     id: 81457,
     name: 'Blast',
@@ -17,9 +19,10 @@ export const blast = /*#__PURE__*/ defineChain({
       default: { name: 'Blastscan', url: 'https://blastscan.io' },
     },
     contracts: {
-        multicall3: {
-          address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-          blockCreated: 212929,
-        },
+      multicall3: {
+        address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+        blockCreated: 212929,
       },
+    },
+    sourceId
   })

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -22,6 +22,7 @@ export { bearNetworkChainTestnet } from './definitions/bearNetworkChainTestnet.j
 export { berachainTestnet } from './definitions/berachainTestnet.js'
 export { bitTorrent } from './definitions/bitTorrent.js'
 export { bitTorrentTestnet } from './definitions/bitTorrentTestnet.js'
+export { blast } from './definitions/blast.js'
 export { blastSepolia } from './definitions/blastSepolia.js'
 export { boba } from './definitions/boba.js'
 export { bronos } from './definitions/bronos.js'


### PR DESCRIPTION
Add chain definition for the Blast network

https://blast.io/

https://docs.blast.io/about-blast

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the Blast chain by introducing the Blast definition with its unique properties.

### Detailed summary
- Added Blast chain definition in `chains/index.ts`
- Created `blast` definition in `chains/definitions/blast.ts` with specific properties
- Included Blast chain's ID, name, native currency, RPC URLs, block explorers, and contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->