### PR TITLE
dev: update kakarot sepolia chain id

### DIFF
--- a/.changeset/khaki-lizards-admire.md
+++ b/.changeset/khaki-lizards-admire.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated `kakarotSepolia` chain id.

--- a/src/chains/definitions/kakarotSepolia.ts
+++ b/src/chains/definitions/kakarotSepolia.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const kakarotSepolia = /*#__PURE__*/ defineChain({
-  id: 107107114116,
+  id: 1802203764,
   name: 'Kakarot Sepolia',
   nativeCurrency: {
     name: 'Ether',


### PR DESCRIPTION
The Kakarot Sepolia chain ID as of now is **1802203764** and the change has already been merged on [ethereum-lists/chains](https://github.com/ethereum-lists/chains/blob/d6ca7d03e818fd0855cb47ae2836888b3fe46be1/_data/chains/eip155-1802203764.json#L4)

This PR corrects the chain id on viem as well, which will make it possible for people to use Viem with Kakarot Sepolia.

Thanks 🥕

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `kakarotSepolia` chain id in the `kakarotSepolia.ts` file.

### Detailed summary
- Updated `kakarotSepolia` chain id from 107107114116 to 1802203764.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->