### PR TITLE
chore: Add name to root package.json

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,5 +13,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["example-*", "test-*", "site", "test"]
+  "ignore": ["example-*", "test-*", "site", "test", "viem-root"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "workspaces": ["examples/*", "environments/*", "site", "src", "test"],
   "private": true,
+  "name": "viem-root",
   "type": "module",
   "scripts": {
     "bench": "vitest bench",


### PR DESCRIPTION
Add name to root package.json. This makes it so you can npm install viem directly from github which is helpful when trying to hack using an unpublished viem commit because you can install it, build viem, and then add a "viem": "file:path/to/viem/src" to package.json. 

Without this only way to do it is to use github submodules or to use unstable pnpm 9 which supports installing the `viem/src` nested folder

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the project configuration by adding a new name "viem-root" and setting the type to "module".

### Detailed summary
- Added project name "viem-root"
- Set project type to "module"
- Updated `ignore` field in `changeset/config.json` to include "viem-root"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->