### PR TITLE
feat: Add Xai mainnet and testnet chains.

### DIFF
--- a/.changeset/nasty-zoos-breathe.md
+++ b/.changeset/nasty-zoos-breathe.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Xai and Xai testnet chains.

--- a/src/chains/definitions/xai.ts
+++ b/src/chains/definitions/xai.ts
@@ -1,0 +1,25 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xai = /*#__PURE__*/ defineChain({
+    id: 660279,
+    name: 'Xai Mainnet',
+    nativeCurrency: { name: 'Xai', symbol: 'XAI', decimals: 18 },
+    rpcUrls: {
+        default: {
+            http: ['https://xai-chain.net/rpc'],
+        },
+    },
+    blockExplorers: {
+        default: {
+            name: 'Blockscout',
+            url: 'https://explorer.xai-chain.net',
+        },
+    },
+    contracts: {
+        multicall3: {
+            address: '0xca11bde05977b3631167028862be2a173976ca11',
+            blockCreated: 222549,
+        },
+    },
+    testnet: false,
+})

--- a/src/chains/definitions/xaiTestnet.ts
+++ b/src/chains/definitions/xaiTestnet.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xaiTestnet = /*#__PURE__*/ defineChain({
+    id: 37714555429,
+    name: 'Xai Testnet',
+    nativeCurrency: { name: 'sXai', symbol: 'sXAI', decimals: 18 },
+    rpcUrls: {
+        default: {
+            http: ['https://testnet-v2.xai-chain.net/rpc'],
+        },
+    },
+    blockExplorers: {
+        default: {
+            name: 'Blockscout',
+            url: 'https://testnet-explorer-v2.xai-chain.net',
+        },
+    },
+    testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -270,6 +270,8 @@ export {
   x1Testnet,
 } from './definitions/xLayerTestnet.js'
 export { xLayer } from './definitions/xLayer.js'
+export { xai } from './definitions/xai.js'
+export { xaiTestnet } from './definitions/xaiTestnet.js'
 export { xdc } from './definitions/xdc.js'
 export { xdcTestnet } from './definitions/xdcTestnet.js'
 export { yooldoVerse } from './definitions/yooldoVerse.js'


### PR DESCRIPTION
* Add Xai Mainnet definition
* Add Xai Testnet definition
* Update chains/index.ts
* Create .changeset/nasty-zoos-breathe.md


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Xai and Xai testnet chains.

### Detailed summary
- Added `xai` and `xaiTestnet` chains
- Defined properties for Xai and Xai testnet chains
- Updated chain definitions in `index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->