### PR TITLE
fix: add apiUrl to blast definition

### DIFF
--- a/.changeset/spotty-news-act.md
+++ b/.changeset/spotty-news-act.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added API URLs to Blast chains.

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -14,7 +14,11 @@ export const blast = /*#__PURE__*/ defineChain({
     default: { http: ['https://rpc.blast.io'] },
   },
   blockExplorers: {
-    default: { name: 'Blastscan', url: 'https://blastscan.io' },
+    default: { 
+      name: 'Blastscan', 
+      url: 'https://blastscan.io',
+      apiUrl: 'https://api.blastscan.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/blastSepolia.ts
+++ b/src/chains/definitions/blastSepolia.ts
@@ -19,6 +19,7 @@ export const blastSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blastscan',
       url: 'https://testnet.blastscan.io',
+      apiUrl: 'https://api-sepolia.blastscan.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/blastSepolia.ts
+++ b/src/chains/definitions/blastSepolia.ts
@@ -18,7 +18,7 @@ export const blastSepolia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Blastscan',
-      url: 'https://sepolia.blastscan.io/',
+      url: 'https://sepolia.blastscan.io',
       apiUrl: 'https://api-sepolia.blastscan.io/api',
     },
   },

--- a/src/chains/definitions/blastSepolia.ts
+++ b/src/chains/definitions/blastSepolia.ts
@@ -18,7 +18,7 @@ export const blastSepolia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Blastscan',
-      url: 'https://testnet.blastscan.io',
+      url: 'https://sepolia.blastscan.io/',
       apiUrl: 'https://api-sepolia.blastscan.io/api',
     },
   },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds API URLs to Blast chains for improved data retrieval.

### Detailed summary
- Added API URLs to `blastSepolia.ts` for Blastscan chain
- Updated API URLs in `blast.ts` for Blastscan chain
- Added API URLs to `blockExplorers` in `blast.ts` for Blastscan chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->