### PR TITLE
Add multicall3 contract to Polygon Amoy

### DIFF
--- a/.changeset/long-ravens-smile.md
+++ b/.changeset/long-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 to Polygon Amoy chain

--- a/src/chains/definitions/polygonAmoy.ts
+++ b/src/chains/definitions/polygonAmoy.ts
@@ -15,5 +15,11 @@ export const polygonAmoy = /*#__PURE__*/ defineChain({
       url: 'https://www.oklink.com/amoy',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 3127388,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Source: https://www.oklink.com/amoy/tx/0x07471adfe8f4ec553c1199f495be97fc8be8e0626ae307281c22534460184ed1

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `multicall3` contract to the Polygon Amoy chain.

### Detailed summary
- Added `multicall3` contract with address and block created information to the Polygon Amoy chain definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->