### PR TITLE
Update name of optimism chain

### DIFF
--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -6,7 +6,7 @@ const sourceId = 1 // mainnet
 export const optimism = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 10,
-  name: 'OP Mainnet',
+  name: 'Optimism Mainnet',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {


### PR DESCRIPTION
Updated to the non-abbreviated name, consistent with all other definition files.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the name of the chain from 'OP Mainnet' to 'Optimism Mainnet' in the `optimism.ts` file.

### Detailed summary
- Updated chain name from 'OP Mainnet' to 'Optimism Mainnet'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->