### PR TITLE
feat: support `exactOptionalPropertyTypes`

### DIFF
--- a/.changeset/hip-bikes-switch.md
+++ b/.changeset/hip-bikes-switch.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support `exactOptionalPropertyTypes`.

--- a/src/accounts/generateMnemonic.ts
+++ b/src/accounts/generateMnemonic.ts
@@ -13,7 +13,7 @@ export type GenerateMnemonicErrorType = ErrorType
  */
 export function generateMnemonic(
   wordlist: string[],
-  strength?: number,
+  strength?: number | undefined,
 ): string {
   return generateMnemonic_(wordlist, strength)
 }

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -25,9 +25,11 @@ export type CustomSource = {
     transaction extends Parameters<serializer>[0] = Parameters<serializer>[0],
   >(
     transaction: transaction,
-    args?: {
-      serializer?: serializer
-    },
+    args?:
+      | {
+          serializer?: serializer | undefined
+        }
+      | undefined,
   ) => Promise<
     IsNarrowable<
       TransactionSerialized<GetTransactionType<transaction>>,
@@ -66,17 +68,17 @@ export type HDAccount = LocalAccount<'hd'> & {
 export type HDOptions =
   | {
       /** The account index to use in the path (`"m/44'/60'/${accountIndex}'/0/0"`). */
-      accountIndex?: number
+      accountIndex?: number | undefined
       /** The address index to use in the path (`"m/44'/60'/0'/0/${addressIndex}"`). */
-      addressIndex?: number
+      addressIndex?: number | undefined
       /** The change index to use in the path (`"m/44'/60'/0'/${changeIndex}/0"`). */
-      changeIndex?: number
-      path?: never
+      changeIndex?: number | undefined
+      path?: never | undefined
     }
   | {
-      accountIndex?: never
-      addressIndex?: never
-      changeIndex?: never
+      accountIndex?: never | undefined
+      addressIndex?: never | undefined
+      changeIndex?: never | undefined
       /** The HD path. */
       path: `m/44'/60'/${string}`
     }

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -23,7 +23,7 @@ export type SignTransactionParameters<
 > = {
   privateKey: Hex
   transaction: transaction
-  serializer?: serializer
+  serializer?: serializer | undefined
 }
 
 export type SignTransactionReturnType<

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -38,15 +38,15 @@ import {
 export type GetEnsAddressParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** ENSIP-9 compliant coinType used to resolve addresses for other chains */
-    coinType?: number
+    coinType?: number | undefined
     /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
-    gatewayUrls?: string[]
+    gatewayUrls?: string[] | undefined
     /** Name to get the address for. */
     name: string
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
-    strict?: boolean
+    strict?: boolean | undefined
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -19,7 +19,7 @@ import {
 export type GetEnsAvatarParameters = Prettify<
   Omit<GetEnsTextParameters, 'key'> & {
     /** Gateway urls to resolve IPFS and/or Arweave assets. */
-    assetGatewayUrls?: AssetGatewayUrls
+    assetGatewayUrls?: AssetGatewayUrls | undefined
   }
 >
 

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -28,11 +28,11 @@ export type GetEnsNameParameters = Prettify<
     /** Address to get ENS name for. */
     address: Address
     /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
-    gatewayUrls?: string[]
+    gatewayUrls?: string[] | undefined
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
-    strict?: boolean
+    strict?: boolean | undefined
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -25,7 +25,7 @@ export type GetEnsResolverParameters = Prettify<
     /** Name to get the address for. */
     name: string
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -39,13 +39,13 @@ export type GetEnsTextParameters = Prettify<
     /** ENS name to get Text for. */
     name: string
     /** Universal Resolver gateway URLs to use for resolving CCIP-read requests. */
-    gatewayUrls?: string[]
+    gatewayUrls?: string[] | undefined
     /** Text record to retrieve. */
     key: string
     /** Whether or not to throw errors propagated from the ENS Universal Resolver Contract. */
-    strict?: boolean
+    strict?: boolean | undefined
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -327,7 +327,7 @@ test('with and without wallet client `account`', () => {
 
   expectTypeOf(contractWithAccount.write.approve)
     .parameter(1)
-    .extract<{ account?: Account | Address }>()
+    .extract<{ account?: Account | Address | undefined }>()
     // @ts-expect-error
     .toBeNever()
   expectTypeOf(contractWithoutAccount.write.approve)
@@ -349,7 +349,7 @@ test('with and without wallet client `chain`', () => {
 
   expectTypeOf(contractWithChain.write.approve)
     .parameter(1)
-    .extract<{ chain?: Chain | null }>()
+    .extract<{ chain?: Chain | null | undefined }>()
     // @ts-expect-error
     .toBeNever()
   expectTypeOf(contractWithoutChain.write.approve)

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -74,12 +74,12 @@ type KeyedClient<
   TAccount extends Account | undefined = Account | undefined,
 > =
   | {
-      public?: Client<TTransport, TChain>
+      public?: Client<TTransport, TChain> | undefined
       wallet: Client<TTransport, TChain, TAccount>
     }
   | {
       public: Client<TTransport, TChain>
-      wallet?: Client<TTransport, TChain, TAccount>
+      wallet?: Client<TTransport, TChain, TAccount> | undefined
     }
 
 export type GetContractParameters<
@@ -786,7 +786,7 @@ export function getContract<
  * @internal exporting for testing only
  */
 export function getFunctionParameters(
-  values: [args?: readonly unknown[], options?: object],
+  values: [args?: readonly unknown[] | undefined, options?: object | undefined],
 ) {
   const hasArgs = values.length && Array.isArray(values[0])
   const args = hasArgs ? values[0]! : []

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -44,7 +44,7 @@ import type {
 } from '../../types/rpc.js'
 import type { StateMapping, StateOverride } from '../../types/stateOverride.js'
 import type { TransactionRequest } from '../../types/transaction.js'
-import type { UnionOmit } from '../../types/utils.js'
+import type { ExactPartial, UnionOmit } from '../../types/utils.js'
 import {
   type DecodeFunctionResultErrorType,
   decodeFunctionResult,
@@ -90,24 +90,24 @@ export type FormattedCall<
 export type CallParameters<
   TChain extends Chain | undefined = Chain | undefined,
 > = UnionOmit<FormattedCall<TChain>, 'from'> & {
-  account?: Account | Address
-  batch?: boolean
+  account?: Account | Address | undefined
+  batch?: boolean | undefined
 } & (
     | {
         /** The balance of the account at a block number. */
-        blockNumber?: bigint
-        blockTag?: never
+        blockNumber?: bigint | undefined
+        blockTag?: never | undefined
       }
     | {
-        blockNumber?: never
+        blockNumber?: never | undefined
         /**
          * The balance of the account at a block tag.
          * @default 'latest'
          */
-        blockTag?: BlockTag
+        blockTag?: BlockTag | undefined
       }
   ) & {
-    stateOverride?: StateOverride
+    stateOverride?: StateOverride | undefined
   }
 
 export type CallReturnType = { data: Hex | undefined }
@@ -219,8 +219,12 @@ export async function call<TChain extends Chain | undefined>(
     const response = await client.request({
       method: 'eth_call',
       params: rpcStateOverride
-        ? [request as Partial<RpcTransactionRequest>, block, rpcStateOverride]
-        : [request as Partial<RpcTransactionRequest>, block],
+        ? [
+            request as ExactPartial<RpcTransactionRequest>,
+            block,
+            rpcStateOverride,
+          ]
+        : [request as ExactPartial<RpcTransactionRequest>, block],
     })
     if (response === '0x') return { data: undefined }
     return { data: response }
@@ -262,7 +266,7 @@ type ScheduleMulticallParameters<TChain extends Chain | undefined> = Pick<
   'blockNumber' | 'blockTag'
 > & {
   data: Hex
-  multicallAddress?: Address
+  multicallAddress?: Address | undefined
   to: Address
 }
 
@@ -422,7 +426,7 @@ export type ParseStateOverrideErrorType =
   | ParseAccountStateOverrideErrorType
 
 export function parseStateOverride(
-  args?: StateOverride,
+  args?: StateOverride | undefined,
 ): RpcStateOverride | undefined {
   if (!args) return undefined
   const rpcStateOverride: RpcStateOverride = {}

--- a/src/actions/public/createContractEventFilter.ts
+++ b/src/actions/public/createContractEventFilter.ts
@@ -33,26 +33,29 @@ export type CreateContractEventFilterParameters<
   fromBlock extends BlockNumber | BlockTag | undefined = undefined,
   toBlock extends BlockNumber | BlockTag | undefined = undefined,
 > = {
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   abi: abi
   eventName?: eventName | ContractEventName<abi> | undefined
-  fromBlock?: fromBlock | BlockNumber | BlockTag
+  fromBlock?: fromBlock | BlockNumber | BlockTag | undefined
   /**
    * Whether or not the logs must match the indexed/non-indexed arguments in the event ABI item.
    * @default false
    */
   strict?: strict | boolean | undefined
-  toBlock?: toBlock | BlockNumber | BlockTag
+  toBlock?: toBlock | BlockNumber | BlockTag | undefined
 } & (undefined extends eventName
   ? {
-      args?: never
+      args?: never | undefined
     }
   : MaybeExtractEventArgsFromAbi<abi, eventName> extends infer TEventFilterArgs
     ? {
-        args?: TEventFilterArgs | (args extends TEventFilterArgs ? args : never)
+        args?:
+          | TEventFilterArgs
+          | (args extends TEventFilterArgs ? args : never)
+          | undefined
       }
     : {
-        args?: never
+        args?: never | undefined
       })
 
 export type CreateContractEventFilterReturnType<

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -38,9 +38,9 @@ export type CreateEventFilterParameters<
     | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
     | undefined = undefined,
 > = {
-  address?: Address | Address[]
-  fromBlock?: TFromBlock | BlockNumber | BlockTag
-  toBlock?: TToBlock | BlockNumber | BlockTag
+  address?: Address | Address[] | undefined
+  fromBlock?: TFromBlock | BlockNumber | BlockTag | undefined
+  toBlock?: TToBlock | BlockNumber | BlockTag | undefined
 } & (MaybeExtractEventArgsFromAbi<
   TAbiEvents,
   _EventName
@@ -51,44 +51,44 @@ export type CreateEventFilterParameters<
             | TEventFilterArgs
             | (_Args extends TEventFilterArgs ? _Args : never)
           event: TAbiEvent
-          events?: never
+          events?: never | undefined
           /**
            * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
            * @default false
            */
-          strict?: TStrict
+          strict?: TStrict | undefined
         }
       | {
-          args?: never
-          event?: TAbiEvent
-          events?: never
+          args?: never | undefined
+          event?: TAbiEvent | undefined
+          events?: never | undefined
           /**
            * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
            * @default false
            */
-          strict?: TStrict
+          strict?: TStrict | undefined
         }
       | {
-          args?: never
-          event?: never
-          events: TAbiEvents
+          args?: never | undefined
+          event?: never | undefined
+          events: TAbiEvents | undefined
           /**
            * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
            * @default false
            */
-          strict?: TStrict
+          strict?: TStrict | undefined
         }
       | {
-          args?: never
-          event?: never
-          events?: never
-          strict?: never
+          args?: never | undefined
+          event?: never | undefined
+          events?: never | undefined
+          strict?: never | undefined
         }
   : {
-      args?: never
-      event?: never
-      events?: never
-      strict?: never
+      args?: never | undefined
+      event?: never | undefined
+      events?: never | undefined
+      strict?: never | undefined
     })
 
 export type CreateEventFilterReturnType<

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -41,7 +41,7 @@ export type EstimateFeesPerGasParameters<
    *
    * @default 'eip1559'
    */
-  type?: type | FeeValuesType
+  type?: type | FeeValuesType | undefined
 } & GetChainParameter<chain, chainOverride>
 
 export type EstimateFeesPerGasReturnType<
@@ -86,7 +86,7 @@ export async function estimateFeesPerGas<
   type extends FeeValuesType = 'eip1559',
 >(
   client: Client<Transport, chain>,
-  args?: EstimateFeesPerGasParameters<chain, chainOverride, type>,
+  args?: EstimateFeesPerGasParameters<chain, chainOverride, type> | undefined,
 ): Promise<EstimateFeesPerGasReturnType<type>> {
   return internal_estimateFeesPerGas(client, args as any)
 }
@@ -98,8 +98,8 @@ export async function internal_estimateFeesPerGas<
 >(
   client: Client<Transport, chain>,
   args: EstimateFeesPerGasParameters<chain, chainOverride, type> & {
-    block?: Block
-    request?: PrepareTransactionRequestParameters
+    block?: Block | undefined
+    request?: PrepareTransactionRequestParameters | undefined
   },
 ): Promise<EstimateFeesPerGasReturnType<type>> {
   const {

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -42,20 +42,20 @@ export type FormattedEstimateGas<
 export type EstimateGasParameters<
   TChain extends Chain | undefined = Chain | undefined,
 > = UnionOmit<FormattedEstimateGas<TChain>, 'from'> & {
-  account?: Account | Address
+  account?: Account | Address | undefined
 } & (
     | {
         /** The balance of the account at a block number. */
-        blockNumber?: bigint
-        blockTag?: never
+        blockNumber?: bigint | undefined
+        blockTag?: never | undefined
       }
     | {
-        blockNumber?: never
+        blockNumber?: never | undefined
         /**
          * The balance of the account at a block tag.
          * @default 'latest'
          */
-        blockTag?: BlockTag
+        blockTag?: BlockTag | undefined
       }
   )
 

--- a/src/actions/public/estimateMaxPriorityFeePerGas.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.ts
@@ -62,7 +62,9 @@ export async function estimateMaxPriorityFeePerGas<
   chainOverride extends Chain | undefined,
 >(
   client: Client<Transport, chain>,
-  args?: EstimateMaxPriorityFeePerGasParameters<chain, chainOverride>,
+  args?:
+    | EstimateMaxPriorityFeePerGasParameters<chain, chainOverride>
+    | undefined,
 ): Promise<EstimateMaxPriorityFeePerGasReturnType> {
   return internal_estimateMaxPriorityFeePerGas(client, args as any)
 }
@@ -73,12 +75,14 @@ export async function internal_estimateMaxPriorityFeePerGas<
 >(
   client: Client<Transport, chain>,
   args: EstimateMaxPriorityFeePerGasParameters<chain, chainOverride> & {
-    block?: Block
-    request?: PrepareTransactionRequestParameters<
-      chain,
-      Account | undefined,
-      chainOverride
-    >
+    block?: Block | undefined
+    request?:
+      | PrepareTransactionRequestParameters<
+          chain,
+          Account | undefined,
+          chainOverride
+        >
+      | undefined
   },
 ): Promise<EstimateMaxPriorityFeePerGasReturnType> {
   const { block: block_, chain = client.chain, request } = args || {}

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -17,13 +17,13 @@ export type GetBalanceParameters = {
 } & (
   | {
       /** The balance of the account at a block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /** The balance of the account at a block tag. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -26,28 +26,28 @@ export type GetBlockParameters<
   TBlockTag extends BlockTag = 'latest',
 > = {
   /** Whether or not to include transaction data in the response. */
-  includeTransactions?: TIncludeTransactions
+  includeTransactions?: TIncludeTransactions | undefined
 } & (
   | {
       /** Hash of the block. */
-      blockHash?: Hash
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: Hash | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /**
        * The block tag.
        * @default 'latest'
        */
-      blockTag?: TBlockTag | BlockTag
+      blockTag?: TBlockTag | BlockTag | undefined
     }
 )
 

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -7,7 +7,7 @@ import { getCache, withCache } from '../../utils/promise/withCache.js'
 
 export type GetBlockNumberParameters = {
   /** Time (in ms) that cached block number will remain in memory. */
-  cacheTime?: number
+  cacheTime?: number | undefined
 }
 
 export type GetBlockNumberReturnType = bigint

--- a/src/actions/public/getBlockTransactionCount.ts
+++ b/src/actions/public/getBlockTransactionCount.ts
@@ -18,21 +18,21 @@ import {
 export type GetBlockTransactionCountParameters =
   | {
       /** Hash of the block. */
-      blockHash?: Hash
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: Hash | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /** The block tag. Defaults to 'latest'. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 
 export type GetBlockTransactionCountReturnType = number

--- a/src/actions/public/getBytecode.ts
+++ b/src/actions/public/getBytecode.ts
@@ -16,12 +16,12 @@ export type GetBytecodeParameters = {
   address: Address
 } & (
   | {
-      blockNumber?: never
-      blockTag?: BlockTag
+      blockNumber?: never | undefined
+      blockTag?: BlockTag | undefined
     }
   | {
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 

--- a/src/actions/public/getContractEvents.ts
+++ b/src/actions/public/getContractEvents.ts
@@ -33,7 +33,7 @@ export type GetContractEventsParameters<
   toBlock extends BlockNumber | BlockTag | undefined = undefined,
 > = {
   /** The address of the contract. */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   /** Contract ABI. */
   abi: abi
   args?:
@@ -54,16 +54,16 @@ export type GetContractEventsParameters<
 } & (
   | {
       /** Block number or tag after which to include logs */
-      fromBlock?: fromBlock | BlockNumber | BlockTag
+      fromBlock?: fromBlock | BlockNumber | BlockTag | undefined
       /** Block number or tag before which to include logs */
-      toBlock?: toBlock | BlockNumber | BlockTag
+      toBlock?: toBlock | BlockNumber | BlockTag | undefined
       blockHash?: undefined
     }
   | {
       fromBlock?: undefined
       toBlock?: undefined
       /** Hash of block to include logs from */
-      blockHash?: Hash
+      blockHash?: Hash | undefined
     }
 )
 

--- a/src/actions/public/getFeeHistory.ts
+++ b/src/actions/public/getFeeHistory.ts
@@ -24,17 +24,17 @@ export type GetFeeHistoryParameters = {
   rewardPercentiles: number[]
 } & (
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /**
        * Highest number block of the requested range.
        * @default 'latest'
        */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
   | {
       /** Highest number block of the requested range. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 export type GetFeeHistoryReturnType = FeeHistory

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -41,48 +41,48 @@ export type GetLogsParameters<
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = {
   /** Address or list of addresses from which logs originated */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
 } & (
   | {
       event: TAbiEvent
-      events?: never
-      args?: MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
+      events?: never | undefined
+      args?: MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName> | undefined
       /**
        * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
        * @default false
        */
-      strict?: TStrict
+      strict?: TStrict | undefined
     }
   | {
-      event?: never
+      event?: never | undefined
       events: TAbiEvents
-      args?: never
+      args?: never | undefined
       /**
        * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
        * @default false
        */
-      strict?: TStrict
+      strict?: TStrict | undefined
     }
   | {
-      event?: never
-      events?: never
-      args?: never
-      strict?: never
+      event?: never | undefined
+      events?: never | undefined
+      args?: never | undefined
+      strict?: never | undefined
     }
 ) &
   (
     | {
         /** Block number or tag after which to include logs */
-        fromBlock?: TFromBlock | BlockNumber | BlockTag
+        fromBlock?: TFromBlock | BlockNumber | BlockTag | undefined
         /** Block number or tag before which to include logs */
-        toBlock?: TToBlock | BlockNumber | BlockTag
-        blockHash?: never
+        toBlock?: TToBlock | BlockNumber | BlockTag | undefined
+        blockHash?: never | undefined
       }
     | {
-        fromBlock?: never
-        toBlock?: never
+        fromBlock?: never | undefined
+        toBlock?: never | undefined
         /** Hash of block to include logs from */
-        blockHash?: Hash
+        blockHash?: Hash | undefined
       }
   )
 

--- a/src/actions/public/getProof.ts
+++ b/src/actions/public/getProof.ts
@@ -24,16 +24,16 @@ export type GetProofParameters = {
 } & (
   | {
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /**
        * The block tag.
        * @default 'latest'
        */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 

--- a/src/actions/public/getStorageAt.ts
+++ b/src/actions/public/getStorageAt.ts
@@ -17,12 +17,12 @@ export type GetStorageAtParameters = {
   slot: Hex
 } & (
   | {
-      blockNumber?: never
-      blockTag?: BlockTag
+      blockNumber?: never | undefined
+      blockTag?: BlockTag | undefined
     }
   | {
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -21,37 +21,37 @@ export type GetTransactionParameters<TBlockTag extends BlockTag = 'latest'> =
   | {
       /** The block hash */
       blockHash: Hash
-      blockNumber?: never
-      blockTag?: never
-      hash?: never
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number */
       blockNumber: bigint
-      blockTag?: never
-      hash?: never
+      blockTag?: never | undefined
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /** The block tag. */
       blockTag: TBlockTag | BlockTag
-      hash?: never
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
       /** The hash of the transaction. */
       hash: Hash
-      index?: number
+      index?: number | undefined
     }
 
 export type GetTransactionReturnType<

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -21,10 +21,10 @@ export type GetTransactionConfirmationsParameters<
   | {
       /** The transaction hash. */
       hash: Hash
-      transactionReceipt?: never
+      transactionReceipt?: never | undefined
     }
   | {
-      hash?: never
+      hash?: never | undefined
       /** The transaction receipt. */
       transactionReceipt: FormattedTransactionReceipt<TChain>
     }

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -22,13 +22,13 @@ export type GetTransactionCountParameters = {
 } & (
   | {
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /** The block tag. Defaults to 'latest'. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 export type GetTransactionCountReturnType = number

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -54,10 +54,10 @@ export type SimulateContractParameters<
   ///
   derivedChain extends Chain | undefined = DeriveChain<chain, chainOverride>,
 > = {
-  account?: accountOverride
-  chain?: chainOverride
+  account?: accountOverride | undefined
+  chain?: chainOverride | undefined
   /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
-  dataSuffix?: Hex
+  dataSuffix?: Hex | undefined
 } & ContractFunctionParameters<
   abi,
   'nonpayable' | 'payable',

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -55,28 +55,28 @@ export type WaitForTransactionReceiptParameters<
    * The number of confirmations (blocks that have passed) to wait before resolving.
    * @default 1
    */
-  confirmations?: number
+  confirmations?: number | undefined
   /** The hash of the transaction. */
   hash: Hash
   /** Optional callback to emit if the transaction has been replaced. */
-  onReplaced?: (response: ReplacementReturnType<TChain>) => void
+  onReplaced?: ((response: ReplacementReturnType<TChain>) => void) | undefined
   /**
    * Polling frequency (in ms). Defaults to the client's pollingInterval config.
    * @default client.pollingInterval
    */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
   /**
    * Number of times to retry if the transaction or block is not found.
    * @default 6 (exponential backoff)
    */
-  retryCount?: WithRetryParameters['retryCount']
+  retryCount?: WithRetryParameters['retryCount'] | undefined
   /**
    * Time to wait (in ms) between retries.
    * @default `({ count }) => ~~(1 << count) * 200` (exponential backoff)
    */
-  retryDelay?: WithRetryParameters['delay']
+  retryDelay?: WithRetryParameters['delay'] | undefined
   /** Optional timeout (in milliseconds) to wait before stopping polling. */
-  timeout?: number
+  timeout?: number | undefined
 }
 
 export type WaitForTransactionReceiptErrorType =

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -26,7 +26,7 @@ export type WatchBlockNumberParameters<
   /** The callback to call when a new block number is received. */
   onBlockNumber: OnBlockNumberFn
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: ((error: Error) => void) | undefined
 } & (
   | (GetTransportConfig<TTransport>['type'] extends 'webSocket'
       ? {

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -69,38 +69,38 @@ export type WatchEventParameters<
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = {
   /** The address of the contract. */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: ((error: Error) => void) | undefined
   /** The callback to call when new event logs are received. */
   onLogs: WatchEventOnLogsFn<TAbiEvent, TAbiEvents, TStrict, _EventName>
 } & GetPollOptions<TTransport> &
   (
     | {
         event: TAbiEvent
-        events?: never
-        args?: MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
+        events?: never | undefined
+        args?: MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName> | undefined
         /**
          * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
          * @default false
          */
-        strict?: TStrict
+        strict?: TStrict | undefined
       }
     | {
-        event?: never
-        events?: TAbiEvents
-        args?: never
+        event?: never | undefined
+        events?: TAbiEvents | undefined
+        args?: never | undefined
         /**
          * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
          * @default false
          */
-        strict?: TStrict
+        strict?: TStrict | undefined
       }
     | {
-        event?: never
-        events?: never
-        args?: never
-        strict?: never
+        event?: never | undefined
+        events?: never | undefined
+        args?: never | undefined
+        strict?: never | undefined
       }
   )
 

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -21,7 +21,7 @@ export type WatchPendingTransactionsParameters<
   TTransport extends Transport = Transport,
 > = {
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: ((error: Error) => void) | undefined
   /** The callback to call when new transactions are received. */
   onTransactions: OnTransactionsFn
 } & GetPollOptions<TTransport>

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -13,7 +13,7 @@ export type MineParameters = {
   /** Number of blocks to mine. */
   blocks: number
   /** Interval between each block in seconds. */
-  interval?: number
+  interval?: number | undefined
 }
 
 export type MineErrorType = RequestErrorType | ErrorType

--- a/src/actions/test/reset.ts
+++ b/src/actions/test/reset.ts
@@ -10,9 +10,9 @@ import type { RequestErrorType } from '../../utils/buildRequest.js'
 
 export type ResetParameters = {
   /** The block number to reset from. */
-  blockNumber?: bigint
+  blockNumber?: bigint | undefined
   /** The JSON RPC URL. */
-  jsonRpcUrl?: string
+  jsonRpcUrl?: string | undefined
 }
 
 export type ResetErrorType = RequestErrorType | ErrorType

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -42,6 +42,7 @@ import type {
   TransactionSerializable,
 } from '../../types/transaction.js'
 import type {
+  ExactPartial,
   IsNever,
   Prettify,
   UnionOmit,
@@ -76,7 +77,7 @@ export type PrepareTransactionRequestRequest<
   _derivedChain extends Chain | undefined = DeriveChain<chain, chainOverride>,
 > = UnionOmit<FormattedTransactionRequest<_derivedChain>, 'from'> &
   GetTransactionRequestKzgParameter & {
-    parameters?: PrepareTransactionRequestParameterType[]
+    parameters?: PrepareTransactionRequestParameterType[] | undefined
   }
 
 export type PrepareTransactionRequestParameters<
@@ -94,7 +95,7 @@ export type PrepareTransactionRequestParameters<
 > = request &
   GetAccountParameter<account, accountOverride, false> &
   GetChainParameter<chain, chainOverride> &
-  GetTransactionRequestKzgParameter<request> & { chainId?: number }
+  GetTransactionRequestKzgParameter<request> & { chainId?: number | undefined }
 
 export type PrepareTransactionRequestReturnType_<
   chain extends Chain | undefined = Chain | undefined,
@@ -156,8 +157,8 @@ export type PrepareTransactionRequestReturnType<
           : { account?: undefined; from?: undefined }),
       IsNever<_transactionRequest> extends true
         ? unknown
-        : Partial<_transactionRequest>
-    > & { chainId?: number },
+        : ExactPartial<_transactionRequest>
+    > & { chainId?: number | undefined },
     ParameterTypeToParameters<
       request['parameters'] extends PrepareTransactionRequestParameterType[]
         ? request['parameters'][number]

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -64,7 +64,7 @@ export type WriteContractParameters<
         FormattedTransactionRequest<derivedChain>['value']
       > & {
         /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
-        dataSuffix?: Hex
+        dataSuffix?: Hex | undefined
       }
   > &
   UnionEvaluate<

--- a/src/chains/celo/formatters.test-d.ts
+++ b/src/chains/celo/formatters.test-d.ts
@@ -11,7 +11,7 @@ import { http } from '../../clients/transports/http.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
-import type { Assign } from '../../types/utils.js'
+import type { Assign, ExactPartial } from '../../types/utils.js'
 import { celo } from '../index.js'
 import { formatters } from './formatters.js'
 import type {
@@ -23,7 +23,7 @@ import type {
 describe('block', () => {
   expectTypeOf(formatters.block.format).parameter(0).toEqualTypeOf<
     Assign<
-      Partial<RpcBlock>,
+      ExactPartial<RpcBlock>,
       CeloBlockOverrides & {
         transactions: `0x${string}`[] | CeloRpcTransaction[]
       }
@@ -68,7 +68,7 @@ describe('transactionRequest', () => {
   expectTypeOf(formatters.transactionRequest.format)
     .parameter(0)
     .toEqualTypeOf<
-      Assign<Partial<TransactionRequest>, CeloTransactionRequest>
+      Assign<ExactPartial<TransactionRequest>, CeloTransactionRequest>
     >()
   expectTypeOf<
     ReturnType<typeof formatters.transactionRequest.format>['feeCurrency']

--- a/src/chains/celo/parsers.ts
+++ b/src/chains/celo/parsers.ts
@@ -1,5 +1,6 @@
 import { InvalidSerializedTransactionError } from '../../errors/transaction.js'
 import type { Hex } from '../../types/misc.js'
+import type { ExactPartial } from '../../types/utils.js'
 import { isHex } from '../../utils/data/isHex.js'
 import { sliceHex } from '../../utils/data/slice.js'
 import { hexToBigInt, hexToNumber } from '../../utils/encoding/fromHex.js'
@@ -102,7 +103,7 @@ function parseTransactionCIP42(
     })
   }
 
-  const transaction: Partial<TransactionSerializableCIP42> = {
+  const transaction: ExactPartial<TransactionSerializableCIP42> = {
     chainId: hexToNumber(chainId as Hex),
     type: 'cip42',
   }
@@ -177,7 +178,7 @@ function parseTransactionCIP64(
     })
   }
 
-  const transaction: Partial<TransactionSerializableCIP64> = {
+  const transaction: ExactPartial<TransactionSerializableCIP64> = {
     chainId: hexToNumber(chainId as Hex),
     type: 'cip64',
   }

--- a/src/chains/celo/serializers.ts
+++ b/src/chains/celo/serializers.ts
@@ -24,7 +24,7 @@ import { isCIP42, isCIP64, isEmpty, isPresent } from './utils.js'
 
 export function serializeTransaction(
   transaction: CeloTransactionSerializable,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ) {
   if (isCIP64(transaction))
     return serializeTransactionCIP64(transaction, signature)
@@ -48,7 +48,7 @@ export type SerializeTransactionCIP64ReturnType = TransactionSerializedCIP64
 // This will be in addition to the type 0x02 transaction as specified in EIP-1559.
 function serializeTransactionCIP42(
   transaction: TransactionSerializableCIP42,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): SerializeTransactionCIP42ReturnType {
   assertTransactionCIP42(transaction)
   const {
@@ -90,7 +90,7 @@ function serializeTransactionCIP42(
 
 function serializeTransactionCIP64(
   transaction: TransactionSerializableCIP64,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): SerializeTransactionCIP64ReturnType {
   assertTransactionCIP64(transaction)
   const {

--- a/src/chains/celo/types.ts
+++ b/src/chains/celo/types.ts
@@ -21,7 +21,7 @@ import type {
   TransactionSerializableBase,
   TransactionSerialized,
 } from '../../types/transaction.js'
-import type { NeverBy, OneOf } from '../../types/utils.js'
+import type { ExactPartial, NeverBy, OneOf } from '../../types/utils.js'
 
 type CeloBlockExclude =
   | 'difficulty'
@@ -112,9 +112,9 @@ type RpcTransaction<TPending extends boolean = boolean> =
   }
 
 type RpcTransactionRequest = RpcTransactionRequest_ & {
-  feeCurrency?: Address
-  gatewayFee?: Hex
-  gatewayFeeRecipient?: Address
+  feeCurrency?: Address | undefined
+  gatewayFee?: Hex | undefined
+  gatewayFeeRecipient?: Address | undefined
 }
 
 export type RpcTransactionCIP42<TPending extends boolean = boolean> = Omit<
@@ -143,24 +143,24 @@ export type RpcTransactionRequestCIP42 = TransactionRequestBase<
   Quantity,
   Index
 > &
-  Partial<FeeValuesEIP1559<Quantity>> & {
-    accessList?: AccessList
-    feeCurrency?: Address
-    gatewayFee?: Hex
-    gatewayFeeRecipient?: Address
-    type?: '0x7c'
+  ExactPartial<FeeValuesEIP1559<Quantity>> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
+    gatewayFee?: Hex | undefined
+    gatewayFeeRecipient?: Address | undefined
+    type?: '0x7c' | undefined
   }
 
 export type RpcTransactionRequestCIP64 = TransactionRequestBase<
   Quantity,
   Index
 > &
-  Partial<FeeValuesEIP1559<Quantity>> & {
-    accessList?: AccessList
-    feeCurrency?: Address
+  ExactPartial<FeeValuesEIP1559<Quantity>> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
     gatewayFee?: undefined
     gatewayFeeRecipient?: undefined
-    type?: '0x7b'
+    type?: '0x7b' | undefined
   }
 
 type Transaction<TPending extends boolean = boolean> = Transaction_<
@@ -192,53 +192,53 @@ export type TransactionCIP64<TPending extends boolean = boolean> =
     }
 
 type TransactionRequest = TransactionRequest_ & {
-  feeCurrency?: Address
-  gatewayFee?: bigint
-  gatewayFeeRecipient?: Address
+  feeCurrency?: Address | undefined
+  gatewayFee?: bigint | undefined
+  gatewayFeeRecipient?: Address | undefined
 }
 
 export type TransactionRequestCIP42 = TransactionRequestBase &
-  Partial<FeeValuesEIP1559> & {
-    accessList?: AccessList
-    feeCurrency?: Address
-    gatewayFee?: bigint
-    gatewayFeeRecipient?: Address
-    type?: 'cip42'
+  ExactPartial<FeeValuesEIP1559> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
+    gatewayFee?: bigint | undefined
+    gatewayFeeRecipient?: Address | undefined
+    type?: 'cip42' | undefined
   }
 
 export type TransactionRequestCIP64 = TransactionRequestBase &
-  Partial<FeeValuesEIP1559> & {
-    accessList?: AccessList
-    feeCurrency?: Address
+  ExactPartial<FeeValuesEIP1559> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
     gatewayFee?: undefined
     gatewayFeeRecipient?: undefined
-    type?: 'cip64'
+    type?: 'cip64' | undefined
   }
 
 export type TransactionSerializableCIP42<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
-    feeCurrency?: Address
-    gatewayFeeRecipient?: Address
-    gatewayFee?: TQuantity
+  ExactPartial<FeeValuesEIP1559<TQuantity>> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
+    gatewayFeeRecipient?: Address | undefined
+    gatewayFee?: TQuantity | undefined
     chainId: number
-    type?: 'cip42'
+    type?: 'cip42' | undefined
   }
 
 export type TransactionSerializableCIP64<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
-    feeCurrency?: Address
+  ExactPartial<FeeValuesEIP1559<TQuantity>> & {
+    accessList?: AccessList | undefined
+    feeCurrency?: Address | undefined
     gatewayFee?: undefined
     gatewayFeeRecipient?: undefined
     chainId: number
-    type?: 'cip64'
+    type?: 'cip64' | undefined
   }
 
 export type TransactionSerializedCIP42 = `0x7c${string}`

--- a/src/chains/opStack/actions/buildDepositTransaction.ts
+++ b/src/chains/opStack/actions/buildDepositTransaction.ts
@@ -37,19 +37,19 @@ export type BuildDepositTransactionParameters<
 > = GetAccountParameter<account, accountOverride, false> &
   GetChainParameter<chain, chainOverride> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint
+    gas?: bigint | undefined
     /** Value in wei to mint (deposit) on the L2. Debited from the caller's L1 balance. */
-    mint?: bigint
+    mint?: bigint | undefined
     /** Value in wei sent with this transaction on the L2. Debited from the caller's L2 balance. */
-    value?: bigint
+    value?: bigint | undefined
   } & (
     | {
         /** Encoded contract method & arguments. */
-        data?: Hex
+        data?: Hex | undefined
         /** Whether or not this is a contract deployment transaction. */
-        isCreation?: false
+        isCreation?: false | undefined
         /** L2 Transaction recipient. */
-        to?: Address
+        to?: Address | undefined
       }
     | {
         /** Contract deployment bytecode. Required for contract deployment transactions. */
@@ -57,7 +57,7 @@ export type BuildDepositTransactionParameters<
         /** Whether or not this is a contract deployment transaction. */
         isCreation: true
         /** L2 Transaction recipient. Cannot exist for contract deployment transactions. */
-        to?: never
+        to?: never | undefined
       }
   )
 

--- a/src/chains/opStack/actions/buildInitiateWithdrawal.ts
+++ b/src/chains/opStack/actions/buildInitiateWithdrawal.ts
@@ -28,13 +28,13 @@ export type BuildInitiateWithdrawalParameters<
 > = GetAccountParameter<account, accountOverride, false> &
   GetChainParameter<chain, chainOverride> & {
     /** Encoded contract method & arguments. */
-    data?: Hex
+    data?: Hex | undefined
     /** Gas limit for transaction execution on the L1. */
-    gas?: bigint
+    gas?: bigint | undefined
     /** L1 Transaction recipient. */
     to: Address
     /** Value in wei to withdrawal to the L1. Debited from the caller's L2 balance. */
-    value?: bigint
+    value?: bigint | undefined
   }
 
 export type BuildInitiateWithdrawalReturnType<

--- a/src/chains/opStack/actions/depositTransaction.ts
+++ b/src/chains/opStack/actions/depositTransaction.ts
@@ -53,7 +53,7 @@ export type DepositTransactionParameters<
      * Gas limit for transaction execution on the L1.
      * `null` to skip gas estimation & defer calculation to signer.
      */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
   }
 export type DepositTransactionReturnType = Hash
 export type DepositTransactionErrorType =

--- a/src/chains/opStack/actions/estimateDepositTransactionGas.ts
+++ b/src/chains/opStack/actions/estimateDepositTransactionGas.ts
@@ -44,7 +44,7 @@ export type EstimateDepositTransactionGasParameters<
     /** L2 transaction request. */
     request: DepositRequest
     /** Gas limit for transaction execution on the L1. */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
   }
 export type EstimateDepositTransactionGasReturnType = bigint
 export type EstimateDepositTransactionGasErrorType =

--- a/src/chains/opStack/actions/estimateFinalizeWithdrawalGas.ts
+++ b/src/chains/opStack/actions/estimateFinalizeWithdrawalGas.ts
@@ -41,7 +41,7 @@ export type EstimateFinalizeWithdrawalGasParameters<
   GetChainParameter<chain, chainOverride> &
   GetContractAddressParameter<_derivedChain, 'portal'> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
     withdrawal: Withdrawal
   }
 export type EstimateFinalizeWithdrawalGasReturnType = bigint

--- a/src/chains/opStack/actions/estimateInitiateWithdrawalGas.ts
+++ b/src/chains/opStack/actions/estimateInitiateWithdrawalGas.ts
@@ -40,7 +40,7 @@ export type EstimateInitiateWithdrawalGasParameters<
   GetAccountParameter<account, Account | Address> &
   GetChainParameter<chain, chainOverride> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
     /**
      * Withdrawal request.
      * Supplied to the L2ToL1MessagePasser `initiateWithdrawal` method.

--- a/src/chains/opStack/actions/estimateL1Fee.ts
+++ b/src/chains/opStack/actions/estimateL1Fee.ts
@@ -41,7 +41,7 @@ export type EstimateL1FeeParameters<
   GetAccountParameter<TAccount> &
   GetChainParameter<TChain, TChainOverride> & {
     /** Gas price oracle address. */
-    gasPriceOracleAddress?: Address
+    gasPriceOracleAddress?: Address | undefined
   }
 
 export type EstimateL1FeeReturnType = bigint

--- a/src/chains/opStack/actions/estimateL1Gas.ts
+++ b/src/chains/opStack/actions/estimateL1Gas.ts
@@ -41,7 +41,7 @@ export type EstimateL1GasParameters<
   GetAccountParameter<TAccount> &
   GetChainParameter<TChain, TChainOverride> & {
     /** Gas price oracle address. */
-    gasPriceOracleAddress?: Address
+    gasPriceOracleAddress?: Address | undefined
   }
 
 export type EstimateL1GasReturnType = bigint

--- a/src/chains/opStack/actions/estimateProveWithdrawalGas.ts
+++ b/src/chains/opStack/actions/estimateProveWithdrawalGas.ts
@@ -41,7 +41,7 @@ export type EstimateProveWithdrawalGasParameters<
   GetChainParameter<chain, chainOverride> &
   GetContractAddressParameter<_derivedChain, 'portal'> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
     l2OutputIndex: bigint
     outputRootProof: {
       version: Hex

--- a/src/chains/opStack/actions/finalizeWithdrawal.ts
+++ b/src/chains/opStack/actions/finalizeWithdrawal.ts
@@ -50,7 +50,7 @@ export type FinalizeWithdrawalParameters<
      * Gas limit for transaction execution on the L1.
      * `null` to skip gas estimation & defer calculation to signer.
      */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
     withdrawal: Withdrawal
   }
 export type FinalizeWithdrawalReturnType = Hash

--- a/src/chains/opStack/actions/getL1BaseFee.ts
+++ b/src/chains/opStack/actions/getL1BaseFee.ts
@@ -21,7 +21,7 @@ export type GetL1BaseFeeParameters<
   TChainOverride extends Chain | undefined = undefined,
 > = GetChainParameter<TChain, TChainOverride> & {
   /** Gas price oracle address. */
-  gasPriceOracleAddress?: Address
+  gasPriceOracleAddress?: Address | undefined
 }
 
 export type GetL1BaseFeeReturnType = bigint
@@ -56,7 +56,7 @@ export async function getL1BaseFee<
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain>,
-  args?: GetL1BaseFeeParameters<TChain, TChainOverride>,
+  args?: GetL1BaseFeeParameters<TChain, TChainOverride> | undefined,
 ): Promise<GetL1BaseFeeReturnType> {
   const {
     chain = client.chain,

--- a/src/chains/opStack/actions/getTimeToNextL2Output.ts
+++ b/src/chains/opStack/actions/getTimeToNextL2Output.ts
@@ -28,7 +28,7 @@ export type GetTimeToNextL2OutputParameters<
      * The buffer to account for discrepencies between non-deterministic time intervals.
      * @default 1.1
      */
-    intervalBuffer?: number
+    intervalBuffer?: number | undefined
     l2BlockNumber: bigint
   }
 export type GetTimeToNextL2OutputReturnType = {
@@ -43,7 +43,7 @@ export type GetTimeToNextL2OutputReturnType = {
    * Estimated timestamp of the next L2 output.
    * `undefined` if the next L2 output has already been submitted.
    */
-  timestamp?: number
+  timestamp?: number | undefined
 }
 export type GetTimeToNextL2OutputErrorType =
   | MulticallErrorType

--- a/src/chains/opStack/actions/getTimeToProve.ts
+++ b/src/chains/opStack/actions/getTimeToProve.ts
@@ -26,7 +26,9 @@ export type GetTimeToProveParameters<
      * The buffer to account for discrepencies between non-deterministic time intervals.
      * @default 1.1
      */
-    intervalBuffer?: GetTimeToNextL2OutputParameters['intervalBuffer']
+    intervalBuffer?:
+      | GetTimeToNextL2OutputParameters['intervalBuffer']
+      | undefined
     receipt: TransactionReceipt
   }
 export type GetTimeToProveReturnType = GetTimeToNextL2OutputReturnType

--- a/src/chains/opStack/actions/proveWithdrawal.ts
+++ b/src/chains/opStack/actions/proveWithdrawal.ts
@@ -49,7 +49,7 @@ export type ProveWithdrawalParameters<
      * Gas limit for transaction execution on the L1.
      * `null` to skip gas estimation & defer calculation to signer.
      */
-    gas?: bigint | null
+    gas?: bigint | null | undefined
     l2OutputIndex: bigint
     outputRootProof: {
       version: Hex

--- a/src/chains/opStack/actions/waitForNextL2Output.ts
+++ b/src/chains/opStack/actions/waitForNextL2Output.ts
@@ -31,13 +31,15 @@ export type WaitForNextL2OutputParameters<
      * The buffer to account for discrepencies between non-deterministic time intervals.
      * @default 1.1
      */
-    intervalBuffer?: GetTimeToNextL2OutputParameters['intervalBuffer']
+    intervalBuffer?:
+      | GetTimeToNextL2OutputParameters['intervalBuffer']
+      | undefined
     l2BlockNumber: bigint
     /**
      * Polling frequency (in ms). Defaults to Client's pollingInterval config.
      * @default client.pollingInterval
      */
-    pollingInterval?: number
+    pollingInterval?: number | undefined
   }
 export type WaitForNextL2OutputReturnType = GetL2OutputReturnType
 export type WaitForNextL2OutputErrorType =

--- a/src/chains/opStack/actions/waitToProve.ts
+++ b/src/chains/opStack/actions/waitToProve.ts
@@ -32,7 +32,7 @@ export type WaitToProveParameters<
      * Polling frequency (in ms). Defaults to Client's pollingInterval config.
      * @default client.pollingInterval
      */
-    pollingInterval?: number
+    pollingInterval?: number | undefined
   }
 export type WaitToProveReturnType = {
   withdrawal: Withdrawal

--- a/src/chains/opStack/decorators/publicL2.ts
+++ b/src/chains/opStack/decorators/publicL2.ts
@@ -390,7 +390,7 @@ export type PublicActionsL2<
    * const l1BaseFee = await client.getL1BaseFee()
    */
   getL1BaseFee: <chainOverride extends Chain | undefined = undefined>(
-    parameters?: GetL1BaseFeeParameters<chain, chainOverride>,
+    parameters?: GetL1BaseFeeParameters<chain, chainOverride> | undefined,
   ) => Promise<GetL1BaseFeeReturnType>
   /**
    * Estimates the amount of L1 data gas required to execute an L2 transaction.

--- a/src/chains/opStack/formatters.test-d.ts
+++ b/src/chains/opStack/formatters.test-d.ts
@@ -7,7 +7,7 @@ import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock } from '../../types/rpc.js'
-import type { Assign } from '../../types/utils.js'
+import type { Assign, ExactPartial } from '../../types/utils.js'
 import { optimism } from '../index.js'
 import { formatters } from './formatters.js'
 import type { OpStackRpcBlockOverrides } from './types/block.js'
@@ -16,7 +16,7 @@ import type { OpStackRpcTransaction } from './types/transaction.js'
 describe('block', () => {
   expectTypeOf(formatters.block.format).parameter(0).toEqualTypeOf<
     Assign<
-      Partial<RpcBlock>,
+      ExactPartial<RpcBlock>,
       OpStackRpcBlockOverrides & {
         transactions: `0x${string}`[] | OpStackRpcTransaction[]
       }

--- a/src/chains/opStack/types/deposit.ts
+++ b/src/chains/opStack/types/deposit.ts
@@ -5,17 +5,17 @@ export type DepositRequest = {
   /** Gas limit for transaction execution on the L2. */
   gas: bigint
   /** Value in wei to mint (deposit) on the L2. Debited from the caller's L1 balance. */
-  mint?: bigint
+  mint?: bigint | undefined
   /** Value in wei sent with this transaction on the L2. Debited from the caller's L2 balance. */
-  value?: bigint
+  value?: bigint | undefined
 } & (
   | {
       /** Encoded contract method & arguments. */
-      data?: Hex
+      data?: Hex | undefined
       /** Whether or not this is a contract deployment transaction. */
-      isCreation?: false
+      isCreation?: false | undefined
       /** L2 Transaction recipient. */
-      to?: Address
+      to?: Address | undefined
     }
   | {
       /** Contract deployment bytecode. Required for contract deployment transactions. */
@@ -23,6 +23,6 @@ export type DepositRequest = {
       /** Whether or not this is a contract deployment transaction. */
       isCreation: true
       /** L2 Transaction recipient. Cannot exist for contract deployment transactions. */
-      to?: never
+      to?: never | undefined
     }
 )

--- a/src/chains/opStack/types/transaction.ts
+++ b/src/chains/opStack/types/transaction.ts
@@ -27,8 +27,8 @@ type RpcTransaction<TPending extends boolean = boolean> =
 export type OpStackRpcDepositTransaction<TPending extends boolean = boolean> =
   Omit<TransactionBase<Quantity, Index, TPending>, 'typeHex'> &
     FeeValuesEIP1559<Quantity> & {
-      isSystemTx?: boolean
-      mint?: Hex
+      isSystemTx?: boolean | undefined
+      mint?: Hex | undefined
       sourceHash: Hex
       type: '0x7e'
     }
@@ -59,7 +59,7 @@ export type OpStackDepositTransaction<TPending extends boolean = boolean> =
   TransactionBase<bigint, number, TPending> &
     FeeValuesEIP1559 & {
       isSystemTx?: boolean
-      mint?: bigint
+      mint?: bigint | undefined
       sourceHash: Hex
       type: 'deposit'
     }
@@ -98,7 +98,7 @@ export type TransactionSerializableDeposit<
 > & {
   from: Hex
   isSystemTx?: boolean
-  mint?: bigint
+  mint?: bigint | undefined
   sourceHash: Hex
   type: 'deposit'
 }

--- a/src/chains/opStack/types/withdrawal.ts
+++ b/src/chains/opStack/types/withdrawal.ts
@@ -3,13 +3,13 @@ import type { Hex } from '../../../types/misc.js'
 
 export type WithdrawalRequest = {
   /** Encoded contract method & arguments. */
-  data?: Hex
+  data?: Hex | undefined
   /** Gas limit for transaction execution on the L1. */
   gas: bigint
   /** L1 Transaction recipient. */
   to: Address
   /** Value in wei to withdrawal to the L1. Debited from the caller's L2 balance. */
-  value?: bigint
+  value?: bigint | undefined
 }
 
 export type Withdrawal = {

--- a/src/chains/zksync/formatters.test-d.ts
+++ b/src/chains/zksync/formatters.test-d.ts
@@ -15,7 +15,7 @@ import type { Log } from '../../types/log.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock, RpcTransactionReceipt } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
-import type { Assign } from '../../types/utils.js'
+import type { Assign, ExactPartial } from '../../types/utils.js'
 import { zkSync } from '../index.js'
 import { formatters } from './formatters.js'
 import type { ZkSyncEip712Meta } from './types/eip712.js'
@@ -29,7 +29,7 @@ import type {
 describe('block', () => {
   expectTypeOf(formatters.block.format).parameter(0).toEqualTypeOf<
     Assign<
-      Partial<RpcBlock>,
+      ExactPartial<RpcBlock>,
       {
         l1BatchNumber: `0x${string}` | null
         l1BatchTimestamp: `0x${string}` | null
@@ -49,7 +49,7 @@ describe('transactionReceipt', () => {
     .parameter(0)
     .toEqualTypeOf<
       Assign<
-        Partial<RpcTransactionReceipt>,
+        ExactPartial<RpcTransactionReceipt>,
         ZkSyncRpcTransactionReceiptOverrides
       >
     >()
@@ -117,7 +117,7 @@ describe('transactionRequest', () => {
   expectTypeOf(formatters.transactionRequest.format)
     .parameter(0)
     .toEqualTypeOf<
-      Assign<Partial<TransactionRequest>, ZkSyncTransactionRequest>
+      Assign<ExactPartial<TransactionRequest>, ZkSyncTransactionRequest>
     >()
   expectTypeOf<
     ReturnType<typeof formatters.transactionRequest.format>['eip712Meta']

--- a/src/chains/zksync/formatters.ts
+++ b/src/chains/zksync/formatters.ts
@@ -142,7 +142,7 @@ export const formatters = {
               : {}),
           },
           type: '0x71',
-        } as ZkSyncRpcTransactionRequest
+        } as unknown as ZkSyncRpcTransactionRequest
       return {} as ZkSyncRpcTransactionRequest
     },
   }),

--- a/src/chains/zksync/serializers.ts
+++ b/src/chains/zksync/serializers.ts
@@ -15,7 +15,7 @@ import { isEIP712Transaction } from './utils/isEip712Transaction.js'
 
 export function serializeTransaction(
   transaction: ZkSyncTransactionSerializable,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ) {
   if (isEIP712Transaction(transaction))
     return serializeTransactionEIP712(

--- a/src/chains/zksync/types/eip712.ts
+++ b/src/chains/zksync/types/eip712.ts
@@ -8,10 +8,10 @@ type PaymasterParams = {
 }
 
 export type ZkSyncEip712Meta = {
-  gasPerPubdata?: Hex
-  factoryDeps?: Hex[]
-  customSignature?: Hex
-  paymasterParams?: PaymasterParams
+  gasPerPubdata?: Hex | undefined
+  factoryDeps?: Hex[] | undefined
+  customSignature?: Hex | undefined
+  paymasterParams?: PaymasterParams | undefined
 }
 
 type EIP712FieldType = 'uint256' | 'bytes' | 'bytes32[]'

--- a/src/chains/zksync/types/transaction.ts
+++ b/src/chains/zksync/types/transaction.ts
@@ -20,7 +20,7 @@ import type {
   TransactionSerialized,
   TransactionType,
 } from '../../../types/transaction.js'
-import type { OneOf, UnionOmit } from '../../../types/utils.js'
+import type { ExactPartial, OneOf, UnionOmit } from '../../../types/utils.js'
 import type { ZkSyncEip712Meta } from './eip712.js'
 import type { ZkSyncFeeValues } from './fee.js'
 import type {
@@ -129,11 +129,11 @@ export type ZkSyncTransactionRequestEIP712 = Omit<
   TransactionRequestBase,
   'type'
 > &
-  Partial<FeeValuesEIP1559> & {
-    gasPerPubdata?: bigint
-    customSignature?: Hex
-    factoryDeps?: Hex[]
-    type?: 'eip712' | 'priority'
+  ExactPartial<FeeValuesEIP1559> & {
+    gasPerPubdata?: bigint | undefined
+    customSignature?: Hex | undefined
+    factoryDeps?: Hex[] | undefined
+    type?: 'eip712' | 'priority' | undefined
   } & (
     | { paymaster: Address; paymasterInput: Hex }
     | { paymaster?: undefined; paymasterInput?: undefined }
@@ -149,7 +149,7 @@ export type ZkSyncRpcTransactionRequestEIP712 = TransactionRequestBase<
   Quantity,
   Index
 > &
-  Partial<FeeValuesEIP1559<Quantity>> & {
+  ExactPartial<FeeValuesEIP1559<Quantity>> & {
     eip712Meta: ZkSyncEip712Meta
     type: EIP712Type | PriorityType
   }
@@ -203,12 +203,12 @@ export type ZkSyncTransactionSerializableEIP712<
   TIndex = number,
 > = Omit<TransactionSerializableEIP1559<TQuantity, TIndex>, 'type'> & {
   from: Hex
-  gasPerPubdata?: bigint
-  paymaster?: Address
-  factoryDeps?: Hex[]
-  paymasterInput?: Hex
-  customSignature?: Hex
-  type?: 'eip712'
+  gasPerPubdata?: bigint | undefined
+  paymaster?: Address | undefined
+  factoryDeps?: Hex[] | undefined
+  paymasterInput?: Hex | undefined
+  customSignature?: Hex | undefined
+  type?: 'eip712' | undefined
 }
 
 // EIP712 Signer
@@ -234,12 +234,12 @@ export type TransactionRequestEIP712<
   TIndex = number,
   TTransactionType = 'eip712',
 > = TransactionRequestBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: never
-    gasPerPubdata?: bigint
-    factoryDeps?: Hex[]
-    paymaster?: Address
-    paymasterInput?: Hex
-    customSignature?: Hex
-    type?: TTransactionType
+  ExactPartial<FeeValuesEIP1559<TQuantity>> & {
+    accessList?: never | undefined
+    gasPerPubdata?: bigint | undefined
+    factoryDeps?: Hex[] | undefined
+    paymaster?: Address | undefined
+    paymasterInput?: Hex | undefined
+    customSignature?: Hex | undefined
+    type?: TTransactionType | undefined
   }

--- a/src/chains/zksync/utils/assertEip712Request.ts
+++ b/src/chains/zksync/utils/assertEip712Request.ts
@@ -1,11 +1,12 @@
 import type { ErrorType } from '../../../errors/utils.js'
 import { type AssertRequestErrorType, assertRequest } from '../../../index.js'
+import type { ExactPartial } from '../../../types/utils.js'
 import type { SendTransactionParameters } from '../actions/sendTransaction.js'
 import type { zkSync } from '../chains.js'
 import { InvalidEip712TransactionError } from '../errors/transaction.js'
 import { isEIP712Transaction } from './isEip712Transaction.js'
 
-export type AssertEip712RequestParameters = Partial<
+export type AssertEip712RequestParameters = ExactPartial<
   SendTransactionParameters<typeof zkSync>
 >
 

--- a/src/chains/zksync/utils/assertEip712Transaction.ts
+++ b/src/chains/zksync/utils/assertEip712Transaction.ts
@@ -1,6 +1,7 @@
 import { InvalidAddressError } from '../../../errors/address.js'
 import { BaseError } from '../../../errors/base.js'
 import { InvalidChainIdError } from '../../../errors/chain.js'
+import type { ExactPartial } from '../../../types/utils.js'
 import { isAddress } from '../../../utils/address/isAddress.js'
 import { InvalidEip712TransactionError } from '../errors/transaction.js'
 import type {
@@ -10,7 +11,7 @@ import type {
 import { isEIP712Transaction } from './isEip712Transaction.js'
 
 export function assertEip712Transaction(
-  transaction: Partial<ZkSyncTransactionSerializable>,
+  transaction: ExactPartial<ZkSyncTransactionSerializable>,
 ) {
   const { chainId, to, from, paymaster, paymasterInput } =
     transaction as ZkSyncTransactionSerializableEIP712

--- a/src/chains/zksync/utils/isEip712Transaction.ts
+++ b/src/chains/zksync/utils/isEip712Transaction.ts
@@ -1,7 +1,8 @@
+import type { ExactPartial } from '../../../types/utils.js'
 import type { ZkSyncTransactionSerializable } from '../types/transaction.js'
 
 export function isEIP712Transaction(
-  transaction: Partial<ZkSyncTransactionSerializable>,
+  transaction: ExactPartial<ZkSyncTransactionSerializable>,
 ) {
   if (transaction.type === 'eip712') return true
   if (

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -3,7 +3,7 @@ import { describe, expectTypeOf, test } from 'vitest'
 
 import type { Account, JsonRpcAccount } from '../accounts/types.js'
 import { localhost, optimism } from '../chains/index.js'
-import { publicActions } from '../index.js'
+import { createPublicClient, publicActions } from '../index.js'
 import { type Chain } from '../types/chain.js'
 import { type Client, createClient } from './createClient.js'
 import { walletActions } from './decorators/wallet.js'
@@ -124,5 +124,12 @@ describe('extend', () => {
       return client.extend(walletActions)
     }
     getClient(localhost)
+  })
+})
+
+test('https://github.com/wevm/viem/issues/1955', () => {
+  createPublicClient({
+    chain: optimism,
+    transport: http(),
   })
 })

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -10,7 +10,7 @@ import type {
   EIP1474Methods,
   RpcSchema,
 } from '../types/eip1193.js'
-import type { Prettify } from '../types/utils.js'
+import type { ExactPartial, Prettify } from '../types/utils.js'
 import { parseAccount } from '../utils/accounts.js'
 import { uid } from '../utils/uid.js'
 import type { PublicActions } from './decorators/public.js'
@@ -104,7 +104,7 @@ export type Client<
   (extended extends Extended ? extended : unknown) & {
     extend: <
       const client extends Extended &
-        Partial<ExtendableProtectedActions<transport, chain, account>>,
+        ExactPartial<ExtendableProtectedActions<transport, chain, account>>,
     >(
       fn: (
         client: Client<transport, chain, account, rpcSchema, extended>,
@@ -225,7 +225,7 @@ export function createClient(parameters: ClientConfig): Client {
       const extended = extendFn(base) as Extended
       for (const key in client) delete extended[key]
       const combined = { ...base, ...extended }
-      return Object.assign(combined, { extend: extend(combined) })
+      return Object.assign(combined, { extend: extend(combined as any) })
     }
   }
 

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -376,15 +376,17 @@ export type PublicActions<
       | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
       | undefined = undefined,
   >(
-    args?: CreateEventFilterParameters<
-      TAbiEvent,
-      TAbiEvents,
-      TStrict,
-      TFromBlock,
-      TToBlock,
-      _EventName,
-      _Args
-    >,
+    args?:
+      | CreateEventFilterParameters<
+          TAbiEvent,
+          TAbiEvents,
+          TStrict,
+          TFromBlock,
+          TToBlock,
+          _EventName,
+          _Args
+        >
+      | undefined,
   ) => Promise<
     CreateEventFilterReturnType<
       TAbiEvent,
@@ -562,7 +564,7 @@ export type PublicActions<
     TIncludeTransactions extends boolean = false,
     TBlockTag extends BlockTag = 'latest',
   >(
-    args?: GetBlockParameters<TIncludeTransactions, TBlockTag>,
+    args?: GetBlockParameters<TIncludeTransactions, TBlockTag> | undefined,
   ) => Promise<GetBlockReturnType<TChain, TIncludeTransactions, TBlockTag>>
   /**
    * Returns the number of the most recent block seen.
@@ -586,7 +588,7 @@ export type PublicActions<
    * // 69420n
    */
   getBlockNumber: (
-    args?: GetBlockNumberParameters,
+    args?: GetBlockNumberParameters | undefined,
   ) => Promise<GetBlockNumberReturnType>
   /**
    * Returns the number of Transactions at a block number, hash, or tag.
@@ -610,7 +612,7 @@ export type PublicActions<
    * const count = await client.getBlockTransactionCount()
    */
   getBlockTransactionCount: (
-    args?: GetBlockTransactionCountParameters,
+    args?: GetBlockTransactionCountParameters | undefined,
   ) => Promise<GetBlockTransactionCountReturnType>
   /**
    * Retrieves the bytecode at an address.
@@ -895,7 +897,9 @@ export type PublicActions<
     TChainOverride extends Chain | undefined = undefined,
     TType extends FeeValuesType = 'eip1559',
   >(
-    args?: EstimateFeesPerGasParameters<TChain, TChainOverride, TType>,
+    args?:
+      | EstimateFeesPerGasParameters<TChain, TChainOverride, TType>
+      | undefined,
   ) => Promise<EstimateFeesPerGasReturnType>
   /**
    * Returns a list of logs or hashes based on a [Filter](/docs/glossary/terms#filter) since the last time it was called.
@@ -1093,13 +1097,9 @@ export type PublicActions<
     TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
     TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args?: GetLogsParameters<
-      TAbiEvent,
-      TAbiEvents,
-      TStrict,
-      TFromBlock,
-      TToBlock
-    >,
+    args?:
+      | GetLogsParameters<TAbiEvent, TAbiEvents, TStrict, TFromBlock, TToBlock>
+      | undefined,
   ) => Promise<
     GetLogsReturnType<TAbiEvent, TAbiEvents, TStrict, TFromBlock, TToBlock>
   >
@@ -1151,7 +1151,9 @@ export type PublicActions<
   estimateMaxPriorityFeePerGas: <
     TChainOverride extends Chain | undefined = undefined,
   >(
-    args?: EstimateMaxPriorityFeePerGasParameters<TChain, TChainOverride>,
+    args?:
+      | EstimateMaxPriorityFeePerGasParameters<TChain, TChainOverride>
+      | undefined,
   ) => Promise<EstimateMaxPriorityFeePerGasReturnType>
   /**
    * Returns the value from a storage slot at a given address.

--- a/src/clients/decorators/test.ts
+++ b/src/clients/decorators/test.ts
@@ -335,7 +335,7 @@ export type TestActions = {
    * })
    * await client.reset({ blockNumber: 69420n })
    */
-  reset: (args?: ResetParameters) => Promise<void>
+  reset: (args?: ResetParameters | undefined) => Promise<void>
   /**
    * Revert the state of the blockchain at the current block.
    *

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -15,11 +15,11 @@ export type TransportConfig<
   /** The JSON-RPC request function that matches the EIP-1193 request spec. */
   request: TEIP1193RequestFn
   /** The base delay (in ms) between retries. */
-  retryDelay?: number
+  retryDelay?: number | undefined
   /** The max number of times to retry. */
-  retryCount?: number
+  retryCount?: number | undefined
   /** The timeout (in ms) for requests. */
-  timeout?: number
+  timeout?: number | undefined
   /** The type of the transport. */
   type: TType
 }
@@ -31,14 +31,14 @@ export type Transport<
 > = <TChain extends Chain | undefined = Chain>({
   chain,
 }: {
-  chain?: TChain
-  pollingInterval?: ClientConfig['pollingInterval']
-  retryCount?: TransportConfig['retryCount']
-  timeout?: TransportConfig['timeout']
+  chain?: TChain | undefined
+  pollingInterval?: ClientConfig['pollingInterval'] | undefined
+  retryCount?: TransportConfig['retryCount'] | undefined
+  timeout?: TransportConfig['timeout'] | undefined
 }) => {
   config: TransportConfig<TType>
   request: TEIP1193RequestFn
-  value?: TRpcAttributes
+  value?: TRpcAttributes | undefined
 }
 
 export type CreateTransportErrorType = ErrorType
@@ -59,7 +59,7 @@ export function createTransport<
     timeout,
     type,
   }: TransportConfig<TType>,
-  value?: TRpcAttributes,
+  value?: TRpcAttributes | undefined,
 ): ReturnType<Transport<TType, TRpcAttributes>> {
   return {
     config: { key, name, request, retryCount, retryDelay, timeout, type },

--- a/src/clients/transports/custom.ts
+++ b/src/clients/transports/custom.ts
@@ -10,13 +10,13 @@ type EthereumProvider = { request(...args: any): Promise<any> }
 
 export type CustomTransportConfig = {
   /** The key of the transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
 }
 
 export type CustomTransport = Transport<

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -20,13 +20,13 @@ export type OnResponseFn = (
     transport: ReturnType<Transport>
   } & (
     | {
-        error?: never
+        error?: never | undefined
         response: unknown
         status: 'success'
       }
     | {
         error: Error
-        response?: never
+        response?: never | undefined
         status: 'error'
       }
   ),
@@ -37,45 +37,47 @@ type RankOptions = {
    * The polling interval (in ms) at which the ranker should ping the RPC URL.
    * @default client.pollingInterval
    */
-  interval?: number
+  interval?: number | undefined
   /**
    * The number of previous samples to perform ranking on.
    * @default 10
    */
-  sampleCount?: number
+  sampleCount?: number | undefined
   /**
    * Timeout when sampling transports.
    * @default 1_000
    */
-  timeout?: number
+  timeout?: number | undefined
   /**
    * Weights to apply to the scores. Weight values are proportional.
    */
-  weights?: {
-    /**
-     * The weight to apply to the latency score.
-     * @default 0.3
-     */
-    latency?: number
-    /**
-     * The weight to apply to the stability score.
-     * @default 0.7
-     */
-    stability?: number
-  }
+  weights?:
+    | {
+        /**
+         * The weight to apply to the latency score.
+         * @default 0.3
+         */
+        latency?: number | undefined
+        /**
+         * The weight to apply to the stability score.
+         * @default 0.7
+         */
+        stability?: number | undefined
+      }
+    | undefined
 }
 
 export type FallbackTransportConfig = {
   /** The key of the Fallback transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the Fallback transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** Toggle to enable ranking, or rank options. */
-  rank?: boolean | RankOptions
+  rank?: boolean | RankOptions | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
 }
 
 export type FallbackTransport = Transport<
@@ -198,13 +200,13 @@ export function rankTransports({
   transports,
   weights = {},
 }: {
-  chain?: Chain
+  chain?: Chain | undefined
   interval: RankOptions['interval']
   onTransports: (transports: Transport[]) => void
-  sampleCount?: RankOptions['sampleCount']
-  timeout?: RankOptions['timeout']
+  sampleCount?: RankOptions['sampleCount'] | undefined
+  timeout?: RankOptions['timeout'] | undefined
   transports: Transport[]
-  weights?: RankOptions['weights']
+  weights?: RankOptions['weights'] | undefined
 }) {
   const { stability: stabilityWeight = 0.7, latency: latencyWeight = 0.3 } =
     weights

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -20,9 +20,9 @@ import {
 
 export type BatchOptions = {
   /** The maximum number of JSON-RPC requests to send in a batch. @default 1_000 */
-  batchSize?: number
+  batchSize?: number | undefined
   /** The maximum number of milliseconds to wait before sending a batch. @default 0 */
-  wait?: number
+  wait?: number | undefined
 }
 
 export type HttpTransportConfig = {
@@ -30,33 +30,33 @@ export type HttpTransportConfig = {
    * Whether to enable Batch JSON-RPC.
    * @link https://www.jsonrpc.org/specification#batch
    */
-  batch?: boolean | BatchOptions
+  batch?: boolean | BatchOptions | undefined
   /**
    * Request configuration to pass to `fetch`.
    * @link https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
-  fetchOptions?: HttpRpcClientOptions['fetchOptions']
+  fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
   /**
    * A callback to handle the response from `fetch`.
    */
-  onFetchResponse?: HttpRpcClientOptions['onResponse']
+  onFetchResponse?: HttpRpcClientOptions['onResponse'] | undefined
   /** The key of the HTTP transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the HTTP transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
-  timeout?: TransportConfig['timeout']
+  timeout?: TransportConfig['timeout'] | undefined
 }
 
 export type HttpTransport = Transport<
   'http',
   {
-    fetchOptions?: HttpTransportConfig['fetchOptions']
-    url?: string
+    fetchOptions?: HttpTransportConfig['fetchOptions'] | undefined
+    url?: string | undefined
   }
 >
 
@@ -70,7 +70,7 @@ export type HttpTransportErrorType =
  */
 export function http(
   /** URL of the JSON-RPC API. Defaults to the chain's public RPC URL. */
-  url?: string,
+  url?: string | undefined,
   config: HttpTransportConfig = {},
 ): HttpTransport {
   const {

--- a/src/clients/transports/ipc.ts
+++ b/src/clients/transports/ipc.ts
@@ -13,7 +13,7 @@ import {
 
 type IpcTransportSubscribeParameters = {
   onData: (data: RpcResponse) => void
-  onError?: (error: any) => void
+  onError?: ((error: any) => void) | undefined
 }
 
 type IpcTransportSubscribeReturnType = {
@@ -35,15 +35,15 @@ type IpcTransportSubscribe = {
 
 export type IpcTransportConfig = {
   /** The key of the Ipc transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the Ipc transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for async Ipc requests. Default: 10_000 */
-  timeout?: TransportConfig['timeout']
+  timeout?: TransportConfig['timeout'] | undefined
 }
 
 export type IpcTransport = Transport<

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -18,7 +18,7 @@ import {
 
 type WebSocketTransportSubscribeParameters = {
   onData: (data: RpcResponse) => void
-  onError?: (error: any) => void
+  onError?: ((error: any) => void) | undefined
 }
 
 type WebSocketTransportSubscribeReturnType = {
@@ -40,15 +40,15 @@ type WebSocketTransportSubscribe = {
 
 export type WebSocketTransportConfig = {
   /** The key of the WebSocket transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the WebSocket transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for async WebSocket requests. Default: 10_000 */
-  timeout?: TransportConfig['timeout']
+  timeout?: TransportConfig['timeout'] | undefined
 }
 
 export type WebSocketTransport = Transport<

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -198,7 +198,10 @@ export type AbiErrorNotFoundErrorType = AbiErrorNotFoundError & {
 }
 export class AbiErrorNotFoundError extends BaseError {
   override name = 'AbiErrorNotFoundError'
-  constructor(errorName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    errorName?: string | undefined,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Error ${errorName ? `"${errorName}" ` : ''}not found on ABI.`,
@@ -273,7 +276,10 @@ export type AbiEventNotFoundErrorType = AbiEventNotFoundError & {
 }
 export class AbiEventNotFoundError extends BaseError {
   override name = 'AbiEventNotFoundError'
-  constructor(eventName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    eventName?: string | undefined,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Event ${eventName ? `"${eventName}" ` : ''}not found on ABI.`,
@@ -291,7 +297,10 @@ export type AbiFunctionNotFoundErrorType = AbiFunctionNotFoundError & {
 }
 export class AbiFunctionNotFoundError extends BaseError {
   override name = 'AbiFunctionNotFoundError'
-  constructor(functionName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    functionName?: string | undefined,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Function ${functionName ? `"${functionName}" ` : ''}not found on ABI.`,

--- a/src/errors/account.ts
+++ b/src/errors/account.ts
@@ -5,7 +5,7 @@ export type AccountNotFoundErrorType = AccountNotFoundError & {
 }
 export class AccountNotFoundError extends BaseError {
   override name = 'AccountNotFoundError'
-  constructor({ docsPath }: { docsPath?: string } = {}) {
+  constructor({ docsPath }: { docsPath?: string | undefined } = {}) {
     super(
       [
         'Could not find an Account to execute with this Action.',

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -1,25 +1,25 @@
 import { getVersion } from './utils.js'
 
 type BaseErrorParameters = {
-  docsPath?: string
-  docsSlug?: string
-  metaMessages?: string[]
+  docsPath?: string | undefined
+  docsSlug?: string | undefined
+  metaMessages?: string[] | undefined
 } & (
   | {
-      cause?: never
-      details?: string
+      cause?: never | undefined
+      details?: string | undefined
     }
   | {
-      cause: BaseError | Error
-      details?: never
+      cause: BaseError | Error | undefined
+      details?: never | undefined
     }
 )
 
 export type BaseErrorType = BaseError & { name: 'ViemError' }
 export class BaseError extends Error {
   details: string
-  docsPath?: string
-  metaMessages?: string[]
+  docsPath?: string | undefined
+  metaMessages?: string[] | undefined
   shortMessage: string
 
   override name = 'ViemError'
@@ -68,7 +68,10 @@ export class BaseError extends Error {
   }
 }
 
-function walk(err: unknown, fn?: (err: unknown) => boolean): unknown {
+function walk(
+  err: unknown,
+  fn?: ((err: unknown) => boolean) | undefined,
+): unknown {
   if (fn?.(err)) return err
   if (err && typeof err === 'object' && 'cause' in err)
     return walk(err.cause, fn)

--- a/src/errors/block.ts
+++ b/src/errors/block.ts
@@ -11,8 +11,8 @@ export class BlockNotFoundError extends BaseError {
     blockHash,
     blockNumber,
   }: {
-    blockHash?: Hash
-    blockNumber?: bigint
+    blockHash?: Hash | undefined
+    blockNumber?: bigint | undefined
   }) {
     let identifier = 'Block'
     if (blockHash) identifier = `Block at hash "${blockHash}"`

--- a/src/errors/chain.ts
+++ b/src/errors/chain.ts
@@ -13,9 +13,9 @@ export class ChainDoesNotSupportContract extends BaseError {
     chain,
     contract,
   }: {
-    blockNumber?: bigint
+    blockNumber?: bigint | undefined
     chain: Chain
-    contract: { name: string; blockCreated?: number }
+    contract: { name: string; blockCreated?: number | undefined }
   }) {
     super(
       `Chain "${chain.name}" does not support contract "${contract.name}".`,
@@ -96,7 +96,7 @@ export type InvalidChainIdErrorType = InvalidChainIdError & {
 export class InvalidChainIdError extends BaseError {
   override name = 'InvalidChainIdError'
 
-  constructor({ chainId }: { chainId?: number }) {
+  constructor({ chainId }: { chainId?: number | undefined }) {
     super(
       typeof chainId === 'number'
         ? `Chain ID "${chainId}" is invalid.`

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -44,7 +44,10 @@ export class CallExecutionError extends BaseError {
       to,
       value,
       stateOverride,
-    }: CallParameters & { chain?: Chain; docsPath?: string },
+    }: CallParameters & {
+      chain?: Chain | undefined
+      docsPath?: string | undefined
+    },
   ) {
     const account = account_ ? parseAccount(account_) : undefined
     let prettyArgs = prettyPrint({
@@ -89,12 +92,12 @@ export type ContractFunctionExecutionErrorType =
   }
 export class ContractFunctionExecutionError extends BaseError {
   abi: Abi
-  args?: unknown[]
+  args?: unknown[] | undefined
   override cause: BaseError
-  contractAddress?: Address
-  formattedArgs?: string
+  contractAddress?: Address | undefined
+  formattedArgs?: string | undefined
   functionName: string
-  sender?: Address
+  sender?: Address | undefined
 
   override name = 'ContractFunctionExecutionError'
 
@@ -109,11 +112,11 @@ export class ContractFunctionExecutionError extends BaseError {
       sender,
     }: {
       abi: Abi
-      args?: any
-      contractAddress?: Address
-      docsPath?: string
+      args?: any | undefined
+      contractAddress?: Address | undefined
+      docsPath?: string | undefined
       functionName: string
-      sender?: Address
+      sender?: Address | undefined
     },
   ) {
     const abiItem = getAbiItem({ abi, args, name: functionName })
@@ -170,16 +173,21 @@ export type ContractFunctionRevertedErrorType =
 export class ContractFunctionRevertedError extends BaseError {
   override name = 'ContractFunctionRevertedError'
 
-  data?: DecodeErrorResultReturnType
-  reason?: string
-  signature?: Hex
+  data?: DecodeErrorResultReturnType | undefined
+  reason?: string | undefined
+  signature?: Hex | undefined
 
   constructor({
     abi,
     data,
     functionName,
     message,
-  }: { abi: Abi; data?: Hex; functionName: string; message?: string }) {
+  }: {
+    abi: Abi
+    data?: Hex | undefined
+    functionName: string
+    message?: string | undefined
+  }) {
     let cause: Error | undefined
     let decodedData: DecodeErrorResultReturnType | undefined = undefined
     let metaMessages: string[] | undefined
@@ -277,12 +285,15 @@ export class RawContractError extends BaseError {
   code = 3
   override name = 'RawContractError'
 
-  data?: Hex | { data?: Hex }
+  data?: Hex | { data?: Hex | undefined } | undefined
 
   constructor({
     data,
     message,
-  }: { data?: Hex | { data?: Hex }; message?: string }) {
+  }: {
+    data?: Hex | { data?: Hex | undefined } | undefined
+    message?: string | undefined
+  }) {
     super(message || '')
     this.data = data
   }

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -14,10 +14,10 @@ export class IntegerOutOfRangeError extends BaseError {
     size,
     value,
   }: {
-    max?: string
+    max?: string | undefined
     min: string
-    signed?: boolean
-    size?: number
+    signed?: boolean | undefined
+    size?: number | undefined
     value: string
   }) {
     super(

--- a/src/errors/estimateGas.ts
+++ b/src/errors/estimateGas.ts
@@ -30,9 +30,9 @@ export class EstimateGasExecutionError extends BaseError {
       to,
       value,
     }: Omit<EstimateGasParameters<any>, 'account'> & {
-      account?: Account
-      chain?: Chain
-      docsPath?: string
+      account?: Account | undefined
+      chain?: Chain | undefined
+      docsPath?: string | undefined
     },
   ) {
     const prettyArgs = prettyPrint({

--- a/src/errors/node.ts
+++ b/src/errors/node.ts
@@ -24,7 +24,7 @@ export class ExecutionRevertedError extends BaseError {
   constructor({
     cause,
     message,
-  }: { cause?: BaseError; message?: string } = {}) {
+  }: { cause?: BaseError | undefined; message?: string | undefined } = {}) {
     const reason = message
       ?.replace('execution reverted: ', '')
       ?.replace('execution reverted', '')
@@ -49,7 +49,10 @@ export class FeeCapTooHighError extends BaseError {
   constructor({
     cause,
     maxFeePerGas,
-  }: { cause?: BaseError; maxFeePerGas?: bigint } = {}) {
+  }: {
+    cause?: BaseError | undefined
+    maxFeePerGas?: bigint | undefined
+  } = {}) {
     super(
       `The fee cap (\`maxFeePerGas\`${
         maxFeePerGas ? ` = ${formatGwei(maxFeePerGas)} gwei` : ''
@@ -71,7 +74,10 @@ export class FeeCapTooLowError extends BaseError {
   constructor({
     cause,
     maxFeePerGas,
-  }: { cause?: BaseError; maxFeePerGas?: bigint } = {}) {
+  }: {
+    cause?: BaseError | undefined
+    maxFeePerGas?: bigint | undefined
+  } = {}) {
     super(
       `The fee cap (\`maxFeePerGas\`${
         maxFeePerGas ? ` = ${formatGwei(maxFeePerGas)}` : ''
@@ -89,7 +95,10 @@ export type NonceTooHighErrorType = NonceTooHighError & {
 export class NonceTooHighError extends BaseError {
   static nodeMessage = /nonce too high/
   override name = 'NonceTooHighError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
@@ -106,7 +115,10 @@ export class NonceTooLowError extends BaseError {
   static nodeMessage =
     /nonce too low|transaction already imported|already known/
   override name = 'NonceTooLowError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       [
         `Nonce provided for the transaction ${
@@ -125,7 +137,10 @@ export type NonceMaxValueErrorType = NonceMaxValueError & {
 export class NonceMaxValueError extends BaseError {
   static nodeMessage = /nonce has max value/
   override name = 'NonceMaxValueError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
@@ -141,7 +156,7 @@ export type InsufficientFundsErrorType = InsufficientFundsError & {
 export class InsufficientFundsError extends BaseError {
   static nodeMessage = /insufficient funds/
   override name = 'InsufficientFundsError'
-  constructor({ cause }: { cause?: BaseError } = {}) {
+  constructor({ cause }: { cause?: BaseError | undefined } = {}) {
     super(
       [
         'The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.',
@@ -169,7 +184,10 @@ export type IntrinsicGasTooHighErrorType = IntrinsicGasTooHighError & {
 export class IntrinsicGasTooHighError extends BaseError {
   static nodeMessage = /intrinsic gas too high|gas limit reached/
   override name = 'IntrinsicGasTooHighError'
-  constructor({ cause, gas }: { cause?: BaseError; gas?: bigint } = {}) {
+  constructor({
+    cause,
+    gas,
+  }: { cause?: BaseError | undefined; gas?: bigint | undefined } = {}) {
     super(
       `The amount of gas ${
         gas ? `(${gas}) ` : ''
@@ -187,7 +205,10 @@ export type IntrinsicGasTooLowErrorType = IntrinsicGasTooLowError & {
 export class IntrinsicGasTooLowError extends BaseError {
   static nodeMessage = /intrinsic gas too low/
   override name = 'IntrinsicGasTooLowError'
-  constructor({ cause, gas }: { cause?: BaseError; gas?: bigint } = {}) {
+  constructor({
+    cause,
+    gas,
+  }: { cause?: BaseError | undefined; gas?: bigint | undefined } = {}) {
     super(
       `The amount of gas ${
         gas ? `(${gas}) ` : ''
@@ -206,7 +227,7 @@ export type TransactionTypeNotSupportedErrorType =
 export class TransactionTypeNotSupportedError extends BaseError {
   static nodeMessage = /transaction type not valid/
   override name = 'TransactionTypeNotSupportedError'
-  constructor({ cause }: { cause?: BaseError }) {
+  constructor({ cause }: { cause?: BaseError | undefined }) {
     super('The transaction type is not supported for this chain.', {
       cause,
     })
@@ -225,9 +246,9 @@ export class TipAboveFeeCapError extends BaseError {
     maxPriorityFeePerGas,
     maxFeePerGas,
   }: {
-    cause?: BaseError
-    maxPriorityFeePerGas?: bigint
-    maxFeePerGas?: bigint
+    cause?: BaseError | undefined
+    maxPriorityFeePerGas?: bigint | undefined
+    maxFeePerGas?: bigint | undefined
   } = {}) {
     super(
       [
@@ -252,7 +273,7 @@ export type UnknownNodeErrorType = UnknownNodeError & {
 export class UnknownNodeError extends BaseError {
   override name = 'UnknownNodeError'
 
-  constructor({ cause }: { cause?: BaseError }) {
+  constructor({ cause }: { cause?: BaseError | undefined }) {
     super(`An error occurred while executing: ${cause?.shortMessage}`, {
       cause,
     })

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -9,9 +9,9 @@ export type HttpRequestErrorType = HttpRequestError & {
 export class HttpRequestError extends BaseError {
   override name = 'HttpRequestError'
 
-  body?: { [x: string]: unknown } | { [y: string]: unknown }[]
-  headers?: Headers
-  status?: number
+  body?: { [x: string]: unknown } | { [y: string]: unknown }[] | undefined
+  headers?: Headers | undefined
+  status?: number | undefined
   url: string
 
   constructor({
@@ -21,10 +21,10 @@ export class HttpRequestError extends BaseError {
     status,
     url,
   }: {
-    body?: { [x: string]: unknown } | { [y: string]: unknown }[]
-    details?: string
-    headers?: Headers
-    status?: number
+    body?: { [x: string]: unknown } | { [y: string]: unknown }[] | undefined
+    details?: string | undefined
+    headers?: Headers | undefined
+    status?: number | undefined
     url: string
   }) {
     super('HTTP request failed.', {

--- a/src/errors/rpc.ts
+++ b/src/errors/rpc.ts
@@ -21,9 +21,9 @@ export type RpcErrorCode =
   | -32042 // Method not found
 
 type RpcErrorOptions<TCode extends number = RpcErrorCode> = {
-  code?: TCode | (number & {})
-  docsPath?: string
-  metaMessages?: string[]
+  code?: TCode | (number & {}) | undefined
+  docsPath?: string | undefined
+  metaMessages?: string[] | undefined
   shortMessage: string
 }
 
@@ -76,13 +76,13 @@ export class ProviderRpcError<
 > extends RpcError<ProviderRpcErrorCode> {
   override name = 'ProviderRpcError'
 
-  data?: T
+  data?: T | undefined
 
   constructor(
     cause: Error,
     options: Prettify<
       RpcErrorOptions<ProviderRpcErrorCode> & {
-        data?: T
+        data?: T | undefined
       }
     >,
   ) {

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -165,8 +165,8 @@ export class TransactionExecutionError extends BaseError {
       value,
     }: Omit<SendTransactionParameters, 'account' | 'chain'> & {
       account: Account
-      chain?: Chain
-      docsPath?: string
+      chain?: Chain | undefined
+      docsPath?: string | undefined
     },
   ) {
     const prettyArgs = prettyPrint({
@@ -214,11 +214,11 @@ export class TransactionNotFoundError extends BaseError {
     hash,
     index,
   }: {
-    blockHash?: Hash
-    blockNumber?: bigint
-    blockTag?: BlockTag
-    hash?: Hash
-    index?: number
+    blockHash?: Hash | undefined
+    blockNumber?: bigint | undefined
+    blockTag?: BlockTag | undefined
+    hash?: Hash | undefined
+    index?: number | undefined
   }) {
     let identifier = 'Transaction'
     if (blockTag && index !== undefined)

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -62,14 +62,14 @@ export type Block<
   /** List of uncle hashes */
   uncles: Hash[]
   /** List of withdrawal objects */
-  withdrawals?: Withdrawal[]
+  withdrawals?: Withdrawal[] | undefined
   /** Root of the this block’s withdrawals trie */
-  withdrawalsRoot?: Hex
+  withdrawalsRoot?: Hex | undefined
 }
 
 export type BlockIdentifier<TQuantity = bigint> = {
   /** Whether or not to throw an error if the block is not in the canonical chain as described below. Only allowed in conjunction with the blockHash tag. Defaults to false. */
-  requireCanonical?: boolean
+  requireCanonical?: boolean | undefined
 } & (
   | {
       /** The block in the canonical chain with this number */

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -60,7 +60,7 @@ export type Chain<
   testnet?: boolean | undefined
 
   /** Custom chain data. */
-  custom?: custom
+  custom?: custom | undefined
   /**
    * Modifies how chain data structures (ie. Blocks, Transactions, etc)
    * are formatted & typed.

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -308,11 +308,11 @@ export type GetValue<
   _Narrowable extends boolean = IsNarrowable<TAbi, Abi>,
 > = _Narrowable extends true
   ? TAbiFunction['stateMutability'] extends 'payable'
-    ? { value?: NoUndefined<TValueType> }
+    ? { value?: NoUndefined<TValueType> | undefined }
     : TAbiFunction['payable'] extends true
-      ? { value?: NoUndefined<TValueType> }
-      : { value?: never }
-  : { value?: TValueType }
+      ? { value?: NoUndefined<TValueType> | undefined }
+      : { value?: never | undefined }
+  : { value?: TValueType | undefined }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -399,7 +399,9 @@ export type AbiEventParametersToPrimitiveTypes<
               name: infer Name extends string
             }
               ? Name
-              : never]?: AbiEventParameterToPrimitiveType<Parameter, Options>
+              : never]?:
+              | AbiEventParameterToPrimitiveType<Parameter, Options>
+              | undefined
           } extends infer Mapped
         ? Prettify<
             MaybeRequired<

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -16,7 +16,7 @@ import type {
   RpcTransactionRequest as TransactionRequest,
   RpcUncle as Uncle,
 } from './rpc.js'
-import type { Prettify } from './utils.js'
+import type { ExactPartial, Prettify } from './utils.js'
 
 //////////////////////////////////////////////////
 // Provider
@@ -86,14 +86,16 @@ export type AddEthereumChainParameter = {
   /** The chain name. */
   chainName: string
   /** Native currency for the chain. */
-  nativeCurrency?: {
-    name: string
-    symbol: string
-    decimals: number
-  }
+  nativeCurrency?:
+    | {
+        name: string
+        symbol: string
+        decimals: number
+      }
+    | undefined
   rpcUrls: readonly string[]
-  blockExplorerUrls?: string[]
-  iconUrls?: string[]
+  blockExplorerUrls?: string[] | undefined
+  iconUrls?: string[] | undefined
 }
 
 export type NetworkSync = {
@@ -129,7 +131,7 @@ export type WatchAssetParams = {
     /** The number of token decimals */
     decimals: number
     /** A string url of the token logo */
-    image?: string
+    image?: string | undefined
   }
 }
 
@@ -228,13 +230,13 @@ export type PublicRpcSchema = [
   {
     Method: 'eth_call'
     Parameters:
-      | [transaction: Partial<TransactionRequest>]
+      | [transaction: ExactPartial<TransactionRequest>]
       | [
-          transaction: Partial<TransactionRequest>,
+          transaction: ExactPartial<TransactionRequest>,
           block: BlockNumber | BlockTag | BlockIdentifier,
         ]
       | [
-          transaction: Partial<TransactionRequest>,
+          transaction: ExactPartial<TransactionRequest>,
           block: BlockNumber | BlockTag | BlockIdentifier,
           stateOverrideSet: RpcStateOverride,
         ]
@@ -451,18 +453,18 @@ export type PublicRpcSchema = [
     Method: 'eth_getLogs'
     Parameters: [
       {
-        address?: Address | Address[]
-        topics?: LogTopic[]
+        address?: Address | Address[] | undefined
+        topics?: LogTopic[] | undefined
       } & (
         | {
-            fromBlock?: BlockNumber | BlockTag
-            toBlock?: BlockNumber | BlockTag
-            blockHash?: never
+            fromBlock?: BlockNumber | BlockTag | undefined
+            toBlock?: BlockNumber | BlockTag | undefined
+            blockHash?: never | undefined
           }
         | {
-            fromBlock?: never
-            toBlock?: never
-            blockHash?: Hash
+            fromBlock?: never | undefined
+            toBlock?: never | undefined
+            blockHash?: Hash | undefined
           }
       ),
     ]
@@ -650,10 +652,10 @@ export type PublicRpcSchema = [
     Method: 'eth_newFilter'
     Parameters: [
       filter: {
-        fromBlock?: BlockNumber | BlockTag
-        toBlock?: BlockNumber | BlockTag
-        address?: Address | Address[]
-        topics?: LogTopic[]
+        fromBlock?: BlockNumber | BlockTag | undefined
+        toBlock?: BlockNumber | BlockTag | undefined
+        address?: Address | Address[] | undefined
+        topics?: LogTopic[] | undefined
       },
     ]
     ReturnType: Quantity
@@ -766,7 +768,7 @@ export type TestRpcSchema<TMode extends string> = [
    */
   {
     Method: `${TMode}_loadState`
-    Parameters?: [Hex]
+    Parameters?: [Hex] | undefined
     ReturnType: void
   },
   /**
@@ -1008,7 +1010,7 @@ export type TestRpcSchema<TMode extends string> = [
    */
   {
     Method: 'evm_revert'
-    Parameters?: [id: Quantity]
+    Parameters?: [id: Quantity] | undefined
     ReturnType: void
   },
   /**
@@ -1080,12 +1082,14 @@ export type TestRpcSchema<TMode extends string> = [
    */
   {
     Method: 'evm_mine'
-    Parameters?: [
-      {
-        /** Number of blocks to mine. */
-        blocks: Hex
-      },
-    ]
+    Parameters?:
+      | [
+          {
+            /** Number of blocks to mine. */
+            blocks: Hex
+          },
+        ]
+      | undefined
     ReturnType: void
   },
   /**
@@ -1321,7 +1325,7 @@ export type WalletRpcSchema = [
 
 export type RpcSchema = readonly {
   Method: string
-  Parameters?: unknown
+  Parameters?: unknown | undefined
   ReturnType: unknown
 }[]
 
@@ -1338,21 +1342,21 @@ export type EIP1193Parameters<
             : never
         } & (TRpcSchema[K] extends TRpcSchema[number]
           ? TRpcSchema[K]['Parameters'] extends undefined
-            ? { params?: never }
+            ? { params?: never | undefined }
             : { params: TRpcSchema[K]['Parameters'] }
           : never)
       >
     }[number]
   : {
       method: string
-      params?: unknown
+      params?: unknown | undefined
     }
 
 export type EIP1193RequestOptions = {
   // The base delay (in ms) between retries.
-  retryDelay?: number
+  retryDelay?: number | undefined
   // The max number of times to retry.
-  retryCount?: number
+  retryCount?: number | undefined
 }
 
 type DerivedRpcSchema<
@@ -1380,5 +1384,5 @@ export type EIP1193RequestFn<
     : unknown,
 >(
   args: TParameters,
-  options?: EIP1193RequestOptions,
+  options?: EIP1193RequestOptions | undefined,
 ) => Promise<_ReturnType>

--- a/src/types/ens.ts
+++ b/src/types/ens.ts
@@ -1,5 +1,5 @@
 export type AssetGateway = 'ipfs' | 'arweave'
 
 export type AssetGatewayUrls = {
-  [_key in AssetGateway]?: string
+  [_key in AssetGateway]?: string | undefined
 }

--- a/src/types/fee.ts
+++ b/src/types/fee.ts
@@ -11,20 +11,20 @@ export type FeeHistory<TQuantity = bigint> = {
   /** Lowest number block of the returned range. */
   oldestBlock: TQuantity
   /** An array of effective priority fees (in wei) per gas data points from a single block. All zeroes are returned if the block is empty. */
-  reward?: TQuantity[][]
+  reward?: TQuantity[][] | undefined
 }
 
 export type FeeValuesLegacy<TQuantity = bigint> = {
   /** Base fee per gas. */
   gasPrice: TQuantity
-  maxFeePerBlobGas?: never
-  maxFeePerGas?: never
-  maxPriorityFeePerGas?: never
+  maxFeePerBlobGas?: never | undefined
+  maxFeePerGas?: never | undefined
+  maxPriorityFeePerGas?: never | undefined
 }
 
 export type FeeValuesEIP1559<TQuantity = bigint> = {
-  gasPrice?: never
-  maxFeePerBlobGas?: never
+  gasPrice?: never | undefined
+  maxFeePerBlobGas?: never | undefined
   /** Total fee per gas in wei (gasPrice/baseFeePerGas + maxPriorityFeePerGas). */
   maxFeePerGas: TQuantity
   /** Max priority fee per gas (in wei). */

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -31,14 +31,14 @@ export type Filter<
   type: TFilterType
 } & (TFilterType extends 'event'
   ? {
-      fromBlock?: TFromBlock
-      toBlock?: TToBlock
+      fromBlock?: TFromBlock | undefined
+      toBlock?: TToBlock | undefined
     } & (TAbi extends Abi
       ? undefined extends TEventName
         ? {
             abi: TAbi
-            args?: never
-            eventName?: never
+            args?: never | undefined
+            eventName?: never | undefined
             strict: TStrict
           }
         : TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName>
@@ -50,14 +50,14 @@ export type Filter<
             }
           : {
               abi: TAbi
-              args?: never
+              args?: never | undefined
               eventName: TEventName
               strict: TStrict
             }
       : {
-          abi?: never
-          args?: never
-          eventName?: never
-          strict?: never
+          abi?: never | undefined
+          args?: never | undefined
+          eventName?: never | undefined
+          strict?: never | undefined
         })
   : {})

--- a/src/types/kzg.ts
+++ b/src/types/kzg.ts
@@ -21,7 +21,7 @@ export type GetTransactionRequestKzgParameter<
 > = MaybeRequired<
   {
     /** KZG implementation */
-    kzg?: Kzg
+    kzg?: Kzg | undefined
   },
   request extends {
     account: LocalAccount<string, Address>

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -22,13 +22,13 @@ export type Signature = OneOf<
       s: Hex
       /** @deprecated use `yParity`. */
       v: bigint
-      yParity?: number
+      yParity?: number | undefined
     }
   | {
       r: Hex
       s: Hex
       /** @deprecated use `yParity`. */
-      v?: bigint
+      v?: bigint | undefined
       yParity: number
     }
 >

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -68,38 +68,38 @@ export type RpcTransaction<TPending extends boolean = boolean> = UnionOmit<
 >
 
 type SuccessResult<T> = {
-  method?: never
+  method?: never | undefined
   result: T
-  error?: never
+  error?: never | undefined
 }
 type ErrorResult<T> = {
-  method?: never
-  result?: never
+  method?: never | undefined
+  result?: never | undefined
   error: T
 }
 type Subscription<TResult, TError> = {
   method: 'eth_subscription'
-  error?: never
-  result?: never
+  error?: never | undefined
+  result?: never | undefined
   params: {
     subscription: string
   } & (
     | {
         result: TResult
-        error?: never
+        error?: never | undefined
       }
     | {
-        result?: never
+        result?: never | undefined
         error: TError
       }
   )
 }
 
 export type RpcRequest = {
-  jsonrpc?: '2.0'
+  jsonrpc?: '2.0' | undefined
   method: string
-  params?: any
-  id?: number
+  params?: any | undefined
+  id?: number | undefined
 }
 
 export type RpcResponse<TResult = any, TError = any> = {
@@ -118,15 +118,15 @@ export type RpcStateMapping = {
 
 export type RpcAccountStateOverride = {
   /** Fake balance to set for the account before executing the call. <32 bytes */
-  balance?: Hex
+  balance?: Hex | undefined
   /** Fake nonce to set for the account before executing the call. <8 bytes */
-  nonce?: Hex
+  nonce?: Hex | undefined
   /** Fake EVM bytecode to inject into the account before executing the call. */
-  code?: Hex
+  code?: Hex | undefined
   /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-  state?: RpcStateMapping
+  state?: RpcStateMapping | undefined
   /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-  stateDiff?: RpcStateMapping
+  stateDiff?: RpcStateMapping | undefined
 }
 
 export type RpcStateOverride = {

--- a/src/types/stateOverride.ts
+++ b/src/types/stateOverride.ts
@@ -10,17 +10,17 @@ export type StateMapping = Array<{
 export type StateOverride = Array<
   {
     address: Address
-    balance?: bigint
-    nonce?: number
-    code?: Hex
+    balance?: bigint | undefined
+    nonce?: number | undefined
+    code?: Hex | undefined
   } & OneOf<
     | {
         /** Fake key-value mapping to override all slots in the account storage before executing the call. */
-        state?: StateMapping
+        state?: StateMapping | undefined
       }
     | {
         /** Fake key-value mapping to override individual slots in the account storage before executing the call. */
-        stateDiff?: StateMapping
+        stateDiff?: StateMapping | undefined
       }
   >
 >

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -9,7 +9,13 @@ import type {
 import type { Kzg } from './kzg.js'
 import type { Log } from './log.js'
 import type { ByteArray, Hash, Hex, Signature } from './misc.js'
-import type { Branded, IsNever, OneOf, RequiredBy } from './utils.js'
+import type {
+  Branded,
+  ExactPartial,
+  IsNever,
+  OneOf,
+  RequiredBy,
+} from './utils.js'
 
 export type AccessList = { address: Address; storageKeys: Hex[] }[]
 
@@ -27,15 +33,15 @@ export type TransactionReceipt<
   TType = TransactionType,
 > = {
   /** The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844. */
-  blobGasPrice?: TQuantity
+  blobGasPrice?: TQuantity | undefined
   /** The amount of blob gas used. Only specified for blob transactions as defined by EIP-4844. */
-  blobGasUsed?: TQuantity
+  blobGasUsed?: TQuantity | undefined
   /** Hash of block containing this transaction */
   blockHash: Hash
   /** Number of block containing this transaction */
   blockNumber: TQuantity
   /** Address of new contract or `null` if no contract was created */
-  contractAddress: Address | null
+  contractAddress: Address | null | undefined
   /** Gas used by this and all preceding transactions in this block */
   cumulativeGasUsed: TQuantity
   /** Pre-London, it is equal to the transaction's gasPrice. Post-London, it is equal to the actual gas price paid for inclusion. */
@@ -49,7 +55,7 @@ export type TransactionReceipt<
   /** Logs bloom filter */
   logsBloom: Hex
   /** The post-transaction state root. Only specified for transactions included before the Byzantium upgrade. */
-  root?: Hash
+  root?: Hash | undefined
   /** `success` if this transaction was successful or `reverted` if it failed */
   status: TStatus
   /** Transaction recipient or `null` if deploying a contract */
@@ -106,11 +112,11 @@ export type TransactionLegacy<
 > = Omit<TransactionBase<TQuantity, TIndex, TPending>, 'yParity'> &
   FeeValuesLegacy<TQuantity> & {
     /** EIP-2930 Access List. */
-    accessList?: never
-    blobVersionedHashes?: never
+    accessList?: never | undefined
+    blobVersionedHashes?: never | undefined
     /** Chain ID that this transaction is valid on. */
-    chainId?: TIndex
-    yParity?: never
+    chainId?: TIndex | undefined
+    yParity?: never | undefined
     type: TType
   }
 export type TransactionEIP2930<
@@ -122,7 +128,7 @@ export type TransactionEIP2930<
   FeeValuesLegacy<TQuantity> & {
     /** EIP-2930 Access List. */
     accessList: AccessList
-    blobVersionedHashes?: never
+    blobVersionedHashes?: never | undefined
     /** Chain ID that this transaction is valid on. */
     chainId: TIndex
     type: TType
@@ -136,7 +142,7 @@ export type TransactionEIP1559<
   FeeValuesEIP1559<TQuantity> & {
     /** EIP-2930 Access List. */
     accessList: AccessList
-    blobVersionedHashes?: never
+    blobVersionedHashes?: never | undefined
     /** Chain ID that this transaction is valid on. */
     chainId: TIndex
     type: TType
@@ -169,58 +175,58 @@ export type Transaction<
 
 export type TransactionRequestBase<TQuantity = bigint, TIndex = number> = {
   /** Contract code or a hashed method call with encoded args */
-  data?: Hex
+  data?: Hex | undefined
   /** Transaction sender */
   from: Address
   /** Gas provided for transaction execution */
-  gas?: TQuantity
+  gas?: TQuantity | undefined
   /** Unique number identifying this transaction */
-  nonce?: TIndex
+  nonce?: TIndex | undefined
   /** Transaction recipient */
-  to?: Address | null
+  to?: Address | null | undefined
   /** Value in wei sent with this transaction */
-  value?: TQuantity
+  value?: TQuantity | undefined
 }
 export type TransactionRequestLegacy<
   TQuantity = bigint,
   TIndex = number,
   TTransactionType = 'legacy',
 > = TransactionRequestBase<TQuantity, TIndex> &
-  Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: never
+  ExactPartial<FeeValuesLegacy<TQuantity>> & {
+    accessList?: never | undefined
     blobs?: undefined
-    type?: TTransactionType
+    type?: TTransactionType | undefined
   }
 export type TransactionRequestEIP2930<
   TQuantity = bigint,
   TIndex = number,
   TTransactionType = 'eip2930',
 > = TransactionRequestBase<TQuantity, TIndex> &
-  Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: AccessList
+  ExactPartial<FeeValuesLegacy<TQuantity>> & {
+    accessList?: AccessList | undefined
     blobs?: undefined
-    type?: TTransactionType
+    type?: TTransactionType | undefined
   }
 export type TransactionRequestEIP1559<
   TQuantity = bigint,
   TIndex = number,
   TTransactionType = 'eip1559',
 > = TransactionRequestBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
+  ExactPartial<FeeValuesEIP1559<TQuantity>> & {
+    accessList?: AccessList | undefined
     blobs?: undefined
-    type?: TTransactionType
+    type?: TTransactionType | undefined
   }
 export type TransactionRequestEIP4844<
   TQuantity = bigint,
   TIndex = number,
   TTransactionType = 'eip4844',
 > = RequiredBy<TransactionRequestBase<TQuantity, TIndex>, 'to'> &
-  RequiredBy<Partial<FeeValuesEIP4844<TQuantity>>, 'maxFeePerBlobGas'> & {
-    accessList?: AccessList
+  RequiredBy<ExactPartial<FeeValuesEIP4844<TQuantity>>, 'maxFeePerBlobGas'> & {
+    accessList?: AccessList | undefined
     /** The blobs associated with this transaction. */
     blobs: readonly Hex[] | readonly ByteArray[]
-    type?: TTransactionType
+    type?: TTransactionType | undefined
   }
 export type TransactionRequest<TQuantity = bigint, TIndex = number> = OneOf<
   | TransactionRequestLegacy<TQuantity, TIndex>
@@ -246,64 +252,65 @@ export type TransactionSerialized<
 export type TransactionSerializableBase<
   TQuantity = bigint,
   TIndex = number,
-> = Omit<TransactionRequestBase<TQuantity, TIndex>, 'from'> & Partial<Signature>
+> = Omit<TransactionRequestBase<TQuantity, TIndex>, 'from'> &
+  ExactPartial<Signature>
 
 export type TransactionSerializableLegacy<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesLegacy<TQuantity>> & {
+  ExactPartial<FeeValuesLegacy<TQuantity>> & {
     accessList?: undefined
     blobs?: undefined
     blobVersionedHashes?: undefined
-    chainId?: number
-    type?: 'legacy'
+    chainId?: number | undefined
+    type?: 'legacy' | undefined
   }
 
 export type TransactionSerializableEIP2930<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: AccessList
+  ExactPartial<FeeValuesLegacy<TQuantity>> & {
+    accessList?: AccessList | undefined
     blobs?: undefined
     blobVersionedHashes?: undefined
     chainId: number
-    type?: 'eip2930'
-    yParity?: number
+    type?: 'eip2930' | undefined
+    yParity?: number | undefined
   }
 
 export type TransactionSerializableEIP1559<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
+  ExactPartial<FeeValuesEIP1559<TQuantity>> & {
+    accessList?: AccessList | undefined
     blobs?: undefined
     blobVersionedHashes?: undefined
     chainId: number
-    type?: 'eip1559'
-    yParity?: number
+    type?: 'eip1559' | undefined
+    yParity?: number | undefined
   }
 
 export type TransactionSerializableEIP4844<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
-  Partial<FeeValuesEIP4844<TQuantity>> & {
-    accessList?: AccessList
+  ExactPartial<FeeValuesEIP4844<TQuantity>> & {
+    accessList?: AccessList | undefined
     chainId: number
-    type?: 'eip4844'
-    yParity?: number
+    type?: 'eip4844' | undefined
+    yParity?: number | undefined
   } & OneOf<
     | {
         blobVersionedHashes: readonly Hex[]
-        sidecars?: readonly BlobSidecar<Hex>[] | false
+        sidecars?: readonly BlobSidecar<Hex>[] | false | undefined
       }
     | {
         blobs: readonly Hex[] | readonly ByteArray[]
         kzg: Kzg
-        sidecars?: false
+        sidecars?: false | undefined
       }
   >
 
@@ -311,16 +318,16 @@ export type TransactionSerializableGeneric<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> & {
-  accessList?: AccessList
-  blobs?: readonly Hex[] | readonly ByteArray[]
-  blobVersionedHashes?: readonly Hex[]
-  chainId?: number
-  gasPrice?: TQuantity
-  maxFeePerBlobGas?: TQuantity
-  maxFeePerGas?: TQuantity
-  maxPriorityFeePerGas?: TQuantity
-  sidecars?: readonly BlobSidecar<Hex>[] | false
-  type?: string
+  accessList?: AccessList | undefined
+  blobs?: readonly Hex[] | readonly ByteArray[] | undefined
+  blobVersionedHashes?: readonly Hex[] | undefined
+  chainId?: number | undefined
+  gasPrice?: TQuantity | undefined
+  maxFeePerBlobGas?: TQuantity | undefined
+  maxFeePerGas?: TQuantity | undefined
+  maxPriorityFeePerGas?: TQuantity | undefined
+  sidecars?: readonly BlobSidecar<Hex>[] | false | undefined
+  type?: string | undefined
 }
 
 export type TransactionSerializable<

--- a/src/types/typedData.ts
+++ b/src/types/typedData.ts
@@ -56,5 +56,5 @@ type EIP712DomainDefinition<
   domain: schema extends { EIP712Domain: infer domain }
     ? domain
     : Prettify<TypedDataDomain>
-  message?: never
+  message?: never | undefined
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -115,7 +115,7 @@ export type MaybePromise<T> = T | Promise<T>
  * => { a: string, b?: number }
  */
 export type MaybeRequired<T, TRequired extends boolean> = TRequired extends true
-  ? Required<T>
+  ? ExactRequired<T>
   : T
 
 /**
@@ -166,7 +166,8 @@ export type Omit<type, keys extends keyof type> = Pick<
  * PartialBy<{ a: string, b: number }, 'a'>
  * => { a?: string, b: number }
  */
-export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+export type PartialBy<T, K extends keyof T> = Omit<T, K> &
+  ExactPartial<Pick<T, K>>
 
 /**
  * @description Combines members of an intersection into a readable type.
@@ -187,7 +188,8 @@ export type Prettify<T> = {
  * RequiredBy<{ a?: string, b: number }, 'a'>
  * => { a: string, b: number }
  */
-export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+export type RequiredBy<T, K extends keyof T> = Omit<T, K> &
+  ExactRequired<Pick<T, K>>
 
 /**
  * @description Creates a type that extracts the values of T.
@@ -229,6 +231,10 @@ export type MaybePartial<
 
 export type ExactPartial<type> = {
   [key in keyof type]?: type[key] | undefined
+}
+
+export type ExactRequired<type> = {
+  [P in keyof type]-?: Exclude<type[P], undefined>
 }
 
 export type OneOf<

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -2,6 +2,6 @@ import type { EIP1193Provider } from './eip1193.js'
 
 declare global {
   interface Window {
-    ethereum?: EIP1193Provider
+    ethereum?: EIP1193Provider | undefined
   }
 }

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -46,7 +46,7 @@ export type DecodeEventLogParameters<
 > = {
   abi: abi
   data?: data | undefined
-  eventName?: eventName | ContractEventName<abi>
+  eventName?: eventName | ContractEventName<abi> | undefined
   strict?: strict | boolean | undefined
   topics: [signature: Hex, ...args: topics] | []
 }

--- a/src/utils/abi/decodeFunctionResult.ts
+++ b/src/utils/abi/decodeFunctionResult.ts
@@ -64,9 +64,9 @@ export type DecodeFunctionResultParameters<
 } & UnionEvaluate<
   IsNarrowable<abi, Abi> extends true
     ? abi['length'] extends 1
-      ? { functionName?: functionName | allFunctionNames }
+      ? { functionName?: functionName | allFunctionNames | undefined }
       : { functionName: functionName | allFunctionNames }
-    : { functionName?: functionName | allFunctionNames }
+    : { functionName?: functionName | allFunctionNames | undefined }
 > &
   UnionEvaluate<
     readonly [] extends allArgs

--- a/src/utils/abi/encodeErrorResult.ts
+++ b/src/utils/abi/encodeErrorResult.ts
@@ -50,9 +50,9 @@ export type EncodeErrorResultParameters<
 } & UnionEvaluate<
   IsNarrowable<abi, Abi> extends true
     ? abi['length'] extends 1
-      ? { errorName?: errorName | allErrorNames }
+      ? { errorName?: errorName | allErrorNames | undefined }
       : { errorName: errorName | allErrorNames }
-    : { errorName?: errorName | allErrorNames }
+    : { errorName?: errorName | allErrorNames | undefined }
 > &
   (hasErrors extends true ? unknown : never)
 

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -60,9 +60,9 @@ export type EncodeEventTopicsParameters<
 } & UnionEvaluate<
   IsNarrowable<abi, Abi> extends true
     ? abi['length'] extends 1
-      ? { eventName?: eventName | allErrorNames }
+      ? { eventName?: eventName | allErrorNames | undefined }
       : { eventName: eventName | allErrorNames }
-    : { eventName?: eventName | allErrorNames }
+    : { eventName?: eventName | allErrorNames | undefined }
 > &
   (hasEvents extends true ? unknown : never)
 

--- a/src/utils/abi/encodeFunctionData.ts
+++ b/src/utils/abi/encodeFunctionData.ts
@@ -52,9 +52,9 @@ export type EncodeFunctionDataParameters<
 } & UnionEvaluate<
   IsNarrowable<abi, Abi> extends true
     ? abi['length'] extends 1
-      ? { functionName?: functionName | allFunctionNames }
+      ? { functionName?: functionName | allFunctionNames | undefined }
       : { functionName: functionName | allFunctionNames }
-    : { functionName?: functionName | allFunctionNames }
+    : { functionName?: functionName | allFunctionNames | undefined }
 > &
   UnionEvaluate<
     readonly [] extends allArgs

--- a/src/utils/abi/encodeFunctionResult.ts
+++ b/src/utils/abi/encodeFunctionResult.ts
@@ -49,9 +49,9 @@ export type EncodeFunctionResultParameters<
 } & UnionEvaluate<
   IsNarrowable<abi, Abi> extends true
     ? abi['length'] extends 1
-      ? { functionName?: functionName | allFunctionNames }
+      ? { functionName?: functionName | allFunctionNames | undefined }
       : { functionName: functionName | allFunctionNames }
-    : { functionName?: functionName | allFunctionNames }
+    : { functionName?: functionName | allFunctionNames | undefined }
 > &
   (hasFunctions extends true ? unknown : never)
 

--- a/src/utils/abi/formatAbiItem.ts
+++ b/src/utils/abi/formatAbiItem.ts
@@ -14,7 +14,7 @@ export type FormatAbiItemErrorType =
 
 export function formatAbiItem(
   abiItem: AbiItem,
-  { includeName = false }: { includeName?: boolean } = {},
+  { includeName = false }: { includeName?: boolean | undefined } = {},
 ) {
   if (
     abiItem.type !== 'function' &&
@@ -30,7 +30,7 @@ export type FormatAbiParamsErrorType = ErrorType
 
 export function formatAbiParams(
   params: readonly AbiParameter[] | undefined,
-  { includeName = false }: { includeName?: boolean } = {},
+  { includeName = false }: { includeName?: boolean | undefined } = {},
 ): string {
   if (!params) return ''
   return params

--- a/src/utils/abi/formatAbiItemWithArgs.ts
+++ b/src/utils/abi/formatAbiItemWithArgs.ts
@@ -14,8 +14,8 @@ export function formatAbiItemWithArgs({
 }: {
   abiItem: AbiItem
   args: readonly unknown[]
-  includeFunctionName?: boolean
-  includeName?: boolean
+  includeFunctionName?: boolean | undefined
+  includeName?: boolean | undefined
 }) {
   if (!('name' in abiItem)) return
   if (!('inputs' in abiItem)) return

--- a/src/utils/address/getAddress.ts
+++ b/src/utils/address/getAddress.ts
@@ -14,7 +14,10 @@ export type ChecksumAddressErrorType =
   | StringToBytesErrorType
   | ErrorType
 
-export function checksumAddress(address_: Address, chainId?: number): Address {
+export function checksumAddress(
+  address_: Address,
+  chainId?: number | undefined,
+): Address {
   const hexAddress = chainId
     ? `${chainId}${address_.toLowerCase()}`
     : address_.substring(2).toLowerCase()

--- a/src/utils/address/getContractAddress.ts
+++ b/src/utils/address/getContractAddress.ts
@@ -31,7 +31,7 @@ export type GetCreate2AddressOptions =
 
 export type GetContractAddressOptions =
   | ({
-      opcode?: 'CREATE'
+      opcode?: 'CREATE' | undefined
     } & GetCreateAddressOptions)
   | ({ opcode: 'CREATE2' } & GetCreate2AddressOptions)
 

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -13,7 +13,7 @@ export type IsAddressOptions = {
    *
    * @default true
    */
-  strict?: boolean
+  strict?: boolean | undefined
 }
 
 export type IsAddressErrorType = ErrorType

--- a/src/utils/blob/commitmentToVersionedHash.ts
+++ b/src/utils/blob/commitmentToVersionedHash.ts
@@ -14,7 +14,7 @@ export type CommitmentToVersionedHashParameters<
   /** Return type. */
   to?: to | To | undefined
   /** Version to tag onto the hash. */
-  version?: number
+  version?: number | undefined
 }
 
 export type CommitmentToVersionedHashReturnType<to extends To> =

--- a/src/utils/blob/commitmentsToVersionedHashes.ts
+++ b/src/utils/blob/commitmentsToVersionedHashes.ts
@@ -16,7 +16,7 @@ export type CommitmentsToVersionedHashesParameters<
   /** Return type. */
   to?: to | To | undefined
   /** Version to tag onto the hashes. */
-  version?: number
+  version?: number | undefined
 }
 
 export type CommitmentsToVersionedHashesReturnType<to extends To> =

--- a/src/utils/blob/sidecarsToVersionedHashes.ts
+++ b/src/utils/blob/sidecarsToVersionedHashes.ts
@@ -17,7 +17,7 @@ export type SidecarsToVersionedHashesParameters<
   /** Return type. */
   to?: to | To | undefined
   /** Version to tag onto the hashes. */
-  version?: number
+  version?: number | undefined
 }
 
 export type SidecarsToVersionedHashesReturnType<to extends To> =

--- a/src/utils/chain/assertCurrentChain.ts
+++ b/src/utils/chain/assertCurrentChain.ts
@@ -8,7 +8,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 
 export type AssertCurrentChainParameters = {
-  chain?: Chain
+  chain?: Chain | undefined
   currentChainId: number
 }
 

--- a/src/utils/chain/getChainContractAddress.ts
+++ b/src/utils/chain/getChainContractAddress.ts
@@ -12,7 +12,7 @@ export function getChainContractAddress({
   chain,
   contract: name,
 }: {
-  blockNumber?: bigint
+  blockNumber?: bigint | undefined
   chain: Chain
   contract: string
 }) {

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -210,7 +210,7 @@ const staticCursor: Cursor = {
   },
 }
 
-type CursorConfig = { recursiveReadLimit?: number }
+type CursorConfig = { recursiveReadLimit?: number | undefined }
 
 export function createCursor(
   bytes: ByteArray,

--- a/src/utils/data/isHex.ts
+++ b/src/utils/data/isHex.ts
@@ -5,7 +5,7 @@ export type IsHexErrorType = ErrorType
 
 export function isHex(
   value: unknown,
-  { strict = true }: { strict?: boolean } = {},
+  { strict = true }: { strict?: boolean | undefined } = {},
 ): value is Hex {
   if (!value) return false
   if (typeof value !== 'string') return false

--- a/src/utils/data/pad.ts
+++ b/src/utils/data/pad.ts
@@ -6,8 +6,8 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
 
 type PadOptions = {
-  dir?: 'left' | 'right'
-  size?: number | null
+  dir?: 'left' | 'right' | undefined
+  size?: number | null | undefined
 }
 export type PadReturnType<TValue extends ByteArray | Hex> = TValue extends Hex
   ? Hex

--- a/src/utils/data/slice.ts
+++ b/src/utils/data/slice.ts
@@ -27,9 +27,9 @@ export type SliceErrorType =
  */
 export function slice<TValue extends ByteArray | Hex>(
   value: TValue,
-  start?: number,
-  end?: number,
-  { strict }: { strict?: boolean } = {},
+  start?: number | undefined,
+  end?: number | undefined,
+  { strict }: { strict?: boolean | undefined } = {},
 ): SliceReturnType<TValue> {
   if (isHex(value, { strict: false }))
     return sliceHex(value as Hex, start, end, {
@@ -45,7 +45,7 @@ export type AssertStartOffsetErrorType =
   | SizeErrorType
   | ErrorType
 
-function assertStartOffset(value: Hex | ByteArray, start?: number) {
+function assertStartOffset(value: Hex | ByteArray, start?: number | undefined) {
   if (typeof start === 'number' && start > 0 && start > size(value) - 1)
     throw new SliceOffsetOutOfBoundsError({
       offset: start,
@@ -59,7 +59,11 @@ export type AssertEndOffsetErrorType =
   | SizeErrorType
   | ErrorType
 
-function assertEndOffset(value: Hex | ByteArray, start?: number, end?: number) {
+function assertEndOffset(
+  value: Hex | ByteArray,
+  start?: number | undefined,
+  end?: number | undefined,
+) {
   if (
     typeof start === 'number' &&
     typeof end === 'number' &&
@@ -87,9 +91,9 @@ export type SliceBytesErrorType =
  */
 export function sliceBytes(
   value_: ByteArray,
-  start?: number,
-  end?: number,
-  { strict }: { strict?: boolean } = {},
+  start?: number | undefined,
+  end?: number | undefined,
+  { strict }: { strict?: boolean | undefined } = {},
 ): ByteArray {
   assertStartOffset(value_, start)
   const value = value_.slice(start, end)
@@ -111,9 +115,9 @@ export type SliceHexErrorType =
  */
 export function sliceHex(
   value_: Hex,
-  start?: number,
-  end?: number,
-  { strict }: { strict?: boolean } = {},
+  start?: number | undefined,
+  end?: number | undefined,
+  { strict }: { strict?: boolean | undefined } = {},
 ): Hex {
   assertStartOffset(value_, start)
   const value = `0x${value_

--- a/src/utils/data/trim.ts
+++ b/src/utils/data/trim.ts
@@ -2,7 +2,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
 
 type TrimOptions = {
-  dir?: 'left' | 'right'
+  dir?: 'left' | 'right' | undefined
 }
 export type TrimReturnType<TValue extends ByteArray | Hex> = TValue extends Hex
   ? Hex

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -19,7 +19,7 @@ export type FromBytesParameters<
   | TTo
   | {
       /** Size of the bytes. */
-      size?: number
+      size?: number | undefined
       /** Type to convert to. */
       to: TTo
     }
@@ -89,9 +89,9 @@ export function fromBytes<
 
 export type BytesToBigIntOpts = {
   /** Whether or not the number of a signed representation. */
-  signed?: boolean
+  signed?: boolean | undefined
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BytesToBigIntErrorType =
@@ -124,7 +124,7 @@ export function bytesToBigInt(
 
 export type BytesToBoolOpts = {
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BytesToBoolErrorType =
@@ -192,7 +192,7 @@ export function bytesToNumber(
 
 export type BytesToStringOpts = {
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BytesToStringErrorType =

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -33,7 +33,7 @@ export type FromHexParameters<
   | TTo
   | {
       /** Size (in bytes) of the hex value. */
-      size?: number
+      size?: number | undefined
       /** Type to convert to. */
       to: TTo
     }
@@ -101,9 +101,9 @@ export function fromHex<
 
 export type HexToBigIntOpts = {
   /** Whether or not the number of a signed representation. */
-  signed?: boolean
+  signed?: boolean | undefined
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type HexToBigIntErrorType = AssertSizeErrorType | ErrorType
@@ -144,7 +144,7 @@ export function hexToBigInt(hex: Hex, opts: HexToBigIntOpts = {}): bigint {
 
 export type HexToBoolOpts = {
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type HexToBoolErrorType =
@@ -212,7 +212,7 @@ export function hexToNumber(hex: Hex, opts: HexToNumberOpts = {}): number {
 
 export type HexToStringOpts = {
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type HexToStringErrorType =

--- a/src/utils/encoding/toBytes.ts
+++ b/src/utils/encoding/toBytes.ts
@@ -15,7 +15,7 @@ const encoder = /*#__PURE__*/ new TextEncoder()
 
 export type ToBytesParameters = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type ToBytesErrorType =
@@ -64,7 +64,7 @@ export function toBytes(
 
 export type BoolToBytesOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BoolToBytesErrorType =
@@ -123,7 +123,7 @@ function charCodeToBase16(char: number) {
 
 export type HexToBytesOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type HexToBytesErrorType = AssertSizeErrorType | PadErrorType | ErrorType
@@ -198,14 +198,17 @@ export type NumberToBytesErrorType =
  * const data = numberToBytes(420, { size: 4 })
  * // Uint8Array([0, 0, 1, 164])
  */
-export function numberToBytes(value: bigint | number, opts?: NumberToHexOpts) {
+export function numberToBytes(
+  value: bigint | number,
+  opts?: NumberToHexOpts | undefined,
+) {
   const hex = numberToHex(value, opts)
   return hexToBytes(hex)
 }
 
 export type StringToBytesOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 export type StringToBytesErrorType =

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -14,7 +14,7 @@ const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (_v, i) =>
 
 export type ToHexParameters = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type ToHexErrorType =
@@ -64,7 +64,7 @@ export function toHex(
 
 export type BoolToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
@@ -104,7 +104,7 @@ export function boolToHex(value: boolean, opts: BoolToHexOpts = {}): Hex {
 
 export type BytesToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
@@ -145,14 +145,14 @@ export function bytesToHex(value: ByteArray, opts: BytesToHexOpts = {}): Hex {
 export type NumberToHexOpts =
   | {
       /** Whether or not the number of a signed representation. */
-      signed?: boolean
+      signed?: boolean | undefined
       /** The size (in bytes) of the output hex value. */
       size: number
     }
   | {
-      signed?: never
+      signed?: never | undefined
       /** The size (in bytes) of the output hex value. */
-      size?: number
+      size?: number | undefined
     }
 
 export type NumberToHexErrorType =
@@ -218,7 +218,7 @@ export function numberToHex(
 
 export type StringToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 export type StringToHexErrorType = BytesToHexErrorType | ErrorType

--- a/src/utils/ens/avatar/parseAvatarRecord.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.ts
@@ -30,7 +30,7 @@ export async function parseAvatarRecord<TChain extends Chain | undefined>(
     gatewayUrls,
     record,
   }: {
-    gatewayUrls?: AssetGatewayUrls
+    gatewayUrls?: AssetGatewayUrls | undefined
     record: string
   },
 ): Promise<string> {
@@ -54,7 +54,7 @@ async function parseNftAvatarUri<TChain extends Chain | undefined>(
     gatewayUrls,
     record,
   }: {
-    gatewayUrls?: AssetGatewayUrls
+    gatewayUrls?: AssetGatewayUrls | undefined
     record: string
   },
 ): Promise<string> {

--- a/src/utils/errors/getCallError.ts
+++ b/src/utils/errors/getCallError.ts
@@ -27,8 +27,8 @@ export function getCallError<err extends ErrorType<string>>(
     docsPath,
     ...args
   }: CallParameters & {
-    chain?: Chain
-    docsPath?: string
+    chain?: Chain | undefined
+    docsPath?: string | undefined
   },
 ): GetCallErrorReturnType<err> {
   const cause = (() => {

--- a/src/utils/errors/getContractError.ts
+++ b/src/utils/errors/getContractError.ts
@@ -38,10 +38,10 @@ export function getContractError<err extends ErrorType<string>>(
   }: {
     abi: Abi
     args: any
-    address?: Address
-    docsPath?: string
+    address?: Address | undefined
+    docsPath?: string | undefined
     functionName: string
-    sender?: Address
+    sender?: Address | undefined
   },
 ): GetContractErrorReturnType {
   const { code, data, message, shortMessage } = (

--- a/src/utils/errors/getEstimateGasError.ts
+++ b/src/utils/errors/getEstimateGasError.ts
@@ -26,9 +26,9 @@ export function getEstimateGasError<err extends ErrorType<string>>(
     docsPath,
     ...args
   }: Omit<EstimateGasParameters, 'account'> & {
-    account?: Account
-    chain?: Chain
-    docsPath?: string
+    account?: Account | undefined
+    chain?: Chain | undefined
+    docsPath?: string | undefined
   },
 ): GetEstimateGasErrorReturnType<err> {
   const cause = (() => {

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -31,6 +31,7 @@ import {
   InvalidInputRpcError,
   TransactionRejectedRpcError,
 } from '../../errors/rpc.js'
+import type { ExactPartial } from '../../types/utils.js'
 
 export function containsNodeError(err: BaseError) {
   return (
@@ -40,7 +41,9 @@ export function containsNodeError(err: BaseError) {
   )
 }
 
-export type GetNodeErrorParameters = Partial<SendTransactionParameters<any>>
+export type GetNodeErrorParameters = ExactPartial<
+  SendTransactionParameters<any>
+>
 
 export type GetNodeErrorReturnType =
   | ExecutionRevertedErrorType

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -20,8 +20,8 @@ export type GetTransactionErrorParameters = Omit<
   'account' | 'chain'
 > & {
   account: Account
-  chain?: Chain
-  docsPath?: string
+  chain?: Chain | undefined
+  docsPath?: string | undefined
 }
 
 export type GetTransactionErrorReturnType<cause = ErrorType> = Omit<

--- a/src/utils/formatters/block.ts
+++ b/src/utils/formatters/block.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../types/chain.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock } from '../../types/rpc.js'
-import type { Prettify } from '../../types/utils.js'
+import type { ExactPartial, Prettify } from '../../types/utils.js'
 
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
 import { type FormattedTransaction, formatTransaction } from './transaction.js'
@@ -40,7 +40,7 @@ export type FormattedBlock<
 
 export type FormatBlockErrorType = ErrorType
 
-export function formatBlock(block: Partial<RpcBlock>) {
+export function formatBlock(block: ExactPartial<RpcBlock>) {
   const transactions = block.transactions?.map((transaction) => {
     if (typeof transaction === 'string') return transaction
     return formatTransaction(transaction)

--- a/src/utils/formatters/extract.ts
+++ b/src/utils/formatters/extract.ts
@@ -8,7 +8,7 @@ export type ExtractErrorType = ErrorType
  */
 export function extract(
   value_: Record<string, unknown>,
-  { format }: { format?: ChainFormatter['format'] },
+  { format }: { format?: ChainFormatter['format'] | undefined },
 ) {
   if (!format) return {}
 

--- a/src/utils/formatters/formatter.ts
+++ b/src/utils/formatters/formatter.ts
@@ -15,7 +15,7 @@ export function defineFormatter<TType extends string, TParameters, TReturnType>(
     exclude,
     format: overrides,
   }: {
-    exclude?: TExclude
+    exclude?: TExclude | undefined
     format: (_: TOverrideParameters) => TOverrideReturnType
   }) => {
     return {

--- a/src/utils/formatters/log.ts
+++ b/src/utils/formatters/log.ts
@@ -1,12 +1,16 @@
 import type { ErrorType } from '../../errors/utils.js'
 import type { Log } from '../../types/log.js'
 import type { RpcLog } from '../../types/rpc.js'
+import type { ExactPartial } from '../../types/utils.js'
 
 export type FormatLogErrorType = ErrorType
 
 export function formatLog(
-  log: Partial<RpcLog>,
-  { args, eventName }: { args?: unknown; eventName?: string } = {},
+  log: ExactPartial<RpcLog>,
+  {
+    args,
+    eventName,
+  }: { args?: unknown | undefined; eventName?: string | undefined } = {},
 ) {
   return {
     ...log,

--- a/src/utils/formatters/proof.ts
+++ b/src/utils/formatters/proof.ts
@@ -1,6 +1,7 @@
 import type { ErrorType } from '../../errors/utils.js'
 import type { Proof } from '../../types/proof.js'
 import type { RpcProof } from '../../types/rpc.js'
+import type { ExactPartial } from '../../types/utils.js'
 import { hexToNumber } from '../index.js'
 
 export type FormatProofErrorType = ErrorType
@@ -12,7 +13,7 @@ function formatStorageProof(storageProof: RpcProof['storageProof']) {
   }))
 }
 
-export function formatProof(proof: Partial<RpcProof>) {
+export function formatProof(proof: ExactPartial<RpcProof>) {
   return {
     ...proof,
     balance: proof.balance ? BigInt(proof.balance) : undefined,

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -8,7 +8,7 @@ import type {
 import type { Hex } from '../../types/misc.js'
 import type { RpcTransaction } from '../../types/rpc.js'
 import type { Transaction, TransactionType } from '../../types/transaction.js'
-import type { UnionLooseOmit } from '../../types/utils.js'
+import type { ExactPartial, UnionLooseOmit } from '../../types/utils.js'
 import { hexToNumber } from '../encoding/fromHex.js'
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
 
@@ -43,7 +43,7 @@ export const transactionType = {
 
 export type FormatTransactionErrorType = ErrorType
 
-export function formatTransaction(transaction: Partial<RpcTransaction>) {
+export function formatTransaction(transaction: ExactPartial<RpcTransaction>) {
   const transaction_ = {
     ...transaction,
     blockHash: transaction.blockHash ? transaction.blockHash : null,

--- a/src/utils/formatters/transactionReceipt.ts
+++ b/src/utils/formatters/transactionReceipt.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../types/chain.js'
 import type { RpcTransactionReceipt } from '../../types/rpc.js'
 import type { TransactionReceipt } from '../../types/transaction.js'
+import type { ExactPartial } from '../../types/utils.js'
 import { hexToNumber } from '../encoding/fromHex.js'
 
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
@@ -27,7 +28,7 @@ const statuses = {
 export type FormatTransactionReceiptErrorType = ErrorType
 
 export function formatTransactionReceipt(
-  transactionReceipt: Partial<RpcTransactionReceipt>,
+  transactionReceipt: ExactPartial<RpcTransactionReceipt>,
 ) {
   const receipt = {
     ...transactionReceipt,

--- a/src/utils/formatters/transactionRequest.ts
+++ b/src/utils/formatters/transactionRequest.ts
@@ -6,6 +6,7 @@ import type {
 import type { ByteArray } from '../../types/misc.js'
 import type { RpcTransactionRequest } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
+import type { ExactPartial } from '../../types/utils.js'
 import { bytesToHex, numberToHex } from '../encoding/toHex.js'
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
 
@@ -26,7 +27,9 @@ export const rpcTransactionType = {
 
 export type FormatTransactionRequestErrorType = ErrorType
 
-export function formatTransactionRequest(request: Partial<TransactionRequest>) {
+export function formatTransactionRequest(
+  request: ExactPartial<TransactionRequest>,
+) {
   const rpcRequest = { ...request } as RpcTransactionRequest
 
   if (

--- a/src/utils/hash/keccak256.ts
+++ b/src/utils/hash/keccak256.ts
@@ -20,7 +20,7 @@ export type Keccak256ErrorType =
 
 export function keccak256<TTo extends To = 'hex'>(
   value: Hex | ByteArray,
-  to_?: TTo,
+  to_?: TTo | undefined,
 ): Keccak256Hash<TTo> {
   const to = to_ || 'hex'
   const bytes = keccak_256(

--- a/src/utils/hash/ripemd160.ts
+++ b/src/utils/hash/ripemd160.ts
@@ -20,7 +20,7 @@ export type Ripemd160ErrorType =
 
 export function ripemd160<TTo extends To = 'hex'>(
   value: Hex | ByteArray,
-  to_?: TTo,
+  to_?: TTo | undefined,
 ): Ripemd160Hash<TTo> {
   const to = to_ || 'hex'
   const bytes = noble_ripemd160(

--- a/src/utils/hash/sha256.ts
+++ b/src/utils/hash/sha256.ts
@@ -20,7 +20,7 @@ export type Sha256ErrorType =
 
 export function sha256<TTo extends To = 'hex'>(
   value: Hex | ByteArray,
-  to_?: TTo,
+  to_?: TTo | undefined,
 ): Sha256Hash<TTo> {
   const to = to_ || 'hex'
   const bytes = noble_sha256(

--- a/src/utils/poll.ts
+++ b/src/utils/poll.ts
@@ -3,9 +3,9 @@ import { wait } from './wait.js'
 
 type PollOptions<TData> = {
   // Whether or not to emit when the polling starts.
-  emitOnBegin?: boolean
+  emitOnBegin?: boolean | undefined
   // The initial wait time (in ms) before polling.
-  initialWaitTime?: (data: TData | void) => Promise<number>
+  initialWaitTime?: ((data: TData | void) => Promise<number>) | undefined
   // The interval (in ms).
   interval: number
 }

--- a/src/utils/promise/createBatchScheduler.ts
+++ b/src/utils/promise/createBatchScheduler.ts
@@ -6,8 +6,8 @@ type Resolved<TReturnType extends readonly unknown[] = any> = [
 ]
 
 type PendingPromise<TReturnType extends readonly unknown[] = any> = {
-  resolve?: (data: Resolved<TReturnType>) => void
-  reject?: (reason?: unknown) => void
+  resolve?: ((data: Resolved<TReturnType>) => void) | undefined
+  reject?: ((reason?: unknown) => void) | undefined
 }
 
 type SchedulerItem = { args: unknown; pendingPromise: PendingPromise }
@@ -23,9 +23,9 @@ export type CreateBatchSchedulerArguments<
 > = {
   fn: (args: TParameters[]) => Promise<TReturnType>
   id: number | string
-  shouldSplitBatch?: (args: TParameters[]) => boolean
-  wait?: number
-  sort?: BatchResultsCompareFn<TReturnType[number]>
+  shouldSplitBatch?: ((args: TParameters[]) => boolean) | undefined
+  wait?: number | undefined
+  sort?: BatchResultsCompareFn<TReturnType[number]> | undefined
 }
 
 export type CreateBatchSchedulerReturnType<
@@ -34,7 +34,7 @@ export type CreateBatchSchedulerReturnType<
 > = {
   flush: () => void
   schedule: TParameters extends undefined
-    ? (args?: TParameters) => Promise<Resolved<TReturnType>>
+    ? (args?: TParameters | undefined) => Promise<Resolved<TReturnType>>
     : (args: TParameters) => Promise<Resolved<TReturnType>>
 }
 

--- a/src/utils/promise/withCache.ts
+++ b/src/utils/promise/withCache.ts
@@ -32,7 +32,7 @@ export type WithCacheParameters = {
   /** The key to cache the data against. */
   cacheKey: string
   /** The time that cached data will remain in memory. Default: Infinity (no expiry) */
-  cacheTime?: number
+  cacheTime?: number | undefined
 }
 
 /**

--- a/src/utils/promise/withRetry.ts
+++ b/src/utils/promise/withRetry.ts
@@ -3,17 +3,22 @@ import { wait } from '../wait.js'
 
 export type WithRetryParameters = {
   // The delay (in ms) between retries.
-  delay?: ((config: { count: number; error: Error }) => number) | number
+  delay?:
+    | ((config: { count: number; error: Error }) => number)
+    | number
+    | undefined
   // The max number of times to retry.
-  retryCount?: number
+  retryCount?: number | undefined
   // Whether or not to retry when an error is thrown.
-  shouldRetry?: ({
-    count,
-    error,
-  }: {
-    count: number
-    error: Error
-  }) => Promise<boolean> | boolean
+  shouldRetry?:
+    | (({
+        count,
+        error,
+      }: {
+        count: number
+        error: Error
+      }) => Promise<boolean> | boolean)
+    | undefined
 }
 
 export type WithRetryErrorType = ErrorType

--- a/src/utils/promise/withTimeout.ts
+++ b/src/utils/promise/withTimeout.ts
@@ -3,18 +3,20 @@ import type { ErrorType } from '../../errors/utils.js'
 export type WithTimeoutErrorType = ErrorType
 
 export function withTimeout<TData>(
-  fn: ({ signal }: { signal?: AbortController['signal'] }) => Promise<TData>,
+  fn: ({
+    signal,
+  }: { signal: AbortController['signal'] | null }) => Promise<TData>,
   {
     errorInstance = new Error('timed out'),
     timeout,
     signal,
   }: {
     // The error instance to throw when the timeout is reached.
-    errorInstance?: Error
+    errorInstance?: Error | undefined
     // The timeout (in ms).
     timeout: number
     // Whether or not the timeout should use an abort signal.
-    signal?: boolean
+    signal?: boolean | undefined
   },
 ): Promise<TData> {
   return new Promise((resolve, reject) => {
@@ -31,7 +33,7 @@ export function withTimeout<TData>(
             }
           }, timeout)
         }
-        resolve(await fn({ signal: controller?.signal }))
+        resolve(await fn({ signal: controller?.signal || null }))
       } catch (err) {
         if ((err as Error).name === 'AbortError') reject(errorInstance)
         reject(err)

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -15,11 +15,11 @@ import { idCache } from './id.js'
 
 export type HttpRpcClientOptions = {
   // Request configuration to pass to `fetch`.
-  fetchOptions?: Omit<RequestInit, 'body'>
+  fetchOptions?: Omit<RequestInit, 'body'> | undefined
   // A callback to handle the response.
-  onResponse?: (response: Response) => Promise<void> | void
+  onResponse?: ((response: Response) => Promise<void> | void) | undefined
   // The timeout (in ms) for the request.
-  timeout?: number
+  timeout?: number | undefined
 }
 
 export type HttpRequestParameters<
@@ -28,11 +28,11 @@ export type HttpRequestParameters<
   // The RPC request body.
   body: TBody
   // Request configuration to pass to `fetch`.
-  fetchOptions?: HttpRpcClientOptions['fetchOptions']
+  fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
   // A callback to handle the response.
-  onResponse?: (response: Response) => Promise<void> | void
+  onResponse?: ((response: Response) => Promise<void> | void) | undefined
   // The timeout (in ms) for the request.
-  timeout?: HttpRpcClientOptions['timeout']
+  timeout?: HttpRpcClientOptions['timeout'] | undefined
 }
 
 export type HttpRequestReturnType<
@@ -92,7 +92,7 @@ export function getHttpRpcClient(
                 'Content-Type': 'application/json',
               },
               method: method || 'POST',
-              signal: signal_ || (timeout > 0 ? signal : undefined),
+              signal: signal_ || (timeout > 0 ? signal : null),
             })
             return response
           },

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -28,12 +28,12 @@ export type SocketRpcClient<socket extends {}> = {
   socket: Socket<socket>
   request(params: {
     body: RpcRequest
-    onError?: (error: Error) => void
+    onError?: ((error: Error) => void) | undefined
     onResponse: (message: RpcResponse) => void
   }): void
   requestAsync(params: {
     body: RpcRequest
-    timeout?: number
+    timeout?: number | undefined
   }): Promise<RpcResponse>
   requests: CallbackMap
   subscriptions: CallbackMap

--- a/src/utils/signature/hashMessage.ts
+++ b/src/utils/signature/hashMessage.ts
@@ -25,7 +25,7 @@ export type HashMessageErrorType =
 
 export function hashMessage<TTo extends To = 'hex'>(
   message: SignableMessage,
-  to_?: TTo,
+  to_?: TTo | undefined,
 ): HashMessage<TTo> {
   const messageBytes = (() => {
     if (typeof message === 'string') return stringToBytes(message)

--- a/src/utils/transaction/assertRequest.ts
+++ b/src/utils/transaction/assertRequest.ts
@@ -19,9 +19,12 @@ import {
 } from '../../errors/transaction.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
+import type { ExactPartial } from '../../types/utils.js'
 import { isAddress } from '../address/isAddress.js'
 
-export type AssertRequestParameters = Partial<SendTransactionParameters<Chain>>
+export type AssertRequestParameters = ExactPartial<
+  SendTransactionParameters<Chain>
+>
 
 export type AssertRequestErrorType =
   | InvalidAddressErrorType

--- a/src/utils/transaction/getTransactionType.ts
+++ b/src/utils/transaction/getTransactionType.ts
@@ -20,7 +20,13 @@ import type {
   TransactionSerializableGeneric,
   TransactionSerializableLegacy,
 } from '../../types/transaction.js'
-import type { Assign, IsNever, OneOf, Opaque } from '../../types/utils.js'
+import type {
+  Assign,
+  ExactPartial,
+  IsNever,
+  OneOf,
+  Opaque,
+} from '../../types/utils.js'
 
 type BaseProperties = {
   accessList?: undefined
@@ -45,18 +51,18 @@ type EIP1559Properties = Assign<
       },
     FeeValuesEIP1559
   > & {
-    accessList?: TransactionSerializableEIP2930['accessList']
+    accessList?: TransactionSerializableEIP2930['accessList'] | undefined
   }
 >
 type EIP2930Properties = Assign<
   BaseProperties,
-  Partial<FeeValuesLegacy> & {
+  ExactPartial<FeeValuesLegacy> & {
     accessList: TransactionSerializableEIP2930['accessList']
   }
 >
 type EIP4844Properties = Assign<
   BaseProperties,
-  Partial<FeeValuesEIP4844> &
+  ExactPartial<FeeValuesEIP4844> &
     OneOf<
       | {
           blobs: TransactionSerializableEIP4844['blobs']

--- a/src/utils/transaction/parseTransaction.ts
+++ b/src/utils/transaction/parseTransaction.ts
@@ -364,7 +364,7 @@ type ParseTransactionLegacyErrorType =
 function parseTransactionLegacy(
   serializedTransaction: Hex,
 ): Omit<TransactionRequestLegacy, 'from'> &
-  ({ chainId?: number } | ({ chainId: number } & Signature)) {
+  ({ chainId?: number | undefined } | ({ chainId: number } & Signature)) {
   const transactionArray = fromRlp(serializedTransaction, 'hex')
 
   const [nonce, gasPrice, gas, to, value, data, chainIdOrV_, r, s] =

--- a/src/utils/transaction/serializeAccessList.ts
+++ b/src/utils/transaction/serializeAccessList.ts
@@ -28,7 +28,7 @@ export type SerializeAccessListErrorType =
  * @returns Array of hex strings
  */
 export function serializeAccessList(
-  accessList?: AccessList,
+  accessList?: AccessList | undefined,
 ): RecursiveArray<Hex> {
   if (!accessList || accessList.length === 0) return []
 

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -94,7 +94,7 @@ export function serializeTransaction<
   _transactionType extends TransactionType = GetTransactionType<transaction>,
 >(
   transaction: transaction,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): SerializedTransactionReturnType<transaction, _transactionType> {
   const type = getTransactionType(transaction) as GetTransactionType
 
@@ -137,7 +137,7 @@ type SerializeTransactionEIP4844ErrorType =
 
 function serializeTransactionEIP4844(
   transaction: TransactionSerializableEIP4844,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): TransactionSerializedEIP4844 {
   const {
     chainId,
@@ -226,7 +226,7 @@ type SerializeTransactionEIP1559ErrorType =
 
 function serializeTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): TransactionSerializedEIP1559 {
   const {
     chainId,
@@ -274,7 +274,7 @@ type SerializeTransactionEIP2930ErrorType =
 
 function serializeTransactionEIP2930(
   transaction: TransactionSerializableEIP2930,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ): TransactionSerializedEIP2930 {
   const { chainId, gas, data, nonce, to, value, accessList, gasPrice } =
     transaction
@@ -310,7 +310,7 @@ type SerializeTransactionLegacyErrorType =
 
 function serializeTransactionLegacy(
   transaction: TransactionSerializableLegacy,
-  signature?: SignatureLegacy,
+  signature?: SignatureLegacy | undefined,
 ): TransactionSerializedLegacy {
   const { chainId = 0, gas, data, nonce, to, value, gasPrice } = transaction
 
@@ -364,7 +364,7 @@ function serializeTransactionLegacy(
 
 export function toYParitySignatureArray(
   transaction: TransactionSerializableGeneric,
-  signature?: Signature,
+  signature?: Signature | undefined,
 ) {
   const { r, s, v, yParity } = signature ?? transaction
   if (typeof r === 'undefined') return []

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -83,7 +83,7 @@ export type GetTypesForEIP712DomainErrorType = ErrorType
 
 export function getTypesForEIP712Domain({
   domain,
-}: { domain?: TypedDataDomain }): TypedDataParameter[] {
+}: { domain?: TypedDataDomain | undefined }): TypedDataParameter[] {
   return [
     typeof domain?.name === 'string' && { name: 'name', type: 'string' },
     domain?.version && { name: 'version', type: 'string' },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,8 +15,8 @@
     "noImplicitOverride": true, // Not enabled by default in `strict` mode.
     "noUnusedLocals": true, // Not enabled by default in `strict` mode.
     "noUnusedParameters": true, // Not enabled by default in `strict` mode.
-    // TODO: The following options are also not enabled by default in `strict` mode and would be nice to have but would require some adjustments to the codebase.
     "exactOptionalPropertyTypes": true,
+    // TODO: Uncomment and fix types.
     // "noUncheckedIndexedAccess": true,
 
     // JavaScript support

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": true, // Not enabled by default in `strict` mode.
     "noUnusedParameters": true, // Not enabled by default in `strict` mode.
     // TODO: The following options are also not enabled by default in `strict` mode and would be nice to have but would require some adjustments to the codebase.
-    // "exactOptionalPropertyTypes": true,
+    "exactOptionalPropertyTypes": true,
     // "noUncheckedIndexedAccess": true,
 
     // JavaScript support


### PR DESCRIPTION
fixes #1955

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for `undefined` types in various parts of the codebase for better type safety and clarity.

### Detailed summary
- Added support for `undefined` types in multiple type definitions for enhanced type safety.
- Updated function parameters to accept `undefined` values where applicable.
- Improved clarity by specifying `undefined` types in various object properties.

> The following files were skipped due to too many changes: `src/actions/wallet/writeContract.ts`, `src/utils/errors/getEstimateGasError.ts`, `src/chains/opStack/actions/estimateInitiateWithdrawalGas.ts`, `src/chains/opStack/actions/estimateDepositTransactionGas.ts`, `src/errors/account.ts`, `src/utils/errors/getContractError.ts`, `src/actions/public/watchBlockNumber.ts`, `src/chains/opStack/actions/estimateFinalizeWithdrawalGas.ts`, `src/chains/opStack/actions/getTimeToProve.ts`, `src/actions/public/getProof.ts`, `src/utils/address/getAddress.ts`, `src/chains/zksync/utils/isEip712Transaction.ts`, `src/utils/typedData.ts`, `src/actions/public/watchPendingTransactions.ts`, `src/utils/rpc/socket.ts`, `src/actions/public/getBalance.ts`, `src/chains/opStack/decorators/publicL2.ts`, `src/chains/zksync/types/eip712.ts`, `src/utils/poll.ts`, `src/utils/transaction/parseTransaction.ts`, `src/actions/public/getTransactionCount.ts`, `src/utils/abi/encodeErrorResult.ts`, `src/utils/abi/encodeEventTopics.ts`, `src/utils/ens/avatar/parseAvatarRecord.ts`, `src/chains/opStack/types/withdrawal.ts`, `src/utils/abi/encodeFunctionData.ts`, `src/utils/abi/decodeFunctionResult.ts`, `src/actions/public/getFeeHistory.ts`, `src/utils/abi/encodeFunctionResult.ts`, `src/actions/ens/getEnsName.ts`, `src/utils/formatters/log.ts`, `src/utils/transaction/assertRequest.ts`, `tsconfig.base.json`, `src/chains/opStack/actions/buildInitiateWithdrawal.ts`, `src/chains/opStack/actions/getTimeToNextL2Output.ts`, `src/actions/ens/getEnsText.ts`, `src/utils/errors/getNodeError.ts`, `src/chains/opStack/actions/waitForNextL2Output.ts`, `src/types/stateOverride.ts`, `src/actions/public/simulateContract.ts`, `src/utils/formatters/proof.ts`, `src/utils/abi/formatAbiItem.ts`, `src/actions/public/estimateGas.ts`, `src/errors/rpc.ts`, `src/actions/getContract.test-d.ts`, `src/chains/opStack/actions/getL1BaseFee.ts`, `src/chains/zksync/utils/assertEip712Request.ts`, `src/types/block.ts`, `src/clients/transports/custom.ts`, `src/clients/createClient.test-d.ts`, `src/errors/transaction.ts`, `src/errors/chain.ts`, `src/utils/formatters/transactionReceipt.ts`, `src/actions/public/getBlockTransactionCount.ts`, `src/utils/promise/withRetry.ts`, `src/chains/opStack/types/transaction.ts`, `src/actions/ens/getEnsAddress.ts`, `src/actions/getContract.ts`, `src/chains/opStack/formatters.test-d.ts`, `src/types/filter.ts`, `src/utils/formatters/transactionRequest.ts`, `src/errors/request.ts`, `src/chains/zksync/utils/assertEip712Transaction.ts`, `src/actions/public/getContractEvents.ts`, `src/utils/formatters/block.ts`, `src/chains/celo/parsers.ts`, `src/utils/formatters/transaction.ts`, `src/actions/public/getBlock.ts`, `src/utils/encoding/fromBytes.ts`, `src/types/contract.ts`, `src/types/fee.ts`, `src/utils/transaction/getTransactionType.ts`, `src/utils/promise/withTimeout.ts`, `src/actions/public/estimateMaxPriorityFeePerGas.ts`, `src/chains/celo/serializers.ts`, `src/chains/opStack/types/deposit.ts`, `src/chains/celo/formatters.test-d.ts`, `src/utils/encoding/fromHex.ts`, `src/actions/public/estimateFeesPerGas.ts`, `src/accounts/types.ts`, `src/clients/transports/ipc.ts`, `src/clients/createClient.ts`, `src/errors/base.ts`, `src/actions/public/createContractEventFilter.ts`, `src/clients/transports/webSocket.ts`, `src/actions/public/getTransaction.ts`, `src/chains/opStack/actions/buildDepositTransaction.ts`, `src/utils/encoding/toBytes.ts`, `src/utils/promise/createBatchScheduler.ts`, `src/actions/public/waitForTransactionReceipt.ts`, `src/types/utils.ts`, `src/chains/zksync/formatters.test-d.ts`, `src/errors/abi.ts`, `src/clients/transports/createTransport.ts`, `src/actions/public/watchEvent.ts`, `src/utils/rpc/http.ts`, `src/actions/wallet/prepareTransactionRequest.ts`, `src/utils/encoding/toHex.ts`, `src/actions/public/getLogs.ts`, `src/types/rpc.ts`, `src/utils/transaction/serializeTransaction.ts`, `src/actions/public/createEventFilter.ts`, `src/utils/data/slice.ts`, `src/clients/transports/http.ts`, `src/actions/public/call.ts`, `src/errors/contract.ts`, `src/chains/zksync/types/transaction.ts`, `src/clients/transports/fallback.ts`, `src/clients/decorators/public.ts`, `src/chains/celo/types.ts`, `src/types/eip1193.ts`, `src/errors/node.ts`, `src/types/transaction.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->