### PR TITLE
Oasis Sapphire: update explorers

### DIFF
--- a/.changeset/old-onions-cover.md
+++ b/.changeset/old-onions-cover.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Sapphire and Sapphire Testnet chains.

--- a/src/chains/definitions/sapphire.ts
+++ b/src/chains/definitions/sapphire.ts
@@ -13,9 +13,13 @@ export const sapphire = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
+      name: 'Oasis Explorer',
+      url: 'https://explorer.oasis.io/mainnet/sapphire',
+    },
+    blockscout: {
       name: 'Oasis Sapphire Explorer',
-      url: 'https://explorer.sapphire.oasis.io',
-      apiUrl: 'https://explorer.sapphire.oasis.io/api',
+      url: 'https://old-explorer.sapphire.oasis.io',
+      apiUrl: 'https://old-explorer.sapphire.oasis.io/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/sapphireTestnet.ts
+++ b/src/chains/definitions/sapphireTestnet.ts
@@ -13,9 +13,13 @@ export const sapphireTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
+      name: 'Oasis Explorer',
+      url: 'https://explorer.oasis.io/testnet/sapphire',
+    },
+    blockscout: {
       name: 'Oasis Sapphire Testnet Explorer',
-      url: 'https://testnet.explorer.sapphire.oasis.dev',
-      apiUrl: 'https://testnet.explorer.sapphire.oasis.dev/api',
+      url: 'https://testnet.old-explorer.sapphire.oasis.dev',
+      apiUrl: 'https://testnet.old-explorer.sapphire.oasis.dev/api',
     },
   },
   testnet: true,


### PR DESCRIPTION
- the explorers listed are now at different URLs
- there's a new default explorer for both Sapphire and Sapphire Testnet
- the new explorers have an API (https://nexus.oasis.io/v1/spec/v1.html, https://testnet.nexus.oasis.io/v1/spec/v1.html) but they aren't compatible with blockscout, so we're not including them in the chain definition

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the block explorer URLs for the Sapphire and Sapphire Testnet chains.

### Detailed summary
- Updated Oasis Explorer URL for Sapphire chain.
- Updated Oasis Explorer URL for Sapphire Testnet chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->