### PR TITLE
Update to Use Snowtrace as Default Block Explorer

### DIFF
--- a/.changeset/tidy-toes-scream.md
+++ b/.changeset/tidy-toes-scream.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Avalanche explorer URLs.

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -15,7 +15,7 @@ export const avalanche = /*#__PURE__*/ defineChain({
     default: {
       name: 'SnowTrace',
       url: 'https://snowtrace.io/',
-      apiUrl: 'https://api.routescan.io/',
+      apiUrl: 'https://api.snowtrace.io/',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -14,8 +14,8 @@ export const avalanche = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'SnowTrace',
-      url: 'https://snowtrace.io/',
-      apiUrl: 'https://api.snowtrace.io/',
+      url: 'https://snowtrace.io',
+      apiUrl: 'https://api.snowtrace.io',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -13,9 +13,9 @@ export const avalanche = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'SnowScan',
-      url: 'https://snowscan.xyz',
-      apiUrl: 'https://api.snowscan.xyz/api',
+      name: 'SnowTrace',
+      url: 'https://snowtrace.io/',
+      apiUrl: 'https://api.routescan.io/',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -15,7 +15,7 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
     default: {
       name: 'SnowTrace',
       url: 'https://testnet.snowtrace.io/',
-      apiUrl: 'https://api.routescan.io/', //https://api.routescan.io/v2/network/testnet/..
+      apiUrl: 'https://api.snowtrace.io/', //https://api.snowtrace.io/v2/network/testnet/..
     },
   },
   contracts: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -15,7 +15,7 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
     default: {
       name: 'SnowTrace',
       url: 'https://testnet.snowtrace.io/',
-      apiUrl: 'https://api.snowtrace.io/', //https://api.snowtrace.io/v2/network/testnet/..
+      apiUrl: 'https://api-testnet.snowtrace.io',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -13,9 +13,9 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'SnowScan',
-      url: 'https://testnet.snowscan.xyz',
-      apiUrl: 'https://api-testnet.snowscan.xyz',
+      name: 'SnowTrace',
+      url: 'https://testnet.snowtrace.io/',
+      apiUrl: 'https://api.routescan.io/', //https://api.routescan.io/v2/network/testnet/..
     },
   },
   contracts: {

--- a/src/chains/definitions/avalancheFuji.ts
+++ b/src/chains/definitions/avalancheFuji.ts
@@ -14,7 +14,7 @@ export const avalancheFuji = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'SnowTrace',
-      url: 'https://testnet.snowtrace.io/',
+      url: 'https://testnet.snowtrace.io',
       apiUrl: 'https://api-testnet.snowtrace.io',
     },
   },


### PR DESCRIPTION
### Description

According to the [Avalanche documentation](https://docs.avax.network/build/dapp/launch-dapp), Snowtrace and testnet-snowtrace are the officially recommended block explorers for the Avalanche network. This change ensures that our users are directed to the most reliable and feature-rich explorer available.

Snowtrace has a significantly higher number of verified contracts compared to Snowscan, providing more reliable and secure information for users. For example, on May 27, 75 contracts were verified on snowtrace.io compared to 12 on snowscan.xyz. You can observe the differences in the number of verified contracts:
- [Snowtrace verified contracts](https://snowtrace.io/chart?id=verified-contracts&metrics=ecosystem%3Aavalanche%3AVerified+Contracts%3A%23ef9b20%3Aday%3Alinear%3Aline%3Avisible%3Ay1%2Cchain%3A43114%3AVerified+Contracts%3A%2327aeef%3Aday%3Alogarithmic%3Acolumn%3Avisible%3Ay1&zoom=1week)
- [Snowscan verified contracts](https://snowscan.xyz/contractsVerified)

Same case for testnet-snowtrace For example, on May 27, 44 contracts were verified on testnet.snowtrace.io compared to 0 on testnet.snowscan.xyz You can observe the differences in the number of verified contracts:
- [Testnet - Snowtrace verified contracts](https://testnet.snowtrace.io/chart?id=verified-contracts&metrics=chain%3A43113%3AVerified+Contracts%3A%2327aeef%3Aday%3Alogarithmic%3Acolumn%3Avisible%3Ay1&zoom=1week)
- [Testnet - Snowscan verified contracts](https://testnet.snowscan.xyz/contractsVerified)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Avalanche explorer URLs to `SnowTrace` for both mainnet and testnet.

### Detailed summary
- Updated mainnet Avalanche explorer URLs to `SnowTrace`
- Updated testnet Avalanche explorer URLs to `SnowTrace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->