### PR TITLE
Adds contracts field with multicall3 to dfk chain definition

### DIFF
--- a/.changeset/loud-garlics-worry.md
+++ b/.changeset/loud-garlics-worry.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
-Adds multicall3 contract to dfk definition
+Added multicall3 contract to dfk definition

--- a/.changeset/loud-garlics-worry.md
+++ b/.changeset/loud-garlics-worry.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Adds multicall3 contract to dfk definition

--- a/src/chains/definitions/dfk.ts
+++ b/src/chains/definitions/dfk.ts
@@ -19,4 +19,10 @@ export const dfk = /*#__PURE__*/ defineChain({
       url: 'https://subnets.avax.network/defi-kingdoms',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 14790551,
+    },
+  },
 })


### PR DESCRIPTION
The `dfk` chain definition is currently missing a `multicall3` contract, so this PR adds it.

Source for contract `address` and `blockCreated`: https://subnets.avax.network/defi-kingdoms/address/0xca11bde05977b3631167028862be2a173976ca11

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `multicall3` contract to the `dfk` definition in the codebase.

### Detailed summary
- Added `multicall3` contract with address and blockCreated to `dfk` definition in `src/chains/definitions/dfk.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->