### PR TITLE
chore: change sepolia symbol

### DIFF
--- a/.changeset/wise-worms-turn.md
+++ b/.changeset/wise-worms-turn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Sepolia ether symbol.

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const sepolia = /*#__PURE__*/ defineChain({
   id: 11_155_111,
   name: 'Sepolia',
-  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SETH', decimals: 18 },
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://rpc.sepolia.org'],

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const sepolia = /*#__PURE__*/ defineChain({
   id: 11_155_111,
   name: 'Sepolia',
-  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SETH', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://rpc.sepolia.org'],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Sepolia chain definition by changing the symbol of the native currency from 'SEP' to 'ETH'.

### Detailed summary
- Updated the symbol of the native currency from 'SEP' to 'ETH' in `Sepolia` chain definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->