### PR TITLE
fix(siwe): createSiweMessage domain validation

### DIFF
--- a/.changeset/chatty-flies-tan.md
+++ b/.changeset/chatty-flies-tan.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `createSiweMessage` `domain` validation.

--- a/src/utils/siwe/createSiweMessage.test.ts
+++ b/src/utils/siwe/createSiweMessage.test.ts
@@ -332,3 +332,37 @@ test('behavior: invalid resources', () => {
     Version: viem@1.0.2]
   `)
 })
+
+test.each([
+  'example.com',
+  'localhost',
+  '127.0.0.1',
+  'example.com:3000',
+  'localhost:3000',
+  '127.0.0.1:3000',
+])('valid domain `%s`', (domain) => {
+  expect(
+    createSiweMessage({
+      ...message,
+      domain,
+    }),
+  ).toBeTypeOf('string')
+})
+
+test.each([
+  'http://example.com',
+  'http://localhost',
+  'http://127.0.0.1',
+  'http://example.com:3000',
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+  'foobarbaz',
+  '-example.com',
+])('invalid domain `%s`', (domain) => {
+  expect(() =>
+    createSiweMessage({
+      ...message,
+      domain,
+    }),
+  ).toThrowError()
+})

--- a/src/utils/siwe/createSiweMessage.ts
+++ b/src/utils/siwe/createSiweMessage.ts
@@ -61,7 +61,13 @@ export function createSiweMessage(
           `Provided value: ${chainId}`,
         ],
       })
-    if (!domainRegex.test(domain))
+    if (
+      !(
+        domainRegex.test(domain) ||
+        ipRegex.test(domain) ||
+        localhostRegex.test(domain)
+      )
+    )
       throw new SiweInvalidMessageFieldError({
         field: 'domain',
         metaMessages: [
@@ -163,6 +169,10 @@ export function createSiweMessage(
   return `${prefix}\n${suffix}`
 }
 
-const domainRegex = /^(?:(?:(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63})$/
+const domainRegex =
+  /^([a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9])\.[a-zA-Z]{2,}(:[0-9]{1,5})?$/
+const ipRegex =
+  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:[0-9]{1,5})?$/
+const localhostRegex = /^localhost(:[0-9]{1,5})?$/
 const nonceRegex = /^[a-zA-Z0-9]{8,}$/
 const schemeRegex = /^([a-zA-Z][a-zA-Z0-9+-.]*)$/


### PR DESCRIPTION
Domain validation was overly restrictive.

Fixes #2295 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing `createSiweMessage` `domain` validation by adding tests for valid and invalid domains and updating the regex patterns.

### Detailed summary
- Added tests for valid and invalid domains in `createSiweMessage.test.ts`
- Updated `createSiweMessage` to validate domains using new regex patterns
- Added `ipRegex` and `localhostRegex` for domain validation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->