### PR TITLE
feat: Berachain bArtio 80084

### DIFF
--- a/src/chains/definitions/berachainTestnetbArtio.ts
+++ b/src/chains/definitions/berachainTestnetbArtio.ts
@@ -1,0 +1,21 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const berachainTestnetbArtio = /*#__PURE__*/ defineChain({
+  id: 80084,
+  name: 'Berachain bArtio',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'BERA Token',
+    symbol: 'BERA',
+  },
+  rpcUrls: {
+    default: { http: ['https://bartio.rpc.berachain.com'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Berachain bArtio Beratrail',
+      url: 'https://bartio.beratrail.io',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Berachain's Latest V2 bArtio Network

BREAKING CHANGE: No

This is adding Berachain's latest V2 network called bArtio - https://blog.berachain.com/blog/berachain-v2-an-explanation-of-the-changes-how-it-affects-pol-dynamics-and-why-its-an-important-next-step



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new chain definition for `Berachain bArtio` on testnet.

### Detailed summary
- Added `berachainTestnetbArtio` chain definition
- Chain ID: 80084
- Native currency: BERA Token
- RPC URL: https://bartio.rpc.berachain.com
- Block explorer: https://bartio.beratrail.io

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->