### PR TITLE
fix: remove trailing slash from polygonAmoy explorer URL

### DIFF
--- a/.changeset/thin-mirrors-ring.md
+++ b/.changeset/thin-mirrors-ring.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed trailing slash from polygonAmoy explorer URL.

--- a/src/chains/definitions/polygonAmoy.ts
+++ b/src/chains/definitions/polygonAmoy.ts
@@ -12,7 +12,7 @@ export const polygonAmoy = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'PolygonScan',
-      url: 'https://amoy.polygonscan.com/',
+      url: 'https://amoy.polygonscan.com',
       apiUrl: 'https://api-amoy.polygonscan.com/api',
     },
   },


### PR DESCRIPTION
This pull request addresses an inconsistency in the polygonAmoy explorer URL. Currently, the URL has a trailing slash at the end. This trailing slash is not necessary and can potentially cause issues in some cases.

This PR removes the trailing slash from the polygonAmoy explorer URL to ensure consistency and avoid potential problems.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove the trailing slash from the `polygonAmoy` explorer URL.

### Detailed summary
- Removed trailing slash from `polygonAmoy` explorer URL in `polygonAmoy.ts` definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->