### PR TITLE
refactor: minimize redundant requests in `prepareTransactionRequest`

### DIFF
--- a/.changeset/popular-fireants-shop.md
+++ b/.changeset/popular-fireants-shop.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Minimized redundant requests in `prepareTransactionRequest` (addressed #2017).


### PR DESCRIPTION
Addresses #2017

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on minimizing redundant requests in the `prepareTransactionRequest` function by optimizing fee calculations.

### Detailed summary
- Removed redundant `getBlock` request
- Optimized fee calculations based on request parameters
- Improved error handling for fee calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->