### PR TITLE
chore: add Flow's previewnet evm network

### DIFF
--- a/.changeset/gentle-jokes-rule.md
+++ b/.changeset/gentle-jokes-rule.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Add Flow previewnet evm network
+Added Flow previewnet evm network

--- a/.changeset/gentle-jokes-rule.md
+++ b/.changeset/gentle-jokes-rule.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add Flow previewnet evm network

--- a/src/chains/definitions/flowMainnet.ts
+++ b/src/chains/definitions/flowMainnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const flowMainnet= /*#__PURE__*/ defineChain({
   id: 747,
-  name: 'Mainnet',
+  name: 'FlowEVM Mainnet',
   nativeCurrency: {
     decimals: 18,
     name: 'Flow',

--- a/src/chains/definitions/flowMainnet.ts
+++ b/src/chains/definitions/flowMainnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const flowMainnet= /*#__PURE__*/ defineChain({
   id: 747,
-  name: 'Flow Mainnet',
+  name: 'Mainnet',
   nativeCurrency: {
     decimals: 18,
     name: 'Flow',

--- a/src/chains/definitions/flowMainnet.ts
+++ b/src/chains/definitions/flowMainnet.ts
@@ -1,0 +1,22 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const flowMainnet= /*#__PURE__*/ defineChain({
+  id: 747,
+  name: 'Flow Mainnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Flow',
+    symbol: 'FLOW',
+  },
+  rpcUrls: {
+    default: {
+        http: ['https://mainnet.evm.nodes.onflow.org']
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Mainnet Explorer',
+      url: 'https://flowdiver.io',
+    },
+  },
+})

--- a/src/chains/definitions/flowPreviewnet.ts
+++ b/src/chains/definitions/flowPreviewnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const flowPreviewnet = /*#__PURE__*/ defineChain({
   id: 646,
-  name: 'Previewnet',
+  name: 'FlowEVM Previewnet',
   nativeCurrency: {
     decimals: 18,
     name: 'Flow',

--- a/src/chains/definitions/flowPreviewnet.ts
+++ b/src/chains/definitions/flowPreviewnet.ts
@@ -3,7 +3,6 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const flowPreviewnet = /*#__PURE__*/ defineChain({
   id: 646,
   name: 'Flow Previewnet',
-  network: 'previewnet',
   nativeCurrency: {
     decimals: 18,
     name: 'Flow',

--- a/src/chains/definitions/flowPreviewnet.ts
+++ b/src/chains/definitions/flowPreviewnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const flowPreviewnet = /*#__PURE__*/ defineChain({
   id: 646,
-  name: 'Flow Previewnet',
+  name: 'Previewnet',
   nativeCurrency: {
     decimals: 18,
     name: 'Flow',

--- a/src/chains/definitions/flowPreviewnet.ts
+++ b/src/chains/definitions/flowPreviewnet.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const flowPreviewnet = /*#__PURE__*/ defineChain({
+  id: 646,
+  name: 'Flow Previewnet',
+  network: 'previewnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Flow',
+    symbol: 'FLOW',
+  },
+  rpcUrls: {
+    default: {
+        http: ['https://previewnet.evm.nodes.onflow.org']
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Previewnet Explorer',
+      url: 'https://previewnet.flowdiver.io',
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -72,6 +72,7 @@ export { filecoinCalibration } from './definitions/filecoinCalibration.js'
 export { filecoinHyperspace } from './definitions/filecoinHyperspace.js'
 export { flare } from './definitions/flare.js'
 export { flareTestnet } from './definitions/flareTestnet.js'
+export { flowPreviewnet } from './definitions/flowPreviewnet.js'
 /** @deprecated Use `anvil` instead. */
 export { foundry } from './definitions/foundry.js'
 export { fraxtal } from './definitions/fraxtal.js'

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -73,6 +73,7 @@ export { filecoinHyperspace } from './definitions/filecoinHyperspace.js'
 export { flare } from './definitions/flare.js'
 export { flareTestnet } from './definitions/flareTestnet.js'
 export { flowPreviewnet } from './definitions/flowPreviewnet.js'
+export { flowMainnet } from './definitions/flowMainnet.js'
 /** @deprecated Use `anvil` instead. */
 export { foundry } from './definitions/foundry.js'
 export { fraxtal } from './definitions/fraxtal.js'


### PR DESCRIPTION
## Description

Flow blockchain network is building out evm compatibility. Here is a PR for adding previewnet (testnet).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the Flow EVM network on both previewnet and mainnet. It includes the definition of the FlowPreviewnet chain and updates the index to export the new chains.

### Detailed summary
- Added definition for `flowPreviewnet` chain
- Added definition for `flowMainnet` chain
- Updated index to export `flowPreviewnet` and `flowMainnet` chains

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->