### PR TITLE
Update bitTorrentTestnet.ts

### DIFF
--- a/src/chains/definitions/bitTorrentTestnet.ts
+++ b/src/chains/definitions/bitTorrentTestnet.ts
@@ -1,13 +1,13 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const bitTorrentTestnet = /*#__PURE__*/ defineChain({
-  id: 1028,
+  id: 1029,
   name: 'BitTorrent Chain Testnet',
   network: 'bittorrent-chain-testnet',
   nativeCurrency: { name: 'BitTorrent', symbol: 'BTT', decimals: 18 },
   rpcUrls: {
-    default: { http: ['https://testrpc.bittorrentchain.io'] },
-    public: { http: ['https://testrpc.bittorrentchain.io'] },
+    default: { http: ['https://pre-rpc.bt.io'] },
+    public: { http: ['https://pre-rpc.bt.io'] },
   },
   blockExplorers: {
     default: {


### PR DESCRIPTION
Update new Bttc testnet rpc.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the BitTorrent Testnet configuration to use new RPC URLs.

### Detailed summary
- Updated BitTorrent Testnet ID to 1029
- Changed default and public RPC URLs to 'https://pre-rpc.bt.io'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->