### PR TITLE
ci: enable old ts versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: ['5.3.3', '5.4.5']
+        version: ['5.0.4', '5.1.6', '5.2.2', '5.3.3', '5.4.5']
 
     steps:
       - name: Clone repository
@@ -84,6 +84,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Bench types
+        if: matrix.version != '5.0.4'
         run: pnpm typebench
 
       # Redundant with `pnpm typecheck`

--- a/src/actions/public/estimateContractGas.test-d.ts
+++ b/src/actions/public/estimateContractGas.test-d.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 
-import { wagmiContractConfig } from '~test/src/abis.js'
+import { baycContractConfig, wagmiContractConfig } from '~test/src/abis.js'
 import { accounts } from '~test/src/constants.js'
 import { anvilMainnet } from '../../../test/src/anvil.js'
 
@@ -129,5 +129,33 @@ test('eip2930', () => {
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
     type: 'eip2930',
+  })
+})
+
+test('args: value', () => {
+  // payable function
+  estimateContractGas(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+    value: 5n,
+  })
+
+  // payable function (undefined)
+  estimateContractGas(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+  })
+
+  // nonpayable function
+  estimateContractGas(clientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'approve',
+    // @ts-expect-error
+    value: 5n,
   })
 })

--- a/src/celo/formatters.test-d.ts
+++ b/src/celo/formatters.test-d.ts
@@ -158,8 +158,6 @@ describe('smoke', () => {
 
     prepareTransactionRequest(client, {
       feeCurrency: '0x',
-      gatewayFee: 0n,
-      gatewayFeeRecipient: '0x',
     })
 
     // @ts-expect-error `gasPrice` is not defined
@@ -179,8 +177,6 @@ describe('smoke', () => {
 
     sendTransaction(client, {
       feeCurrency: '0x',
-      gatewayFee: 0n,
-      gatewayFeeRecipient: '0x',
     })
   })
 
@@ -193,8 +189,6 @@ describe('smoke', () => {
 
     signTransaction(client, {
       feeCurrency: '0x',
-      gatewayFee: 0n,
-      gatewayFeeRecipient: '0x',
     })
   })
 
@@ -207,8 +201,6 @@ describe('smoke', () => {
     sendTransaction(client, {
       chain: celo,
       feeCurrency: '0x',
-      gatewayFee: 0n,
-      gatewayFeeRecipient: '0x',
     })
   })
 })

--- a/src/celo/formatters.ts
+++ b/src/celo/formatters.ts
@@ -72,9 +72,7 @@ export const formatters = {
         feeCurrency: args.feeCurrency,
       } as CeloRpcTransactionRequest
 
-      if (isCIP64(args)) {
-        request.type = '0x7b'
-      }
+      if (isCIP64(args)) request.type = '0x7b'
 
       return request
     },

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -1838,7 +1838,7 @@ export function publicActions<
     getTransactionReceipt: (args) => getTransactionReceipt(client, args),
     multicall: (args) => multicall(client, args),
     prepareTransactionRequest: (args) =>
-      prepareTransactionRequest(client as any, args as any),
+      prepareTransactionRequest(client as any, args as any) as any,
     readContract: (args) => readContract(client, args),
     sendRawTransaction: (args) => sendRawTransaction(client, args),
     simulateContract: (args) => simulateContract(client, args),

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -703,7 +703,7 @@ export function walletActions<
     getChainId: () => getChainId(client),
     getPermissions: () => getPermissions(client),
     prepareTransactionRequest: (args) =>
-      prepareTransactionRequest(client as any, args as any),
+      prepareTransactionRequest(client as any, args as any) as any,
     requestAddresses: () => requestAddresses(client),
     requestPermissions: (args) => requestPermissions(client, args),
     sendRawTransaction: (args) => sendRawTransaction(client, args),

--- a/src/op-stack/actions/estimateFinalizeWithdrawalGas.ts
+++ b/src/op-stack/actions/estimateFinalizeWithdrawalGas.ts
@@ -41,7 +41,7 @@ export type EstimateFinalizeWithdrawalGasParameters<
   GetChainParameter<chain, chainOverride> &
   GetContractAddressParameter<_derivedChain, 'portal'> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null | undefined
+    gas?: bigint | undefined
     withdrawal: Withdrawal
   }
 export type EstimateFinalizeWithdrawalGasReturnType = bigint
@@ -103,16 +103,23 @@ export async function estimateFinalizeWithdrawalGas<
     return Object.values(targetChain!.contracts.portal)[0].address
   })()
 
-  return estimateContractGas(client, {
+  const params = {
     account,
     abi: portalAbi,
     address: portalAddress,
-    chain,
     functionName: 'finalizeWithdrawalTransaction',
     args: [withdrawal],
     gas,
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
-  } as EstimateContractGasParameters)
+    // TODO: Not sure `chain` is necessary since it's not used downstream
+    // in `estimateContractGas` or `estimateGas`
+    // @ts-ignore
+    chain,
+  } satisfies EstimateContractGasParameters<
+    typeof portalAbi,
+    'finalizeWithdrawalTransaction'
+  >
+  return estimateContractGas(client, params as any)
 }

--- a/src/op-stack/actions/estimateInitiateWithdrawalGas.ts
+++ b/src/op-stack/actions/estimateInitiateWithdrawalGas.ts
@@ -40,7 +40,7 @@ export type EstimateInitiateWithdrawalGasParameters<
   GetAccountParameter<account, Account | Address> &
   GetChainParameter<chain, chainOverride> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null | undefined
+    gas?: bigint | undefined
     /**
      * Withdrawal request.
      * Supplied to the L2ToL1MessagePasser `initiateWithdrawal` method.
@@ -102,11 +102,10 @@ export async function estimateInitiateWithdrawalGas<
     request: { data = '0x', gas: l1Gas, to, value },
   } = parameters
 
-  return estimateContractGas(client, {
+  const params = {
     account,
     abi: l2ToL1MessagePasserAbi,
     address: contracts.l2ToL1MessagePasser.address,
-    chain,
     functionName: 'initiateWithdrawal',
     args: [to, l1Gas, data],
     gas,
@@ -114,5 +113,13 @@ export async function estimateInitiateWithdrawalGas<
     maxPriorityFeePerGas,
     nonce,
     value,
-  } as EstimateContractGasParameters)
+    // TODO: Not sure `chain` is necessary since it's not used downstream
+    // in `estimateContractGas` or `estimateGas`
+    // @ts-ignore
+    chain,
+  } satisfies EstimateContractGasParameters<
+    typeof l2ToL1MessagePasserAbi,
+    'initiateWithdrawal'
+  >
+  return estimateContractGas(client, params as any)
 }

--- a/src/op-stack/actions/estimateProveWithdrawalGas.ts
+++ b/src/op-stack/actions/estimateProveWithdrawalGas.ts
@@ -41,7 +41,7 @@ export type EstimateProveWithdrawalGasParameters<
   GetChainParameter<chain, chainOverride> &
   GetContractAddressParameter<_derivedChain, 'portal'> & {
     /** Gas limit for transaction execution on the L2. */
-    gas?: bigint | null | undefined
+    gas?: bigint | undefined
     l2OutputIndex: bigint
     outputRootProof: {
       version: Hex
@@ -124,16 +124,23 @@ export async function estimateProveWithdrawalGas<
     return Object.values(targetChain!.contracts.portal)[0].address
   })()
 
-  return estimateContractGas(client, {
+  const params = {
     account,
     abi: portalAbi,
     address: portalAddress,
-    chain,
     functionName: 'proveWithdrawalTransaction',
     args: [withdrawal, l2OutputIndex, outputRootProof, withdrawalProof],
     gas,
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
-  } as EstimateContractGasParameters)
+    // TODO: Not sure `chain` is necessary since it's not used downstream
+    // in `estimateContractGas` or `estimateGas`
+    // @ts-ignore
+    chain,
+  } satisfies EstimateContractGasParameters<
+    typeof portalAbi,
+    'proveWithdrawalTransaction'
+  >
+  return estimateContractGas(client, params as any)
 }

--- a/src/types/chain.test-d.ts
+++ b/src/types/chain.test-d.ts
@@ -59,6 +59,15 @@ test('ExtractChainFormatterParameters', () => {
   expectTypeOf<Result3['feeCurrency']>().toEqualTypeOf<
     `0x${string}` | undefined
   >()
+
+  type Result4 = ExtractChainFormatterParameters<
+    typeof celo,
+    'transaction',
+    TransactionRequest
+  >
+  expectTypeOf<Result4['gatewayFee']>().toEqualTypeOf<
+    `0x${string}` | null | undefined
+  >()
 })
 
 test('GetChainParameter', () => {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -180,9 +180,9 @@ export type ChainEstimateFeesPerGasFnParameters<
 export type ExtractChainFormatterExclude<
   chain extends Chain | undefined,
   type extends keyof ChainFormatters,
-> = chain extends { formatters?: infer _Formatters extends ChainFormatters }
-  ? _Formatters[type] extends { exclude: infer Exclude }
-    ? Extract<Exclude, string[]>[number]
+> = chain extends { formatters?: infer formatters extends ChainFormatters }
+  ? formatters[type] extends { exclude: infer exclude }
+    ? Extract<exclude, string[]>[number]
     : ''
   : ''
 
@@ -190,9 +190,9 @@ export type ExtractChainFormatterParameters<
   chain extends Chain | undefined,
   type extends keyof ChainFormatters,
   fallback,
-> = chain extends { formatters?: infer _Formatters extends ChainFormatters }
-  ? _Formatters[type] extends ChainFormatter
-    ? Parameters<_Formatters[type]['format']>[0]
+> = chain extends { formatters?: infer formatters extends ChainFormatters }
+  ? formatters[type] extends ChainFormatter
+    ? Parameters<formatters[type]['format']>[0]
     : fallback
   : fallback
 

--- a/src/zksync/actions/sendTransaction.ts
+++ b/src/zksync/actions/sendTransaction.ts
@@ -1,25 +1,33 @@
 import type { Account } from '../../accounts/types.js'
-import { sendTransaction as sendTransaction_ } from '../../actions/wallet/sendTransaction.js'
+import { sendTransaction as core_sendTransaction } from '../../actions/wallet/sendTransaction.js'
 import type {
-  SendTransactionErrorType as SendTransactionErrorType_,
-  SendTransactionParameters as SendTransactionParameters_,
-  SendTransactionReturnType as SendTransactionReturnType_,
+  SendTransactionRequest,
+  SendTransactionErrorType as core_SendTransactionErrorType,
+  SendTransactionParameters as core_SendTransactionParameters,
+  SendTransactionReturnType as core_SendTransactionReturnType,
 } from '../../actions/wallet/sendTransaction.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import type { ChainEIP712 } from '../types/chain.js'
 import { isEIP712Transaction } from '../utils/isEip712Transaction.js'
-import { sendEip712Transaction } from './sendEip712Transaction.js'
+import {
+  type SendEip712TransactionParameters,
+  sendEip712Transaction,
+} from './sendEip712Transaction.js'
 
 export type SendTransactionParameters<
-  TChain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
-  TAccount extends Account | undefined = Account | undefined,
-  TChainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
-> = SendTransactionParameters_<TChain, TAccount, TChainOverride>
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  request extends SendTransactionRequest<
+    chain,
+    chainOverride
+  > = SendTransactionRequest<chain, chainOverride>,
+> = core_SendTransactionParameters<chain, account, chainOverride, request>
 
-export type SendTransactionReturnType = SendTransactionReturnType_
+export type SendTransactionReturnType = core_SendTransactionReturnType
 
-export type SendTransactionErrorType = SendTransactionErrorType_
+export type SendTransactionErrorType = core_SendTransactionErrorType
 
 /**
  * Creates, signs, and sends a new transaction to the network.
@@ -66,13 +74,21 @@ export type SendTransactionErrorType = SendTransactionErrorType_
  * })
  */
 export async function sendTransaction<
-  TChain extends ChainEIP712 | undefined,
-  TAccount extends Account | undefined,
-  TChainOverride extends ChainEIP712 | undefined = undefined,
+  chain extends ChainEIP712 | undefined,
+  account extends Account | undefined,
+  const request extends SendTransactionRequest<chain, chainOverride>,
+  chainOverride extends ChainEIP712 | undefined = undefined,
 >(
-  client: Client<Transport, TChain, TAccount>,
-  args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
+  client: Client<Transport, chain, account>,
+  parameters: SendTransactionParameters<chain, account, chainOverride, request>,
 ): Promise<SendTransactionReturnType> {
-  if (isEIP712Transaction(args)) return sendEip712Transaction(client, args)
-  return sendTransaction_(client, args)
+  if (isEIP712Transaction(parameters))
+    return sendEip712Transaction(
+      client,
+      parameters as SendEip712TransactionParameters,
+    )
+  return core_sendTransaction(
+    client,
+    parameters as core_SendTransactionParameters,
+  )
 }

--- a/src/zksync/decorators/eip712.ts
+++ b/src/zksync/decorators/eip712.ts
@@ -1,4 +1,6 @@
 import type { Abi } from 'abitype'
+
+import type { SendTransactionRequest } from '../../actions/wallet/sendTransaction.js'
 import { writeContract } from '../../actions/wallet/writeContract.js'
 import type { Client } from '../../clients/createClient.js'
 import type { WalletActions } from '../../clients/decorators/wallet.js'
@@ -69,8 +71,11 @@ export type Eip712WalletActions<
    *   value: 1000000000000000000n,
    * })
    */
-  sendTransaction: <chainOverride extends ChainEIP712 | undefined = undefined>(
-    args: SendTransactionParameters<chain, account, chainOverride>,
+  sendTransaction: <
+    const request extends SendTransactionRequest<chain, chainOverride>,
+    chainOverride extends ChainEIP712 | undefined = undefined,
+  >(
+    args: SendTransactionParameters<chain, account, chainOverride, request>,
   ) => Promise<SendTransactionReturnType>
   /**
    * Signs a transaction.

--- a/src/zksync/types/chain.ts
+++ b/src/zksync/types/chain.ts
@@ -6,20 +6,20 @@ import type { ZkSyncTransactionSerializable } from './transaction.js'
 export type ChainEIP712<
   formatters extends ChainFormatters | undefined = ChainFormatters | undefined,
   TransactionSignable = {},
+  ///
+  transactionSerializable extends
+    ZkSyncTransactionSerializable = formatters extends ChainFormatters
+    ? formatters['transactionRequest'] extends ChainFormatter
+      ? ZkSyncTransactionSerializable &
+          Parameters<formatters['transactionRequest']['format']>[0]
+      : ZkSyncTransactionSerializable
+    : ZkSyncTransactionSerializable,
 > = Chain<
   formatters,
   {
     /** Return EIP712 Domain for EIP712 transaction */
     getEip712Domain?:
-      | EIP712DomainFn<
-          formatters extends ChainFormatters
-            ? formatters['transactionRequest'] extends ChainFormatter
-              ? ZkSyncTransactionSerializable &
-                  Parameters<formatters['transactionRequest']['format']>[0]
-              : ZkSyncTransactionSerializable
-            : ZkSyncTransactionSerializable,
-          TransactionSignable
-        >
+      | EIP712DomainFn<transactionSerializable, TransactionSignable>
       | undefined
   }
 >


### PR DESCRIPTION
Enables older TS versions in CI

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various files across the codebase. It includes changes related to transaction requests, gas estimation, and code formatting.

### Detailed summary
- Updated transaction request handling in `formatters.ts`
- Modified workflow versions in `verify.yml`
- Adjusted functions in `decorators` files
- Added type definitions in `types` and `actions`
- Refactored gas estimation functions in `actions`

> The following files were skipped due to too many changes: `src/zksync/actions/sendEip712Transaction.ts`, `src/zksync/actions/sendTransaction.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->