### PR TITLE
feat: Add support for changing baseUrl in errors

### DIFF
--- a/.changeset/shaggy-crabs-push.md
+++ b/.changeset/shaggy-crabs-push.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for changing baseUrl in BaseError so third party libraries can keep consistency in errors

--- a/.changeset/shaggy-crabs-push.md
+++ b/.changeset/shaggy-crabs-push.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added support for changing baseUrl in BaseError so third party libraries can keep consistency in errors
+Added `docsBaseUrl` to `BaseError`.

--- a/src/errors/base.test.ts
+++ b/src/errors/base.test.ts
@@ -75,6 +75,23 @@ test('BaseError (w/ docsPath)', () => {
   `)
 })
 
+test('BaseError (w/ docsBaseUrl)', () => {
+  expect(
+    new BaseError('An error occurred.', {
+      docsBaseUrl: 'https://test',
+      details: 'details',
+      docsPath: '/lol',
+      docsSlug: 'test',
+    }),
+  ).toMatchInlineSnapshot(`
+    [ViemError: An error occurred.
+
+    Docs: https://test/lol#test
+    Details: details
+    Version: viem@1.0.2]
+  `)
+})
+
 test('BaseError (w/ metaMessages)', () => {
   expect(
     new BaseError('An error occurred.', {
@@ -85,7 +102,7 @@ test('BaseError (w/ metaMessages)', () => {
     [ViemError: An error occurred.
 
     Reason: idk
-    Cause: lol
+      Cause: lol
 
     Details: details
     Version: viem@1.0.2]
@@ -103,7 +120,7 @@ test('inherited BaseError', () => {
     }),
   ).toMatchInlineSnapshot(`
     [ViemError: An internal error occurred.
-
+    
     Docs: https://viem.sh/lol
     Details: details
     Version: viem@1.0.2]
@@ -119,7 +136,7 @@ test('inherited Error', () => {
     }),
   ).toMatchInlineSnapshot(`
     [ViemError: An internal error occurred.
-
+    
     Docs: https://viem.sh/lol
     Details: details
     Version: viem@1.0.2]

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -1,6 +1,7 @@
 import { getVersion } from './utils.js'
 
 type BaseErrorParameters = {
+  docsBaseUrl?: string | undefined
   docsPath?: string | undefined
   docsSlug?: string | undefined
   metaMessages?: string[] | undefined
@@ -45,7 +46,7 @@ export class BaseError extends Error {
       ...(args.metaMessages ? [...args.metaMessages, ''] : []),
       ...(docsPath
         ? [
-            `Docs: https://viem.sh${docsPath}${
+            `Docs: ${args.docsBaseUrl ?? 'https://viem.sh'}${docsPath}${
               args.docsSlug ? `#${args.docsSlug}` : ''
             }`,
           ]


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
In order to create consistency in errors experience, I am looking to use baseUrl. The only blocker is the baseUrl is hardcoded to viem.  This pr makes baseUrl configurable.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `docsBaseUrl` property to `BaseError` in the `errors` module for dynamic documentation URL generation.

### Detailed summary
- Added `docsBaseUrl` property to `BaseError`
- Updated `BaseErrorParameters` type to include `docsBaseUrl`
- Modified `BaseError` constructor to use `docsBaseUrl` for documentation URL
- Added test cases for `BaseError` with `docsBaseUrl` and `metaMessages`
- Ensured inline snapshots reflect changes in `docsBaseUrl` usage

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->