### PR TITLE
Add celo fee.estimateFeePerGas

### DIFF
--- a/.changeset/nervous-cows-agree.md
+++ b/.changeset/nervous-cows-agree.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
 Added custom Celo fees estimation function for cases when feeCurrency is used to send a transaction.

--- a/.changeset/nervous-cows-agree.md
+++ b/.changeset/nervous-cows-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added custom Celo fees estimation function for cases when feeCurrency is used to send a transaction.

--- a/src/actions/public/estimateFeesPerGas.test.ts
+++ b/src/actions/public/estimateFeesPerGas.test.ts
@@ -6,6 +6,7 @@ import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
 
 import { localHttpUrl } from '~test/src/constants.js'
+import { createTestClient } from '~viem/index.js'
 import {
   estimateFeesPerGas,
   internal_estimateFeesPerGas,
@@ -29,6 +30,28 @@ test('legacy', async () => {
     getGasPrice(publicClient),
   ])
   expect(gasPrice).toBe((gasPrice_! * 120n) / 100n)
+})
+
+test('args: chain `estimateFeesPerGas` override (when null returned)', async () => {
+  const client = createTestClient({
+    transport: http(localHttpUrl),
+    mode: 'anvil',
+  })
+
+  const { maxFeePerGas, maxPriorityFeePerGas } = await estimateFeesPerGas(
+    client,
+    {
+      chain: {
+        ...anvilChain,
+        fees: {
+          estimateFeesPerGas: async () => null,
+        },
+      },
+    },
+  )
+
+  expect(maxFeePerGas).toBeTypeOf('bigint')
+  expect(maxPriorityFeePerGas).toBeTypeOf('bigint')
 })
 
 test('args: chain `estimateFeesPerGas` override', async () => {

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -139,9 +139,7 @@ export async function internal_estimateFeesPerGas<
       type,
     } as ChainEstimateFeesPerGasFnParameters)) as unknown as EstimateFeesPerGasReturnType<type>
 
-    if (fees !== null) {
-      return fees
-    }
+    if (fees !== null) return fees
   }
 
   if (type === 'eip1559') {

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -12,8 +12,8 @@ import type {
   Chain,
   ChainEstimateFeesPerGasFnParameters,
   ChainFeesFnParameters,
+  GetChainParameter,
 } from '../../types/chain.js'
-import type { GetChainParameter } from '../../types/chain.js'
 import type {
   FeeValuesEIP1559,
   FeeValuesLegacy,
@@ -130,14 +130,19 @@ export async function internal_estimateFeesPerGas<
     ? block_
     : await getAction(client, getBlock, 'getBlock')({})
 
-  if (typeof chain?.fees?.estimateFeesPerGas === 'function')
-    return chain.fees.estimateFeesPerGas({
+  if (typeof chain?.fees?.estimateFeesPerGas === 'function') {
+    const fees = (await chain.fees.estimateFeesPerGas({
       block: block_ as Block,
       client,
       multiply,
       request,
       type,
-    } as ChainEstimateFeesPerGasFnParameters) as unknown as EstimateFeesPerGasReturnType<type>
+    } as ChainEstimateFeesPerGasFnParameters)) as unknown as EstimateFeesPerGasReturnType<type>
+
+    if (fees !== null) {
+      return fees
+    }
+  }
 
   if (type === 'eip1559') {
     if (typeof block.baseFeePerGas !== 'bigint')

--- a/src/celo/chainConfig.ts
+++ b/src/celo/chainConfig.ts
@@ -1,7 +1,9 @@
+import { fees } from './fees.js'
 import { formatters } from './formatters.js'
 import { serializers } from './serializers.js'
 
 export const chainConfig = {
   formatters,
   serializers,
+  fees,
 } as const

--- a/src/celo/fees.test.ts
+++ b/src/celo/fees.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, vi } from 'vitest'
+import { celo } from '~viem/chains/index.js'
+import { http, createTestClient } from '~viem/index.js'
+import type { ChainEstimateFeesPerGasFn } from '~viem/types/chain.js'
+
+const client = createTestClient({
+  transport: http(),
+  chain: celo,
+  mode: 'anvil',
+})
+
+describe('celo/fees', () => {
+  const celoestimateFeesPerGasFn = celo.fees
+    .estimateFeesPerGas as ChainEstimateFeesPerGasFn
+
+  test("doesn't call the client when feeCurrency is not provided", async () => {
+    const requestMock = vi.spyOn(client, 'request')
+
+    expect(celo.fees.estimateFeesPerGas).toBeTypeOf('function')
+
+    const fees = await celoestimateFeesPerGasFn({
+      client,
+      request: {},
+    } as any)
+
+    expect(fees).toBeNull()
+    expect(requestMock).not.toHaveBeenCalled()
+  })
+
+  test('calls the client when feeCurrency is provided', async () => {
+    const requestMock = vi.spyOn(client, 'request')
+    requestMock.mockImplementation((request) => {
+      switch (request.method) {
+        case 'eth_gasPrice':
+          return '11619349802'
+        case 'eth_maxPriorityFeePerGas':
+          return '2323869960'
+      }
+    })
+
+    expect(celo.fees.estimateFeesPerGas).toBeTypeOf('function')
+
+    const fees = await celoestimateFeesPerGasFn({
+      client,
+      request: {
+        feeCurrency: '0xfee',
+      },
+    } as any)
+
+    expect(fees).toMatchInlineSnapshot(`
+        {
+          "maxFeePerGas": 11619349802n,
+          "maxPriorityFeePerGas": 2323869960n,
+        }
+      `)
+    expect(requestMock).toHaveBeenCalledWith({
+      method: 'eth_maxPriorityFeePerGas',
+      params: ['0xfee'],
+    })
+    expect(requestMock).toHaveBeenCalledWith({
+      method: 'eth_gasPrice',
+      params: ['0xfee'],
+    })
+  })
+})

--- a/src/celo/fees.ts
+++ b/src/celo/fees.ts
@@ -21,9 +21,7 @@ export const fees: ChainFees<typeof formatters> = {
   estimateFeesPerGas: async (
     params: ChainEstimateFeesPerGasFnParameters<typeof formatters>,
   ) => {
-    if (!params.request?.feeCurrency) {
-      return null
-    }
+    if (!params.request?.feeCurrency) return null
 
     const [maxFeePerGas, maxPriorityFeePerGas] = await Promise.all([
       estimateFeePerGasInFeeCurrency(params.client, params.request.feeCurrency),

--- a/src/celo/fees.ts
+++ b/src/celo/fees.ts
@@ -1,0 +1,94 @@
+import type { Client } from '../clients/createClient.js'
+import {
+  type Address,
+  type ChainEstimateFeesPerGasFnParameters,
+  type ChainFees,
+  type Hex,
+} from '../index.js'
+
+import { formatters } from './formatters.js'
+
+export const fees: ChainFees<typeof formatters> = {
+  /*
+   * Estimates the fees per gas for a transaction.
+
+   * If the transaction is to be paid in a token (feeCurrency is present) then the fees 
+   * are estimated in the value of the token. Otherwise falls back to the default
+   * estimation by returning null.
+   * 
+   * @param params fee estimation function parameters
+   */
+  estimateFeesPerGas: async (
+    params: ChainEstimateFeesPerGasFnParameters<typeof formatters>,
+  ) => {
+    if (!params.request?.feeCurrency) {
+      return null
+    }
+
+    const [maxFeePerGas, maxPriorityFeePerGas] = await Promise.all([
+      estimateFeePerGasInFeeCurrency(params.client, params.request.feeCurrency),
+      estimateMaxPriorityFeePerGasInFeeCurrency(
+        params.client,
+        params.request.feeCurrency,
+      ),
+    ])
+
+    return {
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+    }
+  },
+}
+
+type RequestGasPriceInFeeCurrencyParams = {
+  Method: 'eth_gasPrice'
+  Parameters: [Address]
+  ReturnType: Hex
+}
+
+/*
+ * Estimate the fee per gas in the value of the fee token
+
+ *
+ * @param client - Client to use
+ * @param feeCurrency -  Address of a whitelisted fee token
+ * @returns The fee per gas in wei in the value of the  fee token
+ *
+ */
+async function estimateFeePerGasInFeeCurrency(
+  client: Client,
+  feeCurrency: Address,
+) {
+  const fee = await client.request<RequestGasPriceInFeeCurrencyParams>({
+    method: 'eth_gasPrice',
+    params: [feeCurrency],
+  })
+  return BigInt(fee)
+}
+
+type RequestMaxGasPriceInFeeCurrencyParams = {
+  Method: 'eth_maxPriorityFeePerGas'
+  Parameters: [Address]
+  ReturnType: Hex
+}
+
+/*
+ * Estimate the max priority fee per gas in the value of the fee token
+
+ *
+ * @param client - Client to use
+ * @param feeCurrency -  Address of a whitelisted fee token
+ * @returns The fee per gas in wei in the value of the  fee token
+ *
+ */
+async function estimateMaxPriorityFeePerGasInFeeCurrency(
+  client: Client,
+  feeCurrency: Address,
+) {
+  const feesPerGas =
+    await client.request<RequestMaxGasPriceInFeeCurrencyParams>({
+      method: 'eth_maxPriorityFeePerGas',
+      params: [feeCurrency],
+    })
+  return BigInt(feesPerGas)
+}

--- a/src/celo/sendTransaction.test.ts
+++ b/src/celo/sendTransaction.test.ts
@@ -32,6 +32,13 @@ describe('sendTransaction()', () => {
       return 1n
     }
 
+    if (
+      request.method === 'eth_gasPrice' &&
+      (request.params as string[])[0] === feeCurrencyAddress
+    ) {
+      return 2n
+    }
+
     if (request.method === 'eth_estimateGas') {
       return 1n
     }
@@ -92,7 +99,7 @@ describe('sendTransaction()', () => {
     expect(transportRequestMock).toHaveBeenLastCalledWith({
       method: 'eth_sendRawTransaction',
       params: [
-        '0x7cf89282a4ec8001850165a0bc0101940000000000000000000000000000000000000fee9400000000000000000000000000000000000000017b94f39fd6e51aad88f6f4ce6ab8827279cfffb922660180c080a004389976320970e0227b20df6f79f2f35a2832d18b9732cb017d15db9f80fb44a0735b9abf965b7f38d1c659527cc93a9fc37b3a3b7bd5910d0c7db4b740be860f',
+        '0x7cf88d82a4ec80010201940000000000000000000000000000000000000fee9400000000000000000000000000000000000000017b94f39fd6e51aad88f6f4ce6ab8827279cfffb922660180c080a049b4b40c685a0bf9e3d1cca92a9175382bfa3a5e1bbd65610abcb0bd28b4ad90a009b40f809939683763bec0943101c7a7c79ea60239fd0d73975f555e6777ee1d',
       ],
     })
   })

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -129,12 +129,16 @@ export type ChainFees<
    * Overrides the return value in the [`estimateFeesPerGas` Action](/docs/actions/public/estimateFeesPerGas).
    */
   estimateFeesPerGas?:
-    | ((
-        args: ChainEstimateFeesPerGasFnParameters<formatters>,
-      ) => Promise<EstimateFeesPerGasReturnType>)
+    | ChainEstimateFeesPerGasFn<formatters>
     | bigint
     | undefined
 }
+
+export type ChainEstimateFeesPerGasFn<
+  formatters extends ChainFormatters | undefined = ChainFormatters | undefined,
+> = (
+  args: ChainEstimateFeesPerGasFnParameters<formatters>,
+) => Promise<EstimateFeesPerGasReturnType | null>
 
 export type ChainFormatters = {
   /** Modifies how the Block structure is formatted & typed. */


### PR DESCRIPTION
**Overview**

This PR introduces custom Celo fee estimation for cases when `feeCurrency` is used to send a transaction.

**Other changes**

It also introduces a fallback behaviour of the custom estimation logic.

**Tested**

* Introduced new unit tests and adapted existing ones.
* Tested for different fee currencies (as well as without it) on alfajores

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a custom Celo fees estimation function for transactions with `feeCurrency`. It also refactors `ChainEstimateFeesPerGasFn` and updates related tests.

### Detailed summary
- Added custom fees estimation function for `feeCurrency` transactions in Celo
- Refactored `ChainEstimateFeesPerGasFn` in `chain.ts`
- Updated tests for `estimateFeesPerGas`
- Added new functions for estimating fees in `fees.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->