### PR TITLE
Remove constant declaration in account types generics

### DIFF
--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -43,7 +43,7 @@ export type CustomSource = {
       : Hash
   >
   signTypedData: <
-    const typedData extends TypedData | Record<string, unknown>,
+    typedData extends TypedData | Record<string, unknown>,
     primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
   >(
     typedDataDefinition: TypedDataDefinition<typedData, primaryType>,


### PR DESCRIPTION
LSP see the `const` as type variable

<img width="1052" alt="Screenshot 2567-04-26 at 13 46 02" src="https://github.com/wevm/viem/assets/73651621/859579ea-0934-4748-8f30-ae2b3a112f6a">

after remove `const` everything works perfectly
<img width="1026" alt="Screenshot 2567-04-26 at 13 46 08" src="https://github.com/wevm/viem/assets/73651621/bbdfaec4-2f6e-4928-bad0-85ab8d23d6a4">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `signTypedData` function in `types.ts` to allow `primaryType` to default to `'EIP712Domain'`.

### Detailed summary
- Updated `signTypedData` function to allow `primaryType` to default to `'EIP712Domain'` if not specified.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->