### PR TITLE
export `AbiEvent` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   type Abi,
   type AbiFunction,
   type AbiParameter,
+  type AbiEvent,
   type AbiStateMutability,
   type AbiParameterKind,
   type AbiParameterToPrimitiveType,


### PR DESCRIPTION
I'm using viem's `watchEvent` function and passing `event` value. When I use `getAbiItem` to get a event item, the type is `AbiConstructor | AbiError | AbiEvent | AbiFallback | AbiFunction | AbiReceive | undefined`. So I have to assert the return value of `getAbiItem` is `AbiEvent`, but viem does not export that.

```typescript
import { UniswapV2Pair_ABI } from "../../constant/abi";

const Swap_Event_ABI = getAbiItem({
    abi: UniswapV2Pair_ABI,
    name: "Swap"
})

export const unwatch = publicClient.watchEvent({
    address: pair,
    event: Swap_Event_ABI as AbiEvent,
    onLogs: (logs) => {
        // Logic
    }
});
```

Without `as AbiEvent`, it will shows an error:
```bash
Type 'AbiConstructor | AbiError | AbiEvent | AbiFallback | AbiFunction | AbiReceive | undefined' is not assignable to type 'AbiEvent | undefined'.
  Property 'name' is missing in type 'AbiConstructor' but required in type 'AbiEvent'.
  ```
  
  I do not want to use `as any`, because it goes against the original design intent of TypeScript.