### PR TITLE
fix: Update Arbitrum Sepolia Explorer API URL

### DIFF
--- a/.changeset/popular-fireants-cover.md
+++ b/.changeset/popular-fireants-cover.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Arbitrum Sepolia API URL.

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -17,7 +17,7 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Arbiscan',
       url: 'https://sepolia.arbiscan.io',
-      apiUrl: 'https://sepolia.arbiscan.io/api',
+      apiUrl: 'https://api-sepolia.arbiscan.io/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Update to be the correct api URL

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Arbitrum Sepolia API URL.

### Detailed summary
- Updated the Arbitrum Sepolia API URL in `arbitrumSepolia.ts` from `https://sepolia.arbiscan.io/api` to `https://api-sepolia.arbiscan.io/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->