### PR TITLE
feat: Add support for linea_estimateGas

### DIFF
--- a/src/chains/definitions/linea.ts
+++ b/src/chains/definitions/linea.ts
@@ -1,4 +1,5 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { lineaEstimateFeesPerGas } from '../../linea/index.js'
 
 export const linea = /*#__PURE__*/ defineChain({
   id: 59_144,
@@ -24,4 +25,22 @@ export const linea = /*#__PURE__*/ defineChain({
     },
   },
   testnet: false,
+  fees: {
+    // Override the fees calculation to accurately price the fees
+    // on Linea using the rpc call linea_estimateGas
+    estimateFeesPerGas: lineaEstimateFeesPerGas,
+    async defaultPriorityFee(args): Promise<bigint> {
+      const { maxPriorityFeePerGas } = await lineaEstimateFeesPerGas({
+        client: args.client,
+        request: args.request,
+        type: 'eip1559',
+      } as any)
+
+      if (maxPriorityFeePerGas === undefined) {
+        throw new Error('maxPriorityFeePerGas is undefined')
+      }
+
+      return maxPriorityFeePerGas
+    },
+  },
 })

--- a/src/chains/definitions/lineaSepolia.ts
+++ b/src/chains/definitions/lineaSepolia.ts
@@ -1,4 +1,5 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { lineaEstimateFeesPerGas } from '../../linea/index.js'
 
 export const lineaSepolia = /*#__PURE__*/ defineChain({
   id: 59_141,
@@ -24,4 +25,22 @@ export const lineaSepolia = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  fees: {
+    // Override the fees calculation to accurately price the fees
+    // on Linea using the rpc call linea_estimateGas
+    estimateFeesPerGas: lineaEstimateFeesPerGas,
+    async defaultPriorityFee(args): Promise<bigint> {
+      const { maxPriorityFeePerGas } = await lineaEstimateFeesPerGas({
+        client: args.client,
+        request: args.request,
+        type: 'eip1559',
+      } as any)
+
+      if (maxPriorityFeePerGas === undefined) {
+        throw new Error('maxPriorityFeePerGas is undefined')
+      }
+
+      return maxPriorityFeePerGas
+    },
+  },
 })

--- a/src/linea/actions/lineaEstimateGas.ts
+++ b/src/linea/actions/lineaEstimateGas.ts
@@ -1,0 +1,112 @@
+import type { Account } from '../../accounts/types.js'
+import { parseAccount } from '../../accounts/utils/parseAccount.js'
+import {
+  type PrepareTransactionRequestParameters,
+  prepareTransactionRequest,
+} from '../../actions/wallet/prepareTransactionRequest.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { BaseError } from '../../errors/base.js'
+import type { EstimateGasParameters } from '../../index.js'
+import type { Chain } from '../../types/chain.js'
+import type { TransactionRequest } from '../../types/transaction.js'
+import { numberToHex } from '../../utils/encoding/toHex.js'
+import { extract } from '../../utils/formatters/extract.js'
+import { formatTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import { getCallError } from '../../utils/index.js'
+import {
+  type AssertRequestParameters,
+  assertRequest,
+} from '../../utils/transaction/assertRequest.js'
+import type { LineaEstimateGasReturnType } from '../types/fee.js'
+import type { LineaEstimateGasRpcSchema } from '../types/rpc.js'
+
+/**
+ * Estimates the gas, gas fee per gas and priority fee per gas necessary to complete a transaction without submitting it to the network.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link EstimateGasParameters}
+ * @returns An estimate (in wei) for the base fee per gas, the priority fee per gas and the gas limit. {@link LineaEstimateGasReturnType}
+ *
+ * @example
+ * import { createPublicClient, http, parseEther } from 'viem'
+ * import { lineaTestnet } from 'viem/chains'
+ * import { lineaEstimateGas } from 'viem/public'
+ *
+ * const client = createPublicClient({
+ *   chain: lineaTestnet,
+ *   transport: http(),
+ * })
+ * const gasEstimate = await lineaEstimateGas(client, {
+ *   account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+ *   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *   value: 0n,
+ * })
+ */
+export async function lineaEstimateGas<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: Client<Transport, TChain, TAccount>,
+  args: EstimateGasParameters<TChain>,
+): Promise<LineaEstimateGasReturnType> {
+  const account_ = args.account ?? client.account
+  const account = account_ ? parseAccount(account_) : undefined
+
+  try {
+    const {
+      accessList,
+      blockNumber,
+      blockTag,
+      data,
+      gas,
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      nonce,
+      to,
+      value,
+      ...rest
+    } =
+      account?.type === 'local'
+        ? ((await prepareTransactionRequest(
+            client,
+            args as PrepareTransactionRequestParameters,
+          )) as EstimateGasParameters)
+        : args
+
+    const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
+    const block = blockNumberHex || blockTag
+
+    assertRequest(args as AssertRequestParameters)
+
+    const chainFormat = client.chain?.formatters?.transactionRequest?.format
+    const format = chainFormat || formatTransactionRequest
+
+    const request = format({
+      // Pick out extra data that might exist on the chain's transaction request type.
+      ...extract(rest, { format: chainFormat }),
+      from: account?.address,
+      accessList,
+      data,
+      gas,
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      nonce,
+      to,
+      value,
+    } as TransactionRequest)
+
+    return await client.request<LineaEstimateGasRpcSchema>({
+      method: 'linea_estimateGas',
+      params: block ? [request, block] : [request],
+    })
+  } catch (err) {
+    throw getCallError(err as BaseError, {
+      ...args,
+      account,
+      chain: client.chain,
+    })
+  }
+}

--- a/src/linea/chains.ts
+++ b/src/linea/chains.ts
@@ -1,0 +1,2 @@
+export { linea } from '../chains/definitions/linea.js'
+export { lineaTestnet } from '../chains/definitions/lineaTestnet.js'

--- a/src/linea/index.ts
+++ b/src/linea/index.ts
@@ -1,0 +1,4 @@
+export { lineaEstimateGas } from './actions/lineaEstimateGas.js'
+export { lineaEstimateFeesPerGas } from './actions/lineaEstimateFeesPerGas.js'
+
+export { linea, lineaTestnet } from './chains.js'

--- a/src/linea/types/fee.ts
+++ b/src/linea/types/fee.ts
@@ -1,0 +1,11 @@
+import type { EstimateFeesPerGasReturnType } from '../../index.js'
+
+export type LineaEstimateGasReturnType = {
+  gasLimit: bigint
+  baseFeePerGas: bigint
+  priorityFeePerGas: bigint
+}
+
+export type LineaEstimateFeesPerGasReturnType = {
+  gasLimit: bigint
+} & EstimateFeesPerGasReturnType

--- a/src/linea/types/rpc.ts
+++ b/src/linea/types/rpc.ts
@@ -1,0 +1,18 @@
+import type { LineaEstimateGasReturnType } from './fee.js'
+
+export type LineaEstimateGasRpcSchema =
+  /**
+   * @description Returns the gasLimit, baseFeePerGas and priorityFeePerGas
+   * on the linea chain
+   *
+   * @example
+   * provider.request({ method: 'linea_estimateGas'
+   * ,"params":[{"from":"0x42c27251C710864Cf76f1b9918Ace3E585e6E21b"
+   * ,"value":"0x1","gasPrice":"0x100000000","gas":"0x21000"}] })
+   * // => {"jsonrpc":"2.0","id":53,"result":{"baseFeePerGas":"0x7","gasLimit":"0xcf08","priorityFeePerGas":"0xa92469a"}}
+   */
+  {
+    Method: 'linea_estimateGas'
+    Parameters?: any
+    ReturnType: LineaEstimateGasReturnType
+  }


### PR DESCRIPTION
Linea, a layer 2 blockchain, supports the Ethereum EIP-1559 gas price model, known for making transaction fees more predictable. Unlike the base Ethereum layer, Linea aims to offer a more stable and cost-effective approach to handling transaction fees. For detailed information, you can visit [Linea's Gas Fees Documentation](https://docs.linea.build/build-on-linea/gas-fees).

To further enhance the efficiency of transaction fee calculations, Linea has introduced a new RPC method designed to provide the best gas price estimates. This new method is documented in detail [here](https://docs.linea.build/reference/api/linea-estimategas).

The introduction of this new RPC method necessitates changes in how web3 libraries calculate gas prices. Traditionally, these libraries used the eth_gasPrice method. Linea's update shifts this approach to utilize the newly introduced linea_estimateGas method.

Detailed summary

- Added linea_estimateGas RPC method to calculate accurate gas price on Linea network
- Updated linea and lineaTestnet definitions to override fee calculation using linea_estimateGas
- Added lineaEstimateGas and lineaEstimateFeesPerGas actions to calculate gas and fees
- Updated types and imports related to fee calculation on Linea network

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the Linea chain implementation by adding new fee estimation functionalities and refining gas estimation logic.

### Detailed summary
- Added `lineaEstimateFeesPerGas` and `lineaEstimateGas` functions
- Defined new types for fee estimation return values
- Updated chain definitions for Linea and LineaSepolia
- Improved RPC schema for Linea gas estimation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->