### PR TITLE
Update mantle.ts

### DIFF
--- a/.changeset/swift-cooks-flow.md
+++ b/.changeset/swift-cooks-flow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Mantle block explorer.

--- a/src/chains/definitions/mantle.ts
+++ b/src/chains/definitions/mantle.ts
@@ -14,8 +14,8 @@ export const mantle = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Mantle Explorer',
-      url: 'https://explorer.mantle.xyz',
-      apiUrl: 'https://explorer.mantle.xyz/api',
+      url: 'https://mantlescan.xyz/',
+      apiUrl: 'https://api.mantlescan.xyz/api',
     },
   },
   contracts: {


### PR DESCRIPTION
The official explorer is now https://mantlescan.xyz

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Mantle block explorer URLs in the Swift Cooks Flow project.

### Detailed summary
- Updated Mantle block explorer URL to `https://mantlescan.xyz/`
- Updated Mantle block explorer API URL to `https://api.mantlescan.xyz/api`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->