### PR TITLE
add normalizeChainId util function

### DIFF
--- a/src/utils/chain/normalizeChainId
+++ b/src/utils/chain/normalizeChainId
@@ -1,0 +1,12 @@
+export function normalizeChainId(chainId: bigint | number | string | unknown): number {
+  if (typeof chainId === 'string')
+    return Number.parseInt(
+      chainId,
+      chainId.trim().substring(0, 2) === '0x' ? 16 : 10,
+    )
+  if (typeof chainId === 'bigint') return Number(chainId)
+  if (typeof chainId === 'number') return chainId
+  throw new Error(
+    `Cannot normalize chainId "${chainId}" of type "${typeof chainId}"`,
+  )
+}


### PR DESCRIPTION
chainId has some format like string、hex string、hex number、number. A function for normalize is handful

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function `normalizeChainId` in `normalizeChainId.ts` to convert chain IDs to numbers. 

### Detailed summary
- Added `normalizeChainId` function to convert chain IDs to numbers
- Handles `bigint`, `number`, `string`, and `unknown` types
- Throws an error for unsupported types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->