### PR TITLE
decodeEventLog bug fixed: named args with a missing name

### DIFF
--- a/.changeset/curvy-pots-watch.md
+++ b/.changeset/curvy-pots-watch.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed decoding of event logs when an event argument was missing a name.

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -80,6 +80,52 @@ test('named args: Transfer(address,address,uint256)', () => {
   })
 })
 
+test('named args with a missing name: Transfer(address,address,uint256)', () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+      '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    ],
+  })
+  assertType<typeof event>({
+    eventName: 'Transfer',
+    args: ['0x', '0x', 1n],
+  })
+  expect(event).toEqual({
+    args: [
+      '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      1n,
+    ],
+    eventName: 'Transfer',
+  })
+})
+
 test('unnamed args: Transfer(address,address,uint256)', () => {
   const event = decodeEventLog({
     abi: [

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -139,7 +139,7 @@ export function decodeEventLog<
         abiItem,
         param: param as AbiParameter & { indexed: boolean },
       })
-    args[param.name || i] = decodeTopic({ param, value: topic })
+    args[isUnnamed ? i : param.name || i] = decodeTopic({ param, value: topic })
   }
 
   // Decode data (non-indexed args).


### PR DESCRIPTION
Issue: https://github.com/wevm/viem/issues/2081

Description:
If an ABI event parameter name is undefined or is an empty string (""), decodeEventLog seems to partially decode it. This happens even if the number of indexed/non-indexed parameters in the ABI item matches the log data/topics, regardless of the strict option.

Fix:
decodeEventLog will return the arguments as an array, ordered the same way as the ABI parameters, omitting all argument names but still decoding all arguments properly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the decoding of event logs when an event argument is missing a name.

### Detailed summary
- Fixed decoding of event logs with missing argument names
- Adjusted handling of unnamed event arguments in decoding logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->