### PR TITLE
Add Lisk

### DIFF
--- a/.changeset/silver-files-shave.md
+++ b/.changeset/silver-files-shave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Lisk mainnet

--- a/src/chains/definitions/lisk.ts
+++ b/src/chains/definitions/lisk.ts
@@ -1,0 +1,31 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
+
+export const lisk = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 1135,
+  name: 'Lisk',
+  network: 'lisk',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.api.lisk.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'https://blockscout.lisk.com',
+      apiUrl: 'https://blockscout.lisk.com/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xA9d71E1dd7ca26F26e656E66d6AA81ed7f745bf0',
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -129,6 +129,7 @@ export { lineaGoerli } from './definitions/lineaGoerli.js'
 export { lineaSepolia } from './definitions/lineaSepolia.js'
 /** @deprecated Use `lineaGoerli` instead. */
 export { lineaTestnet } from './definitions/lineaTestnet.js'
+export { lisk } from './definitions/lisk.js'
 export { liskSepolia } from './definitions/liskSepolia.js'
 export { localhost } from './definitions/localhost.js'
 export { lukso } from './definitions/lukso.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the Lisk mainnet to the project.

### Detailed summary
- Added Lisk mainnet to supported chains
- Deprecated `lineaTestnet`, use `lineaGoerli` instead
- Defined `lisk` chain with necessary configurations
- Updated `chains/index.ts` and `chains/definitions/lisk.ts` files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->