### PR TITLE
fix: merge fetchOptions from HttpRpcClient options with request-specific options

### DIFF
--- a/.changeset/many-eagles-hang.md
+++ b/.changeset/many-eagles-hang.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `fetchOptions` declaration on HTTP RPC.

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -63,16 +63,21 @@ export function getHttpRpcClient(
     async request(params) {
       const {
         body,
-        fetchOptions = {},
         onRequest = options.onRequest,
         onResponse = options.onResponse,
         timeout = options.timeout ?? 10_000,
       } = params
+
+      const fetchOptions = {
+        ...(options.fetchOptions ?? {}),
+        ...(params.fetchOptions ?? {}),
+      }
+
       const {
         headers,
         method,
         signal: signal_,
-      } = { ...options.fetchOptions, ...fetchOptions }
+      } = fetchOptions
 
       try {
         const response = await withTimeout(


### PR DESCRIPTION
While integrating proxies in viem as per the recent [fix](https://github.com/wevm/viem/commit/581dc93fb5216ee910ac741af617f0c45edf582b), I noticed that the implementation was only considering request-specific `fetchOptions` and skipping those passed to the HTTP transport

This PR fixes it by merging the `fetchOptions` from the `HttpRpcClient` options with those from individual requests

For anyone facing this issue, you can use a temporary fix until the PR is merged:

1. Install [patch-package](https://www.npmjs.com/package/patch-package)
2. Add npm script `"postinstall": "patch-package"`
3. Open `node_modues/viem` and go to folder that corresponds to module systems currently being used (_esm, _cjs)
4. Edit `getHttpRpcClient` function from `utils/rpc/http.js`: add ` ...(options.fetchOptions || {}),` at the first line of `const init = {` object.
5. Run `npx patch-package viem`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the declaration of `fetchOptions` on HTTP RPC.

### Detailed summary
- Fixed `fetchOptions` declaration on HTTP RPC in `http.ts`
- Updated `fetchOptions` object merging logic to include both `options` and `params` properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->