### PR TITLE
Zetachain Network Updation

### DIFF
--- a/src/chains/definitions/zetachain.ts
+++ b/src/chains/definitions/zetachain.ts
@@ -1,23 +1,20 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
-export const zetachain = /*#__PURE__*/ defineChain({
+export const zetachain = /*#__PURE__*/defineChain({
   id: 7000,
-  name: 'ZetaChain',
-  nativeCurrency: {
-    decimals: 18,
-    name: 'Zeta',
-    symbol: 'ZETA',
-  },
+  name: "Zetachain Mainnet",
+  iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
+  nativeCurrency: { name: "Zetachain", symbol: "ZETA", decimals: 18 },
   rpcUrls: {
-    default: {
-      http: ['https://zetachain-evm.blockpi.network/v1/rpc/public'],
-    },
+    default: { http: ["https://zetachain-evm.blockpi.network/v1/rpc/public"] },
   },
   blockExplorers: {
-    default: {
-      name: 'ZetaScan',
-      url: 'https://explorer.zetachain.com',
+    default: { name: "zetachain", url: "https://explorer.zetachain.com/" },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 14353601,
     },
   },
-  testnet: false,
 })

--- a/src/chains/definitions/zetachain.ts
+++ b/src/chains/definitions/zetachain.ts
@@ -3,7 +3,6 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const zetachain = /*#__PURE__*/defineChain({
   id: 7000,
   name: "ZetaChain Mainnet",
-  iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
   nativeCurrency: { name: "ZetaChain", symbol: "ZETA", decimals: 18 },
   rpcUrls: {
     default: { http: ["https://zetachain-evm.blockpi.network/v1/rpc/public"] },

--- a/src/chains/definitions/zetachain.ts
+++ b/src/chains/definitions/zetachain.ts
@@ -2,14 +2,14 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const zetachain = /*#__PURE__*/defineChain({
   id: 7000,
-  name: "Zetachain Mainnet",
+  name: "ZetaChain Mainnet",
   iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
-  nativeCurrency: { name: "Zetachain", symbol: "ZETA", decimals: 18 },
+  nativeCurrency: { name: "ZetaChain", symbol: "ZETA", decimals: 18 },
   rpcUrls: {
     default: { http: ["https://zetachain-evm.blockpi.network/v1/rpc/public"] },
   },
   blockExplorers: {
-    default: { name: "zetachain", url: "https://explorer.zetachain.com/" },
+    default: { name: "ZetaScan", url: "https://explorer.zetachain.com/" },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -2,22 +2,29 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
   id: 7001,
-  name: 'ZetaChain Athens Testnet',
+  name: "Zetachain Athens 3 Testnet",
+  testnet:true,
+  iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
   nativeCurrency: {
+    name: "ZetaChain Athens 3 Testnet",
+    symbol: "ZETA",
     decimals: 18,
-    name: 'Zeta',
-    symbol: 'aZETA',
   },
   rpcUrls: {
     default: {
-      http: ['https://zetachain-athens-evm.blockpi.network/v1/rpc/public'],
+      http: ["https://zetachain-athens-evm.blockpi.network/v1/rpc/public"],
     },
   },
   blockExplorers: {
     default: {
-      name: 'ZetaScan',
-      url: 'https://athens.explorer.zetachain.com',
+      name: "zetachain",
+      url: "https://athens.explorer.zetachain.com/",
     },
   },
-  testnet: true,
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 14353601,
+    },
+  },
 })

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -6,7 +6,7 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
   testnet:true,
   iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
   nativeCurrency: {
-    name: "ZetaChain Athens 3 Testnet",
+    name: "ZetaChain Testnet",
     symbol: "ZETA",
     decimals: 18,
   },
@@ -17,7 +17,7 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: "zetachain",
+      name: "ZetaScan",
       url: "https://athens.explorer.zetachain.com/",
     },
   },

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -4,7 +4,6 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
   id: 7001,
   name: "Zetachain Athens 3 Testnet",
   testnet:true,
-  iconUrl: "https://s2.coinmarketcap.com/static/img/coins/64x64/21259.png",
   nativeCurrency: {
     name: "ZetaChain Testnet",
     symbol: "ZETA",


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
This PR aims to refresh the network details of ZetaChain for both its mainnet and testnet environments. The update is likely intended to ensure Wagmi, a tool or platform that interacts with blockchain networks, has accurate information about ZetaChain. With this updated data, users of Wagmi would be able to seamlessly interact with ZetaChain through Wagmi's functionalities.
<br/>
<img width="785" alt="Screenshot 2024-06-04 at 3 58 01 PM" src="https://github.com/wevm/viem/assets/82640789/92f73227-6e61-4b63-9c40-0806e0f9c99f">

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update chain definitions for Zetachain Athens Testnet and Zetachain Mainnet.

### Detailed summary
- Updated chain name and native currency for Zetachain Athens Testnet
- Added testnet flag for Zetachain Athens Testnet
- Updated RPC URL and block explorer URL for Zetachain Athens Testnet
- Added contracts information for Zetachain Athens Testnet
- Updated chain name for Zetachain Mainnet
- Updated native currency for Zetachain Mainnet
- Updated RPC URL and block explorer URL for Zetachain Mainnet
- Added contracts information for Zetachain Mainnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->