### PR TITLE
feat(chains): update berachain testnet

### DIFF
--- a/.changeset/stale-insects-camp.md
+++ b/.changeset/stale-insects-camp.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed the Berachain Testnet chain information

--- a/src/chains/definitions/berachainTestnet.ts
+++ b/src/chains/definitions/berachainTestnet.ts
@@ -1,20 +1,20 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const berachainTestnet = /*#__PURE__*/ defineChain({
-  id: 80085,
-  name: 'Berachain Artio',
+  id: 80084,
+  name: 'Berachain bArtio',
   nativeCurrency: {
     decimals: 18,
     name: 'BERA Token',
     symbol: 'BERA',
   },
   rpcUrls: {
-    default: { http: ['https://artio.rpc.berachain.com'] },
+    default: { http: ['https://bartio.rpc.berachain.com'] },
   },
   blockExplorers: {
     default: {
-      name: 'Berachain',
-      url: 'https://artio.beratrail.io',
+      name: 'Beratrail',
+      url: 'https://bartio.beratrail.io',
     },
   },
   testnet: true,


### PR DESCRIPTION
This PR updates the berachainTestnet chain to its latest version.
Values taken from [the official docs](https://docs.berachain.com/learn/connect-to-berachain).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Berachain Testnet chain information by fixing names and URLs.

### Detailed summary
- Updated chain ID to 80084 and chain name to 'Berachain bArtio'
- Updated RPC URL to 'https://bartio.rpc.berachain.com'
- Updated block explorer name to 'Beratrail' and URL to 'https://bartio.beratrail.io'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->