### PR TITLE
docs: waitForTransactionReceipt does not throw

### DIFF
--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -88,7 +88,7 @@ export type WaitForTransactionReceiptErrorType =
   | ErrorType
 
 /**
- * Waits for the [Transaction](https://viem.sh/docs/glossary/terms#transaction) to be included on a [Block](https://viem.sh/docs/glossary/terms#block) (one confirmation), and then returns the [Transaction Receipt](https://viem.sh/docs/glossary/terms#transaction-receipt). If the Transaction reverts, then the action will throw an error.
+ * Waits for the [Transaction](https://viem.sh/docs/glossary/terms#transaction) to be included on a [Block](https://viem.sh/docs/glossary/terms#block) (one confirmation), and then returns the [Transaction Receipt](https://viem.sh/docs/glossary/terms#transaction-receipt).
  *
  * - Docs: https://viem.sh/docs/actions/public/waitForTransactionReceipt
  * - Example: https://stackblitz.com/github/wevm/viem/tree/main/examples/transactions/sending-transactions


### PR DESCRIPTION
missed in https://github.com/wevm/viem/commit/3f1c8de4793ab13624189d8177e4dd2423ef4157
related to #1767

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove the part where the action throws an error if the transaction reverts.

### Detailed summary
- Removed the part where the action throws an error if the Transaction reverts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->