### PR TITLE
Add `blockTag` to `observerId` to avoid id collisions

### DIFF
--- a/.changeset/late-walls-agree.md
+++ b/.changeset/late-walls-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `blockTag` to `observerId` in `watchBlocks` to avoid id collisions.

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -128,6 +128,7 @@ export function watchBlocks<
     const observerId = stringify([
       'watchBlocks',
       client.uid,
+      blockTag,
       emitMissed,
       emitOnBegin,
       includeTransactions,


### PR DESCRIPTION
While using `wagmi` I notice that both of my `useWatchBlocks` hooks provide latest blocks even though one was suppose to subscribe to finalized blocks.
```js
  useWatchBlocks({
    blockTag: 'latest',
    emitOnBegin: true,
    onBlock(block) {
      console.log('latest', { block })
    },
  });

  useWatchBlocks({
    blockTag: 'finalized',
    emitOnBegin: true,
    onBlock(block) {
      console.log('finalized', { block })
    },
  });
```

It seems there is `observerId` collision. Fix includes `blockTag` in the `observerId` to make it unique.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `blockTag` to `observerId` in `watchBlocks` to prevent id collisions.

### Detailed summary
- Added `blockTag` parameter to `watchBlocks` function
- Updated `observerId` to include `blockTag` to avoid id collisions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->