### PR TITLE
fix: Jsdoc signUnsignedTx copy pasta

### DIFF
--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -24,9 +24,9 @@ export type SendUnsignedTransactionReturnType = Hash
 export type SendUnsignedTransactionErrorType = RequestErrorType | ErrorType
 
 /**
- * Returns the details of all transactions currently pending for inclusion in the next block(s), as well as the ones that are being scheduled for future execution only.
+ * Executes a transaction regardless of the signature.
  *
- * - Docs: https://viem.sh/docs/actions/test/getTxpoolContent
+ * - Docs: https://viem.sh/docs/actions/test/sendUnsignedTransaction#sendunsignedtransaction
  *
  * @param client - Client to use
  * @param parameters – {@link SendUnsignedTransactionParameters}


### PR DESCRIPTION
Jsdoc had copy pasta

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the functionality of sending transactions by allowing execution without a signature.

### Detailed summary
- Renamed function to `sendUnsignedTransaction`
- Updated function description and documentation link

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->