### PR TITLE
fix: `getAddress` regression

### DIFF
--- a/.changeset/violet-bugs-burn.md
+++ b/.changeset/violet-bugs-burn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed regression where `getAddress` threw an error for invalid checksums instead of converting to a valid checksum.

--- a/.changeset/violet-bugs-burn.md
+++ b/.changeset/violet-bugs-burn.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed regression where `getAddress` threw an error for invalid checksums instead of converting to a valid checksum.
+Fixed regression where `getAddress` threw an error for non-checksum addresses instead of converting to a valid checksum address.

--- a/src/utils/address/getAddress.test.ts
+++ b/src/utils/address/getAddress.test.ts
@@ -27,20 +27,13 @@ test('checksums address', () => {
   expect(
     getAddress('0x3599689e6292b81b2d85451025146515070129bb', 30),
   ).toMatchInlineSnapshot('"0x3599689E6292B81B2D85451025146515070129Bb"')
+  expect(
+    getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac'),
+  ).toMatchInlineSnapshot(`"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"`)
 })
 
 describe('errors', () => {
   test('invalid address', () => {
-    expect(() =>
-      getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac'),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      [InvalidAddressError: Address "0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac" is invalid.
-
-      - Address must be a hex value of 20 bytes (40 hex characters).
-      - Address must match its checksum counterpart.
-
-      Version: viem@1.0.2]
-    `)
     expect(() =>
       getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az'),
     ).toThrowErrorMatchingInlineSnapshot(`

--- a/src/utils/address/getAddress.ts
+++ b/src/utils/address/getAddress.ts
@@ -44,6 +44,7 @@ export type GetAddressErrorType =
   | ErrorType
 
 export function getAddress(address: string, chainId?: number): Address {
-  if (!isAddress(address)) throw new InvalidAddressError({ address })
+  if (!isAddress(address, { strict: false }))
+    throw new InvalidAddressError({ address })
   return checksumAddress(address, chainId)
 }

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -20,8 +20,10 @@ export type IsAddressErrorType = ErrorType
 
 export function isAddress(
   address: string,
-  { strict = true }: IsAddressOptions = {},
+  options?: IsAddressOptions | undefined,
 ): address is Address {
+  const { strict = true } = options ?? {}
+
   if (isAddressCache.has(address)) return isAddressCache.get(address)!
 
   const result = (() => {


### PR DESCRIPTION
Fixes https://discord.com/channels/1156791276818157609/1156791519089541241/1224106930805674147

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix a regression in `getAddress` function where non-checksum addresses were throwing errors instead of converting to valid checksum addresses.

### Detailed summary
- Updated `getAddress` to convert non-checksum addresses instead of throwing errors
- Refactored `isAddress` to handle options parameter
- Updated tests to match new behavior and error messages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->