### PR TITLE
add polygon amoy etherscan api url

### DIFF
--- a/.changeset/fifty-weeks-smoke.md
+++ b/.changeset/fifty-weeks-smoke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Polygon Amoy explorer URL.

--- a/src/chains/definitions/polygonAmoy.ts
+++ b/src/chains/definitions/polygonAmoy.ts
@@ -11,8 +11,9 @@ export const polygonAmoy = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'OK LINK',
-      url: 'https://www.oklink.com/amoy',
+      name: 'PolygonScan',
+      url: 'https://amoy.polygonscan.com/',
+      apiUrl: 'https://api-amoy.polygonscan.com/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Hey guys,

This PR aims to add the API URL to Polygon Amoy, but also changes the block explorer to the official one.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the block explorer URL for Polygon Amoy chain.

### Detailed summary
- Updated block explorer URL from 'OK LINK' to 'PolygonScan' in `polygonAmoy.ts`
- Updated URL to 'https://amoy.polygonscan.com/'
- Added apiUrl as 'https://api-amoy.polygonscan.com/api'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->