### PR TITLE
fix: serialize zero r/s correctly

### DIFF
--- a/.changeset/gold-tables-press.md
+++ b/.changeset/gold-tables-press.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where zero `r` and `s` values were not being serialized correctly.

--- a/src/utils/transaction/serializeTransaction.test.ts
+++ b/src/utils/transaction/serializeTransaction.test.ts
@@ -964,4 +964,26 @@ describe('github', () => {
       '0x6ed21df69b02678dfb290ef2a43d490303562eb387f70795766b37bfa9d09bd2',
     )
   })
+
+  test('https://github.com/wevm/viem/issues/2394', async () => {
+    const serialized = serializeTransaction(
+      {
+        chainId: 17000,
+        gas: BigInt('0x52080'),
+        maxFeePerGas: BigInt('0x0'),
+        maxPriorityFeePerGas: BigInt('0x0'),
+        nonce: 0,
+        to: '0xc000000000000000000000000000000000000000',
+        value: BigInt('0x0'),
+      },
+      {
+        r: '0x0',
+        s: '0x0',
+        yParity: 0,
+      },
+    )
+    expect(serialized).toEqual(
+      '0x02e58242688080808305208094c0000000000000000000000000000000000000008080c0808080',
+    )
+  })
 })

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -370,12 +370,17 @@ function serializeTransactionLegacy(
 
 export function toYParitySignatureArray(
   transaction: TransactionSerializableGeneric,
-  signature?: Signature | undefined,
+  signature_?: Signature | undefined,
 ) {
-  const { r, s, v, yParity } = signature ?? transaction
-  if (typeof r === 'undefined') return []
-  if (typeof s === 'undefined') return []
+  const signature = signature_ ?? transaction
+  const { v, yParity } = signature
+
+  if (typeof signature.r === 'undefined') return []
+  if (typeof signature.s === 'undefined') return []
   if (typeof v === 'undefined' && typeof yParity === 'undefined') return []
+
+  const r = trim(signature.r)
+  const s = trim(signature.s)
 
   const yParity_ = (() => {
     if (typeof yParity === 'number') return yParity ? toHex(1) : '0x'
@@ -384,5 +389,6 @@ export function toYParitySignatureArray(
 
     return v === 27n ? '0x' : toHex(1)
   })()
-  return [yParity_, trim(r), trim(s)]
+
+  return [yParity_, r === '0x00' ? '0x' : r, s === '0x00' ? '0x' : s]
 }


### PR DESCRIPTION
Resolves #2394 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes serialization issue for zero `r` and `s` values in `viem`. 

### Detailed summary
- Fixed serialization bug for zero `r` and `s` values in `viem`
- Added a new test case for issue #2394
- Updated function to handle zero values for `r` and `s`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->