### PR TITLE
fix(types): payable value inference ts value

### DIFF
--- a/.changeset/rich-drinks-grin.md
+++ b/.changeset/rich-drinks-grin.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed type inference for payable `value` property.

--- a/src/actions/public/simulateContract.test-d.ts
+++ b/src/actions/public/simulateContract.test-d.ts
@@ -1,7 +1,7 @@
 import { parseAbi } from 'abitype'
 import { assertType, expectTypeOf, test } from 'vitest'
 
-import { wagmiContractConfig } from '~test/src/abis.js'
+import { baycContractConfig, wagmiContractConfig } from '~test/src/abis.js'
 
 import { anvilMainnet } from '../../../test/src/anvil.js'
 import { celo } from '../../chains/definitions/celo.js'
@@ -65,6 +65,34 @@ test('args: account - with client account, with account arg', async () => {
       type: 'json-rpc'
     }
   }>()
+})
+
+test('args: value', () => {
+  // payable function
+  simulateContract(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+    value: 5n,
+  })
+
+  // payable function (undefined)
+  simulateContract(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+  })
+
+  // nonpayable function
+  simulateContract(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'approve',
+    // @ts-expect-error
+    value: 5n,
+  })
 })
 
 test('args: legacy txn', () => {

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -23,7 +23,7 @@ import type {
   IsNarrowable,
   IsUnion,
   MaybeRequired,
-  NoUndefined,
+  NoInfer,
   Prettify,
   UnionToTuple,
 } from './utils.js'
@@ -309,10 +309,10 @@ export type GetValue<
   _Narrowable extends boolean = IsNarrowable<TAbi, Abi>,
 > = _Narrowable extends true
   ? TAbiFunction['stateMutability'] extends 'payable'
-    ? { value?: NoUndefined<TValueType> | undefined }
+    ? { value?: NoInfer<TValueType> | undefined }
     : TAbiFunction['payable'] extends true
-      ? { value?: NoUndefined<TValueType> | undefined }
-      : { value?: never | undefined }
+      ? { value?: NoInfer<TValueType> | undefined }
+      : { value?: undefined }
   : { value?: TValueType | undefined }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -145,6 +145,9 @@ export type NeverBy<T, K extends keyof T> = {
   [U in keyof T]: U extends K ? never : T[U]
 }
 
+// TODO: Remove when peer dep `typescript@>=4.5` (NoInfer is native)
+export type NoInfer<type> = [type][type extends any ? 0 : never]
+
 /**
  * @description Constructs a type by excluding `undefined` from `T`.
  *


### PR DESCRIPTION
Upstream issue in `wagmi` and `@wagmi/vue` with payable `value` property.

https://github.com/wevm/wagmi/pull/3984

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves type inference for the `value` property in contracts and updates test cases for `simulateContract`.

### Detailed summary
- Fixed type inference for `value` property in contracts
- Added `NoInfer` type utility
- Updated test cases for `simulateContract` with `value` property

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->