### PR TITLE
chore: refactor `getAction`

### DIFF
--- a/.changeset/grumpy-cycles-drop.md
+++ b/.changeset/grumpy-cycles-drop.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `getAction` would ignore nullish return values from a synchronous Client Action.

--- a/src/utils/getAction.test.ts
+++ b/src/utils/getAction.test.ts
@@ -32,6 +32,16 @@ test('uses client action', async () => {
   expect(clientSpy).toBeCalledWith({})
 })
 
+test('nullish return value', async () => {
+  const foo = () => null
+  const foo_2 = () => true
+  const client_2 = client.extend(() => ({
+    foo,
+  }))
+  const result = getAction(client_2, foo_2, 'foo')({})
+  expect(result).toEqual(null)
+})
+
 test('e2e', async () => {
   const client_2 = client.extend(() => ({
     async call() {


### PR DESCRIPTION
supersedes #2404

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue where `getAction` would ignore nullish return values. 

### Detailed summary
- Added type imports for `PublicActions`, `WalletActions`, `Transport`, `Account`, `Chain`, and `RpcSchema`
- Refactored `getAction` function to accept a more generic client type and handle minified function names
- Updated test to cover nullish return values from synchronous Client Actions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->