### PR TITLE
add zetachain blockscan url

### DIFF
--- a/src/chains/definitions/zetachain.ts
+++ b/src/chains/definitions/zetachain.ts
@@ -18,6 +18,10 @@ export const zetachain = /*#__PURE__*/ defineChain({
       name: 'ZetaScan',
       url: 'https://explorer.zetachain.com',
     },
+    blockscout: {
+      name: 'blockscout',
+      url: 'https://zetachain.blockscout.com',
+    },
   },
   testnet: false,
 })

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -18,6 +18,10 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
       name: 'ZetaScan',
       url: 'https://athens.explorer.zetachain.com',
     },
+    blockscout: {
+      name: 'blockscout',
+      url: 'https://zetachain-athens-3.blockscout.com',
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
[blockscout](https://zetachain.blockscout.com) explorer is much better than [default](https://explorer.zetachain.com) explorer. so I added this explorer url.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `blockscout` object with name and URL to the Zetachain and Zetachain Athens Testnet definitions.

### Detailed summary
- Added `blockscout` object with name and URL to Zetachain definition
- Added `blockscout` object with name and URL to Zetachain Athens Testnet definition

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->