### PR TITLE
feat: socket reconnect

### DIFF
--- a/.changeset/good-coins-smoke.md
+++ b/.changeset/good-coins-smoke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added reconnect functionality to `webSocket` & `ipc` transports.

--- a/site/pages/docs/clients/transports/ipc.md
+++ b/site/pages/docs/clients/transports/ipc.md
@@ -65,6 +65,55 @@ const transport = ipc('/tmp/reth.ipc', {
 })
 ```
 
+### reconnect (optional)
+
+- **Type:** `boolean | { maxAttempts?: number, delay?: number }`
+- **Default:** `true`
+
+Whether or not to attempt to reconnect on socket failure.
+
+```ts twoslash
+import { ipc } from 'viem/node'
+// ---cut---
+const transport = ipc('/tmp/reth.ipc', {
+  reconnect: false, // [!code focus]
+})
+```
+
+#### reconnect.attempts (optional)
+
+- **Type:** `number`
+- **Default:** `5`
+
+The max number of times to attempt to reconnect.
+
+```ts twoslash
+import { ipc } from 'viem/node'
+// ---cut---
+const transport = ipc('/tmp/reth.ipc', {
+  reconnect: {
+    attempts: 10, // [!code focus]
+  }
+})
+```
+
+#### reconnect.delay (optional)
+
+- **Type:** `number`
+- **Default:** `2_000`
+
+Retry delay (in ms) between reconnect attempts.
+
+```ts twoslash
+import { ipc } from 'viem/node'
+// ---cut---
+const transport = ipc('/tmp/reth.ipc', {
+  reconnect: {
+    delay: 1_000, // [!code focus]
+  }
+})
+```
+
 ### retryCount (optional)
 
 - **Type:** `number`

--- a/site/pages/docs/clients/transports/websocket.md
+++ b/site/pages/docs/clients/transports/websocket.md
@@ -68,6 +68,55 @@ const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
 })
 ```
 
+### reconnect (optional)
+
+- **Type:** `boolean | { maxAttempts?: number, delay?: number }`
+- **Default:** `true`
+
+Whether or not to attempt to reconnect on socket failure.
+
+```ts twoslash
+import { webSocket } from 'viem'
+// ---cut---
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  reconnect: false, // [!code focus]
+})
+```
+
+#### reconnect.attempts (optional)
+
+- **Type:** `number`
+- **Default:** `5`
+
+The max number of times to attempt to reconnect.
+
+```ts twoslash
+import { webSocket } from 'viem'
+// ---cut---
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  reconnect: {
+    attempts: 10, // [!code focus]
+  }
+})
+```
+
+#### reconnect.delay (optional)
+
+- **Type:** `number`
+- **Default:** `2_000`
+
+Retry delay (in ms) between reconnect attempts.
+
+```ts twoslash
+import { webSocket } from 'viem'
+// ---cut---
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  reconnect: {
+    delay: 1_000, // [!code focus]
+  }
+})
+```
+
 ### retryCount (optional)
 
 - **Type:** `number`

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -8,7 +8,10 @@ import type { Hash } from '../../types/misc.js'
 import type { RpcResponse } from '../../types/rpc.js'
 import { getSocket } from '../../utils/rpc/compat.js'
 import type { SocketRpcClient } from '../../utils/rpc/socket.js'
-import { getWebSocketRpcClient } from '../../utils/rpc/webSocket.js'
+import {
+  type GetWebSocketRpcClientOptions,
+  getWebSocketRpcClient,
+} from '../../utils/rpc/webSocket.js'
 import {
   type CreateTransportErrorType,
   type Transport,
@@ -43,6 +46,11 @@ export type WebSocketTransportConfig = {
   key?: TransportConfig['key'] | undefined
   /** The name of the WebSocket transport. */
   name?: TransportConfig['name'] | undefined
+  /**
+   * Whether or not to attempt to reconnect on socket failure.
+   * @default true
+   */
+  reconnect?: GetWebSocketRpcClientOptions['reconnect'] | undefined
   /** The max number of times to retry. */
   retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
@@ -76,7 +84,12 @@ export function webSocket(
   url?: string,
   config: WebSocketTransportConfig = {},
 ): WebSocketTransport {
-  const { key = 'webSocket', name = 'WebSocket JSON-RPC', retryDelay } = config
+  const {
+    key = 'webSocket',
+    name = 'WebSocket JSON-RPC',
+    reconnect,
+    retryDelay,
+  } = config
   return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
     const retryCount = config.retryCount ?? retryCount_
     const timeout = timeout_ ?? config.timeout ?? 10_000
@@ -88,7 +101,7 @@ export function webSocket(
         name,
         async request({ method, params }) {
           const body = { method, params }
-          const rpcClient = await getWebSocketRpcClient(url_)
+          const rpcClient = await getWebSocketRpcClient(url_, { reconnect })
           const { error, result } = await rpcClient.requestAsync({
             body,
             timeout,

--- a/src/utils/rpc/ipc.ts
+++ b/src/utils/rpc/ipc.ts
@@ -1,10 +1,16 @@
 import { type Socket as NetSocket, connect } from 'node:net'
 import { WebSocketRequestError } from '../../index.js'
 import {
+  type GetSocketRpcClientParameters,
   type Socket,
   type SocketRpcClient,
   getSocketRpcClient,
 } from './socket.js'
+
+export type GetIpcRpcClientOptions = Pick<
+  GetSocketRpcClientParameters,
+  'reconnect'
+>
 
 const openingBrace = '{'.charCodeAt(0)
 const closingBrace = '}'.charCodeAt(0)
@@ -33,7 +39,12 @@ export function extractMessages(buffer: Buffer): [Buffer[], Buffer] {
 
 export type IpcRpcClient = SocketRpcClient<NetSocket>
 
-export async function getIpcRpcClient(path: string): Promise<IpcRpcClient> {
+export async function getIpcRpcClient(
+  path: string,
+  options: GetIpcRpcClientOptions = {},
+): Promise<IpcRpcClient> {
+  const { reconnect } = options
+
   return getSocketRpcClient({
     async getSocket({ onError, onOpen, onResponse }) {
       const socket = connect(path)
@@ -88,6 +99,7 @@ export async function getIpcRpcClient(path: string): Promise<IpcRpcClient> {
         },
       } as Socket<{}>)
     },
+    reconnect,
     url: path,
   })
 }

--- a/src/utils/rpc/ipc.ts
+++ b/src/utils/rpc/ipc.ts
@@ -35,12 +35,14 @@ export type IpcRpcClient = SocketRpcClient<NetSocket>
 
 export async function getIpcRpcClient(path: string): Promise<IpcRpcClient> {
   return getSocketRpcClient({
-    async getSocket({ onResponse }) {
+    async getSocket({ onError, onOpen, onResponse }) {
       const socket = connect(path)
 
       function onClose() {
         socket.off('close', onClose)
         socket.off('message', onData)
+        socket.off('error', onError)
+        socket.off('connect', onOpen)
       }
 
       let lastRemaining = Buffer.alloc(0)
@@ -57,6 +59,8 @@ export async function getIpcRpcClient(path: string): Promise<IpcRpcClient> {
 
       socket.on('close', onClose)
       socket.on('data', onData)
+      socket.on('error', onError)
+      socket.on('connect', onOpen)
 
       // Wait for the socket to open.
       await new Promise<void>((resolve, reject) => {

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -163,8 +163,8 @@ test('reconnect', async () => {
       }
     },
     reconnect: {
-      timeout: 200,
-      maxAttempts: 5,
+      delay: 200,
+      attempts: 5,
     },
     url: localWsUrl,
   })
@@ -307,8 +307,8 @@ test('reconnect (eth_subscribe)', async () => {
       }
     },
     reconnect: {
-      timeout: 200,
-      maxAttempts: 5,
+      delay: 200,
+      attempts: 5,
     },
     url: localWsUrl,
   })

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -9,10 +9,15 @@ import { withTimeout } from '../promise/withTimeout.js'
 import { idCache } from './id.js'
 
 type Id = string | number
-type CallbackFn = (message: any) => void
+type CallbackFn = {
+  onResponse: (message: any) => void
+  onError?: ((error?: Error | undefined) => void) | undefined
+}
 type CallbackMap = Map<Id, CallbackFn>
 
 export type GetSocketParameters = {
+  onError: (error?: Error | undefined) => void
+  onOpen: () => void
   onResponse: (data: RpcResponse) => void
 }
 
@@ -28,7 +33,7 @@ export type SocketRpcClient<socket extends {}> = {
   socket: Socket<socket>
   request(params: {
     body: RpcRequest
-    onError?: ((error: Error) => void) | undefined
+    onError?: ((error?: Error | undefined) => void) | undefined
     onResponse: (message: RpcResponse) => void
   }): void
   requestAsync(params: {
@@ -41,8 +46,27 @@ export type SocketRpcClient<socket extends {}> = {
 }
 
 export type GetSocketRpcClientParameters<socket extends {}> = {
-  url: string
   getSocket(params: GetSocketParameters): Promise<Socket<socket>>
+  /**
+   * Whether or not to attempt to reconnect on socket failure.
+   * @default true
+   */
+  reconnect?:
+    | boolean
+    | {
+        /**
+         * The maximum number of reconnection attempts.
+         * @default 5
+         */
+        maxAttempts?: number | undefined
+        /**
+         * The timeout (in ms) between reconnection attempts.
+         * @default 2_000
+         */
+        timeout?: number | undefined
+      }
+    | undefined
+  url: string
 }
 
 export type GetSocketRpcClientErrorType =
@@ -57,13 +81,16 @@ export const socketClientCache = /*#__PURE__*/ new Map<
 export async function getSocketRpcClient<socket extends {}>(
   params: GetSocketRpcClientParameters<socket>,
 ): Promise<SocketRpcClient<socket>> {
-  const { getSocket, url } = params
+  const { getSocket, reconnect = true, url } = params
+  const { maxAttempts = 5, timeout = 2_000 } =
+    typeof reconnect === 'object' ? reconnect : {}
 
   let socketClient = socketClientCache.get(url)
 
   // If the socket already exists, return it.
   if (socketClient) return socketClient as {} as SocketRpcClient<socket>
 
+  let reconnectAttempts = 0
   const { schedule } = createBatchScheduler<
     undefined,
     [SocketRpcClient<socket>]
@@ -76,17 +103,46 @@ export async function getSocketRpcClient<socket extends {}>(
       // Set up a cache for subscriptions (eth_subscribe).
       const subscriptions = new Map<Id, CallbackFn>()
 
+      let error: Error | undefined
+      let socket: Socket<any>
       // Set up socket implementation.
-      const socket = await getSocket({
-        onResponse(data) {
-          const isSubscription = data.method === 'eth_subscription'
-          const id = isSubscription ? data.params.subscription : data.id
-          const cache = isSubscription ? subscriptions : requests
-          const callback = cache.get(id)
-          if (callback) callback(data)
-          if (!isSubscription) cache.delete(id)
-        },
-      })
+      async function setup() {
+        return getSocket({
+          onError(error_) {
+            error = error_
+
+            // Notify all requests and subscriptions of the error.
+            for (const request of requests.values()) request.onError?.(error)
+            for (const subscription of subscriptions.values())
+              subscription.onError?.(error)
+
+            // Clear all requests and subscriptions.
+            requests.clear()
+            subscriptions.clear()
+
+            // Attempt to reconnect.
+            if (reconnect && reconnectAttempts < maxAttempts)
+              setTimeout(async () => {
+                reconnectAttempts++
+                socket = await setup().catch(console.error)
+              }, timeout)
+          },
+          onOpen() {
+            error = undefined
+            reconnectAttempts = 0
+          },
+          onResponse(data) {
+            const isSubscription = data.method === 'eth_subscription'
+            const id = isSubscription ? data.params.subscription : data.id
+            const cache = isSubscription ? subscriptions : requests
+            const callback = cache.get(id)
+            if (callback) callback.onResponse(data)
+            if (!isSubscription) cache.delete(id)
+          },
+        })
+      }
+      socket = await setup()
+      error = undefined
 
       // Create a new socket instance.
       socketClient = {
@@ -96,6 +152,8 @@ export async function getSocketRpcClient<socket extends {}>(
         },
         socket,
         request({ body, onError, onResponse }) {
+          if (error && onError) onError(error)
+
           const id = body.id ?? idCache.take()
 
           const callback = (response: RpcResponse) => {
@@ -107,18 +165,19 @@ export async function getSocketRpcClient<socket extends {}>(
               body.method === 'eth_subscribe' &&
               typeof response.result === 'string'
             )
-              subscriptions.set(response.result, callback)
+              subscriptions.set(response.result, {
+                onResponse: callback,
+                onError,
+              })
 
             // If we are unsubscribing from a topic, we want to remove the listener.
             if (body.method === 'eth_unsubscribe')
               subscriptions.delete(body.params?.[0])
 
             onResponse(response)
-
-            // TODO: delete request?
           }
 
-          requests.set(id, callback)
+          requests.set(id, { onResponse: callback, onError })
           try {
             socket.request({
               body: {

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -11,13 +11,15 @@ export async function getWebSocketRpcClient(
   url: string,
 ): Promise<SocketRpcClient<WebSocket>> {
   return getSocketRpcClient({
-    async getSocket({ onResponse }) {
+    async getSocket({ onError, onOpen, onResponse }) {
       const WebSocket = await import('isows').then((module) => module.WebSocket)
       const socket = new WebSocket(url)
 
       function onClose() {
         socket.removeEventListener('close', onClose)
         socket.removeEventListener('message', onMessage)
+        socket.removeEventListener('error', () => onError())
+        socket.removeEventListener('open', onOpen)
       }
       function onMessage({ data }: MessageEvent) {
         onResponse(JSON.parse(data))
@@ -26,6 +28,8 @@ export async function getWebSocketRpcClient(
       // Setup event listeners for RPC & subscription responses.
       socket.addEventListener('close', onClose)
       socket.addEventListener('message', onMessage)
+      socket.addEventListener('error', () => onError())
+      socket.addEventListener('open', onOpen)
 
       // Wait for the socket to open.
       if (socket.readyState === WebSocket.CONNECTING) {


### PR DESCRIPTION
Supersedes #1894.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `viem` library by adding reconnect functionality to `webSocket` and `ipc` transports.

### Detailed summary
- Added `reconnect` option with `maxAttempts` and `delay` parameters to `webSocket` and `ipc` transports.
- Updated `ipc.md` and `websocket.md` with reconnect details.
- Added `reconnect` option to `getWebSocketRpcClient` and `getIpcRpcClient`.
- Implemented reconnect feature with delay and attempts in tests.

> The following files were skipped due to too many changes: `src/utils/rpc/socket.test.ts`, `src/utils/rpc/socket.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->