### PR TITLE
Add support for .avax domains on Avalanche via ensUniversalResolver

### DIFF
--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -23,5 +23,8 @@ export const avalanche = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 11907934,
     },
+    ensUniversalresolver: {
+      address: '0x24DFa1455A75f64800BFdB2447958D2B632b94f6'
+    }
   },
 })

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -24,7 +24,7 @@ export const avalanche = /*#__PURE__*/ defineChain({
       blockCreated: 11907934,
     },
     ensUniversalresolver: {
-      address: '0x24DFa1455A75f64800BFdB2447958D2B632b94f6'
+      address: '0x24DFa1455A75f64800BFdB2447958D2B632b94f6',
     }
   },
 })

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -23,7 +23,7 @@ export const avalanche = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 11907934,
     },
-    ensUniversalresolver: {
+    ensUniversalResolver: {
       address: '0x24DFa1455A75f64800BFdB2447958D2B632b94f6',
     }
   },


### PR DESCRIPTION
Hello, this PR is on behalf of Avvy Domains (https://avvy.domains/) the primary naming service on Avalanche network.

This pull request updates the `avalanche` chain definition to point to our `ensUniversalResolver` compatibility contract, adding naming support to the default chain definition.

Happy to address any questions or concerns that may arise!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `ensUniversalResolver` object with its address to the Avalanche chain definitions.

### Detailed summary
- Added `ensUniversalResolver` object with address to Avalanche chain definitions in `avalanche.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->