### PR TITLE
docs: add fetch ENS resolver example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ The below list is not exhaustive, and is a work in progress. If you have an idea
 - ENS
   - [x] Address from ENS Name
   - [x] ENS Name from Address
-  - [ ] Fetch ENS Resolver
+  - [x] Fetch ENS Resolver
 - Filters & Logs
   - [x] Blocks
   - [x] Pending Transactions

--- a/examples/ens/index.ts
+++ b/examples/ens/index.ts
@@ -1,5 +1,6 @@
 import { http, createPublicClient } from 'viem'
 import { mainnet } from 'viem/chains'
+import { normalize } from 'viem/ens'
 
 const client = createPublicClient({
   chain: mainnet,
@@ -11,4 +12,8 @@ const name = await client.getEnsName({
   address: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
 })
 
-export default [`Address: ${address}`, `Name: ${name}`]
+const resolverAddress = await client.getEnsResolver({
+  name: normalize('jxom.eth'),
+})
+
+export default [`Address: ${address}`, `Name: ${name}, Resolver: ${resolverAddress}`]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the ENS functionality in the examples by fetching the ENS resolver address and displaying it alongside the address and name.

### Detailed summary
- Updated `README.md` to reflect fetching ENS Resolver
- Modified `index.ts` to fetch and display ENS resolver address alongside name

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->