### PR TITLE
add l3x

### DIFF
--- a/src/chains/definitions/l3x.ts
+++ b/src/chains/definitions/l3x.ts
@@ -1,0 +1,20 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const arbitrum = /*#__PURE__*/ defineChain({
+  id: 12324,
+  name: 'L3X Protocol',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: [''],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: '',
+      url: '',
+      apiUrl: '',
+    },
+  },
+  contracts: {},
+})


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `arbitrum` chain definition for the L3X Protocol.

### Detailed summary
- Added `arbitrum` chain definition in `l3x.ts`
- Chain ID set to 12324
- Name: L3X Protocol
- Native currency: Ether (ETH)
- RPC URLs configured
- Block explorers details added
- Contracts object initialized

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->