### PR TITLE
feat(http): onFetchRequest

### DIFF
--- a/.changeset/chatty-berries-brake.md
+++ b/.changeset/chatty-berries-brake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `onFetchRequest` to `http` transport.

--- a/site/pages/docs/clients/transports/http.md
+++ b/site/pages/docs/clients/transports/http.md
@@ -171,6 +171,22 @@ const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
 })
 ```
 
+### onFetchRequest (optional)
+
+- **Type:** `(request: Request) => void`
+
+A callback to handle the fetch request. Useful for logging or debugging.
+
+```ts twoslash
+import { http } from 'viem'
+// ---cut---
+const transport = http('https://eth-mainnet.g.alchemy.com/v2/...', {
+  onFetchRequest(request) {
+    console.log(request) // [!code focus]
+  }
+})
+```
+
 ### onFetchResponse (optional)
 
 - **Type:** `(response: Response) => void`

--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -271,6 +271,27 @@ describe('request', () => {
     await server.close()
   })
 
+  test.only('behavior: onFetchRequest', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(JSON.stringify({ result: '0x1' }))
+    })
+
+    const requests: Request[] = []
+    const transport = http(server.url, {
+      key: 'mock',
+      onFetchRequest(request) {
+        requests.push(request)
+      },
+    })({ chain: localhost })
+
+    await transport.request({ method: 'eth_blockNumber' })
+
+    console.log(requests)
+    expect(requests.length).toBe(1)
+
+    await server.close()
+  })
+
   test('behavior: onFetchResponse', async () => {
     const server = await createHttpServer((_, res) => {
       res.end(JSON.stringify({ result: '0x1' }))

--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -271,7 +271,7 @@ describe('request', () => {
     await server.close()
   })
 
-  test.only('behavior: onFetchRequest', async () => {
+  test('behavior: onFetchRequest', async () => {
     const server = await createHttpServer((_, res) => {
       res.end(JSON.stringify({ result: '0x1' }))
     })

--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -286,7 +286,6 @@ describe('request', () => {
 
     await transport.request({ method: 'eth_blockNumber' })
 
-    console.log(requests)
     expect(requests.length).toBe(1)
 
     await server.close()

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -36,9 +36,9 @@ export type HttpTransportConfig = {
    * @link https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
   fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
-  /**
-   * A callback to handle the response from `fetch`.
-   */
+  /** A callback to handle the response from `fetch`. */
+  onFetchRequest?: HttpRpcClientOptions['onRequest'] | undefined
+  /** A callback to handle the response from `fetch`. */
   onFetchResponse?: HttpRpcClientOptions['onResponse'] | undefined
   /** The key of the HTTP transport. */
   key?: TransportConfig['key'] | undefined
@@ -78,6 +78,7 @@ export function http(
     fetchOptions,
     key = 'http',
     name = 'HTTP JSON-RPC',
+    onFetchRequest,
     onFetchResponse,
     retryDelay,
   } = config
@@ -91,6 +92,7 @@ export function http(
 
     const rpcClient = getHttpRpcClient(url_, {
       fetchOptions,
+      onRequest: onFetchRequest,
       onResponse: onFetchResponse,
       timeout,
     })

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -329,12 +329,12 @@ describe('http (batch)', () => {
     ).toMatchInlineSnapshot(`
       [
         {
-          "id": 70,
+          "id": 74,
           "jsonrpc": "2.0",
           "result": "anvil/v0.2.0",
         },
         {
-          "id": 71,
+          "id": 75,
           "jsonrpc": "2.0",
           "result": "anvil/v0.2.0",
         },

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -151,6 +151,32 @@ describe('request', () => {
     await server.close()
   })
 
+  test('onRequest', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(JSON.stringify({ result: '0x1' }))
+    })
+
+    const requests: Request[] = []
+    const client = getHttpRpcClient(server.url, {
+      onRequest: (request) => {
+        requests.push(request)
+      },
+    })
+    await client.request({
+      body: { method: 'web3_clientVersion' },
+    })
+    await client.request({
+      body: { method: 'web3_clientVersion' },
+      onRequest: (request) => {
+        requests.push(request)
+      },
+    })
+
+    expect(requests.length).toBe(2)
+
+    await server.close()
+  })
+
   test('onResponse', async () => {
     const server = await createHttpServer((_, res) => {
       res.end(JSON.stringify({ result: '0x1' }))


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `http` transport in `viem` by adding an `onFetchRequest` callback. 

### Detailed summary
- Added `onFetchRequest` callback to `http` transport for handling fetch requests.
- Modified `http` function to include `onFetchRequest` and `onFetchResponse` options.
- Updated `HttpRpcClientOptions` with `onRequest` and `onResponse` callbacks.
- Implemented `onFetchRequest` and `onRequest` handling in various test cases.
- Improved `getHttpRpcClient` function to utilize `onRequest` callback for request handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->