### PR TITLE
Export DecodeFunctionDataReturnType

### DIFF
--- a/.changeset/warm-radios-glow.md
+++ b/.changeset/warm-radios-glow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+export DecodeFunctionDataReturnType to type decoded function data

--- a/.changeset/warm-radios-glow.md
+++ b/.changeset/warm-radios-glow.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-export DecodeFunctionDataReturnType to type decoded function data
+Exported `DecodeFunctionDataReturnType` type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1097,6 +1097,7 @@ export {
 export {
   type DecodeFunctionDataErrorType,
   type DecodeFunctionDataParameters,
+  type DecodeFunctionDataReturnType,
   decodeFunctionData,
 } from './utils/abi/decodeFunctionData.js'
 export {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,6 +86,7 @@ export {
 export {
   type DecodeFunctionDataErrorType,
   type DecodeFunctionDataParameters,
+  type DecodeFunctionDataReturnType,
   decodeFunctionData,
 } from './abi/decodeFunctionData.js'
 export {


### PR DESCRIPTION
### Description

Export DecodeFunctionDataReturnType so we can use it to type decoded function data in our code

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to export the `DecodeFunctionDataReturnType` type in two files: `src/index.ts` and `.changeset/warm-radios-glow.md`.

### Detailed summary
- Exported `DecodeFunctionDataReturnType` type in `src/index.ts` and `.changeset/warm-radios-glow.md`.


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->