### PR TITLE
Bump `isows` version for `react-native` support

### DIFF
--- a/.changeset/loud-phones-applaud.md
+++ b/.changeset/loud-phones-applaud.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated `isows`.

--- a/src/package.json
+++ b/src/package.json
@@ -117,7 +117,7 @@
     "@scure/bip32": "1.3.2",
     "@scure/bip39": "1.2.1",
     "abitype": "1.0.0",
-    "isows": "1.0.3",
+    "isows": "1.0.4",
     "ws": "8.13.0"
   },
   "license": "MIT",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `isows` package to version 1.0.4.

### Detailed summary
- Updated `isows` package version from 1.0.3 to 1.0.4.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->