### PR TITLE
Update celo.ts

### DIFF
--- a/.changeset/three-pants-relax.md
+++ b/.changeset/three-pants-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Celo explorer URL.

--- a/src/chains/definitions/celo.ts
+++ b/src/chains/definitions/celo.ts
@@ -16,8 +16,8 @@ export const celo = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Celo Explorer',
-      url: 'https://explorer.celo.org/mainnet',
-      apiUrl: 'https://explorer.celo.org/api',
+      url: 'https://celoscan.io',
+      apiUrl: 'https://api.celoscan.io/api',
     },
   },
   contracts: {


### PR DESCRIPTION
The old explorer no longer works.
celoscan is now the official explorer

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Celo explorer URL in the codebase.

### Detailed summary
- Updated Celo explorer URL in `src/chains/definitions/celo.ts` from `https://explorer.celo.org/mainnet` to `https://celoscan.io`.
- Updated Celo explorer API URL from `https://explorer.celo.org/api` to `https://api.celoscan.io/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->