### PR TITLE
Add PlayFi Albireo testnet

### DIFF
--- a/.changeset/fast-numbers-obey.md
+++ b/.changeset/fast-numbers-obey.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added PlayFi Albireo testnet

--- a/.changeset/light-dolls-remain.md
+++ b/.changeset/light-dolls-remain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added albireo chain multicall address + made transactions zksync compatible

--- a/src/chains/definitions/albireo.ts
+++ b/src/chains/definitions/albireo.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../zksync/chainConfig.js'
+
+export const albireo = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 1612127,
+  name: 'PlayFi Albireo testnet',
+  network: 'albireo',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://albireo-rpc.playfi.ai'],
+      webSocket: ['wss://albireo-rpc-ws.playfi.ai/ws'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'PlayFi Explorer',
+      url: 'https://albireo-explorer.playfi.ai/',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/albireo.ts
+++ b/src/chains/definitions/albireo.ts
@@ -19,5 +19,10 @@ export const albireo = /*#__PURE__*/ defineChain({
       url: 'https://albireo-explorer.playfi.ai/',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xF9cda624FBC7e059355ce98a31693d299FACd963',
+    },
+  },
   testnet: true,
 })

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,6 +1,7 @@
 export type { Chain } from '../types/chain.js'
 
 export { acala } from './definitions/acala.js'
+export { albireo } from './definitions/albireo.js'
 export { ancient8 } from './definitions/ancient8.js'
 export { ancient8Sepolia } from './definitions/ancient8Sepolia.js'
 export { anvil } from './definitions/anvil.js'

--- a/src/chains/zksync/chains.ts
+++ b/src/chains/zksync/chains.ts
@@ -1,3 +1,4 @@
 export { zkSync } from '../definitions/zkSync.js'
 export { zkSyncTestnet } from '../definitions/zkSyncTestnet.js'
 export { zkSyncSepoliaTestnet } from '../definitions/zkSyncSepoliaTestnet.js'
+export { albireo } from '../definitions/albireo.js'

--- a/src/chains/zksync/index.ts
+++ b/src/chains/zksync/index.ts
@@ -27,6 +27,7 @@ export {
   zkSync,
   zkSyncTestnet,
   zkSyncSepoliaTestnet,
+  albireo,
 } from './chains.js'
 
 export { chainConfig } from './chainConfig.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the PlayFi Albireo testnet in the project's chain configurations.

### Detailed summary
- Added `albireo` chain to project configurations
- Updated chain definitions and configurations for Albireo testnet
- Made transactions zksync compatible with Albireo
- Added Albireo chain multicall address

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->