### PR TITLE
Adds "observe" function to "watchBlockNumber" when web socket is being used

### DIFF
--- a/.changeset/six-dogs-judge.md
+++ b/.changeset/six-dogs-judge.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Deduped `eth_subscribe` instantiation on `watchBlockNumber`.

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -156,7 +156,7 @@ export function watchBlockNumber<
       emitMissed,
     ])
 
-    return observe(observerId, { onBlockNumber, onError }, () => {
+    return observe(observerId, { onBlockNumber, onError }, (emit) => {
       let active = true
       let unsubscribe = () => (active = false)
       ;(async () => {
@@ -167,11 +167,11 @@ export function watchBlockNumber<
               onData(data: any) {
                 if (!active) return
                 const blockNumber = hexToBigInt(data.result?.number)
-                onBlockNumber(blockNumber, prevBlockNumber)
+                emit.onBlockNumber(blockNumber, prevBlockNumber)
                 prevBlockNumber = blockNumber
               },
               onError(error: Error) {
-                onError?.(error)
+                emit.onError?.(error)
               },
             })
           unsubscribe = unsubscribe_


### PR DESCRIPTION
I'm pushing this up for visibility but could use some guidance on requirements for testing

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `subscribeBlockNumber` function to use a more streamlined and deduped approach for handling block number subscriptions.

### Detailed summary
- Refactored `subscribeBlockNumber` function to dedupe `eth_subscribe` instantiation
- Introduced `observerId` for identification
- Utilized `observe` function for handling block number subscriptions
- Improved error handling and code readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->