### PR TITLE
fix filename to match imports on zkSync docs

### DIFF
--- a/site/pages/zksync/actions/deployContract.md
+++ b/site/pages/zksync/actions/deployContract.md
@@ -33,7 +33,7 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { zksync } from 'viem/chains'
@@ -81,7 +81,7 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { zksync } from 'viem/chains'
@@ -133,7 +133,7 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { zksync } from 'viem/chains'


### PR DESCRIPTION
I noticed the imports in the `deployContract` action for zkSync do not match the filenames in the tabs. I've kept the same filename (config.ts) and in the other actions for consistency.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the file structure by renaming `client.ts` to `config.ts`.

### Detailed summary
- Renamed `client.ts` to `config.ts` for better clarity and organization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->