### PR TITLE
docs(isAddress.md): add options.strict option to the isAddress docs

### DIFF
--- a/site/pages/docs/utilities/isAddress.md
+++ b/site/pages/docs/utilities/isAddress.md
@@ -1,10 +1,10 @@
 ---
-description: Checks if the address is valid.
+description: Checks if the address is valid. By default, it also verifies whether the address is in checksum format.
 ---
 
 # isAddress
 
-Checks if the address is valid.
+Checks if the address is valid. By default, it also verifies whether the address is in checksum format.
 
 ## Import
 
@@ -17,7 +17,7 @@ import { isAddress } from 'viem'
 ```ts
 import { isAddress } from 'viem'
 
-isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac') // [!code focus:2]
+isAddress('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC') // [!code focus:2]
 // true
 ```
 
@@ -25,7 +25,7 @@ isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac') // [!code focus:2]
 
 `boolean`
 
-Whether or not the address is valid.
+Whether or not the address is valid. By default, it also verifies whether the address is in checksum format.
 
 ## Parameters
 
@@ -34,3 +34,21 @@ Whether or not the address is valid.
 - **Type:** `string`
 
 An Ethereum address.
+
+### options.strict (optional)
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Enables strict mode. If enabled, it also verifies whether the address is in checksum format.
+
+```ts
+isAddress('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac', { strict: false })
+// true
+
+isAddress('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac', { strict: true })
+// false
+
+isAddress('lol', { strict: false })
+// false
+```

--- a/site/pages/docs/utilities/isAddress.md
+++ b/site/pages/docs/utilities/isAddress.md
@@ -1,5 +1,5 @@
 ---
-description: Checks if the address is valid. By default, it also verifies whether the address is in checksum format.
+description: Checks if the address is valid.
 ---
 
 # isAddress
@@ -25,7 +25,7 @@ isAddress('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC') // [!code focus:2]
 
 `boolean`
 
-Whether or not the address is valid. By default, it also verifies whether the address is in checksum format.
+Whether or not the address is valid.
 
 ## Parameters
 


### PR DESCRIPTION
Update the `isAddress` docs:
1) the example in current version of documentation of:
```
isAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac')
// true
```
^was not correct, as the address is not in correct checksum format, so it would actually return `false` and not `true` as it says.

2) There was no mention that by default the `isAddress` also checks if the address is in checksum format. I've added this into the docs, as it tripped me out a few times already and I think this behavior should be highlighted.

3) There was no mention of second `options.strict` parameter, I've added it.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `isAddress` utility function by adding an optional `strict` parameter to verify checksum format.

### Detailed summary
- Added optional `strict` parameter to `isAddress` function
- `strict` parameter verifies if the address is in checksum format
- Updated documentation to reflect new functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->