### PR TITLE
Add ENS exports `packetToBytes` and `parseAvatarRecord`

### DIFF
--- a/.changeset/chatty-oranges-rest.md
+++ b/.changeset/chatty-oranges-rest.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported ENS-related utility functions `packetToBytes` and `parseAvatarRecord`.`

--- a/src/ens/index.ts
+++ b/src/ens/index.ts
@@ -31,3 +31,11 @@ export {
 } from '../actions/ens/getEnsText.js'
 export { type LabelhashErrorType, labelhash } from '../utils/ens/labelhash.js'
 export { type NamehashErrorType, namehash } from '../utils/ens/namehash.js'
+export {
+  parseAvatarRecord,
+  type ParseAvatarRecordErrorType,
+} from '../utils/ens/avatar/parseAvatarRecord.js'
+export {
+  packetToBytes,
+  type PacketToBytesErrorType,
+} from '../utils/ens/packetToBytes.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1058,17 +1058,8 @@ export type {
   StateMapping,
   StateOverride,
 } from './types/stateOverride.js'
-export { normalize, type NormalizeErrorType } from './utils/ens/normalize.js'
 export { labelhash, type LabelhashErrorType } from './utils/ens/labelhash.js'
 export { namehash, type NamehashErrorType } from './utils/ens/namehash.js'
-export {
-  packetToBytes,
-  type PacketToBytesErrorType,
-} from './utils/ens/packetToBytes.js'
-export {
-  parseAvatarRecord,
-  type ParseAvatarRecordErrorType,
-} from './utils/ens/avatar/parseAvatarRecord.js'
 export {
   type FormattedBlock,
   defineBlock,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1058,6 +1058,7 @@ export type {
   StateMapping,
   StateOverride,
 } from './types/stateOverride.js'
+export { normalize, type NormalizeErrorType } from './utils/ens/normalize.js'
 export { labelhash, type LabelhashErrorType } from './utils/ens/labelhash.js'
 export { namehash, type NamehashErrorType } from './utils/ens/namehash.js'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1061,6 +1061,14 @@ export type {
 export { labelhash, type LabelhashErrorType } from './utils/ens/labelhash.js'
 export { namehash, type NamehashErrorType } from './utils/ens/namehash.js'
 export {
+  packetToBytes,
+  type PacketToBytesErrorType,
+} from './utils/ens/packetToBytes.js'
+export {
+  parseAvatarRecord,
+  type ParseAvatarRecordErrorType,
+} from './utils/ens/avatar/parseAvatarRecord.js'
+export {
   type FormattedBlock,
   defineBlock,
   type DefineBlockErrorType,

--- a/src/utils/ens/avatar/parseAvatarRecord.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.ts
@@ -24,6 +24,16 @@ export type ParseAvatarRecordErrorType =
   | ParseAvatarUriErrorType
   | ErrorType
 
+/*
+ * @description Parses an ENS avatar record.
+ *
+ * @example
+ * parseAvatarRecord('eip155:1/erc1155:0xb32979486938aa9694bfc898f35dbed459f44424/10063')
+ * 'https://ipfs.io/ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif'
+ *
+ * @see https://docs.ens.domains/web/avatars
+ *
+ */
 export async function parseAvatarRecord<TChain extends Chain | undefined>(
   client: Client<Transport, TChain>,
   {

--- a/src/utils/ens/packetToBytes.ts
+++ b/src/utils/ens/packetToBytes.ts
@@ -19,6 +19,13 @@ export type PacketToBytesErrorType =
 
 /*
  * @description Encodes a DNS packet into a ByteArray containing a UDP payload.
+ *
+ * @example
+ * packetToBytes('awkweb.eth')
+ * '0x0661776b7765620365746800'
+ *
+ * @see https://docs.ens.domains/resolution/names#dns
+ *
  */
 export function packetToBytes(packet: string): ByteArray {
   // strip leading and trailing `.`


### PR DESCRIPTION
- [x] Add new exports `packetToBytes` and `parseAvatarRecord`
- [x] Slightly improved comments of `packetToBytes` and `parseAvatarRecord`
- [x] Added root export (`src/index.ts`) for `normalize` which was missing (don't know if this was intended)
- [x] Changeset

@jxom @tmm Also happy to add related documentation pages, but had the feeling it's good as it is as they are quite niche functions and have an already well documented behavior within the ENS docs (which are linked). :)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting ENS-related utility functions `packetToBytes` and `parseAvatarRecord`.

### Detailed summary
- Exported `packetToBytes` and `parseAvatarRecord` utility functions for ENS-related operations.
- Added `packetToBytes` function to encode a DNS packet into a ByteArray.
- Added `parseAvatarRecord` function to parse an ENS avatar record.
- Updated exports in `index.ts` to include the new utility functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->