### PR TITLE
chore: update Plume Testnet URLs

### DIFF
--- a/src/chains/definitions/plumeTestnet.ts
+++ b/src/chains/definitions/plumeTestnet.ts
@@ -12,15 +12,15 @@ export const plumeTestnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://plume-testnet.rpc.caldera.xyz/http'],
-      webSocket: ['wss://plume-testnet.rpc.caldera.xyz/ws'],
+      http: ['https://testnet-rpc.plumenetwork.xyz/http'],
+      webSocket: ['wss://testnet-rpc.plumenetwork.xyz/ws'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://plume-testnet.explorer.caldera.xyz',
-      apiUrl: 'https://plume-testnet.explorer.caldera.xyz/api',
+      url: 'https://testnet-explorer.plumenetwork.xyz/',
+      apiUrl: 'https://testnet-explorer.plumenetwork.xyz/api',
     },
   },
   testnet: true,

--- a/src/chains/definitions/plumeTestnet.ts
+++ b/src/chains/definitions/plumeTestnet.ts
@@ -19,7 +19,7 @@ export const plumeTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://testnet-explorer.plumenetwork.xyz/',
+      url: 'https://testnet-explorer.plumenetwork.xyz',
       apiUrl: 'https://testnet-explorer.plumenetwork.xyz/api',
     },
   },


### PR DESCRIPTION
This PR updates the Plume testnet URLs that I added in #1915 to point to plumenetwork.xyz instead of Caldera.

<!-- start pr-codex -->

## PR-Codex overview
This PR updates the RPC URLs and block explorer links for the Plume testnet to point to new domains under `plumenetwork.xyz`.

### Detailed summary
- Updated RPC URLs to `https://testnet-rpc.plumenetwork.xyz`
- Updated block explorer URLs to `https://testnet-explorer.plumenetwork.xyz`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->