### PR TITLE
Fix SKALE Chain Crypto Colosseum Chain Id

### DIFF
--- a/.changeset/spicy-forks-repeat.md
+++ b/.changeset/spicy-forks-repeat.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed SKALE Crypto Colloseum Chain Id

--- a/src/chains/definitions/skale/cryptoColosseum.ts
+++ b/src/chains/definitions/skale/cryptoColosseum.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleCryptoColosseum = /*#__PURE__*/ defineChain({
-  id: 2_046_399_126,
+  id: 1_032_942_172,
   name: 'SKALE | Crypto Colosseum',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the SKALE Crypto Colosseum Chain Id to fix an issue.

### Detailed summary
- Updated SKALE Crypto Colosseum Chain Id from 2_046_399_126 to 1_032_942_172.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->