### PR TITLE
feat: change polygon mumbai etherscan api url

### DIFF
--- a/.changeset/few-otters-judge.md
+++ b/.changeset/few-otters-judge.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Polygon Mumbai Etherscan API URL.

--- a/src/chains/definitions/polygonMumbai.ts
+++ b/src/chains/definitions/polygonMumbai.ts
@@ -13,7 +13,7 @@ export const polygonMumbai = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://mumbai.polygonscan.com',
-      apiUrl: 'https://mumbai.polygonscan.com/api',
+      apiUrl: 'https://api-testnet.polygonscan.com/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Hey Viem team,

I think the Polygon Mumbai Etherscan API URL is outdated based on the docs: https://docs.polygonscan.com/v/mumbai-polygonscan

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Etherscan API URL for Polygon Mumbai testnet.

### Detailed summary
- Updated Etherscan API URL in `polygonMumbai.ts` to `https://api-testnet.polygonscan.com/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->