### PR TITLE
lint: remove the testnet tag for cyber mainnet

### DIFF
--- a/.changeset/cold-cougars-begin.md
+++ b/.changeset/cold-cougars-begin.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed `testnet` tag for Cyber Mainnet chain.

--- a/src/chains/definitions/cyber.ts
+++ b/src/chains/definitions/cyber.ts
@@ -21,6 +21,5 @@ export const cyber = /*#__PURE__*/ defineChain({
       address: '0xd1A3cb95E97Abc83777Ced3d474CCdD1AC948F0E',
       blockCreated: 43798,
     },
-  },
-  testnet: true,
+  }
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `testnet` tag for the Cyber Mainnet chain in `src/chains/definitions/cyber.ts`.

### Detailed summary
- Removed `testnet` tag for Cyber Mainnet chain in `cyber.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->