### PR TITLE
fix: parsing SIWE message containing domain with port

### DIFF
--- a/.changeset/shaggy-onions-check.md
+++ b/.changeset/shaggy-onions-check.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed parsing SIWE message containing domain with port

--- a/src/utils/siwe/parseSiweMessage.test.ts
+++ b/src/utils/siwe/parseSiweMessage.test.ts
@@ -41,6 +41,19 @@ Issued At: 2023-02-01T00:00:00.000Z`
   expect(parsed.scheme).toMatchInlineSnapshot(`"https"`)
 })
 
+test('behavior: domain with port', () => {
+  const message = `example.com:8080 wants you to sign in with your Ethereum account:
+0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+URI: https://example.com/path
+Version: 1
+Chain ID: 1
+Nonce: foobarbaz
+Issued At: 2023-02-01T00:00:00.000Z`
+  const parsed = parseSiweMessage(message)
+  expect(parsed.domain).toMatchInlineSnapshot('example.com:8080')
+})
+
 test('behavior: with statement', () => {
   const message = `example.com wants you to sign in with your Ethereum account:
 0xA0Cf798816D4b9b9866b5330EEa46a18382f251e

--- a/src/utils/siwe/parseSiweMessage.ts
+++ b/src/utils/siwe/parseSiweMessage.ts
@@ -48,7 +48,7 @@ export function parseSiweMessage(
 
 // https://regexr.com/80gdj
 const prefixRegex =
-  /^(?:(?<scheme>[a-zA-Z][a-zA-Z0-9+-.]*):\/\/)?(?<domain>[a-zA-Z0-9+-.]*) (?:wants you to sign in with your Ethereum account:\n)(?<address>0x[a-fA-F0-9]{40})\n\n(?:(?<statement>.*)\n\n)?/
+  /^(?:(?<scheme>[a-zA-Z][a-zA-Z0-9+-.]*):\/\/)?(?<domain>[a-zA-Z0-9+-.]*(?::[0-9]{1,5})?) (?:wants you to sign in with your Ethereum account:\n)(?<address>0x[a-fA-F0-9]{40})\n\n(?:(?<statement>.*)\n\n)?/
 
 // https://regexr.com/80gf9
 const suffixRegex =


### PR DESCRIPTION
Fixes parsing of SIWE message where the domain contains a port e.g. `example.com:8080`
This resolves #2302 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the parsing of SIWE messages containing domains with ports. 

### Detailed summary
- Updated regex to support domains with ports in SIWE messages
- Added test case for parsing messages with domains including ports

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->