### PR TITLE
feat(experimental): ERC-7115

### DIFF
--- a/.changeset/many-hairs-bow.md
+++ b/.changeset/many-hairs-bow.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+**Experimental:** Added ERC-7115 extension.

--- a/site/pages/experimental/erc7115/issuePermissions.mdx
+++ b/site/pages/experimental/erc7115/issuePermissions.mdx
@@ -1,0 +1,171 @@
+---
+description: Request permissions from a wallet to perform actions on behalf of a user.
+---
+
+# issuePermissions
+
+Request permissions from a wallet to perform actions on behalf of a user.
+
+[Read more.](https://eips.ethereum.org/EIPS/eip-7115)
+
+:::warning[Warning]
+This is an experimental action that is not supported in most wallets. It is recommended to have a fallback mechanism if using this in production.
+:::
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const result = await walletClient.issuePermissions({ // [!code focus:99]
+  account,
+  expiry: 1716846083638,
+  permissions: [
+    {
+      type: 'native-token-limit',
+      data: {
+        amount: parseEther('0.5'),
+      },
+      required: true,
+    },
+  ],
+})
+```
+
+```ts twoslash [config.ts] filename="config.ts"
+import 'viem/window'
+// ---cut---
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+import { walletActionsErc7115 } from 'viem/experimental'
+
+export const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum!),
+}).extend(walletActionsErc7115())
+
+export const [account] = await walletClient.getAddresses()
+```
+
+:::
+
+## Returns
+
+`IssuePermissionsReturnType`
+
+Response from the wallet after issuing permissions.
+
+## Parameters
+
+### account
+
+- **Type:** `Account | Address | undefined`
+
+The Account to scope the permissions to.
+
+```ts twoslash
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const result = await walletClient.issuePermissions({
+  account, // [!code focus]
+  expiry: 1716846083638,
+  permissions: [
+    {
+      type: 'native-token-limit',
+      data: {
+        amount: parseEther('0.5'),
+      },
+      required: true,
+    },
+  ],
+})
+```
+
+### expiry
+
+- **Type:** `number`
+
+The timestamp (in seconds) when the permissions will expire.
+
+```ts twoslash
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const result = await walletClient.issuePermissions({
+  account,
+  expiry: 1716846083638, // [!code focus]
+  permissions: [
+    {
+      type: 'native-token-limit',
+      data: {
+        amount: parseEther('0.5'),
+      },
+      required: true,
+    },
+  ],
+})
+```
+
+### permissions
+
+- **Type:** `Permission[]`
+
+Set of permissions to grant to the user.
+
+```ts twoslash
+// @noErrors
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const result = await walletClient.issuePermissions({
+  account,
+  expiry: 1716846083638,
+  permissions: [ // [!code focus:99]
+    { 
+      type: 'native-token-limit', 
+      data: { 
+        amount: parseEther('0.5'), 
+      }, 
+      required: true, 
+    }, 
+    { 
+      type: '  
+//           ^| 
+    } 
+  ], 
+})
+``` 
+
+### signer
+
+- **Type:** `Signer | undefined`
+
+Custom signer type to scope the permissions to.
+
+```ts twoslash
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const result = await walletClient.issuePermissions({
+  expiry: 1716846083638,
+  permissions: [ 
+    { 
+      type: 'native-token-limit', 
+      data: { 
+        amount: parseEther('0.5'), 
+      }, 
+      required: true, 
+    }, 
+  ], 
+  signer: { // [!code focus]
+    type: 'key', // [!code focus]
+    data: { // [!code focus]
+      id: '...' // [!code focus]
+    } // [!code focus]
+  } // [!code focus]
+})
+``` 

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1097,6 +1097,20 @@ export const sidebar = {
           },
         ],
       },
+      {
+        text: 'ERC-7115',
+        items: [
+          {
+            text: 'Actions',
+            items: [
+              {
+                text: 'issuePermissions',
+                link: '/experimental/erc7115/issuePermissions',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   '/op-stack': {

--- a/src/experimental/erc7115/actions/issuePermissions.test.ts
+++ b/src/experimental/erc7115/actions/issuePermissions.test.ts
@@ -1,0 +1,275 @@
+import { expect, test } from 'vitest'
+import { accounts } from '../../../../test/src/constants.js'
+import { privateKeyToAccount } from '../../../accounts/privateKeyToAccount.js'
+import { createClient } from '../../../clients/createClient.js'
+import { custom } from '../../../clients/transports/custom.js'
+import { issuePermissions } from './issuePermissions.js'
+
+const getClient = ({ onRequest }: { onRequest: (params: any) => void }) =>
+  createClient({
+    transport: custom({
+      async request({ method, params }) {
+        onRequest(params)
+        if (method === 'wallet_issuePermissions')
+          return {
+            grantedPermissions: params[0].permissions.map(
+              (permission: any) => ({
+                type: permission.type,
+                data: permission.data,
+              }),
+            ),
+            expiry: params[0].expiry,
+            permissionsContext: '0xdeadbeef',
+          }
+        return null
+      },
+    }),
+  })
+
+test('default', async () => {
+  const requests: any[] = []
+  const client = getClient({
+    onRequest(request) {
+      requests.push(request)
+    },
+  })
+
+  expect(
+    await issuePermissions(client, {
+      expiry: 1716846083638,
+      signer: {
+        type: 'account',
+        data: {
+          id: '0x0000000000000000000000000000000000000000',
+        },
+      },
+      permissions: [
+        {
+          type: 'contract-call',
+          data: {
+            address: '0x0000000000000000000000000000000000000000',
+          },
+        },
+        {
+          type: 'native-token-limit',
+          data: {
+            amount: 69420n,
+          },
+          required: true,
+        },
+      ],
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "expiry": 1716846083638,
+      "grantedPermissions": [
+        {
+          "data": {
+            "address": "0x0000000000000000000000000000000000000000",
+          },
+          "type": "contract-call",
+        },
+        {
+          "data": {
+            "amount": 69420n,
+          },
+          "type": "native-token-limit",
+        },
+      ],
+      "permissionsContext": "0xdeadbeef",
+    }
+  `)
+  expect(requests).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "expiry": 1716846083638,
+          "permissions": [
+            {
+              "data": {
+                "address": "0x0000000000000000000000000000000000000000",
+              },
+              "required": false,
+              "type": "contract-call",
+            },
+            {
+              "data": {
+                "amount": "0x10f2c",
+              },
+              "required": true,
+              "type": "native-token-limit",
+            },
+          ],
+          "signer": {
+            "data": {
+              "id": "0x0000000000000000000000000000000000000000",
+            },
+            "type": "account",
+          },
+        },
+      ],
+    ]
+  `)
+})
+
+test('args: account as signer', async () => {
+  const requests: any[] = []
+  const client = getClient({
+    onRequest(request) {
+      requests.push(request)
+    },
+  })
+
+  expect(
+    await issuePermissions(client, {
+      account: privateKeyToAccount(accounts[0].privateKey),
+      expiry: 1716846083638,
+      permissions: [
+        {
+          type: 'contract-call',
+          data: {
+            address: '0x0000000000000000000000000000000000000000',
+          },
+        },
+        {
+          type: 'native-token-limit',
+          data: {
+            amount: 69420n,
+          },
+          required: true,
+        },
+      ],
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "expiry": 1716846083638,
+      "grantedPermissions": [
+        {
+          "data": {
+            "address": "0x0000000000000000000000000000000000000000",
+          },
+          "type": "contract-call",
+        },
+        {
+          "data": {
+            "amount": 69420n,
+          },
+          "type": "native-token-limit",
+        },
+      ],
+      "permissionsContext": "0xdeadbeef",
+    }
+  `)
+  expect(requests).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "expiry": 1716846083638,
+          "permissions": [
+            {
+              "data": {
+                "address": "0x0000000000000000000000000000000000000000",
+              },
+              "required": false,
+              "type": "contract-call",
+            },
+            {
+              "data": {
+                "amount": "0x10f2c",
+              },
+              "required": true,
+              "type": "native-token-limit",
+            },
+          ],
+          "signer": {
+            "data": {
+              "id": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            },
+            "type": "account",
+          },
+        },
+      ],
+    ]
+  `)
+})
+
+test('args: address as signer', async () => {
+  const requests: any[] = []
+  const client = getClient({
+    onRequest(request) {
+      requests.push(request)
+    },
+  })
+
+  expect(
+    await issuePermissions(client, {
+      account: accounts[0].address,
+      expiry: 1716846083638,
+      permissions: [
+        {
+          type: 'contract-call',
+          data: {
+            address: '0x0000000000000000000000000000000000000000',
+          },
+        },
+        {
+          type: 'native-token-limit',
+          data: {
+            amount: 69420n,
+          },
+          required: true,
+        },
+      ],
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "expiry": 1716846083638,
+      "grantedPermissions": [
+        {
+          "data": {
+            "address": "0x0000000000000000000000000000000000000000",
+          },
+          "type": "contract-call",
+        },
+        {
+          "data": {
+            "amount": 69420n,
+          },
+          "type": "native-token-limit",
+        },
+      ],
+      "permissionsContext": "0xdeadbeef",
+    }
+  `)
+  expect(requests).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "expiry": 1716846083638,
+          "permissions": [
+            {
+              "data": {
+                "address": "0x0000000000000000000000000000000000000000",
+              },
+              "required": false,
+              "type": "contract-call",
+            },
+            {
+              "data": {
+                "amount": "0x10f2c",
+              },
+              "required": true,
+              "type": "native-token-limit",
+            },
+          ],
+          "signer": {
+            "data": {
+              "id": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            },
+            "type": "account",
+          },
+        },
+      ],
+    ]
+  `)
+})

--- a/src/experimental/erc7115/actions/issuePermissions.ts
+++ b/src/experimental/erc7115/actions/issuePermissions.ts
@@ -1,0 +1,161 @@
+import type { Address } from 'abitype'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { Account } from '../../../types/account.js'
+import type { WalletIssuePermissionsReturnType } from '../../../types/eip1193.js'
+import type { Hex } from '../../../types/misc.js'
+import type { OneOf } from '../../../types/utils.js'
+import { numberToHex } from '../../../utils/encoding/toHex.js'
+import type { Permission } from '../types/permission.js'
+import type { Signer } from '../types/signer.js'
+
+export type IssuePermissionsParameters = {
+  /** Timestamp (in seconds) that specifies the time by which this session MUST expire. */
+  expiry: number
+  /** Set of permissions to grant to the user. */
+  permissions: readonly Permission[]
+} & OneOf<
+  | {
+      /** Signer to assign the permissions to. */
+      signer?: Signer | undefined
+    }
+  | {
+      /** Account to assign the permissions to. */
+      account?: Address | Account | undefined
+    }
+>
+
+export type IssuePermissionsReturnType = {
+  /** Timestamp (in seconds) that specifies the time by which this session MUST expire. */
+  expiry: number
+  /** ERC-4337 Factory to deploy smart contract account. */
+  factory?: Hex | undefined
+  /** Calldata to use when calling the ERC-4337 Factory. */
+  factoryData?: string | undefined
+  /** Set of granted permissions. */
+  grantedPermissions: Omit<Permission, 'required'>[]
+  /** Permissions identifier. */
+  permissionsContext: string
+  /** Signer attached to the permissions. */
+  signerData?:
+    | {
+        userOpBuilder?: Hex | undefined
+        submitToAddress?: Hex | undefined
+      }
+    | undefined
+}
+
+/**
+ * Request permissions from a wallet to perform actions on behalf of a user.
+ *
+ * - Docs: https://viem.sh/experimental/erc7115/issuePermissions
+ *
+ * @example
+ * import { createWalletClient, custom } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ * import { issuePermissions } from 'viem/experimental'
+ *
+ * const client = createWalletClient({
+ *   chain: mainnet,
+ *   transport: custom(window.ethereum),
+ * })
+ *
+ * const result = await issuePermissions(client, {
+ *   expiry: 1716846083638,
+ *   permissions: [
+ *     {
+ *       type: 'contract-call',
+ *       data: {
+ *         address: '0x0000000000000000000000000000000000000000',
+ *       },
+ *     },
+ *     {
+ *       type: 'native-token-limit',
+ *       data: {
+ *         amount: 69420n,
+ *       },
+ *       required: true,
+ *     },
+ *   ],
+ * })
+ */
+export async function issuePermissions(
+  client: Client<Transport>,
+  parameters: IssuePermissionsParameters,
+): Promise<IssuePermissionsReturnType> {
+  const { expiry, permissions, signer } = parameters
+  const result = await client.request({
+    method: 'wallet_issuePermissions',
+    params: [parseParameters({ expiry, permissions, signer })],
+  })
+  return parseResult(result) as IssuePermissionsReturnType
+}
+
+function parseParameters(parameters: IssuePermissionsParameters) {
+  const { account, expiry, permissions, signer: signer_ } = parameters
+
+  const signer = (() => {
+    if (!account && !signer_) return undefined
+
+    if (account) {
+      // Address as signer.
+      if (typeof account === 'string')
+        return {
+          type: 'account',
+          data: {
+            id: account,
+          },
+        }
+
+      // Viem Account as signer.
+      return {
+        type: 'account',
+        data: {
+          id: account.address,
+        },
+      }
+    }
+
+    // ERC-7115 Signer as signer.
+    return signer_
+  })()
+
+  return {
+    expiry,
+    permissions: permissions.map((permission) => ({
+      ...permission,
+      ...(permission.data && typeof permission.data === 'object'
+        ? {
+            data: {
+              ...permission.data,
+              ...('amount' in permission.data &&
+              typeof permission.data.amount === 'bigint'
+                ? { amount: numberToHex(permission.data.amount) }
+                : {}),
+            },
+          }
+        : {}),
+      required: permission.required ?? false,
+    })),
+    ...(signer ? { signer } : {}),
+  }
+}
+
+function parseResult(result: WalletIssuePermissionsReturnType) {
+  return {
+    expiry: result.expiry,
+    ...(result.factory ? { factory: result.factory } : {}),
+    ...(result.factoryData ? { factoryData: result.factoryData } : {}),
+    grantedPermissions: result.grantedPermissions.map((permission) => ({
+      ...permission,
+      data: {
+        ...permission.data,
+        ...('amount' in permission.data
+          ? { amount: BigInt(permission.data.amount) }
+          : {}),
+      },
+    })),
+    permissionsContext: result.permissionsContext,
+    ...(result.signerData ? { signerData: result.signerData } : {}),
+  }
+}

--- a/src/experimental/erc7115/decorators/erc7115.test.ts
+++ b/src/experimental/erc7115/decorators/erc7115.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+
+import { createClient } from '../../../clients/createClient.js'
+import { custom } from '../../../clients/transports/custom.js'
+import { walletActionsErc7115 } from './erc7115.js'
+
+const client = createClient({
+  transport: custom({
+    async request({ method, params }) {
+      if (method === 'wallet_issuePermissions')
+        return {
+          grantedPermissions: params[0].permissions.map((permission: any) => ({
+            type: permission.type,
+            data: permission.data,
+          })),
+          expiry: params[0].expiry,
+          permissionsContext: '0xdeadbeef',
+        }
+
+      return null
+    },
+  }),
+}).extend(walletActionsErc7115())
+
+test('default', async () => {
+  expect(walletActionsErc7115()(client)).toMatchInlineSnapshot(`
+    {
+      "issuePermissions": [Function],
+    }
+  `)
+})
+
+describe('smoke test', () => {
+  test('issuePermissions', async () => {
+    expect(
+      await client.issuePermissions({
+        expiry: 1716846083638,
+        signer: {
+          type: 'account',
+          data: {
+            id: '0x0000000000000000000000000000000000000000',
+          },
+        },
+        permissions: [
+          {
+            type: 'contract-call',
+            data: {
+              address: '0x0000000000000000000000000000000000000000',
+            },
+          },
+          {
+            type: 'native-token-limit',
+            data: {
+              amount: 69420n,
+            },
+            required: true,
+          },
+        ],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "expiry": 1716846083638,
+        "grantedPermissions": [
+          {
+            "data": {
+              "address": "0x0000000000000000000000000000000000000000",
+            },
+            "type": "contract-call",
+          },
+          {
+            "data": {
+              "amount": 69420n,
+            },
+            "type": "native-token-limit",
+          },
+        ],
+        "permissionsContext": "0xdeadbeef",
+      }
+    `)
+  })
+})

--- a/src/experimental/erc7115/decorators/erc7115.ts
+++ b/src/experimental/erc7115/decorators/erc7115.ts
@@ -1,0 +1,80 @@
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { Account } from '../../../types/account.js'
+import type { Chain } from '../../../types/chain.js'
+import {
+  type IssuePermissionsParameters,
+  type IssuePermissionsReturnType,
+  issuePermissions,
+} from '../actions/issuePermissions.js'
+
+export type WalletActionsErc7115 = {
+  /**
+   * Request permissions from a wallet to perform actions on behalf of a user.
+   *
+   * - Docs: https://viem.sh/experimental/erc7115/issuePermissions
+   *
+   * @example
+   * import { createWalletClient, custom } from 'viem'
+   * import { mainnet } from 'viem/chains'
+   * import { walletActionsErc7115 } from 'viem/experimental'
+   *
+   * const client = createWalletClient({
+   *   chain: mainnet,
+   *   transport: custom(window.ethereum),
+   * }).extend(walletActionsErc7115())
+   *
+   * const result = await client.issuePermissions({
+   *   expiry: 1716846083638,
+   *   permissions: [
+   *     {
+   *       type: 'contract-call',
+   *       data: {
+   *         address: '0x0000000000000000000000000000000000000000',
+   *       },
+   *     },
+   *     {
+   *       type: 'native-token-limit',
+   *       data: {
+   *         amount: 69420n,
+   *       },
+   *       required: true,
+   *     },
+   *   ],
+   * })
+   */
+  issuePermissions: (
+    parameters: IssuePermissionsParameters,
+  ) => Promise<IssuePermissionsReturnType>
+}
+
+/**
+ * A suite of ERC-7115 Wallet Actions.
+ *
+ * - Docs: https://viem.sh/experimental
+ *
+ * @example
+ * import { createPublicClient, createWalletClient, http } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ * import { walletActionsErc7115 } from 'viem/experimental'
+ *
+ * const walletClient = createWalletClient({
+ *   chain: mainnet,
+ *   transport: http(),
+ * }).extend(walletActionsErc7115())
+ *
+ * const result = await walletClient.issuePermissions({...})
+ */
+export function walletActionsErc7115() {
+  return <
+    transport extends Transport,
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  >(
+    client: Client<transport, chain, account>,
+  ): WalletActionsErc7115 => {
+    return {
+      issuePermissions: (parameters) => issuePermissions(client, parameters),
+    }
+  }
+}

--- a/src/experimental/erc7115/types/permission.ts
+++ b/src/experimental/erc7115/types/permission.ts
@@ -1,0 +1,46 @@
+import type { Address } from 'abitype'
+
+import type { OneOf } from '../../../types/utils.js'
+
+export type NativeTokenLimitPermission<amount = bigint> = {
+  type: 'native-token-limit'
+  data: {
+    amount: amount
+  }
+}
+
+export type Erc20LimitPermission<amount = bigint> = {
+  type: 'erc20-limit'
+  data: {
+    erc20Address: Address
+    amount: amount
+  }
+}
+
+export type GasLimitPermission<amount = bigint> = {
+  type: 'gas-limit'
+  data: {
+    amount: amount
+  }
+}
+
+export type ContractCallPermission = {
+  type: 'contract-call'
+  data: unknown
+}
+
+export type RateLimitPermission = {
+  type: 'rate-limit'
+  data: {
+    count: number
+    interval: number
+  }
+}
+
+export type Permission<amount = bigint> = OneOf<
+  | NativeTokenLimitPermission<amount>
+  | Erc20LimitPermission<amount>
+  | GasLimitPermission<amount>
+  | ContractCallPermission
+  | RateLimitPermission
+> & { required?: boolean | undefined }

--- a/src/experimental/erc7115/types/signer.ts
+++ b/src/experimental/erc7115/types/signer.ts
@@ -1,0 +1,25 @@
+import type { Address } from 'abitype'
+import type { OneOf } from '../../../types/utils.js'
+
+export type AccountSigner = {
+  type: 'account'
+  data: {
+    id: Address
+  }
+}
+
+export type KeySigner = {
+  type: 'key'
+  data: {
+    id: string
+  }
+}
+
+export type MultiKeySigner = {
+  type: 'keys'
+  data: {
+    ids: string[]
+  }
+}
+
+export type Signer = OneOf<AccountSigner | KeySigner | MultiKeySigner>

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -52,3 +52,13 @@ export {
   type SerializeErc6492SignatureReturnType,
   serializeErc6492Signature,
 } from './erc6492/serializeErc6492Signature.js'
+
+export {
+  type IssuePermissionsParameters,
+  type IssuePermissionsReturnType,
+  issuePermissions,
+} from './erc7115/actions/issuePermissions.js'
+export {
+  type WalletActionsErc7115,
+  walletActionsErc7115,
+} from './erc7115/decorators/erc7115.js'

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -131,6 +131,38 @@ export type WalletCallReceipt<quantity = Hex, status = Hex> = {
   transactionHash: Hex
 }
 
+export type WalletIssuePermissionsParameters = {
+  signer?:
+    | {
+        type: string
+        data: unknown
+      }
+    | undefined
+  permissions: readonly {
+    type: string
+    data: unknown
+    required: boolean
+  }[]
+  expiry: number
+}
+
+export type WalletIssuePermissionsReturnType = {
+  expiry: number
+  factory?: `0x${string}` | undefined
+  factoryData?: string | undefined
+  grantedPermissions: readonly {
+    type: string
+    data: any
+  }[]
+  permissionsContext: string
+  signerData?:
+    | {
+        userOpBuilder?: `0x${string}` | undefined
+        submitToAddress?: `0x${string}` | undefined
+      }
+    | undefined
+}
+
 export type WalletGetCallsStatusReturnType<quantity = Hex, status = Hex> = {
   status: 'PENDING' | 'CONFIRMED'
   receipts?: WalletCallReceipt<quantity, status>[] | undefined
@@ -1367,6 +1399,18 @@ export type WalletRpcSchema = [
     Method: 'wallet_getPermissions'
     Parameters?: undefined
     ReturnType: WalletPermission[]
+  },
+  /**
+   * @description Requests permissions from a wallet
+   * @link https://eips.ethereum.org/EIPS/eip-7715
+   * @example
+   * provider.request({ method: 'wallet_issuePermissions', params: [{ ... }] })
+   * // => { ... }
+   */
+  {
+    Method: 'wallet_issuePermissions'
+    Parameters?: [WalletIssuePermissionsParameters]
+    ReturnType: Prettify<WalletIssuePermissionsReturnType>
   },
   /**
    * @description Requests the given permissions from the user.


### PR DESCRIPTION
Adding experimental ERC-7115 extension.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an ERC-7115 extension with `issuePermissions` functionality for requesting wallet permissions.

### Detailed summary
- Added ERC-7115 extension with `issuePermissions` feature
- Defined various signer types and permission types
- Implemented `issuePermissions` logic in tests
- Updated documentation and examples for `issuePermissions`

> The following files were skipped due to too many changes: `src/experimental/erc7115/actions/issuePermissions.ts`, `src/experimental/erc7115/actions/issuePermissions.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->