### PR TITLE
feat: `getEip712Domain`

### DIFF
--- a/.changeset/tiny-suits-impress.md
+++ b/.changeset/tiny-suits-impress.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `getEip712Domain` Action.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "test/contracts/lib/solady"]
+	path = test/contracts/lib/solady
+	url = git@github.com:Vectorized/solady.git

--- a/site/pages/docs/actions/public/getEip712Domain.md
+++ b/site/pages/docs/actions/public/getEip712Domain.md
@@ -1,0 +1,53 @@
+---
+description: Reads the EIP-712 domain from a contract.
+---
+
+# getEip712Domain
+
+Reads the EIP-712 domain from a contract, based on the [ERC-5267 specification](https://eips.ethereum.org/EIPS/eip-5267).
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { publicClient } from './client'
+
+const { domain, extensions, fields } = await publicClient.getEip712Domain({ 
+  address: '0x57ba3ec8df619d4d243ce439551cce713bb17411',
+})
+```
+
+```ts [client.ts] filename="client.ts"
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http()
+})
+```
+
+:::
+
+## Returns
+
+`GetEip712DomainReturnType`
+
+The EIP-712 domain (`domain`) for the contract, with `fields` and `extensions`, as per [ERC-5267](https://eips.ethereum.org/EIPS/eip-5267).
+
+## Parameters
+
+### address
+
+- **Type:** `string`
+
+The address of the contract to read the EIP-712 domain from.
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts]
+// ---cut---
+const result = await publicClient.getEip712Domain({ 
+  address: '0x57ba3ec8df619d4d243ce439551cce713bb17411', // [!code focus]
+})
+```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -104,6 +104,15 @@ export const sidebar = {
           ],
         },
         {
+          text: 'EIP-712',
+          items: [
+            {
+              text: 'getEip712Domain',
+              link: '/docs/actions/public/getEip712Domain',
+            },
+          ],
+        },
+        {
           text: 'Fee',
           items: [
             {

--- a/src/actions/public/getEip712Domain.test.ts
+++ b/src/actions/public/getEip712Domain.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from 'vitest'
+import { Mock4337AccountFactory } from '../../../test/contracts/generated.js'
+import { anvilMainnet } from '../../../test/src/anvil.js'
+import { accounts } from '../../../test/src/constants.js'
+import { deployMock4337Account } from '../../../test/src/utils.js'
+import { pad } from '../../utils/index.js'
+import { mine } from '../test/mine.js'
+import { writeContract } from '../wallet/writeContract.js'
+import { getEip712Domain } from './getEip712Domain.js'
+import { simulateContract } from './simulateContract.js'
+
+const client = anvilMainnet.getClient()
+
+test('default', async () => {
+  const { factoryAddress } = await deployMock4337Account()
+
+  const { result: address, request } = await simulateContract(client, {
+    account: accounts[0].address,
+    abi: Mock4337AccountFactory.abi,
+    address: factoryAddress,
+    functionName: 'createAccount',
+    args: [accounts[0].address, pad('0x0')],
+  })
+  await writeContract(client, request)
+  await mine(client, { blocks: 1 })
+
+  expect(
+    await getEip712Domain(client, {
+      address,
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "domain": {
+        "chainId": 1,
+        "name": "Mock4337Account",
+        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "verifyingContract": "0x8a00708a83D977494139D21D618C6C2A71fA8ed1",
+        "version": "1",
+      },
+      "extensions": [],
+      "fields": "0x0f",
+    }
+  `)
+})
+
+test('error: non-existent', async () => {
+  await expect(() =>
+    getEip712Domain(client, {
+      address: '0x0000000000000000000000000000000000000000',
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `
+    [Eip712DomainNotFoundError: No EIP-712 domain found on contract "0x0000000000000000000000000000000000000000".
+
+    Ensure that:
+    - The contract is deployed at the address "0x0000000000000000000000000000000000000000".
+    - \`eip712Domain()\` function exists on the contract.
+    - \`eip712Domain()\` function matches signature to ERC-5267 specification.
+
+    Version: viem@x.y.z]
+  `,
+  )
+})
+
+test('error: default', async () => {
+  await expect(() =>
+    getEip712Domain(client, {
+      address: '0x00000000000000000000000000000000000000000',
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `
+    [ContractFunctionExecutionError: Address "0x00000000000000000000000000000000000000000" is invalid.
+
+    - Address must be a hex value of 20 bytes (40 hex characters).
+    - Address must match its checksum counterpart.
+     
+    Raw Call Arguments:
+      to:    0x00000000000000000000000000000000000000000
+      data:  0x84b0196e
+     
+    Contract Call:
+      address:   0x0000000000000000000000000000000000000000
+      function:  eip712Domain()
+
+    Docs: https://viem.sh/docs/contract/readContract
+    Version: viem@x.y.z]
+  `,
+  )
+})

--- a/src/actions/public/getEip712Domain.ts
+++ b/src/actions/public/getEip712Domain.ts
@@ -1,0 +1,124 @@
+import type { Address, TypedDataDomain } from 'abitype'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import {
+  Eip712DomainNotFoundError,
+  type Eip712DomainNotFoundErrorType,
+} from '../../errors/eip712.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { Hex } from '../../types/misc.js'
+import { getAction } from '../../utils/getAction.js'
+import { type ReadContractErrorType, readContract } from './readContract.js'
+
+export type GetEip712DomainParameters = {
+  address: Address
+}
+
+export type GetEip712DomainReturnType = {
+  domain: TypedDataDomain
+  fields: Hex
+  extensions: readonly bigint[]
+}
+
+export type GetEip712DomainErrorType =
+  | Eip712DomainNotFoundErrorType
+  | ReadContractErrorType
+  | ErrorType
+
+/**
+ * Reads the EIP-712 domain from a contract, based on the ERC-5267 specification.
+ *
+ * @param client - A {@link Client} instance.
+ * @param parameters - The parameters of the action. {@link GetEip712DomainParameters}
+ * @returns The EIP-712 domain, fields, and extensions. {@link GetEip712DomainReturnType}
+ *
+ * @example
+ * ```ts
+ * import { createPublicClient, http, getEip712Domain } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ *
+ * const client = createPublicClient({
+ *   chain: mainnet,
+ *   transport: http(),
+ * })
+ *
+ * const domain = await getEip712Domain(client, {
+ *   address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+ * })
+ * // {
+ * //   domain: {
+ * //     name: 'ExampleContract',
+ * //     version: '1',
+ * //     chainId: 1,
+ * //     verifyingContract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+ * //   },
+ * //   fields: '0x0f',
+ * //   extensions: [],
+ * // }
+ * ```
+ */
+export async function getEip712Domain(
+  client: Client<Transport>,
+  parameters: GetEip712DomainParameters,
+): Promise<GetEip712DomainReturnType> {
+  const { address } = parameters
+
+  try {
+    const [
+      fields,
+      name,
+      version,
+      chainId,
+      verifyingContract,
+      salt,
+      extensions,
+    ] = await getAction(
+      client,
+      readContract,
+      'readContract',
+    )({
+      abi,
+      address,
+      functionName: 'eip712Domain',
+    })
+
+    return {
+      domain: {
+        name,
+        version,
+        chainId: Number(chainId),
+        verifyingContract,
+        salt,
+      },
+      extensions,
+      fields,
+    }
+  } catch (e) {
+    const error = e as ReadContractErrorType
+    if (
+      error.name === 'ContractFunctionExecutionError' &&
+      error.cause.name === 'ContractFunctionZeroDataError'
+    ) {
+      throw new Eip712DomainNotFoundError({ address })
+    }
+    throw error
+  }
+}
+
+const abi = [
+  {
+    inputs: [],
+    name: 'eip712Domain',
+    outputs: [
+      { name: 'fields', type: 'bytes1' },
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'extensions', type: 'uint256[]' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -107,6 +107,11 @@ import {
   getContractEvents,
 } from '../../actions/public/getContractEvents.js'
 import {
+  type GetEip712DomainParameters,
+  type GetEip712DomainReturnType,
+  getEip712Domain,
+} from '../../actions/public/getEip712Domain.js'
+import {
   type GetFeeHistoryParameters,
   type GetFeeHistoryReturnType,
   getFeeHistory,
@@ -703,6 +708,41 @@ export type PublicActions<
   ) => Promise<
     GetContractEventsReturnType<abi, eventName, strict, fromBlock, toBlock>
   >
+  /**
+   * Reads the EIP-712 domain from a contract, based on the ERC-5267 specification.
+   *
+   * @param client - A {@link Client} instance.
+   * @param parameters - The parameters of the action. {@link GetEip712DomainParameters}
+   * @returns The EIP-712 domain, fields, and extensions. {@link GetEip712DomainReturnType}
+   *
+   * @example
+   * ```ts
+   * import { createPublicClient, http } from 'viem'
+   * import { mainnet } from 'viem/chains'
+   *
+   * const client = createPublicClient({
+   *   chain: mainnet,
+   *   transport: http(),
+   * })
+   *
+   * const domain = await client.getEip712Domain({
+   *   address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+   * })
+   * // {
+   * //   domain: {
+   * //     name: 'ExampleContract',
+   * //     version: '1',
+   * //     chainId: 1,
+   * //     verifyingContract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+   * //   },
+   * //   fields: '0x0f',
+   * //   extensions: [],
+   * // }
+   * ```
+   */
+  getEip712Domain: (
+    args: GetEip712DomainParameters,
+  ) => Promise<GetEip712DomainReturnType>
   /**
    * Gets address for ENS name.
    *
@@ -1816,6 +1856,7 @@ export function publicActions<
     getBytecode: (args) => getBytecode(client, args),
     getChainId: () => getChainId(client),
     getContractEvents: (args) => getContractEvents(client, args),
+    getEip712Domain: (args) => getEip712Domain(client, args),
     getEnsAddress: (args) => getEnsAddress(client, args),
     getEnsAvatar: (args) => getEnsAvatar(client, args),
     getEnsName: (args) => getEnsName(client, args),

--- a/src/errors/eip712.ts
+++ b/src/errors/eip712.ts
@@ -1,0 +1,19 @@
+import type { Address } from 'abitype'
+import { BaseError } from './base.js'
+
+export type Eip712DomainNotFoundErrorType = Eip712DomainNotFoundError & {
+  name: 'Eip712DomainNotFoundError'
+}
+export class Eip712DomainNotFoundError extends BaseError {
+  override name = 'Eip712DomainNotFoundError'
+  constructor({ address }: { address: Address }) {
+    super(`No EIP-712 domain found on contract "${address}".`, {
+      metaMessages: [
+        'Ensure that:',
+        `- The contract is deployed at the address "${address}".`,
+        '- `eip712Domain()` function exists on the contract.',
+        '- `eip712Domain()` function matches signature to ERC-5267 specification.',
+      ],
+    })
+  }
+}

--- a/test/contracts/src/Mock4337Account.sol
+++ b/test/contracts/src/Mock4337Account.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+import {ERC4337} from "solady/accounts/ERC4337.sol";
+
+contract Mock4337Account is ERC4337 {
+    function _domainNameAndVersion()
+        internal
+        pure
+        override
+        returns (string memory, string memory)
+    {
+        return ("Mock4337Account", "1");
+    }
+}

--- a/test/contracts/src/Mock4337AccountFactory.sol
+++ b/test/contracts/src/Mock4337AccountFactory.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+import {ERC4337Factory} from "solady/accounts/ERC4337Factory.sol";
+
+contract Mock4337AccountFactory is ERC4337Factory {
+    constructor(address erc4337) ERC4337Factory(erc4337) {}
+}

--- a/test/foundry.toml
+++ b/test/foundry.toml
@@ -1,3 +1,6 @@
 [profile.default]
+remappings = [
+  "solady/=contracts/lib/solady/src/",
+]
 src = "contracts/src"
 out = "contracts/out"

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -28,6 +28,8 @@ import {
   ERC20InvalidTransferEvent,
   EnsAvatarTokenUri,
   ErrorsExample,
+  Mock4337Account,
+  Mock4337AccountFactory,
   OffchainLookupExample,
   Payable,
 } from '../contracts/generated.js'
@@ -133,6 +135,22 @@ export async function deployPayable() {
     abi: Payable.abi,
     bytecode: Payable.bytecode.object,
   })
+}
+
+export async function deployMock4337Account() {
+  const { contractAddress: implementationAddress } = await deploy(client, {
+    abi: Mock4337Account.abi,
+    bytecode: Mock4337Account.bytecode.object,
+  })
+  const { contractAddress: factoryAddress } = await deploy(client, {
+    abi: Mock4337AccountFactory.abi,
+    bytecode: Mock4337AccountFactory.bytecode.object,
+    args: [implementationAddress!],
+  })
+  return {
+    implementationAddress: implementationAddress!,
+    factoryAddress: factoryAddress!,
+  }
 }
 
 export async function setVitalikResolver() {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add the `getEip712Domain` action and related functionality.

### Detailed summary
- Added `getEip712Domain` action to read EIP-712 domain from a contract.
- Updated client decorators and tests.
- Added `Mock4337Account` and `Mock4337AccountFactory`.
- Updated documentation and error handling for `getEip712Domain`.

> The following files were skipped due to too many changes: `src/actions/public/getEip712Domain.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->