### PR TITLE
feat: update degen chain config with websocket rpc and multicall

### DIFF
--- a/.changeset/small-jobs-sing.md
+++ b/.changeset/small-jobs-sing.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added websocket rpc and multicall contract to degen chain config

--- a/src/chains/definitions/degen.ts
+++ b/src/chains/definitions/degen.ts
@@ -11,6 +11,7 @@ export const degen = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://rpc.degen.tips'],
+      webSocket: ["wss://rpc.degen.tips"],
     },
   },
   blockExplorers: {
@@ -18,6 +19,12 @@ export const degen = /*#__PURE__*/ defineChain({
       name: 'Degen Chain Explorer',
       url: 'https://explorer.degen.tips',
       apiUrl: 'https://explorer.degen.tips/api/v2',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xFBF562a98aB8584178efDcFd09755FF9A1e7E3a2",
+      blockCreated: 414273,
     },
   },
 })


### PR DESCRIPTION
* Added websocket rpc config `wss://rpc.degen.tips`
* Added multicall3 deployed at [0xFBF562a98aB8584178efDcFd09755FF9A1e7E3a2](https://explorer.degen.tips/address/0xFBF562a98aB8584178efDcFd09755FF9A1e7E3a2) 

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add websocket rpc and a multicall contract to the `degen` chain configuration in the codebase.

### Detailed summary
- Added websocket rpc configuration to `degen` chain definition
- Included multicall contract with address and block created information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->