### PR TITLE
chore: upgrade ensUniversalResolver on mainnet, sepolia and holesky

### DIFF
--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -25,8 +25,8 @@ export const holesky = /*#__PURE__*/ defineChain({
       blockCreated: 801613,
     },
     ensUniversalResolver: {
-      address: '0x2548a7E09deE955c4d97688dcB6C5b24085725f5',
-      blockCreated: 815385,
+      address: '0xa6AC935D4971E3CD133b950aE053bECD16fE7f3b',
+      blockCreated: 973484,
     },
   },
   testnet: true,

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -21,8 +21,8 @@ export const mainnet = /*#__PURE__*/ defineChain({
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0x8cab227b1162f03b8338331adaad7aadc83b895e',
-      blockCreated: 18_958_930,
+      address: '0xce01f8eee7E479C928F8919abD53E553a36CeF67',
+      blockCreated: 19_258_213,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -23,8 +23,8 @@ export const sepolia = /*#__PURE__*/ defineChain({
     },
     ensRegistry: { address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' },
     ensUniversalResolver: {
-      address: '0xBaBC7678D7A63104f1658c11D6AE9A21cdA09725',
-      blockCreated: 5_043_334,
+      address: '0xc8Af999e38273D658BE1b921b88A9Ddf005769cC',
+      blockCreated: 5_317_080,
     },
   },
   testnet: true,


### PR DESCRIPTION
Upgrade ensUniversalResolver address
* Mainnet: [0xce01f8eee7E479C928F8919abD53E553a36CeF67](https://etherscan.io/address/0xce01f8eee7E479C928F8919abD53E553a36CeF67)
* Sepolia: [0xc8Af999e38273D658BE1b921b88A9Ddf005769cC](https://sepolia.etherscan.io/address/0xc8af999e38273d658be1b921b88a9ddf005769cc)
* Holesky: [0xa6AC935D4971E3CD133b950aE053bECD16fE7f3b](https://holesky.etherscan.io/address/0xa6ac935d4971e3cd133b950ae053becd16fe7f3b)

Reference: https://github.com/ensdomains/ens-contracts/wiki/ENS-Contract-Deployments

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Ethereum chain definitions with new ENS universal resolver contract addresses and block creation numbers for testnet and mainnet.

### Detailed summary
- Updated ENS universal resolver address and block created for testnet
- Updated ENS universal resolver address and block created for mainnet
- Updated ENS universal resolver address and block created for sepolia chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->