### PR TITLE
Update Explorer and its API for Cronos Mainnet

### DIFF
--- a/.changeset/slimy-pillows-hope.md
+++ b/.changeset/slimy-pillows-hope.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Chronos explorer URL.

--- a/src/chains/definitions/cronos.ts
+++ b/src/chains/definitions/cronos.ts
@@ -13,9 +13,9 @@ export const cronos = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Cronoscan',
-      url: 'https://cronoscan.com',
-      apiUrl: 'https://api.cronoscan.com/api',
+      name: 'Cronos Explorer',
+      url: 'https://explorer.cronos.org',
+      apiUrl: 'https://explorer-api.cronos.org/mainnet/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Updating Cronos Explorer due to "[Cronoscan](https://cronoscan.com/)" is sunsetting.
Redirecting user to the [Cronos Explorer](https://explorer.cronos.org/) hosted by the Cronos team (reference [blog post](https://blog.cronos.org/p/introducing-the-new-cronos-explorer-7ee))

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Chronos explorer URL in the `cronos.ts` file.

### Detailed summary
- Updated the default block explorer name to 'Cronos Explorer'
- Updated the block explorer URL to 'https://explorer.cronos.org'
- Updated the block explorer API URL to 'https://explorer-api.cronos.org/mainnet/api'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->