### PR TITLE
Add sourceId to Mode Network

### DIFF
--- a/.changeset/calm-humans-compete.md
+++ b/.changeset/calm-humans-compete.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added sourceId to Mode network

--- a/src/chains/definitions/mode.ts
+++ b/src/chains/definitions/mode.ts
@@ -1,5 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+const sourceId = 1 // mainnet
+
 export const mode = /*#__PURE__*/ defineChain({
   id: 34443,
   name: 'Mode Mainnet',
@@ -21,4 +23,5 @@ export const mode = /*#__PURE__*/ defineChain({
       blockCreated: 2465882,
     },
   },
+  sourceId,
 })

--- a/src/chains/definitions/modeTestnet.ts
+++ b/src/chains/definitions/modeTestnet.ts
@@ -1,5 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+const sourceId = 11_155_111 // sepolia
+
 export const modeTestnet = /*#__PURE__*/ defineChain({
   id: 919,
   name: 'Mode Testnet',
@@ -23,4 +25,5 @@ export const modeTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  sourceId,
 })


### PR DESCRIPTION
Added sourceId to Mode Mainnet and Mode Tesnet.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `sourceId` property to the Mode network definitions for both mainnet and testnet.

### Detailed summary
- Added `sourceId` property to `mode` network definition for mainnet
- Added `sourceId` property to `modeTestnet` network definition for testnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->