### PR TITLE
Add blastMainnet.ts

### DIFF
--- a/src/chains/definitions/blastMainnet.ts
+++ b/src/chains/definitions/blastMainnet.ts
@@ -1,0 +1,29 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const blastMainnet = /*#__PURE__*/ defineChain({
+  id: 238,
+  name: 'Blast Mainnet',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.blastblockchain.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blastscan',
+      url: 'https://blastscan.io',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 0,
+    },
+  },
+  testnet: false,
+})


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the definition for the `Blast Mainnet` chain in the `blastMainnet.ts` file.

### Detailed summary
- Added definition for `Blast Mainnet` chain with ID 238
- Includes native currency Ether (ETH) with 18 decimals
- Specifies RPC URL and block explorer for the chain
- Defines the `multicall3` contract address
- Indicates that it is not a testnet configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->