### PR TITLE
chore: fix JSDoc example

### DIFF
--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -128,7 +128,7 @@ export type WriteContractErrorType =
  *   abi: parseAbi(['function mint(uint32 tokenId) nonpayable']),
  *   functionName: 'mint',
  *   args: [69420],
- * }
+ * })
  * const hash = await writeContract(client, request)
  */
 export async function writeContract<


### PR DESCRIPTION
Fix JSDoc example



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `writeContract` function in `src/actions/wallet/writeContract.ts` to fix an issue with the argument syntax.

### Detailed summary
- Updated argument syntax for `writeContract` function
- Changed object notation from `{}` to `()`
- Ensured consistency in function call syntax

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->