### PR TITLE
fix zetachainAthensTestnet explorer url

### DIFF
--- a/.changeset/real-ducks-applaud.md
+++ b/.changeset/real-ducks-applaud.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated `zetachainAthensTestnet` Explorer URL.

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -16,7 +16,7 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'ZetaScan',
-      url: 'https://athens3.explorer.zetachain.com',
+      url: 'https://athens.explorer.zetachain.com',
     },
   },
   testnet: true,


### PR DESCRIPTION
currently, the exploere [url](https://athens3.explorer.zetachain.com) for zetachain testnet is not correct. change it to correct athens testnet url

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `zetachainAthensTestnet` Explorer URL in the ZetaScan chain definition.

### Detailed summary
- Updated `zetachainAthensTestnet` Explorer URL in `zetachainAthensTestnet.ts` from `https://athens3.explorer.zetachain.com` to `https://athens.explorer.zetachain.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->