### PR TITLE
fix: checksum contract address in logs formatter

### DIFF
--- a/src/utils/formatters/log.test.ts
+++ b/src/utils/formatters/log.test.ts
@@ -23,7 +23,7 @@ test('formats', () => {
     }),
   ).toMatchInlineSnapshot(`
     {
-      "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
       "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
       "blockNumber": 15131999n,
       "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
@@ -59,7 +59,7 @@ test('nullish values', () => {
     }),
   ).toMatchInlineSnapshot(`
     {
-      "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
       "blockHash": null,
       "blockNumber": null,
       "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",

--- a/src/utils/formatters/log.ts
+++ b/src/utils/formatters/log.ts
@@ -2,6 +2,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Log } from '../../types/log.js'
 import type { RpcLog } from '../../types/rpc.js'
 import type { ExactPartial } from '../../types/utils.js'
+import { getAddress } from '../index.js'
 
 export type FormatLogErrorType = ErrorType
 
@@ -14,6 +15,7 @@ export function formatLog(
 ) {
   return {
     ...log,
+    address: log.address ? getAddress(log.address) : null,
     blockHash: log.blockHash ? log.blockHash : null,
     blockNumber: log.blockNumber ? BigInt(log.blockNumber) : null,
     logIndex: log.logIndex ? Number(log.logIndex) : null,


### PR DESCRIPTION
the `address` field in the returned logs wasn't checksummed, this takes care of it and updates the tests.