### PR TITLE
Remove the table for `eth_wagmi`

### DIFF
--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -335,8 +335,7 @@ const publicClient = createPublicClient({
 })
 
 const result = await publicClient.request({ // [!code focus]
-  method: 'eth_wa // [!code focus] 
-//               ^|
+  method: 'eth_wagmi', // [!code focus] 
   params: ['hello'], // [!code focus]
 }) // [!code focus]
 ```


### PR DESCRIPTION
It doesn't seem to belong there.

<img width="430" alt="Screenshot 2024-04-17 at 4 12 27 PM" src="https://github.com/wevm/viem/assets/12722969/8f978a23-78e5-43a6-8a4e-174f18ae181c">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the method called by `publicClient` in `site/pages/docs/clients/public.md`.

### Detailed summary
- Updated method from 'eth_wa' to 'eth_wagmi'
- Added params array with value 'hello'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->