### PR TITLE
Update withdrawals.md

### DIFF
--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -591,7 +591,7 @@ export const walletClientL2 = createWalletClient({
 :::
 
 :::tip
-You can utilize the [`getTimeToFinalize`](/op-stack/actions/getTimeToFinalize) Action if you want to extract the estimated time left to prove the withdrawal from the `waitToFinalize` method and display it to the user or store in a database.
+You can utilize the [`getTimeToFinalize`](/op-stack/actions/getTimeToFinalize) Action if you want to extract the estimated time left to finalize the withdrawal from the `waitToFinalize` method and display it to the user or store in a database.
 
 ```ts
 const { seconds, timestamp } = await publicClientL1.getTimeToFinalize({

--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -602,7 +602,7 @@ const { seconds, timestamp } = await publicClientL1.getTimeToFinalize({
 :::
 
 :::warning
-If you aren't using the `waitToFinalize` Action, it is highly recommended to check if the withdrawal is ready to be proved by using the [`getWithdrawalStatus`](/op-stack/actions/getWithdrawalStatus) Action. This will prevent you from proving a withdrawal that isn't ready yet.
+If you aren't using the `waitToFinalize` Action, it is highly recommended to check if the withdrawal is ready to be finalized by using the [`getWithdrawalStatus`](/op-stack/actions/getWithdrawalStatus) Action. This will prevent you from finalizing a withdrawal that isn't ready yet.
 
 ```ts
 const status = await publicClientL1.getWithdrawalStatus({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the withdrawal guide page to use "finalize" instead of "prove" for consistency and clarity.

### Detailed summary
- Replaced "prove the withdrawal" with "finalize the withdrawal" for clarity and consistency.
- Updated comments to reflect the change in terminology.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->