### PR TITLE
fix: resolves #2294

### DIFF
--- a/.changeset/new-news-deny.md
+++ b/.changeset/new-news-deny.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `isAddress` cache.

--- a/src/utils/address/isAddress.ts
+++ b/src/utils/address/isAddress.ts
@@ -23,8 +23,9 @@ export function isAddress(
   options?: IsAddressOptions | undefined,
 ): address is Address {
   const { strict = true } = options ?? {}
+  const cacheKey = `${address}.${strict}`
 
-  if (isAddressCache.has(address)) return isAddressCache.get(address)!
+  if (isAddressCache.has(cacheKey)) return isAddressCache.get(cacheKey)!
 
   const result = (() => {
     if (!addressRegex.test(address)) return false
@@ -32,6 +33,6 @@ export function isAddress(
     if (strict) return checksumAddress(address as Address) === address
     return true
   })()
-  isAddressCache.set(address, result)
+  isAddressCache.set(cacheKey, result)
   return result
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the `isAddress` cache issue in the `isAddress` function in the `src/utils/address/isAddress.ts` file.

### Detailed summary
- Updated cache key to include `strict` parameter for accurate caching.
- Improved cache retrieval logic to use the updated cache key.
- Ensured correct caching behavior for `isAddress` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->