### PR TITLE
fix: fix filecoin testnet definitions

### DIFF
--- a/.changeset/dry-clouds-shave.md
+++ b/.changeset/dry-clouds-shave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `testnet` properties to Filecoin definitions

--- a/src/chains/definitions/filecoinCalibration.ts
+++ b/src/chains/definitions/filecoinCalibration.ts
@@ -17,4 +17,5 @@ export const filecoinCalibration = /*#__PURE__*/ defineChain({
       url: 'https://calibration.filscan.io',
     },
   },
+  testnet: true,
 })

--- a/src/chains/definitions/filecoinHyperspace.ts
+++ b/src/chains/definitions/filecoinHyperspace.ts
@@ -17,4 +17,5 @@ export const filecoinHyperspace = /*#__PURE__*/ defineChain({
       url: 'https://hyperspace.filfox.info/en',
     },
   },
+  testnet: true,
 })


### PR DESCRIPTION
Fix chain definitions to add the `testnet` flag to the testnet definitions of Filecoin.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `testnet` property to Filecoin definitions in two files. 

### Detailed summary
- Added `testnet: true` property to `filecoinHyperspace.ts` and `filecoinCalibration.ts` in `src/chains/definitions`
- Updated `changeset/dry-clouds-shave.md` to reflect the changes made

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->