### PR TITLE
chore: update Conflux eSpace RPC URL

### DIFF
--- a/.changeset/gentle-tigers-sit.md
+++ b/.changeset/gentle-tigers-sit.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Conflux eSpace RPC URL

--- a/.changeset/gentle-tigers-sit.md
+++ b/.changeset/gentle-tigers-sit.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Update Conflux eSpace RPC URL
+Updated Conflux eSpace RPC URL

--- a/src/chains/definitions/confluxESpace.ts
+++ b/src/chains/definitions/confluxESpace.ts
@@ -6,8 +6,8 @@ export const confluxESpace = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Conflux', symbol: 'CFX', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://evm.confluxrpc.org'],
-      webSocket: ['wss://evm.confluxrpc.org/ws'],
+      http: ['https://evm.confluxrpc.com'],
+      webSocket: ['wss://evm.confluxrpc.com/ws'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/confluxESpaceTestnet.ts
+++ b/src/chains/definitions/confluxESpaceTestnet.ts
@@ -8,8 +8,8 @@ export const confluxESpaceTestnet = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Conflux', symbol: 'CFX', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://evmtestnet.confluxrpc.org'],
-      webSocket: ['wss://evmtestnet.confluxrpc.org/ws'],
+      http: ['https://evmtestnet.confluxrpc.com'],
+      webSocket: ['wss://evmtestnet.confluxrpc.com/ws'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
# Overview

Update the Conflux eSpace PRC URL
# Detailed summary
This PR updates the confluence eSpace PRC URL. You can find the documentation there https://doc.confluxnetwork.org/docs/espace/network-endpoints
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Conflux eSpace RPC URLs to use the domain `confluxrpc.com` instead of `confluxrpc.org`.

### Detailed summary
- Updated Conflux eSpace RPC URLs to use `confluxrpc.com` domain
- Updated URLs for both mainnet and testnet configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->