### PR TITLE
Replace SnowTrace with SnowScan for avalancheFuji

### DIFF
--- a/.changeset/spicy-clocks-perform.md
+++ b/.changeset/spicy-clocks-perform.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaced SnowTrace with SnowScan for avalancheFuji

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -15,7 +15,7 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
     default: {
       name: 'SnowScan',
       url: 'https://testnet.snowscan.xyz',
-      apiUrl: 'https://api.snowscan.xyz/api',
+      apiUrl: 'https://api-testnet.snowscan.xyz',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -13,9 +13,9 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'SnowTrace',
-      url: 'https://testnet.snowtrace.io',
-      apiUrl: 'https://api-testnet.snowtrace.io/api',
+      name: 'SnowScan',
+      url: 'https://testnet.snowscan.xyz',
+      apiUrl: 'https://api.snowscan.xyz/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Same as: https://github.com/wevm/viem/pull/1824

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces `SnowTrace` with `SnowScan` for avalancheFuji block explorer in `avalancheFuji.ts`.

### Detailed summary
- Replaced `SnowTrace` with `SnowScan` for avalancheFuji block explorer
- Updated URL to `https://testnet.snowscan.xyz`
- Updated API URL to `https://api-testnet.snowscan.xyz`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->