### PR TITLE
fix: encodeDeployData type should accept no constructor

### DIFF
--- a/.changeset/itchy-frogs-doubt.md
+++ b/.changeset/itchy-frogs-doubt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated type of encodeDeployData to accept no constructor and no arguments

--- a/.changeset/itchy-frogs-doubt.md
+++ b/.changeset/itchy-frogs-doubt.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated type of encodeDeployData to accept no constructor and no arguments
+Updated `EncodeDeployDataParameters` type.

--- a/src/utils/abi/encodeDeployData.test-d.ts
+++ b/src/utils/abi/encodeDeployData.test-d.ts
@@ -73,9 +73,25 @@ test('no const assertion', () => {
   })
 })
 
-test('abi has no constructor', () => {
-  // @ts-expect-error abi has no constructor
+test('abi has no constructor and no args', () => {
   encodeDeployData({
+    bytecode: '0x420',
+    abi: [
+      {
+        inputs: [],
+        name: 'Foo',
+        outputs: [],
+        type: 'error',
+      },
+    ],
+  })
+})
+
+test('abi has no constructor and includes args', () => {
+  encodeDeployData({
+    bytecode: '0x420',
+    // @ts-expect-error
+    args: [123n],
     abi: [
       {
         inputs: [],

--- a/src/utils/abi/encodeDeployData.ts
+++ b/src/utils/abi/encodeDeployData.ts
@@ -32,11 +32,12 @@ export type EncodeDeployDataParameters<
   abi: abi
   bytecode: Hex
 } & UnionEvaluate<
-  readonly [] extends allArgs
-    ? { args?: allArgs | undefined }
-    : { args: allArgs }
-> &
-  (hasConstructor extends true ? unknown : never)
+  hasConstructor extends false
+    ? { args?: undefined }
+    : readonly [] extends allArgs
+      ? { args?: allArgs | undefined }
+      : { args: allArgs }
+>
 
 export type EncodeDeployDataReturnType = Hex
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Some contracts do not have a constructor and should be allowed by the typesystem.
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `EncodeDeployDataParameters` type and refactors the `encodeDeployData` function to handle cases when ABI has no constructor.

### Detailed summary
- Updated `EncodeDeployDataParameters` type
- Refactored `encodeDeployData` function to handle ABI with no constructor and optional args

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->