### PR TITLE
docs: remove unused client code

### DIFF
--- a/site/pages/docs/contract/decodeDeployData.md
+++ b/site/pages/docs/contract/decodeDeployData.md
@@ -46,16 +46,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ## Return Value

--- a/site/pages/docs/contract/decodeErrorResult.md
+++ b/site/pages/docs/contract/decodeErrorResult.md
@@ -43,16 +43,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ## Return Value

--- a/site/pages/docs/contract/decodeEventLog.md
+++ b/site/pages/docs/contract/decodeEventLog.md
@@ -64,16 +64,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Partial Decode

--- a/site/pages/docs/contract/decodeFunctionData.md
+++ b/site/pages/docs/contract/decodeFunctionData.md
@@ -44,16 +44,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Extracting Arguments
@@ -64,7 +54,6 @@ If your calldata includes argument(s) after the 4byte function signature, you ca
 
 ```ts [example.ts]
 import { decodeFunctionData } from 'viem'
-import { publicClient } from './client'
 import { wagmiAbi } from './abi'
 
 // [!code word:args:1]
@@ -87,16 +76,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::

--- a/site/pages/docs/contract/decodeFunctionResult.md
+++ b/site/pages/docs/contract/decodeFunctionResult.md
@@ -43,16 +43,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Without `functionName`
@@ -78,16 +68,6 @@ const value = decodeFunctionResult({
   data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac'
 })
 // '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::
@@ -162,16 +142,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::

--- a/site/pages/docs/contract/encodeDeployData.md
+++ b/site/pages/docs/contract/encodeDeployData.md
@@ -40,16 +40,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Passing Arguments
@@ -62,9 +52,8 @@ For example, the `constructor` below requires an **address** argument, and it is
 
 :::code-group
 
-```ts [example.ts] {8}
+```ts [example.ts]
 import { encodeDeployData } from 'viem'
-import { publicClient } from './client'
 import { wagmiAbi } from './abi'
 
 const data = encodeDeployData({
@@ -85,16 +74,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::

--- a/site/pages/docs/contract/encodeErrorResult.md
+++ b/site/pages/docs/contract/encodeErrorResult.md
@@ -44,16 +44,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Without `errorName`

--- a/site/pages/docs/contract/encodeEventTopics.md
+++ b/site/pages/docs/contract/encodeEventTopics.md
@@ -52,16 +52,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Passing Arguments
@@ -110,16 +100,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::

--- a/site/pages/docs/contract/encodeFunctionData.md
+++ b/site/pages/docs/contract/encodeFunctionData.md
@@ -41,16 +41,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
-```
-
 :::
 
 ### Passing Arguments
@@ -63,9 +53,8 @@ For example, the `balanceOf` function name below requires an **address** argumen
 
 :::code-group
 
-```ts [example.ts] {8}
+```ts [example.ts]
 import { encodeFunctionData } from 'viem'
-import { publicClient } from './client'
 import { wagmiAbi } from './abi'
 
 const data = encodeFunctionData({
@@ -87,16 +76,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
-import { mainnet } from 'viem/chains'
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http()
-})
 ```
 
 :::

--- a/site/pages/docs/contract/encodeFunctionResult.md
+++ b/site/pages/docs/contract/encodeFunctionResult.md
@@ -43,16 +43,6 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem';
-import { mainnet } from 'viem/chains';
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(),
-});
-```
-
 :::
 
 ### A more complex example
@@ -125,16 +115,6 @@ export const wagmiAbi = [
   },
   ...
 ] as const;
-```
-
-```ts [client.ts]
-import { createPublicClient, http } from 'viem';
-import { mainnet } from 'viem/chains';
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(),
-});
 ```
 
 :::


### PR DESCRIPTION
Update your website doc.
Encode and Decode do not need `client`, so your documentation has some redundant code.
I removed the client-related code to prevent developers from thinking that a client is necessary for encoding or decoding.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove redundant code related to creating a public client in various contract-related documentation pages.

### Detailed summary
- Removed redundant code for creating a public client in multiple contract-related documentation pages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->