### PR TITLE
chore: update to use publicnode's new rpc url format before old ones are deprecated

### DIFF
--- a/.changeset/good-geckos-type.md
+++ b/.changeset/good-geckos-type.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated publicnode rpc urls to new format
+Updated Publicnode RPC URLs to new format.

--- a/.changeset/good-geckos-type.md
+++ b/.changeset/good-geckos-type.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated publicnode rpc urls to new format

--- a/src/actions/wallet/sendRawTransaction.test.ts
+++ b/src/actions/wallet/sendRawTransaction.test.ts
@@ -25,7 +25,7 @@ test('default', async () => {
 test.skip('4844', async () => {
   const client = createClient({
     chain: sepolia,
-    transport: http('https://ethereum-sepolia.publicnode.com'),
+    transport: http('https://ethereum-sepolia-rpc.publicnode.com'),
   })
 
   const privateKey = '0x'

--- a/src/chains/definitions/bahamut.ts
+++ b/src/chains/definitions/bahamut.ts
@@ -9,24 +9,24 @@ export const bahamut = /*#__PURE__*/ defineChain({
     default: {
       http: [
         'https://rpc1.bahamut.io',
-        'https://bahamut.publicnode.com',
+        'https://bahamut-rpc.publicnode.com',
         'https://rpc2.bahamut.io',
       ],
       webSocket: [
         'wss://ws1.sahara.bahamutchain.com',
-        'wss://bahamut.publicnode.com',
+        'wss://bahamut-rpc.publicnode.com',
         'wss://ws2.sahara.bahamutchain.com',
       ],
     },
     public: {
       http: [
         'https://rpc1.bahamut.io',
-        'https://bahamut.publicnode.com',
+        'https://bahamut-rpc.publicnode.com',
         'https://rpc2.bahamut.io',
       ],
       webSocket: [
         'wss://ws1.sahara.bahamutchain.com',
-        'wss://bahamut.publicnode.com',
+        'wss://bahamut-rpc.publicnode.com',
         'wss://ws2.sahara.bahamutchain.com',
       ],
     },

--- a/src/chains/definitions/chiliz.ts
+++ b/src/chains/definitions/chiliz.ts
@@ -11,7 +11,10 @@ export const chiliz = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.ankr.com/chiliz', 'https://chiliz-rpc.publicnode.com'],
+      http: [
+        'https://rpc.ankr.com/chiliz',
+        'https://chiliz-rpc.publicnode.com',
+      ],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/chiliz.ts
+++ b/src/chains/definitions/chiliz.ts
@@ -11,7 +11,7 @@ export const chiliz = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.ankr.com/chiliz', 'https://chiliz.publicnode.com'],
+      http: ['https://rpc.ankr.com/chiliz', 'https://chiliz-rpc.publicnode.com'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -6,7 +6,7 @@ export const holesky = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Holesky Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://ethereum-holesky.publicnode.com'],
+      http: ['https://ethereum-holesky-rpc.publicnode.com'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/spicy.ts
+++ b/src/chains/definitions/spicy.ts
@@ -13,11 +13,11 @@ export const spicy = /*#__PURE__*/ defineChain({
     default: {
       http: [
         'https://spicy-rpc.chiliz.com',
-        'https://chiliz-spicy.publicnode.com',
+        'https://chiliz-spicy-rpc.publicnode.com',
       ],
       webSocket: [
         'wss://spicy-rpc-ws.chiliz.com',
-        'wss://chiliz-spicy.publicnode.com',
+        'wss://chiliz-spicy-rpc.publicnode.com',
       ],
     },
   },


### PR DESCRIPTION
example of new format:
before: `https://ethereum-sepolia.publicnode.com`
after: `https://ethereum-sepolia-rpc.publicnode.com`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Publicnode RPC URLs to a new format for multiple chains. 

### Detailed summary
- Updated Publicnode RPC URLs for `holesky`, `chiliz`, `spicy`, and `bahamut` chains
- Updated RPC URLs for `sepolia` chain in `sendRawTransaction.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->