### PR TITLE
fix(chains): add zksync sepolia etherscan and native zksync explorers

### DIFF
--- a/.changeset/selfish-horses-happen.md
+++ b/.changeset/selfish-horses-happen.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Set zkSync Sepolia Etherscan as default explorer for zkSync Sepolia Testnet. Added `native` explorers for zkSync and zkSync Sepolia Testnet chains.
+Added `native` explorers for zkSync and zkSync Sepolia Testnet chains.

--- a/.changeset/selfish-horses-happen.md
+++ b/.changeset/selfish-horses-happen.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Set zkSync Sepolia Etherscan as default explorer for zkSync Sepolia Testnet. Added `native` explorers for zkSync and zkSync Sepolia Testnet chains.

--- a/src/chains/definitions/zkSync.ts
+++ b/src/chains/definitions/zkSync.ts
@@ -23,6 +23,10 @@ export const zkSync = /*#__PURE__*/ defineChain({
       url: 'https://era.zksync.network/',
       apiUrl: 'https://api-era.zksync.network/api',
     },
+    native: {
+      name: 'zkSync Explorer',
+      url: 'https://explorer.zksync.io/',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/zkSyncSepoliaTestnet.ts
+++ b/src/chains/definitions/zkSyncSepoliaTestnet.ts
@@ -15,7 +15,11 @@ export const zkSyncSepoliaTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'zkExplorer',
+      name: 'Etherscan',
+      url: 'https://sepolia-era.zksync.network/',
+    },
+    native: {
+      name: 'zkSync Explorer',
       url: 'https://sepolia.explorer.zksync.io/',
     },
   },


### PR DESCRIPTION
- Set zkSync Etherscan explorer as default one for consistency with zkSync Mainnet.
- Add `native` zkSync Explorers for zkSync Mainnet and zkSync Sepolia Testnet. It might be useful when viewing zkSync specific stuff is needed (paymasters for example).

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add native explorers for zkSync and zkSync Sepolia Testnet chains.

### Detailed summary
- Added native explorer for zkSync chain
- Added native explorer for zkSync Sepolia Testnet chain
- Updated explorer names and URLs for better clarity and consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->