### PR TITLE
fix: #1916

### DIFF
--- a/.changeset/bright-hairs-sneeze.md
+++ b/.changeset/bright-hairs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed overloaded function return types.

--- a/src/actions/public/readContract.test-d.ts
+++ b/src/actions/public/readContract.test-d.ts
@@ -255,7 +255,6 @@ test('behavior', () => {
       functionName: 'foo',
       args: ['0x'],
     })
-    // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
     assertType<string>(result3)
 
     const result4 = await readContract(publicClient, {
@@ -267,7 +266,6 @@ test('behavior', () => {
     assertType<{
       foo: `0x${string}`
       bar: `0x${string}`
-      // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
     }>(result4)
   })
 })

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -96,7 +96,7 @@ export async function readContract<
   chain extends Chain | undefined,
   const abi extends Abi | readonly unknown[],
   functionName extends ContractFunctionName<abi, 'pure' | 'view'>,
-  args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
+  const args extends ContractFunctionArgs<abi, 'pure' | 'view', functionName>,
 >(
   client: Client<Transport, chain>,
   parameters: ReadContractParameters<abi, functionName, args>,

--- a/src/actions/public/simulateContract.test-d.ts
+++ b/src/actions/public/simulateContract.test-d.ts
@@ -184,10 +184,8 @@ test('overloads', async () => {
     functionName: 'foo',
     args: ['0x'],
   })
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   assertType<string>(res2.result)
   expectTypeOf(res2.request.abi).toEqualTypeOf(
-    // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
     parseAbi(['function foo(address) returns (string)']),
   )
 
@@ -200,10 +198,8 @@ test('overloads', async () => {
   assertType<{
     foo: `0x${string}`
     bar: `0x${string}`
-    // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   }>(res3.result)
   expectTypeOf(res3.request.abi).toEqualTypeOf(
-    // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
     parseAbi([
       'function foo(address, address) returns ((address foo, address bar))',
     ]),

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -184,7 +184,7 @@ export async function simulateContract<
   account extends Account | undefined,
   const abi extends Abi | readonly unknown[],
   functionName extends ContractFunctionName<abi, 'nonpayable' | 'payable'>,
-  args extends ContractFunctionArgs<
+  const args extends ContractFunctionArgs<
     abi,
     'nonpayable' | 'payable',
     functionName

--- a/src/utils/abi/decodeFunctionResult.test-d.ts
+++ b/src/utils/abi/decodeFunctionResult.test-d.ts
@@ -113,7 +113,6 @@ test('overloads', () => {
     args: ['0x'],
     data: '0x',
   })
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   expectTypeOf(res3).toEqualTypeOf<string>()
 
   const res4 = decodeFunctionResult({
@@ -122,7 +121,6 @@ test('overloads', () => {
     args: ['0x', '0x'],
     data: '0x',
   })
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   expectTypeOf(res4).toEqualTypeOf<{ foo: Address; bar: Address }>()
 })
 

--- a/src/utils/abi/decodeFunctionResult.ts
+++ b/src/utils/abi/decodeFunctionResult.ts
@@ -127,7 +127,7 @@ export type DecodeFunctionResultErrorType =
 export function decodeFunctionResult<
   const abi extends Abi | readonly unknown[],
   functionName extends ContractFunctionName<abi> | undefined = undefined,
-  args extends ContractFunctionArgs<
+  const args extends ContractFunctionArgs<
     abi,
     AbiStateMutability,
     functionName extends ContractFunctionName<abi>

--- a/src/utils/abi/getAbiItem.test-d.ts
+++ b/src/utils/abi/getAbiItem.test-d.ts
@@ -192,9 +192,7 @@ test('overloads', () => {
     name: 'foo',
     args: ['0x', '0x'],
   })
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   expectTypeOf(inputs[0].type).toEqualTypeOf<'address'>()
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   expectTypeOf(res2).toEqualTypeOf<{
     name: 'foo'
     type: 'function'
@@ -221,7 +219,6 @@ test('overloads', () => {
     name: 'foo',
     args: ['0x'],
   })
-  // @ts-ignore – TODO: Fix https://github.com/wevm/viem/issues/1916
   expectTypeOf(res3).toEqualTypeOf<{
     readonly name: 'foo'
     readonly type: 'function'

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -76,7 +76,7 @@ export type GetAbiItemReturnType<
 export function getAbiItem<
   const abi extends Abi | readonly unknown[],
   name extends AbiItemName<abi>,
-  args extends AbiItemArgs<abi, name> | undefined = undefined,
+  const args extends AbiItemArgs<abi, name> | undefined = undefined,
 >(
   parameters: GetAbiItemParameters<abi, name, args>,
 ): GetAbiItemReturnType<abi, name, args> {


### PR DESCRIPTION
Closes #1916

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes overloaded function return types in `simulateContract.ts`, `decodeFunctionResult.ts`, and `getAbiItem.ts`.

### Detailed summary
- Fixed overloaded function return types in multiple files
- Updated function signatures in `simulateContract.ts`, `decodeFunctionResult.ts`, and `getAbiItem.ts`
- Removed unnecessary `@ts-ignore` comments in test files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->