### PR TITLE
feat: up max blobs

### DIFF
--- a/.changeset/quick-meals-think.md
+++ b/.changeset/quick-meals-think.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated `blobs` limit to 6.

--- a/src/constants/blob.ts
+++ b/src/constants/blob.ts
@@ -1,7 +1,7 @@
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md#parameters
 
 /** Blob limit per transaction. */
-export const blobsPerTransaction = 2
+export const blobsPerTransaction = 6
 
 /** The number of bytes in a BLS scalar field element. */
 export const bytesPerFieldElement = 32

--- a/src/utils/blob/toBlobs.test.ts
+++ b/src/utils/blob/toBlobs.test.ts
@@ -34,12 +34,12 @@ test('error: empty blob data', () => {
 
 test('error: blob data too big', () => {
   expect(() =>
-    toBlobs({ data: stringToHex('we are all gonna make it'.repeat(20000)) }),
+    toBlobs({ data: stringToHex('we are all gonna make it'.repeat(100000)) }),
   ).toThrowErrorMatchingInlineSnapshot(`
     [BlobSizeTooLargeError: Blob size is too large.
 
-    Max: 253951 bytes
-    Given: 480000 bytes
+    Max: 761855 bytes
+    Given: 2400000 bytes
 
     Version: viem@1.0.2]
   `)


### PR DESCRIPTION
supersedes #1991 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the `blobs` limit to 6 per transaction and adjusts the test data size in `toBlobs.test.ts` to align with the new limit.

### Detailed summary
- Updated `blobsPerTransaction` limit to 6 in `blob.ts`
- Adjusted test data size in `toBlobs.test.ts` to match the new limit

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->