### PR TITLE
recoverPublicKey: Does not need to be async

### DIFF
--- a/site/pages/docs/utilities/recoverPublicKey.md
+++ b/site/pages/docs/utilities/recoverPublicKey.md
@@ -11,7 +11,7 @@ Recovers the original signing 64-byte public key from a hash & signature.
 ```ts [example.ts]
 import { recoverPublicKey } from 'viem'
  
-const address = await recoverPublicKey({
+const address = recoverPublicKey({
   hash: '0xd9eba16ed0ecae432b71fe008c98cc872bb4cc214d3220a36f365326cf807d68',
   signature: '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c'
 })
@@ -33,7 +33,7 @@ The signing public key.
 The hash that was signed.
 
 ```ts
-const publicKey = await recoverPublicKey({ 
+const publicKey = recoverPublicKey({ 
   hash: '0xd9eba16ed0ecae432b71fe008c98cc872bb4cc214d3220a36f365326cf807d68', // [!code focus]
   signature: '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c'
 })
@@ -46,7 +46,7 @@ const publicKey = await recoverPublicKey({
 The signature of the hash.
 
 ```ts
-const publicKey = await recoverPublicKey({ 
+const publicKey = recoverPublicKey({ 
   hash: '0xd9eba16ed0ecae432b71fe008c98cc872bb4cc214d3220a36f365326cf807d68',
   signature: '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c' // [!code focus]
 })

--- a/src/utils/signature/recoverAddress.ts
+++ b/src/utils/signature/recoverAddress.ts
@@ -19,5 +19,5 @@ export async function recoverAddress({
   hash,
   signature,
 }: RecoverAddressParameters): Promise<RecoverAddressReturnType> {
-  return publicKeyToAddress(await recoverPublicKey({ hash: hash, signature }))
+  return publicKeyToAddress(recoverPublicKey({ hash: hash, signature }))
 }

--- a/src/utils/signature/recoverPublicKey.test.ts
+++ b/src/utils/signature/recoverPublicKey.test.ts
@@ -7,9 +7,9 @@ import { toBytes } from '../encoding/toBytes.js'
 import { hashMessage } from './hashMessage.js'
 import { recoverPublicKey } from './recoverPublicKey.js'
 
-test('default', async () => {
+test.only('default', () => {
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('hello world'),
       signature:
         '0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b',
@@ -17,7 +17,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('🥵'),
       signature:
         '0x05c99bbbe9fac3ad61721a815d19d6771ad39f3e8dffa7ae7561358f20431d8e7f9e1d487c77355790c79c6eb0b0d63690f690615ef99ee3e4f25eef0317d0701b',
@@ -25,7 +25,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('hello world', 'bytes'),
       signature:
         '0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b',
@@ -33,7 +33,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('🥵', 'bytes'),
       signature:
         '0x05c99bbbe9fac3ad61721a815d19d6771ad39f3e8dffa7ae7561358f20431d8e7f9e1d487c77355790c79c6eb0b0d63690f690615ef99ee3e4f25eef0317d0701b',
@@ -41,7 +41,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('hello world', 'bytes'),
       signature: toBytes(
         '0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b',
@@ -50,7 +50,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: hashMessage('hello world'),
       signature:
         '0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b00',
@@ -58,7 +58,7 @@ test('default', async () => {
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 
   expect(
-    await recoverPublicKey({
+    recoverPublicKey({
       hash: '0x9a74cb859ad30835ffb2da406423233c212cf6dd78e6c2c98b0c9289568954ae',
       signature:
         '0xc4d8bcda762d35ea79d9542b23200f46c2c1899db15bf929bbacaf609581db0831538374a01206517edd934e474212a0f1e2d62e9a01cd64f1cf94ea2e09884901',

--- a/src/utils/signature/recoverPublicKey.ts
+++ b/src/utils/signature/recoverPublicKey.ts
@@ -3,6 +3,7 @@ import type { ByteArray, Hex } from '../../types/misc.js'
 import { type IsHexErrorType, isHex } from '../data/isHex.js'
 import { type HexToNumberErrorType, hexToNumber } from '../encoding/fromHex.js'
 import { toHex } from '../encoding/toHex.js'
+import { secp256k1 } from '@noble/curves/secp256k1';
 
 export type RecoverPublicKeyParameters = {
   hash: Hex | ByteArray
@@ -16,10 +17,10 @@ export type RecoverPublicKeyErrorType =
   | IsHexErrorType
   | ErrorType
 
-export async function recoverPublicKey({
+export function recoverPublicKey({
   hash,
   signature,
-}: RecoverPublicKeyParameters): Promise<RecoverPublicKeyReturnType> {
+}: RecoverPublicKeyParameters): RecoverPublicKeyReturnType {
   const signatureHex = isHex(signature) ? signature : toHex(signature)
   const hashHex = isHex(hash) ? hash : toHex(hash)
 
@@ -28,7 +29,6 @@ export async function recoverPublicKey({
   let v = hexToNumber(`0x${signatureHex.slice(130)}`)
   if (v === 0 || v === 1) v += 27
 
-  const { secp256k1 } = await import('@noble/curves/secp256k1')
   const publicKey = secp256k1.Signature.fromCompact(
     signatureHex.substring(2, 130),
   )

--- a/src/utils/signature/recoverPublicKey.ts
+++ b/src/utils/signature/recoverPublicKey.ts
@@ -1,9 +1,9 @@
+import { secp256k1 } from '@noble/curves/secp256k1'
 import type { ErrorType } from '../../errors/utils.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
 import { type IsHexErrorType, isHex } from '../data/isHex.js'
 import { type HexToNumberErrorType, hexToNumber } from '../encoding/fromHex.js'
 import { toHex } from '../encoding/toHex.js'
-import { secp256k1 } from '@noble/curves/secp256k1';
 
 export type RecoverPublicKeyParameters = {
   hash: Hex | ByteArray


### PR DESCRIPTION
There was an awkward async import inside this method making it asynchronous (when it doesn't need to be). A global search on this project shows that this import is being made everywhere else as the change proposed here. I am not sure if this was intended or what, but this change makes everything much more consistent.


**Note that** ⚠️  this change might require a version bump (for any dependents on this project) since users will have to remove `await` statements as was done here.

<img width="483" alt="Screenshot 2024-04-23 at 13 25 08" src="https://github.com/wevm/viem/assets/11778116/020f23dd-4215-489c-8161-4fc5be78d8f4">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the `recoverPublicKey` function by removing unnecessary async/await operations.

### Detailed summary
- Removed unnecessary async/await from `recoverPublicKey` function
- Updated function signature to remove Promise return type
- Removed import of `secp256k1` from `recoverPublicKey`
- Updated function calls in `recoverPublicKey.md` and test files to reflect changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->