### PR TITLE
Fixed typo inside migration-guide.mdx

### DIFF
--- a/site/pages/docs/migration-guide.mdx
+++ b/site/pages/docs/migration-guide.mdx
@@ -368,7 +368,7 @@ const hash = await walletClient.sendTransaction({
 
 ### `recoverAddress`, `recoverMessageAddress`, `verifyMessage` are now async
 
-he following functions are now `async` functions instead of synchronous functions:
+The following functions are now `async` functions instead of synchronous functions:
 
 - `recoverAddress`
 - `recoverMessageAddress`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates a typo in the `migration-guide.mdx` file.

### Detailed summary
```diff
- he following functions are now `async` functions instead of synchronous functions:
+ The following functions are now `async` functions instead of synchronous functions:
```
> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->