### PR TITLE
Update misc.md

### DIFF
--- a/site/pages/docs/third-party/misc.md
+++ b/site/pages/docs/third-party/misc.md
@@ -37,7 +37,7 @@ bun i reverse-mirage
 ```ts
 import { createClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
-import { publicActionsReverseMirage } from 'reverse-mirage'
+import publicActionsReverseMirage from 'reverse-mirage'
  
 const client = createClient({ 
   chain: mainnet,

--- a/site/pages/docs/third-party/misc.md
+++ b/site/pages/docs/third-party/misc.md
@@ -37,12 +37,12 @@ bun i reverse-mirage
 ```ts
 import { createClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
-import publicActionsReverseMirage from 'reverse-mirage'
+import { publicActionReverseMirage } from 'reverse-mirage'
  
 const client = createClient({ 
   chain: mainnet,
   transport: http()
-}).extend(publicActionsReverseMirage)
+}).extend(publicActionReverseMirage)
 ```
 
 ### 3. Consume Actions


### PR DESCRIPTION
fixed import, otherwise shows

```
export 'publicActionsReverseMirage' (imported as 'publicActionsReverseMirage') was not found in 'reverse-mirage' (possible exports: PermitType, adjustedPrice
```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the import and usage of the `publicActionReverseMirage` instead of `publicActionsReverseMirage`.

### Detailed summary
- Updated import from `publicActionsReverseMirage` to `publicActionReverseMirage`
- Updated the extension of client with `publicActionReverseMirage` instead of `publicActionsReverseMirage`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->