### PR TITLE
fix getAction for cases where minifier changes function names

### DIFF
--- a/.changeset/six-bears-carry.md
+++ b/.changeset/six-bears-carry.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-fix getAction for cases where minifier changes function names
+Fixed `getAction` for cases where the bundler could change function names.

--- a/.changeset/six-bears-carry.md
+++ b/.changeset/six-bears-carry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix getAction for cases where minifier changes function names

--- a/src/utils/getAction.ts
+++ b/src/utils/getAction.ts
@@ -10,14 +10,17 @@ import type { Client } from '../clients/createClient.js'
 export function getAction<params extends {}, returnType extends {}>(
   client: Client,
   action: (_: any, params: params) => returnType,
-  // Some minifiers drop `Function.prototype.name`, meaning that `action.name`
-  // will not work. For that case, the consumer needs to pass the name explicitly.
+  // Some minifiers drop `Function.prototype.name` or can change function
+  // names so that getting the name by reflection through `action.name` will
+  // not work.
   name: string,
 ) {
   return (params: params): returnType =>
-    (
-      client as Client & {
-        [key: string]: (params: params) => returnType
-      }
-    )[action.name || name]?.(params) ?? action(client, params)
+    (client as Client & { [key: string]: (params: params) => returnType })[
+      action.name
+    ]?.(params) ??
+    (client as Client & { [key: string]: (params: params) => returnType })[
+      name
+    ]?.(params) ??
+    action(client, params)
 }


### PR DESCRIPTION
Some minifiers, as esbuild, might change name functions. 
e.g., `sendTransaction` to `sendTransaction5`

So `client[action.name ?? name]` only checks the first value and never falls back to `name`.

closes #2117

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `getAction` function to handle cases where minifiers change function names, ensuring the correct function is called.

### Detailed summary
- Updated `getAction` to handle cases where minifiers change function names
- Refactored function name retrieval logic for reliability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->