### PR TITLE
feat: add multicall address for degen chain

### DIFF
--- a/src/chains/definitions/degen.ts
+++ b/src/chains/definitions/degen.ts
@@ -20,4 +20,10 @@ export const degen = /*#__PURE__*/ defineChain({
       apiUrl: 'https://explorer.degen.tips/api/v2',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 142,
+    },
+  }
 })


### PR DESCRIPTION
Add multicall3 address to support viem multicall

Contract on degen block explorer:  https://explorer.degen.tips/address/0xcA11bde05977b3631167028862bE2a173976CA11

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `address` and `blockCreated` values for the `multicall3` contract in `degen.ts`.

### Detailed summary
- Updated `address` for `multicall3` contract to '0xcA11bde05977b3631167028862bE2a173976CA11'
- Updated `blockCreated` for `multicall3` contract to 142

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->