### PR TITLE
Create truncateAddress util function

### DIFF
--- a/src/utils/address/truncateAddress
+++ b/src/utils/address/truncateAddress
@@ -1,0 +1,5 @@
+export function truncateAddress(address: string): string {
+  return address.length > 10
+    ? address.substring(0, 6) + '...' + address.substring(address.length - 4)
+    : address;
+}


### PR DESCRIPTION
truncateAddress feature used very frequently in many project.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new utility function `truncateAddress` to shorten a given address string for display purposes.

### Detailed summary
- Added new function `truncateAddress` to src/utils/address/truncateAddress
- Function truncates address to 10 characters, adding ellipsis in the middle if longer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->