### PR TITLE
chore: add beam websocket entrypoints

### DIFF
--- a/.changeset/fifty-adults-invent.md
+++ b/.changeset/fifty-adults-invent.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Beam Websocket RPC URLs.

--- a/src/chains/definitions/beam.ts
+++ b/src/chains/definitions/beam.ts
@@ -12,9 +12,11 @@ export const beam = /*#__PURE__*/ defineChain({
   rpcUrls: {
     public: {
       http: ['https://build.onbeam.com/rpc'],
+      webSocket: ['wss://build.onbeam.com/ws'],
     },
     default: {
       http: ['https://build.onbeam.com/rpc'],
+      webSocket: ['wss://build.onbeam.com/ws'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/beamTestnet.ts
+++ b/src/chains/definitions/beamTestnet.ts
@@ -12,9 +12,11 @@ export const beamTestnet = /*#__PURE__*/ defineChain({
   rpcUrls: {
     public: {
       http: ['https://build.onbeam.com/rpc/testnet'],
+      webSocket: ['wss://build.onbeam.com/ws/testnet'],
     },
     default: {
       http: ['https://build.onbeam.com/rpc/testnet'],
+      webSocket: ['wss://build.onbeam.com/ws/testnet'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Hi there @jxom, I hope you're still going strong over there.

I take it the team has been purged by now and the self-proclaimed documentation "experts" have been marked excommunicado?

Just updated the Beam config with websocket entrypoints, those might come in handy. 

Big thanks!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Beam Websocket RPC URLs for both the mainnet and testnet environments.

### Detailed summary
- Added Websocket RPC URLs for Beam mainnet and testnet environments in `beam.ts` and `beamTestnet.ts` definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->