### PR TITLE
feat: `recoverTransactionAddress`

### DIFF
--- a/.changeset/green-llamas-film.md
+++ b/.changeset/green-llamas-film.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `recoverTransactionAddress`.

--- a/site/pages/docs/actions/wallet/sendRawTransaction.md
+++ b/site/pages/docs/actions/wallet/sendRawTransaction.md
@@ -19,9 +19,9 @@ const request = await walletClient.prepareTransactionRequest({
   value: 1000000000000000000n
 })
 
-const signature = await walletClient.signTransaction(request)
+const serializedTransaction = await walletClient.signTransaction(request)
 
-const hash = await walletClient.sendRawTransaction({ serializedTransaction: signature }) // [!code focus]
+const hash = await walletClient.sendRawTransaction({ serializedTransaction }) // [!code focus]
 ```
 
 ```ts twoslash [config.ts] filename="config.ts"

--- a/site/pages/docs/utilities/recoverTransactionAddress.md
+++ b/site/pages/docs/utilities/recoverTransactionAddress.md
@@ -1,0 +1,74 @@
+---
+description: Recovers the signing address from a transaction & signature.
+---
+
+# recoverTransactionAddress
+
+Recovers the original signing address from a transaction & signature.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { recoverTransactionAddress } from 'viem'
+import { walletClient } from './client'
+
+const request = await walletClient.prepareTransactionRequest({
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  value: 1000000000000000000n
+})
+
+const serializedTransaction = await walletClient.signTransaction(request)
+
+const address = await recoverTransactionAddress({ // [!code focus:99]
+  serializedTransaction,
+})
+```
+
+```ts [client.ts (JSON-RPC Account)]
+import { createWalletClient, custom } from 'viem'
+
+// Retrieve Account from an EIP-1193 Provider.
+const [account] = await window.ethereum.request({ 
+  method: 'eth_requestAccounts' 
+})
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum!)
+})
+```
+
+```ts twoslash [config.ts (Local Account)] filename="client.ts"
+import { createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+export const walletClient = createWalletClient({
+  account: privateKeyToAccount('0x...'),
+  transport: http()
+})
+```
+
+:::
+
+## Returns
+
+[`Address`](/docs/glossary/types#address)
+
+The signing address.
+
+## Parameters
+
+### serializedTransaction
+
+- **Type:** `TransactionSerialized`
+
+The RLP serialized transaction.
+
+### signature (optional)
+
+- **Type:** `Signature | Hex | ByteArray`
+- **Default:** Signature inferred on `serializedTransaction` (if exists)
+
+The signature.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -903,6 +903,10 @@ export const sidebar = {
               link: '/docs/utilities/recoverPublicKey',
             },
             {
+              text: 'recoverTransactionAddress',
+              link: '/docs/utilities/recoverTransactionAddress',
+            },
+            {
               text: 'recoverTypedDataAddress',
               link: '/docs/utilities/recoverTypedDataAddress',
             },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -286,6 +286,7 @@ test('exports', () => {
       "recoverAddress",
       "recoverMessageAddress",
       "recoverPublicKey",
+      "recoverTransactionAddress",
       "recoverTypedDataAddress",
       "signatureToCompactSignature",
       "compactSignatureToHex",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1186,6 +1186,12 @@ export {
   recoverPublicKey,
 } from './utils/signature/recoverPublicKey.js'
 export {
+  type RecoverTransactionAddressErrorType,
+  type RecoverTransactionAddressParameters,
+  type RecoverTransactionAddressReturnType,
+  recoverTransactionAddress,
+} from './utils/signature/recoverTransactionAddress.js'
+export {
   type RecoverTypedDataAddressErrorType,
   type RecoverTypedDataAddressParameters,
   type RecoverTypedDataAddressReturnType,

--- a/src/utils/signature/recoverTransactionAddress.test.ts
+++ b/src/utils/signature/recoverTransactionAddress.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'vitest'
+import { accounts, forkBlockNumber } from '../../../test/src/constants.js'
+import { publicClient, walletClient } from '../../../test/src/utils.js'
+import {
+  privateKeyToAccount,
+  sign,
+  signTransaction,
+  signatureToHex,
+} from '../../accounts/index.js'
+import type { TransactionSerializable } from '../../types/transaction.js'
+import { hexToBytes, keccak256, serializeTransaction } from '../index.js'
+import { recoverTransactionAddress } from './recoverTransactionAddress.js'
+
+const transaction: TransactionSerializable = {
+  chainId: 1,
+  maxFeePerGas: 2n,
+  maxPriorityFeePerGas: 1n,
+  to: '0x0000000000000000000000000000000000000000',
+  value: 1n,
+}
+
+test('default', async () => {
+  const address = await recoverTransactionAddress({
+    serializedTransaction:
+      '0x02f8f2018263a0830f4240850a2278a43483025e3d94be9a129909ebcb954bc065536d2bfafbd170d27a80b88455a2ba6800000000000000000000000049caf2309cbafdfa4ab28d11ae18c3ec9b1cdde0000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000000000004d882cd000000000000000000000000000000000000000000000000000000000825d6838c080a02cd166f0be193729bd1cb9e4fb378bc8d956c48abda93425520284c360ff5d43a01934de732de08ba0b890dd6a3f331b4f8dace1b5dccbf1de0118ee4f620fc64b',
+  })
+  expect(address).toMatchInlineSnapshot(
+    `"0x01087f4e1dbc0c52690A9397677dD90983711c37"`,
+  )
+})
+
+test('signature (hex)', async () => {
+  const serializedTransaction = serializeTransaction(transaction)
+  const signature = await sign({
+    hash: keccak256(serializedTransaction),
+    privateKey: accounts[0].privateKey,
+  })
+  const address = await recoverTransactionAddress({
+    serializedTransaction,
+    signature: signatureToHex(signature),
+  })
+  expect(address.toLowerCase()).toBe(accounts[0].address)
+})
+
+test('signature (bytes)', async () => {
+  const serializedTransaction = serializeTransaction(transaction)
+  const signature = await sign({
+    hash: keccak256(serializedTransaction),
+    privateKey: accounts[0].privateKey,
+  })
+  const address = await recoverTransactionAddress({
+    serializedTransaction,
+    signature: hexToBytes(signatureToHex(signature)),
+  })
+  expect(address.toLowerCase()).toBe(accounts[0].address)
+})
+
+test('via `walletClient.signTransaction`', async () => {
+  const serializedTransaction = await walletClient.signTransaction({
+    account: privateKeyToAccount(accounts[0].privateKey),
+    to: '0x0000000000000000000000000000000000000000',
+    value: 1n,
+    type: 'eip1559',
+  })
+  const address = await recoverTransactionAddress({
+    serializedTransaction,
+  })
+  expect(address.toLowerCase()).toBe(accounts[0].address)
+})
+
+test('via account `signTransaction`', async () => {
+  const serializedTransaction = await signTransaction({
+    transaction,
+    privateKey: accounts[0].privateKey,
+  })
+  const address = await recoverTransactionAddress({
+    serializedTransaction,
+  })
+  expect(address.toLowerCase()).toBe(accounts[0].address)
+})
+
+test('via `getTransaction`', async () => {
+  const transaction = await publicClient.getTransaction({
+    blockNumber: forkBlockNumber - 10n,
+    index: 0,
+  })
+  const serializedTransaction = serializeTransaction(transaction)
+  const address = await recoverTransactionAddress({
+    serializedTransaction,
+  })
+  expect(address.toLowerCase()).toBe(transaction.from)
+})

--- a/src/utils/signature/recoverTransactionAddress.ts
+++ b/src/utils/signature/recoverTransactionAddress.ts
@@ -1,0 +1,62 @@
+import type { Address } from 'abitype'
+import type { ErrorType } from '../../errors/utils.js'
+import type { ByteArray, Hex } from '../../types/misc.js'
+import type { TransactionSerialized } from '../../types/transaction.js'
+import { type Keccak256ErrorType, keccak256 } from '../hash/keccak256.js'
+import { parseTransaction } from '../transaction/parseTransaction.js'
+import {
+  type SerializeTransactionErrorType,
+  serializeTransaction,
+} from '../transaction/serializeTransaction.js'
+import {
+  type RecoverAddressErrorType,
+  recoverAddress,
+} from './recoverAddress.js'
+import {
+  type SignatureToHexErrorType,
+  signatureToHex,
+} from './signatureToHex.js'
+
+export type RecoverTransactionAddressParameters = {
+  serializedTransaction: TransactionSerialized
+  signature?: Hex | ByteArray
+}
+
+export type RecoverTransactionAddressReturnType = Address
+
+export type RecoverTransactionAddressErrorType =
+  | SerializeTransactionErrorType
+  | RecoverAddressErrorType
+  | Keccak256ErrorType
+  | SignatureToHexErrorType
+  | ErrorType
+
+export async function recoverTransactionAddress(
+  parameters: RecoverTransactionAddressParameters,
+): Promise<RecoverTransactionAddressReturnType> {
+  const { serializedTransaction, signature: signature_ } = parameters
+
+  const transaction = parseTransaction(serializedTransaction)
+
+  const signature =
+    signature_ ??
+    signatureToHex({
+      r: transaction.r!,
+      s: transaction.s!,
+      v: transaction.v!,
+      yParity: transaction.yParity!,
+    })
+
+  const serialized = serializeTransaction({
+    ...transaction,
+    r: undefined,
+    s: undefined,
+    v: undefined,
+    yParity: undefined,
+  })
+
+  return await recoverAddress({
+    hash: keccak256(serialized),
+    signature,
+  })
+}

--- a/src/utils/transaction/assertTransaction.test.ts
+++ b/src/utils/transaction/assertTransaction.test.ts
@@ -124,19 +124,6 @@ describe('eip1559', () => {
       Version: viem@1.0.2]
     `)
   })
-
-  test('invalid transaction type', () => {
-    expect(() =>
-      assertTransactionEIP1559({
-        gasPrice: parseGwei('1') as unknown as undefined,
-        chainId: 1,
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: \`gasPrice\` is not a valid EIP-1559 Transaction attribute.
-
-      Version: viem@1.0.2]
-    `)
-  })
 })
 
 describe('eip2930', () => {
@@ -229,17 +216,6 @@ describe('legacy', () => {
 })
 
 test('invalid transaction type', () => {
-  expect(() =>
-    assertTransactionEIP1559({
-      gasPrice: parseGwei('1') as unknown as undefined,
-      chainId: 1,
-    }),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`gasPrice\` is not a valid EIP-1559 Transaction attribute.
-
-    Version: viem@1.0.2]
-  `)
-
   expect(() =>
     assertTransactionEIP2930({
       chainId: 1,

--- a/src/utils/transaction/assertTransaction.ts
+++ b/src/utils/transaction/assertTransaction.ts
@@ -74,14 +74,9 @@ export type AssertTransactionEIP1559ErrorType =
 export function assertTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,
 ) {
-  const { chainId, maxPriorityFeePerGas, gasPrice, maxFeePerGas, to } =
-    transaction
+  const { chainId, maxPriorityFeePerGas, maxFeePerGas, to } = transaction
   if (chainId <= 0) throw new InvalidChainIdError({ chainId })
   if (to && !isAddress(to)) throw new InvalidAddressError({ address: to })
-  if (gasPrice)
-    throw new BaseError(
-      '`gasPrice` is not a valid EIP-1559 Transaction attribute.',
-    )
   if (maxFeePerGas && maxFeePerGas > 2n ** 256n - 1n)
     throw new FeeCapTooHighError({ maxFeePerGas })
   if (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `recoverTransactionAddress` to recover signing addresses from transactions. 

### Detailed summary
- Added `recoverTransactionAddress` function to recover signing addresses from transactions
- Updated test files to include tests for `recoverTransactionAddress`
- Updated documentation for `recoverTransactionAddress`
- Modified `assertTransaction.ts` to remove `gasPrice` validation
- Updated usage examples for `recoverTransactionAddress`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->