### PR TITLE
Add: encoding of boolean by string or other equivalent type

### DIFF
--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1,1882 +1,1813 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test } from "vitest";
 
-import { seaportContractConfig } from '~test/src/abis.js'
-import { address } from '~test/src/constants.js'
+import { seaportContractConfig } from "~test/src/abis.js";
+import { address } from "~test/src/constants.js";
 
-import {
-  encodeAbiParameters,
-  getArrayComponents,
-} from './encodeAbiParameters.js'
-import { getAbiItem } from './getAbiItem.js'
+import { encodeAbiParameters, getArrayComponents } from "./encodeAbiParameters.js";
+import { getAbiItem } from "./getAbiItem.js";
 
-describe('static', () => {
-  test('blank', () => {
-    expect(encodeAbiParameters([], [])).toBe('0x')
-  })
+describe("static", () => {
+	test("blank", () => {
+		expect(encodeAbiParameters([], [])).toBe("0x");
+	});
 
-  test('uint', () => {
-    expect(
-      encodeAbiParameters(
-        [
-          {
-            type: 'uint256',
-          },
-        ],
-        [69420n],
-      ),
-    ).toBe('0x0000000000000000000000000000000000000000000000000000000000010f2c')
-  })
+	test("uint", () => {
+		expect(
+			encodeAbiParameters(
+				[
+					{
+						type: "uint256",
+					},
+				],
+				[69420n],
+			),
+		).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
+	});
 
-  describe('uint8', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint8',
-            },
-          ],
-          [32],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000020',
-      )
-    })
+	describe("uint8", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint8",
+						},
+					],
+					[32],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000020");
+		});
 
-    test('invalid value', () => {
-      try {
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint8',
-            },
-          ],
-          // @ts-expect-error
-          [69420n],
-        )
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint8',
-            },
-          ],
-          // @ts-expect-error
-          ['lol'],
-        )
-      } catch {}
-    })
-  })
+		test("invalid value", () => {
+			try {
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint8",
+						},
+					],
+					// @ts-expect-error
+					[69420n],
+				);
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint8",
+						},
+					],
+					// @ts-expect-error
+					["lol"],
+				);
+			} catch {}
+		});
+	});
 
-  describe('uint32', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint32',
-            },
-          ],
-          [69420],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000010f2c',
-      )
-    })
+	describe("uint32", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint32",
+						},
+					],
+					[69420],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
+		});
 
-    test('invalid value', () => {
-      try {
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint32',
-            },
-          ],
-          // @ts-expect-error
-          [69420n],
-        )
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint32',
-            },
-          ],
-          // @ts-expect-error
-          ['lol'],
-        )
-      } catch {}
-    })
-  })
+		test("invalid value", () => {
+			try {
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint32",
+						},
+					],
+					// @ts-expect-error
+					[69420n],
+				);
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint32",
+						},
+					],
+					// @ts-expect-error
+					["lol"],
+				);
+			} catch {}
+		});
+	});
 
-  describe('int', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int256',
-            },
-          ],
-          [69420n],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000010f2c',
-      )
-    })
+	describe("int", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int256",
+						},
+					],
+					[69420n],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
+		});
 
-    test('negative (twos compliment)', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int256',
-            },
-          ],
-          [-69420n],
-        ),
-      ).toBe(
-        '0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffef0d4',
-      )
-    })
-  })
+		test("negative (twos compliment)", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int256",
+						},
+					],
+					[-69420n],
+				),
+			).toBe("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffef0d4");
+		});
+	});
 
-  describe('int8', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int8',
-            },
-          ],
-          [127],
-        ),
-      ).toBe(
-        '0x000000000000000000000000000000000000000000000000000000000000007f',
-      )
-    })
+	describe("int8", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int8",
+						},
+					],
+					[127],
+				),
+			).toBe("0x000000000000000000000000000000000000000000000000000000000000007f");
+		});
 
-    test('negative (twos compliment)', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int8',
-            },
-          ],
-          [-128],
-        ),
-      ).toBe(
-        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80',
-      )
-    })
+		test("negative (twos compliment)", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int8",
+						},
+					],
+					[-128],
+				),
+			).toBe("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80");
+		});
 
-    test('invalid value', () => {
-      try {
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int8',
-            },
-          ],
-          // @ts-expect-error
-          [69420n],
-        )
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int8',
-            },
-          ],
-          // @ts-expect-error
-          ['lol'],
-        )
-      } catch {}
-    })
-  })
+		test("invalid value", () => {
+			try {
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int8",
+						},
+					],
+					// @ts-expect-error
+					[69420n],
+				);
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int8",
+						},
+					],
+					// @ts-expect-error
+					["lol"],
+				);
+			} catch {}
+		});
+	});
 
-  describe('int32', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int32',
-            },
-          ],
-          [2147483647],
-        ),
-      ).toBe(
-        '0x000000000000000000000000000000000000000000000000000000007fffffff',
-      )
-    })
+	describe("int32", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int32",
+						},
+					],
+					[2147483647],
+				),
+			).toBe("0x000000000000000000000000000000000000000000000000000000007fffffff");
+		});
 
-    test('negative (twos compliment)', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int8',
-            },
-          ],
-          [-2147483648],
-        ),
-      ).toBe(
-        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000',
-      )
-    })
+		test("negative (twos compliment)", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int8",
+						},
+					],
+					[-2147483648],
+				),
+			).toBe("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000");
+		});
 
-    test('invalid value', () => {
-      try {
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int32',
-            },
-          ],
-          // @ts-expect-error
-          [69420n],
-        )
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int32',
-            },
-          ],
-          // @ts-expect-error
-          ['lol'],
-        )
-      } catch {}
-    })
-  })
+		test("invalid value", () => {
+			try {
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int32",
+						},
+					],
+					// @ts-expect-error
+					[69420n],
+				);
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int32",
+						},
+					],
+					// @ts-expect-error
+					["lol"],
+				);
+			} catch {}
+		});
+	});
 
-  describe('address', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'address',
-            },
-          ],
-          ['0x14dC79964da2C08b23698B3D3cc7Ca32193d9955'],
-        ),
-      ).toBe(
-        '0x00000000000000000000000014dc79964da2c08b23698b3d3cc7ca32193d9955',
-      )
-    })
-  })
+	describe("address", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "address",
+						},
+					],
+					["0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"],
+				),
+			).toBe("0x00000000000000000000000014dc79964da2c08b23698b3d3cc7ca32193d9955");
+		});
+	});
 
-  describe('bool', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          [true],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-      )
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          [false],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      )
-    })
+	describe("bool", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					[true],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					[false],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
+		});
 
-    test('from string', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          ['False' as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      )
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          ['True' as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-      )
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          ['' as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      )
-    })
+		test("from string", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					["False" as unknown as boolean],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					["True" as unknown as boolean],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+		});
 
-    test('from number', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          [23 as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-      )
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          [BigInt(23) as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-      )
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool',
-            },
-          ],
-          [0 as unknown as boolean],
-        ),
-      ).toBe(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      )
-    })
-  })
+		test("from number", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					[23 as unknown as boolean],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					[BigInt(23) as unknown as boolean],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool",
+						},
+					],
+					[0 as unknown as boolean],
+				),
+			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
+		});
+	});
 
-  describe('bytes8', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes8',
-            },
-          ],
-          ['0x0123456789abcdef'],
-        ),
-      ).toBe(
-        '0x0123456789abcdef000000000000000000000000000000000000000000000000',
-      )
-    })
+	describe("bytes8", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes8",
+						},
+					],
+					["0x0123456789abcdef"],
+				),
+			).toBe("0x0123456789abcdef000000000000000000000000000000000000000000000000");
+		});
 
-    test('overflow', () => {
-      expect(() =>
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes8',
-            },
-          ],
-          [
-            '0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef',
-          ],
-        ),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `
+		test("overflow", () => {
+			expect(() =>
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes8",
+						},
+					],
+					[
+						"0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef",
+					],
+				),
+			).toThrowErrorMatchingInlineSnapshot(
+				`
         [AbiEncodingBytesSizeMismatchError: Size of bytes "0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef" (bytes44) does not match expected size (bytes8).
 
         Version: viem@x.y.z]
       `,
-      )
-    })
-  })
+			);
+		});
+	});
 
-  describe('bytes16', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes16',
-            },
-          ],
-          ['0x42069420694201023210101231415122'],
-        ),
-      ).toBe(
-        '0x4206942069420102321010123141512200000000000000000000000000000000',
-      )
-    })
+	describe("bytes16", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes16",
+						},
+					],
+					["0x42069420694201023210101231415122"],
+				),
+			).toBe("0x4206942069420102321010123141512200000000000000000000000000000000");
+		});
 
-    test('overflow', () => {
-      expect(() =>
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes16',
-            },
-          ],
-          [
-            '0x000000000000000000000000000000000000000000000000000000000000000420',
-          ],
-        ),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `
+		test("overflow", () => {
+			expect(() =>
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes16",
+						},
+					],
+					["0x000000000000000000000000000000000000000000000000000000000000000420"],
+				),
+			).toThrowErrorMatchingInlineSnapshot(
+				`
         [AbiEncodingBytesSizeMismatchError: Size of bytes "0x000000000000000000000000000000000000000000000000000000000000000420" (bytes33) does not match expected size (bytes16).
 
         Version: viem@x.y.z]
       `,
-      )
-    })
-  })
+			);
+		});
+	});
 
-  describe('uint[3]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[3]',
-            },
-          ],
-          [[69420n, 42069n, 420420420n]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b44"',
-      )
-    })
-  })
+	describe("uint[3]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[3]",
+						},
+					],
+					[[69420n, 42069n, 420420420n]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b44"',
+			);
+		});
+	});
 
-  describe('int[3]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'int256[3]',
-            },
-          ],
-          [[69420n, -42069n, 420420420n]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000010f2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5bab00000000000000000000000000000000000000000000000000000000190f1b44"',
-      )
-    })
-  })
+	describe("int[3]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "int256[3]",
+						},
+					],
+					[[69420n, -42069n, 420420420n]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000010f2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5bab00000000000000000000000000000000000000000000000000000000190f1b44"',
+			);
+		});
+	});
 
-  describe('address[2]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'address[2]',
-            },
-          ],
-          [
-            [
-              '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
-              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-            ],
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-      )
-    })
-  })
+	describe("address[2]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "address[2]",
+						},
+					],
+					[
+						[
+							"0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b",
+							"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+						],
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+			);
+		});
+	});
 
-  describe('bool[2]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bool[2]',
-            },
-          ],
-          [[true, false]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("bool[2]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bool[2]",
+						},
+					],
+					[[true, false]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('bytes8[2]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes8[2]',
-            },
-          ],
-          [['0x1211121112111211', '0x1111111111111111']],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x12111211121112110000000000000000000000000000000000000000000000001111111111111111000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("bytes8[2]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes8[2]",
+						},
+					],
+					[["0x1211121112111211", "0x1111111111111111"]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x12111211121112110000000000000000000000000000000000000000000000001111111111111111000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('uint[3][2]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[3][2]',
-            },
-          ],
-          [
-            [
-              [69420n, 42069n, 420420420n],
-              [420n, 44n, 422n],
-            ],
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b4400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000001a6"',
-      )
-    })
-  })
+	describe("uint[3][2]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[3][2]",
+						},
+					],
+					[
+						[
+							[69420n, 42069n, 420420420n],
+							[420n, 44n, 422n],
+						],
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b4400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000001a6"',
+			);
+		});
+	});
 
-  describe('uint[3][2][4]', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[3][2][4]',
-            },
-          ],
-          [
-            [
-              [
-                [1n, 2n, 3n],
-                [4n, 5n, 6n],
-              ],
-              [
-                [7n, 8n, 9n],
-                [10n, 11n, 12n],
-              ],
-              [
-                [13n, 14n, 15n],
-                [16n, 17n, 18n],
-              ],
-              [
-                [19n, 20n, 21n],
-                [22n, 23n, 24n],
-              ],
-            ],
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001300000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000015000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000018"',
-      )
-    })
-  })
+	describe("uint[3][2][4]", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[3][2][4]",
+						},
+					],
+					[
+						[
+							[
+								[1n, 2n, 3n],
+								[4n, 5n, 6n],
+							],
+							[
+								[7n, 8n, 9n],
+								[10n, 11n, 12n],
+							],
+							[
+								[13n, 14n, 15n],
+								[16n, 17n, 18n],
+							],
+							[
+								[19n, 20n, 21n],
+								[22n, 23n, 24n],
+							],
+						],
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001300000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000015000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000018"',
+			);
+		});
+	});
 
-  describe('struct: (uint256,bool,address)', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  name: 'x',
-                  type: 'uint256',
-                },
-                {
-                  name: 'y',
-                  type: 'bool',
-                },
-                {
-                  name: 'z',
-                  type: 'address',
-                },
-              ],
-              name: 'fooIn',
-              type: 'tuple',
-            },
-          ],
-          [
-            {
-              x: 420n,
-              y: true,
-              z: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-            },
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-      )
-    })
-  })
+	describe("struct: (uint256,bool,address)", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									name: "x",
+									type: "uint256",
+								},
+								{
+									name: "y",
+									type: "bool",
+								},
+								{
+									name: "z",
+									type: "address",
+								},
+							],
+							name: "fooIn",
+							type: "tuple",
+						},
+					],
+					[
+						{
+							x: 420n,
+							y: true,
+							z: "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+						},
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+			);
+		});
+	});
 
-  describe('struct: (uint256,bool,address)', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  type: 'uint256',
-                },
-                {
-                  type: 'bool',
-                },
-                {
-                  type: 'address',
-                },
-              ],
-              name: 'fooOut',
-              type: 'tuple',
-            },
-          ],
-          [[420n, true, '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC']],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-      )
-    })
-  })
+	describe("struct: (uint256,bool,address)", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									type: "uint256",
+								},
+								{
+									type: "bool",
+								},
+								{
+									type: "address",
+								},
+							],
+							name: "fooOut",
+							type: "tuple",
+						},
+					],
+					[[420n, true, "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+			);
+		});
+	});
 
-  describe('struct: ((uint256,bool,address),(uint256,bool,address),uint8[2])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(((uint256,bool,address),(uint256,bool,address),uint8[2]))" "((420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC),(69,false,0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b),[1,2])"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  components: [
-                    {
-                      name: 'x',
-                      type: 'uint256',
-                    },
-                    {
-                      name: 'y',
-                      type: 'bool',
-                    },
-                    {
-                      name: 'z',
-                      type: 'address',
-                    },
-                  ],
-                  name: 'foo',
-                  type: 'tuple',
-                },
-                {
-                  components: [
-                    {
-                      name: 'x',
-                      type: 'uint256',
-                    },
-                    {
-                      name: 'y',
-                      type: 'bool',
-                    },
-                    {
-                      name: 'z',
-                      type: 'address',
-                    },
-                  ],
-                  name: 'baz',
-                  type: 'tuple',
-                },
-                {
-                  name: 'x',
-                  type: 'uint8[2]',
-                },
-              ],
-              name: 'barIn',
-              type: 'tuple',
-            },
-          ],
-          [
-            {
-              foo: {
-                x: 420n,
-                y: true,
-                z: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-              },
-              baz: {
-                x: 69n,
-                y: false,
-                z: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
-              },
-              x: [1, 2],
-            },
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac00000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"',
-      )
-    })
-  })
+	describe("struct: ((uint256,bool,address),(uint256,bool,address),uint8[2])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(((uint256,bool,address),(uint256,bool,address),uint8[2]))" "((420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC),(69,false,0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b),[1,2])"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									components: [
+										{
+											name: "x",
+											type: "uint256",
+										},
+										{
+											name: "y",
+											type: "bool",
+										},
+										{
+											name: "z",
+											type: "address",
+										},
+									],
+									name: "foo",
+									type: "tuple",
+								},
+								{
+									components: [
+										{
+											name: "x",
+											type: "uint256",
+										},
+										{
+											name: "y",
+											type: "bool",
+										},
+										{
+											name: "z",
+											type: "address",
+										},
+									],
+									name: "baz",
+									type: "tuple",
+								},
+								{
+									name: "x",
+									type: "uint8[2]",
+								},
+							],
+							name: "barIn",
+							type: "tuple",
+						},
+					],
+					[
+						{
+							foo: {
+								x: 420n,
+								y: true,
+								z: "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+							},
+							baz: {
+								x: 69n,
+								y: false,
+								z: "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b",
+							},
+							x: [1, 2],
+						},
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac00000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"',
+			);
+		});
+	});
 
-  describe('struct: (uint8,bytes[])', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  type: 'uint8',
-                },
-                {
-                  type: 'bytes[]',
-                },
-              ],
-              type: 'tuple',
-            },
-          ],
-          [[69, ['0x123', '0x456']]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024560000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
+	describe("struct: (uint8,bytes[])", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									type: "uint8",
+								},
+								{
+									type: "bytes[]",
+								},
+							],
+							type: "tuple",
+						},
+					],
+					[[69, ["0x123", "0x456"]]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024560000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
 
-    test('empty bytes', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  type: 'uint8',
-                },
-                {
-                  type: 'bytes[]',
-                },
-              ],
-              type: 'tuple',
-            },
-          ],
-          [[0, []]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+		test("empty bytes", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									type: "uint8",
+								},
+								{
+									type: "bytes[]",
+								},
+							],
+							type: "tuple",
+						},
+					],
+					[[0, []]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(uint256[2],bool,string[])', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            { name: 'xOut', type: 'uint256[2]' },
-            { name: 'yOut', type: 'bool' },
-            { name: 'zOut', type: 'string[3]' },
-          ],
-          [[420n, 69n], true, ['wagmi', 'viem', 'lol']],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036c6f6c0000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(uint256[2],bool,string[])", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{ name: "xOut", type: "uint256[2]" },
+						{ name: "yOut", type: "bool" },
+						{ name: "zOut", type: "string[3]" },
+					],
+					[[420n, 69n], true, ["wagmi", "viem", "lol"]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036c6f6c0000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('multiple (uint,bool,address)', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256',
-            },
-            {
-              name: 'yIn',
-              type: 'bool',
-            },
-            {
-              name: 'zIn',
-              type: 'address',
-            },
-          ],
-          [420n, true, '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
-      )
-    })
-  })
+	describe("multiple (uint,bool,address)", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256",
+						},
+						{
+							name: "yIn",
+							type: "bool",
+						},
+						{
+							name: "zIn",
+							type: "address",
+						},
+					],
+					[420n, true, "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
+			);
+		});
+	});
 
-  describe('multiple params unnamed: (uint,bool,address)', () => {
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: '',
-              type: 'uint256',
-            },
-            {
-              name: '',
-              type: 'bool',
-            },
-            {
-              name: '',
-              type: 'address',
-            },
-          ],
-          [420n, true, '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
-      )
-    })
-  })
-})
+	describe("multiple params unnamed: (uint,bool,address)", () => {
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "",
+							type: "uint256",
+						},
+						{
+							name: "",
+							type: "bool",
+						},
+						{
+							name: "",
+							type: "address",
+						},
+					],
+					[420n, true, "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
+			);
+		});
+	});
+});
 
-describe('dynamic', () => {
-  describe('(string)', () => {
-    // cast abi-encode "a(string)" "wagmi"
-    test('default', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xOut',
-              type: 'string',
-            },
-          ],
-          ['wagmi'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-      )
-    })
+describe("dynamic", () => {
+	describe("(string)", () => {
+		// cast abi-encode "a(string)" "wagmi"
+		test("default", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xOut",
+							type: "string",
+						},
+					],
+					["wagmi"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+			);
+		});
 
-    // cast abi-encode "a(string)" "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet."
-    test('> 32 bytes', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xOut',
-              type: 'string',
-            },
-          ],
-          [
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet.',
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002da4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e204e756e63206661756369627573206c6f72656d2061206c696265726f20617563746f7220636f6e64696d656e74756d2e20446f6e6563206f726e617265206d617373612072686f6e637573206c616375732072757472756d2c20656765742070756c76696e6172206172637520656c656d656e74756d2e204e756e63206d6175726973206c6f72656d2c20736f64616c65732065676574207669766572726120696e2c20657569736d6f642071756973206d692e205072616573656e74206e656320636f6d6d6f646f206c656f2e2050686173656c6c757320636f6e64696d656e74756d206d61757269732073656420616363756d73616e20656c656966656e642e205072616573656e7420616320626c616e6469742073656d2c2065742072757472756d20697073756d2e20457469616d20696e2074656c6c757320616320656e696d20666163696c6973697320756c7472696365732e20467573636520616320766573746962756c756d207175616d2e204475697320736564207075727573207363656c657269737175652c20736f6c6c696369747564696e20657261742061632c2070756c76696e6172206e6973692e2050656c6c656e746573717565206575207075727573206e65632073617069656e207665686963756c6120636f6e76616c6c69732075742076656c20656c69742e2053757370656e6469737365206567657420657820766974616520656e696d20766f6c7574706174207363656c657269737175652e20536564207175697320656c6974207472697374697175652065726174206c756374757320656765737461732061206163206f64696f2e2044756973207665686963756c6120656e696d206163206d6574757320677261766964612c2076656c206d6178696d7573206e69736920696d706572646965742e000000000000"',
-      )
-    })
+		// cast abi-encode "a(string)" "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet."
+		test("> 32 bytes", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xOut",
+							type: "string",
+						},
+					],
+					[
+						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet.",
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002da4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e204e756e63206661756369627573206c6f72656d2061206c696265726f20617563746f7220636f6e64696d656e74756d2e20446f6e6563206f726e617265206d617373612072686f6e637573206c616375732072757472756d2c20656765742070756c76696e6172206172637520656c656d656e74756d2e204e756e63206d6175726973206c6f72656d2c20736f64616c65732065676574207669766572726120696e2c20657569736d6f642071756973206d692e205072616573656e74206e656320636f6d6d6f646f206c656f2e2050686173656c6c757320636f6e64696d656e74756d206d61757269732073656420616363756d73616e20656c656966656e642e205072616573656e7420616320626c616e6469742073656d2c2065742072757472756d20697073756d2e20457469616d20696e2074656c6c757320616320656e696d20666163696c6973697320756c7472696365732e20467573636520616320766573746962756c756d207175616d2e204475697320736564207075727573207363656c657269737175652c20736f6c6c696369747564696e20657261742061632c2070756c76696e6172206e6973692e2050656c6c656e746573717565206575207075727573206e65632073617069656e207665686963756c6120636f6e76616c6c69732075742076656c20656c69742e2053757370656e6469737365206567657420657820766974616520656e696d20766f6c7574706174207363656c657269737175652e20536564207175697320656c6974207472697374697175652065726174206c756374757320656765737461732061206163206f64696f2e2044756973207665686963756c6120656e696d206163206d6574757320677261766964612c2076656c206d6178696d7573206e69736920696d706572646965742e000000000000"',
+			);
+		});
 
-    // cast abi-encode "a(string)" "👨‍👨‍👦‍👦🏴‍☠️"
-    test('emojis', () => {
-      expect(
-        encodeAbiParameters(
-          [
-            {
-              name: 'xOut',
-              type: 'string',
-            },
-          ],
-          ['👨‍👨‍👦‍👦🏴‍☠️'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026f09f91a8e2808df09f91a8e2808df09f91a6e2808df09f91a6f09f8fb4e2808de298a0efb88f0000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+		// cast abi-encode "a(string)" "👨‍👨‍👦‍👦🏴‍☠️"
+		test("emojis", () => {
+			expect(
+				encodeAbiParameters(
+					[
+						{
+							name: "xOut",
+							type: "string",
+						},
+					],
+					["👨‍👨‍👦‍👦🏴‍☠️"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026f09f91a8e2808df09f91a8e2808df09f91a6e2808df09f91a6f09f8fb4e2808de298a0efb88f0000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(string,uint,bool)', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(string,uint,bool)" "wagmi" 420 true
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'string',
-            },
-            {
-              name: 'yIn',
-              type: 'uint256',
-            },
-            {
-              name: 'zIn',
-              type: 'bool',
-            },
-          ],
-          ['wagmi', 420n, true],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(string,uint,bool)", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(string,uint,bool)" "wagmi" 420 true
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "string",
+						},
+						{
+							name: "yIn",
+							type: "uint256",
+						},
+						{
+							name: "zIn",
+							type: "bool",
+						},
+					],
+					["wagmi", 420n, true],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(uint[2],bool,string)', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(uint[2],bool,string)" "[420,69]" true "wagmi"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[2]',
-            },
-            {
-              name: 'yIn',
-              type: 'bool',
-            },
-            {
-              name: 'zIn',
-              type: 'string',
-            },
-          ],
-          [[420n, 69n], true, 'wagmi'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(uint[2],bool,string)", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(uint[2],bool,string)" "[420,69]" true "wagmi"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[2]",
+						},
+						{
+							name: "yIn",
+							type: "bool",
+						},
+						{
+							name: "zIn",
+							type: "string",
+						},
+					],
+					[[420n, 69n], true, "wagmi"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(bytes)', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(bytes)" "0x42069"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes',
-            },
-          ],
-          ['0x042069'],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030420690000000000000000000000000000000000000000000000000000000000"',
-      )
-      expect(
-        // cast abi-encode "a(bytes)" "0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes',
-            },
-          ],
-          [
-            '0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f',
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020d83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"',
-      )
-      expect(
-        // cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes',
-            },
-          ],
-          [
-            '0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002470a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000"',
-      )
-      expect(
-        // cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'bytes',
-            },
-          ],
-          [
-            '0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004870a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000"',
-      )
-      expect(
-        // cast abi-encode "a(bytes)" "0x"
-        encodeAbiParameters([{ type: 'bytes' }], ['0x']),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(bytes)", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(bytes)" "0x42069"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes",
+						},
+					],
+					["0x042069"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030420690000000000000000000000000000000000000000000000000000000000"',
+			);
+			expect(
+				// cast abi-encode "a(bytes)" "0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes",
+						},
+					],
+					["0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020d83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"',
+			);
+			expect(
+				// cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes",
+						},
+					],
+					["0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002470a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000"',
+			);
+			expect(
+				// cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "bytes",
+						},
+					],
+					[
+						"0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004870a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000"',
+			);
+			expect(
+				// cast abi-encode "a(bytes)" "0x"
+				encodeAbiParameters([{ type: "bytes" }], ["0x"]),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(uint[])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(uint[])" "[420,69,22,55]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[]',
-            },
-          ],
-          [[420n, 69n, 22n, 55n]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000037"',
-      )
-    })
+	describe("(uint[])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(uint[])" "[420,69,22,55]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[]",
+						},
+					],
+					[[420n, 69n, 22n, 55n]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000037"',
+			);
+		});
 
-    test('empty', () => {
-      expect(
-        // cast abi-encode "a(uint[])" "[]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[]',
-            },
-          ],
-          [[]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+		test("empty", () => {
+			expect(
+				// cast abi-encode "a(uint[])" "[]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[]",
+						},
+					],
+					[[]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(uint[][])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(uint[][])" "[[420,69]]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[][]',
-            },
-          ],
-          [[[420n, 69n]]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
-      )
-    })
+	describe("(uint[][])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(uint[][])" "[[420,69]]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[][]",
+						},
+					],
+					[[[420n, 69n]]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
+			);
+		});
 
-    test('empty', () => {
-      expect(
-        // cast abi-encode "a(uint[][])" "[[]]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[][]',
-            },
-          ],
-          [[[]]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-      )
-    })
+		test("empty", () => {
+			expect(
+				// cast abi-encode "a(uint[][])" "[[]]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[][]",
+						},
+					],
+					[[[]]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+			);
+		});
 
-    test('complex', () => {
-      expect(
-        // cast abi-encode "a(uint[][])" "[[420,69],[22,55,22],[51,52,66,11]]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[][]',
-            },
-          ],
-          [
-            [
-              [420n, 69n],
-              [22n, 55n, 22n],
-              [51n, 52n, 66n, 11n],
-            ],
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000003700000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003300000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000b"',
-      )
-    })
-  })
+		test("complex", () => {
+			expect(
+				// cast abi-encode "a(uint[][])" "[[420,69],[22,55,22],[51,52,66,11]]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[][]",
+						},
+					],
+					[
+						[
+							[420n, 69n],
+							[22n, 55n, 22n],
+							[51n, 52n, 66n, 11n],
+						],
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000003700000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003300000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000b"',
+			);
+		});
+	});
 
-  describe('(uint[][][])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(uint[][][])" "[[[420,69]]]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'uint256[][][]',
-            },
-          ],
-          [[[[420n, 69n]]]],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
-      )
-    })
-  })
+	describe("(uint[][][])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(uint[][][])" "[[[420,69]]]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "uint256[][][]",
+						},
+					],
+					[[[[420n, 69n]]]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
+			);
+		});
+	});
 
-  describe('(string[2])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(string[2])" "["wagmi","viem"]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'string[2]',
-            },
-          ],
-          [['wagmi', 'viem']],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(string[2])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(string[2])" "["wagmi","viem"]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "string[2]",
+						},
+					],
+					[["wagmi", "viem"]],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(string[2][3])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(string[2][3])" "[["wagmi","viem"],["jake","tom"],["lol","haha"]]"
-        encodeAbiParameters(
-          [
-            {
-              name: 'xIn',
-              type: 'string[2][3]',
-            },
-          ],
-          [
-            [
-              ['wagmi', 'viem'],
-              ['jake', 'tom'],
-              ['lol', 'haha'],
-            ],
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046a616b65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003746f6d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(string[2][3])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(string[2][3])" "[["wagmi","viem"],["jake","tom"],["lol","haha"]]"
+				encodeAbiParameters(
+					[
+						{
+							name: "xIn",
+							type: "string[2][3]",
+						},
+					],
+					[
+						[
+							["wagmi", "viem"],
+							["jake", "tom"],
+							["lol", "haha"],
+						],
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046a616b65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003746f6d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('((uint256[],bool,string[]))', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a((uint256[],bool,string[]))" "([1,2,3,4],true,[hello,world])"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  name: 'x',
-                  type: 'uint256[]',
-                },
-                {
-                  name: 'y',
-                  type: 'bool',
-                },
-                {
-                  name: 'z',
-                  type: 'string[]',
-                },
-              ],
-              name: 'bazIn',
-              type: 'tuple',
-            },
-          ],
-          [
-            {
-              x: [1n, 2n, 3n, 4n],
-              y: true,
-              z: ['hello', 'world'],
-            },
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c64000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("((uint256[],bool,string[]))", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a((uint256[],bool,string[]))" "([1,2,3,4],true,[hello,world])"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									name: "x",
+									type: "uint256[]",
+								},
+								{
+									name: "y",
+									type: "bool",
+								},
+								{
+									name: "z",
+									type: "string[]",
+								},
+							],
+							name: "bazIn",
+							type: "tuple",
+						},
+					],
+					[
+						{
+							x: [1n, 2n, 3n, 4n],
+							y: true,
+							z: ["hello", "world"],
+						},
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c64000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(((uint256[],bool,string[])),uint256,string[])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a(((uint256[],bool,string[]),uint256,string[]))" "(([1,2,3,4],true,[hello,world]),420,[wagmi,viem])"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  components: [
-                    {
-                      name: 'x',
-                      type: 'uint256[]',
-                    },
-                    {
-                      name: 'y',
-                      type: 'bool',
-                    },
-                    {
-                      name: 'z',
-                      type: 'string[]',
-                    },
-                  ],
-                  name: 'foo',
-                  type: 'tuple',
-                },
-                {
-                  name: 'a',
-                  type: 'uint256',
-                },
-                {
-                  name: 'b',
-                  type: 'string[]',
-                },
-              ],
-              name: 'wagmiIn',
-              type: 'tuple',
-            },
-          ],
-          [
-            {
-              foo: {
-                x: [1n, 2n, 3n, 4n],
-                y: true,
-                z: ['hello', 'world'],
-              },
-              a: 420n,
-              b: ['wagmi', 'viem'],
-            },
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c6400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
+	describe("(((uint256[],bool,string[])),uint256,string[])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a(((uint256[],bool,string[]),uint256,string[]))" "(([1,2,3,4],true,[hello,world]),420,[wagmi,viem])"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									components: [
+										{
+											name: "x",
+											type: "uint256[]",
+										},
+										{
+											name: "y",
+											type: "bool",
+										},
+										{
+											name: "z",
+											type: "string[]",
+										},
+									],
+									name: "foo",
+									type: "tuple",
+								},
+								{
+									name: "a",
+									type: "uint256",
+								},
+								{
+									name: "b",
+									type: "string[]",
+								},
+							],
+							name: "wagmiIn",
+							type: "tuple",
+						},
+					],
+					[
+						{
+							foo: {
+								x: [1n, 2n, 3n, 4n],
+								y: true,
+								z: ["hello", "world"],
+							},
+							a: 420n,
+							b: ["wagmi", "viem"],
+						},
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c6400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
 
-  describe('(((uint256[],bool,string[]))[],uint256,string[])', () => {
-    test('default', () => {
-      expect(
-        // cast abi-encode "a((uint256[],bool,string[]),(((uint256[],bool,string),uint256,string[]),((uint256[],bool,string),uint256,string[]),uint256,string[]))" "([1,2,3,4],true,[hello, world])" "((([420,69],true,[nice,haha]),420,[wagmi,allday]),(([420,420],true,[this,is,a,param]),69420,[hello,there]),4204202,[lol,haha])"
-        encodeAbiParameters(
-          [
-            {
-              components: [
-                {
-                  name: 'x',
-                  type: 'uint256[]',
-                },
-                {
-                  name: 'y',
-                  type: 'bool',
-                },
-                {
-                  name: 'z',
-                  type: 'string[]',
-                },
-              ],
-              name: 'bazIn',
-              type: 'tuple[]',
-            },
-            {
-              components: [
-                {
-                  components: [
-                    {
-                      components: [
-                        {
-                          name: 'x',
-                          type: 'uint256[]',
-                        },
-                        {
-                          name: 'y',
-                          type: 'bool',
-                        },
-                        {
-                          name: 'z',
-                          type: 'string[]',
-                        },
-                      ],
-                      name: 'foo',
-                      type: 'tuple',
-                    },
-                    {
-                      name: 'a',
-                      type: 'uint256',
-                    },
-                    {
-                      name: 'b',
-                      type: 'string[]',
-                    },
-                  ],
-                  name: 'foo',
-                  type: 'tuple',
-                },
-                {
-                  components: [
-                    {
-                      components: [
-                        {
-                          name: 'x',
-                          type: 'uint256[]',
-                        },
-                        {
-                          name: 'y',
-                          type: 'bool',
-                        },
-                        {
-                          name: 'z',
-                          type: 'string[]',
-                        },
-                      ],
-                      name: 'foo',
-                      type: 'tuple',
-                    },
-                    {
-                      name: 'a',
-                      type: 'uint256',
-                    },
-                    {
-                      name: 'b',
-                      type: 'string[]',
-                    },
-                  ],
-                  name: 'bar',
-                  type: 'tuple',
-                },
-                {
-                  name: 'c',
-                  type: 'uint256',
-                },
-                {
-                  name: 'd',
-                  type: 'string[]',
-                },
-              ],
-              name: 'gmiIn',
-              type: 'tuple',
-            },
-          ],
-          [
-            [
-              {
-                x: [1n, 2n, 3n, 4n],
-                y: true,
-                z: ['hello', 'world'],
-              },
-            ],
-            {
-              bar: {
-                a: 69420n,
-                b: ['hello', 'there'],
-                foo: {
-                  x: [420n, 420n],
-                  y: true,
-                  z: ['this', 'is', 'a', 'param'],
-                },
-              },
-              c: 4204202n,
-              d: ['lol', 'haha'],
-              foo: {
-                a: 420n,
-                b: ['wagmi', 'allday'],
-                foo: {
-                  x: [420n, 69n],
-                  y: true,
-                  z: ['nice', 'haha'],
-                },
-              },
-            },
-          ],
-        ),
-      ).toMatchInlineSnapshot(
-        '"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000002600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000004026aa0000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046e696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004686168610000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d690000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006616c6c646179000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000010f2c00000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000004746869730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026973000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000161000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005706172616d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005746865726500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
-      )
-    })
-  })
-})
+	describe("(((uint256[],bool,string[]))[],uint256,string[])", () => {
+		test("default", () => {
+			expect(
+				// cast abi-encode "a((uint256[],bool,string[]),(((uint256[],bool,string),uint256,string[]),((uint256[],bool,string),uint256,string[]),uint256,string[]))" "([1,2,3,4],true,[hello, world])" "((([420,69],true,[nice,haha]),420,[wagmi,allday]),(([420,420],true,[this,is,a,param]),69420,[hello,there]),4204202,[lol,haha])"
+				encodeAbiParameters(
+					[
+						{
+							components: [
+								{
+									name: "x",
+									type: "uint256[]",
+								},
+								{
+									name: "y",
+									type: "bool",
+								},
+								{
+									name: "z",
+									type: "string[]",
+								},
+							],
+							name: "bazIn",
+							type: "tuple[]",
+						},
+						{
+							components: [
+								{
+									components: [
+										{
+											components: [
+												{
+													name: "x",
+													type: "uint256[]",
+												},
+												{
+													name: "y",
+													type: "bool",
+												},
+												{
+													name: "z",
+													type: "string[]",
+												},
+											],
+											name: "foo",
+											type: "tuple",
+										},
+										{
+											name: "a",
+											type: "uint256",
+										},
+										{
+											name: "b",
+											type: "string[]",
+										},
+									],
+									name: "foo",
+									type: "tuple",
+								},
+								{
+									components: [
+										{
+											components: [
+												{
+													name: "x",
+													type: "uint256[]",
+												},
+												{
+													name: "y",
+													type: "bool",
+												},
+												{
+													name: "z",
+													type: "string[]",
+												},
+											],
+											name: "foo",
+											type: "tuple",
+										},
+										{
+											name: "a",
+											type: "uint256",
+										},
+										{
+											name: "b",
+											type: "string[]",
+										},
+									],
+									name: "bar",
+									type: "tuple",
+								},
+								{
+									name: "c",
+									type: "uint256",
+								},
+								{
+									name: "d",
+									type: "string[]",
+								},
+							],
+							name: "gmiIn",
+							type: "tuple",
+						},
+					],
+					[
+						[
+							{
+								x: [1n, 2n, 3n, 4n],
+								y: true,
+								z: ["hello", "world"],
+							},
+						],
+						{
+							bar: {
+								a: 69420n,
+								b: ["hello", "there"],
+								foo: {
+									x: [420n, 420n],
+									y: true,
+									z: ["this", "is", "a", "param"],
+								},
+							},
+							c: 4204202n,
+							d: ["lol", "haha"],
+							foo: {
+								a: 420n,
+								b: ["wagmi", "allday"],
+								foo: {
+									x: [420n, 69n],
+									y: true,
+									z: ["nice", "haha"],
+								},
+							},
+						},
+					],
+				),
+			).toMatchInlineSnapshot(
+				'"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000002600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000004026aa0000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046e696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004686168610000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d690000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006616c6c646179000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000010f2c00000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000004746869730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026973000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000161000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005706172616d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005746865726500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
+			);
+		});
+	});
+});
 
 const orderComponents = [
-  {
-    conduitKey:
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-    consideration: [
-      {
-        endAmount: 420n,
-        identifierOrCriteria: 69n,
-        itemType: 10,
-        recipient: address.vitalik,
-        startAmount: 6n,
-        token: address.burn,
-      },
-      {
-        endAmount: 141n,
-        identifierOrCriteria: 55n,
-        itemType: 16,
-        recipient: address.vitalik,
-        startAmount: 15n,
-        token: address.burn,
-      },
-    ],
-    counter: 1234123123n,
-    endTime: 123123123123n,
-    offer: [
-      {
-        endAmount: 420n,
-        identifierOrCriteria: 69n,
-        itemType: 10,
-        startAmount: 6n,
-        token: address.burn,
-      },
-      {
-        endAmount: 11n,
-        identifierOrCriteria: 515n,
-        itemType: 10,
-        startAmount: 6n,
-        token: address.usdcHolder,
-      },
-      {
-        endAmount: 123123n,
-        identifierOrCriteria: 55555511n,
-        itemType: 10,
-        startAmount: 111n,
-        token: address.vitalik,
-      },
-    ],
-    offerer: address.vitalik,
-    orderType: 10,
-    salt: 1234123123n,
-    startTime: 123123123123n,
-    zone: address.vitalik,
-    zoneHash:
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-  },
-  {
-    conduitKey:
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-    consideration: [
-      {
-        endAmount: 420n,
-        identifierOrCriteria: 69n,
-        itemType: 10,
-        recipient: address.vitalik,
-        startAmount: 6n,
-        token: address.burn,
-      },
-      {
-        endAmount: 141n,
-        identifierOrCriteria: 55n,
-        itemType: 16,
-        recipient: address.vitalik,
-        startAmount: 15n,
-        token: address.burn,
-      },
-    ],
-    counter: 1234123123n,
-    endTime: 123123123123n,
-    offer: [
-      {
-        endAmount: 420n,
-        identifierOrCriteria: 69n,
-        itemType: 10,
-        startAmount: 6n,
-        token: address.burn,
-      },
-      {
-        endAmount: 11n,
-        identifierOrCriteria: 515n,
-        itemType: 10,
-        startAmount: 6n,
-        token: address.usdcHolder,
-      },
-      {
-        endAmount: 123123n,
-        identifierOrCriteria: 55555511n,
-        itemType: 10,
-        startAmount: 111n,
-        token: address.vitalik,
-      },
-    ],
-    offerer: address.vitalik,
-    orderType: 10,
-    salt: 1234123123n,
-    startTime: 123123123123n,
-    zone: address.vitalik,
-    zoneHash:
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-  },
-] as const
+	{
+		conduitKey: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+		consideration: [
+			{
+				endAmount: 420n,
+				identifierOrCriteria: 69n,
+				itemType: 10,
+				recipient: address.vitalik,
+				startAmount: 6n,
+				token: address.burn,
+			},
+			{
+				endAmount: 141n,
+				identifierOrCriteria: 55n,
+				itemType: 16,
+				recipient: address.vitalik,
+				startAmount: 15n,
+				token: address.burn,
+			},
+		],
+		counter: 1234123123n,
+		endTime: 123123123123n,
+		offer: [
+			{
+				endAmount: 420n,
+				identifierOrCriteria: 69n,
+				itemType: 10,
+				startAmount: 6n,
+				token: address.burn,
+			},
+			{
+				endAmount: 11n,
+				identifierOrCriteria: 515n,
+				itemType: 10,
+				startAmount: 6n,
+				token: address.usdcHolder,
+			},
+			{
+				endAmount: 123123n,
+				identifierOrCriteria: 55555511n,
+				itemType: 10,
+				startAmount: 111n,
+				token: address.vitalik,
+			},
+		],
+		offerer: address.vitalik,
+		orderType: 10,
+		salt: 1234123123n,
+		startTime: 123123123123n,
+		zone: address.vitalik,
+		zoneHash: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+	},
+	{
+		conduitKey: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+		consideration: [
+			{
+				endAmount: 420n,
+				identifierOrCriteria: 69n,
+				itemType: 10,
+				recipient: address.vitalik,
+				startAmount: 6n,
+				token: address.burn,
+			},
+			{
+				endAmount: 141n,
+				identifierOrCriteria: 55n,
+				itemType: 16,
+				recipient: address.vitalik,
+				startAmount: 15n,
+				token: address.burn,
+			},
+		],
+		counter: 1234123123n,
+		endTime: 123123123123n,
+		offer: [
+			{
+				endAmount: 420n,
+				identifierOrCriteria: 69n,
+				itemType: 10,
+				startAmount: 6n,
+				token: address.burn,
+			},
+			{
+				endAmount: 11n,
+				identifierOrCriteria: 515n,
+				itemType: 10,
+				startAmount: 6n,
+				token: address.usdcHolder,
+			},
+			{
+				endAmount: 123123n,
+				identifierOrCriteria: 55555511n,
+				itemType: 10,
+				startAmount: 111n,
+				token: address.vitalik,
+			},
+		],
+		offerer: address.vitalik,
+		orderType: 10,
+		salt: 1234123123n,
+		startTime: 123123123123n,
+		zone: address.vitalik,
+		zoneHash: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+	},
+] as const;
 
-describe('seaport', () => {
-  test('cancel', () => {
-    const cancel = getAbiItem({
-      abi: seaportContractConfig.abi,
-      name: 'cancel',
-    })
-    const data = encodeAbiParameters(cancel.inputs, [orderComponents])
-    expect(data).toMatchInlineSnapshot(
-      '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
-    )
-  })
+describe("seaport", () => {
+	test("cancel", () => {
+		const cancel = getAbiItem({
+			abi: seaportContractConfig.abi,
+			name: "cancel",
+		});
+		const data = encodeAbiParameters(cancel.inputs, [orderComponents]);
+		expect(data).toMatchInlineSnapshot(
+			'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
+		);
+	});
 
-  test('fulfillAdvancedOrder', () => {
-    const {
-      conduitKey,
-      consideration,
-      endTime,
-      offer,
-      offerer,
-      orderType,
-      salt,
-      startTime,
-      zone,
-      zoneHash,
-    } = orderComponents[0]
+	test("fulfillAdvancedOrder", () => {
+		const {
+			conduitKey,
+			consideration,
+			endTime,
+			offer,
+			offerer,
+			orderType,
+			salt,
+			startTime,
+			zone,
+			zoneHash,
+		} = orderComponents[0];
 
-    const fulfillAdvancedOrder = getAbiItem({
-      abi: seaportContractConfig.abi,
-      name: 'fulfillAdvancedOrder',
-    })
-    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-      {
-        denominator: 69n,
-        extraData: '0x123123',
-        numerator: 420n,
-        parameters: {
-          conduitKey,
-          consideration,
-          endTime,
-          offer,
-          offerer,
-          orderType,
-          salt,
-          startTime,
-          totalOriginalConsiderationItems: 69420n,
-          zone,
-          zoneHash,
-        },
-        signature: '0x123123',
-      },
-      [
-        {
-          criteriaProof: [
-            '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-          ],
-          identifier: 4242n,
-          index: 1231n,
-          orderIndex: 11n,
-          side: 1,
-        },
-      ],
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-      address.vitalik,
-    ])
-    expect(data).toMatchInlineSnapshot(
-      '"0x000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000006a0511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000004cf000000000000000000000000000000000000000000000000000000000000109200000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"',
-    )
-  })
+		const fulfillAdvancedOrder = getAbiItem({
+			abi: seaportContractConfig.abi,
+			name: "fulfillAdvancedOrder",
+		});
+		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+			{
+				denominator: 69n,
+				extraData: "0x123123",
+				numerator: 420n,
+				parameters: {
+					conduitKey,
+					consideration,
+					endTime,
+					offer,
+					offerer,
+					orderType,
+					salt,
+					startTime,
+					totalOriginalConsiderationItems: 69420n,
+					zone,
+					zoneHash,
+				},
+				signature: "0x123123",
+			},
+			[
+				{
+					criteriaProof: ["0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"],
+					identifier: 4242n,
+					index: 1231n,
+					orderIndex: 11n,
+					side: 1,
+				},
+			],
+			"0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+			address.vitalik,
+		]);
+		expect(data).toMatchInlineSnapshot(
+			'"0x000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000006a0511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000004cf000000000000000000000000000000000000000000000000000000000000109200000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"',
+		);
+	});
 
-  test('fulfillAvailableAdvancedOrders', () => {
-    const {
-      conduitKey,
-      consideration,
-      endTime,
-      offer,
-      offerer,
-      orderType,
-      salt,
-      startTime,
-      zone,
-      zoneHash,
-    } = orderComponents[0]
+	test("fulfillAvailableAdvancedOrders", () => {
+		const {
+			conduitKey,
+			consideration,
+			endTime,
+			offer,
+			offerer,
+			orderType,
+			salt,
+			startTime,
+			zone,
+			zoneHash,
+		} = orderComponents[0];
 
-    const fulfillAdvancedOrder = getAbiItem({
-      abi: seaportContractConfig.abi,
-      name: 'fulfillAvailableAdvancedOrders',
-    })
-    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-      [
-        {
-          denominator: 24n,
-          extraData: '0x123123',
-          numerator: 41n,
-          parameters: {
-            conduitKey,
-            consideration,
-            endTime,
-            offer,
-            offerer,
-            orderType,
-            salt,
-            startTime,
-            totalOriginalConsiderationItems: 69420n,
-            zone,
-            zoneHash,
-          },
-          signature: '0x123123',
-        },
-      ],
-      [
-        {
-          criteriaProof: [
-            '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-          ],
-          identifier: 12n,
-          index: 1n,
-          orderIndex: 1n,
-          side: 1,
-        },
-      ],
-      [[{ itemIndex: 1n, orderIndex: 1n }]],
-      [[{ itemIndex: 1n, orderIndex: 2n }]],
-      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
-      address.vitalik,
-      10n,
-    ])
-    expect(data).toMatchInlineSnapshot(
-      '"0x00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000074000000000000000000000000000000000000000000000000000000000000008600000000000000000000000000000000000000000000000000000000000000900511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000029000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001"',
-    )
-  })
+		const fulfillAdvancedOrder = getAbiItem({
+			abi: seaportContractConfig.abi,
+			name: "fulfillAvailableAdvancedOrders",
+		});
+		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+			[
+				{
+					denominator: 24n,
+					extraData: "0x123123",
+					numerator: 41n,
+					parameters: {
+						conduitKey,
+						consideration,
+						endTime,
+						offer,
+						offerer,
+						orderType,
+						salt,
+						startTime,
+						totalOriginalConsiderationItems: 69420n,
+						zone,
+						zoneHash,
+					},
+					signature: "0x123123",
+				},
+			],
+			[
+				{
+					criteriaProof: ["0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"],
+					identifier: 12n,
+					index: 1n,
+					orderIndex: 1n,
+					side: 1,
+				},
+			],
+			[[{ itemIndex: 1n, orderIndex: 1n }]],
+			[[{ itemIndex: 1n, orderIndex: 2n }]],
+			"0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
+			address.vitalik,
+			10n,
+		]);
+		expect(data).toMatchInlineSnapshot(
+			'"0x00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000074000000000000000000000000000000000000000000000000000000000000008600000000000000000000000000000000000000000000000000000000000000900511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000029000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001"',
+		);
+	});
 
-  test('getCounter', () => {
-    const getCounter = getAbiItem({
-      abi: seaportContractConfig.abi,
-      name: 'getCounter',
-    })
-    const data = encodeAbiParameters(getCounter.inputs, [address.vitalik])
-    expect(data).toMatchInlineSnapshot(
-      '"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
-    )
-  })
+	test("getCounter", () => {
+		const getCounter = getAbiItem({
+			abi: seaportContractConfig.abi,
+			name: "getCounter",
+		});
+		const data = encodeAbiParameters(getCounter.inputs, [address.vitalik]);
+		expect(data).toMatchInlineSnapshot(
+			'"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
+		);
+	});
 
-  test('fulfillAvailableAdvancedOrders', () => {
-    const {
-      conduitKey,
-      consideration,
-      endTime,
-      offer,
-      offerer,
-      orderType,
-      salt,
-      startTime,
-      zone,
-      zoneHash,
-    } = orderComponents[0]
+	test("fulfillAvailableAdvancedOrders", () => {
+		const {
+			conduitKey,
+			consideration,
+			endTime,
+			offer,
+			offerer,
+			orderType,
+			salt,
+			startTime,
+			zone,
+			zoneHash,
+		} = orderComponents[0];
 
-    const fulfillAdvancedOrder = getAbiItem({
-      abi: seaportContractConfig.abi,
-      name: 'validate',
-    })
-    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-      [
-        {
-          parameters: {
-            conduitKey,
-            consideration,
-            endTime,
-            offer,
-            offerer,
-            orderType,
-            salt,
-            startTime,
-            totalOriginalConsiderationItems: 2n,
-            zone,
-            zoneHash,
-          },
-          signature: '0x123123',
-        },
-      ],
-    ])
-    expect(data).toMatchInlineSnapshot(
-      '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000031231230000000000000000000000000000000000000000000000000000000000"',
-    )
-  })
-})
+		const fulfillAdvancedOrder = getAbiItem({
+			abi: seaportContractConfig.abi,
+			name: "validate",
+		});
+		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+			[
+				{
+					parameters: {
+						conduitKey,
+						consideration,
+						endTime,
+						offer,
+						offerer,
+						orderType,
+						salt,
+						startTime,
+						totalOriginalConsiderationItems: 2n,
+						zone,
+						zoneHash,
+					},
+					signature: "0x123123",
+				},
+			],
+		]);
+		expect(data).toMatchInlineSnapshot(
+			'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000031231230000000000000000000000000000000000000000000000000000000000"',
+		);
+	});
+});
 
-test('invalid type', () => {
-  expect(() =>
-    encodeAbiParameters([{ name: 'x', type: 'lol' }], [69]),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid type", () => {
+	expect(() => encodeAbiParameters([{ name: "x", type: "lol" }], [69]))
+		.toThrowErrorMatchingInlineSnapshot(`
     [InvalidAbiEncodingType: Type "lol" is not a valid encoding type.
     Please provide a valid ABI type.
 
     Docs: https://viem.sh/docs/contract/encodeAbiParameters
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('invalid params/values lengths', () => {
-  expect(() =>
-    encodeAbiParameters(
-      [{ name: 'x', type: 'uint256[3]' }],
-      /* @ts-expect-error */
-      [69, 420],
-    ),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid params/values lengths", () => {
+	expect(() =>
+		encodeAbiParameters(
+			[{ name: "x", type: "uint256[3]" }],
+			/* @ts-expect-error */
+			[69, 420],
+		),
+	).toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingLengthMismatchError: ABI encoding params/values length mismatch.
     Expected length (params): 1
     Given length (values): 2
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('invalid address', () => {
-  expect(() =>
-    encodeAbiParameters([{ name: 'x', type: 'address' }], ['0x111']),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid address", () => {
+	expect(() => encodeAbiParameters([{ name: "x", type: "address" }], ["0x111"]))
+		.toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x111" is invalid.
 
     - Address must be a hex value of 20 bytes (40 hex characters).
     - Address must match its checksum counterpart.
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('invalid array', () => {
-  expect(() =>
-    encodeAbiParameters(
-      [{ name: 'x', type: 'uint256[3]' }],
-      /* @ts-expect-error */
-      [69],
-    ),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid array", () => {
+	expect(() =>
+		encodeAbiParameters(
+			[{ name: "x", type: "uint256[3]" }],
+			/* @ts-expect-error */
+			[69],
+		),
+	).toThrowErrorMatchingInlineSnapshot(`
     [InvalidArrayError: Value "69" is not a valid array.
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('invalid array lengths', () => {
-  expect(() =>
-    encodeAbiParameters(
-      [{ name: 'x', type: 'uint256[3]' }],
-      /* @ts-expect-error */
-      [[69n, 420n]],
-    ),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid array lengths", () => {
+	expect(() =>
+		encodeAbiParameters(
+			[{ name: "x", type: "uint256[3]" }],
+			/* @ts-expect-error */
+			[[69n, 420n]],
+		),
+	).toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingArrayLengthMismatchError: ABI encoding array length mismatch for type uint256[3].
     Expected length: 3
     Given length: 2
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('invalid bytes', () => {
-  expect(() =>
-    encodeAbiParameters([{ name: 'x', type: 'bytes8' }], ['0x111']),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("invalid bytes", () => {
+	expect(() => encodeAbiParameters([{ name: "x", type: "bytes8" }], ["0x111"]))
+		.toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingBytesSizeMismatchError: Size of bytes "0x111" (bytes2) does not match expected size (bytes8).
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});
 
-test('getArrayComponents', () => {
-  expect(getArrayComponents('uint256[2]')).toEqual([2, 'uint256'])
-  expect(getArrayComponents('uint256[2][3]')).toEqual([3, 'uint256[2]'])
-  expect(getArrayComponents('uint256[][3]')).toEqual([3, 'uint256[]'])
-  expect(getArrayComponents('uint256[]')).toEqual([null, 'uint256'])
-  expect(getArrayComponents('uint256[][]')).toEqual([null, 'uint256[]'])
-  expect(getArrayComponents('uint256')).toBeUndefined()
-})
+test("getArrayComponents", () => {
+	expect(getArrayComponents("uint256[2]")).toEqual([2, "uint256"]);
+	expect(getArrayComponents("uint256[2][3]")).toEqual([3, "uint256[2]"]);
+	expect(getArrayComponents("uint256[][3]")).toEqual([3, "uint256[]"]);
+	expect(getArrayComponents("uint256[]")).toEqual([null, "uint256"]);
+	expect(getArrayComponents("uint256[][]")).toEqual([null, "uint256[]"]);
+	expect(getArrayComponents("uint256")).toBeUndefined();
+});
 
-test('https://github.com/wevm/viem/issues/1960', () => {
-  expect(() =>
-    encodeAbiParameters(
-      [
-        {
-          name: 'boolz',
-          type: 'bool[]',
-          internalType: 'bool[]',
-        },
-      ] as const,
-      // @ts-expect-error
-      [['true']],
-    ),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: Invalid boolean value: "true" (type: string). Expected: \`true\` or \`false\`.
+test("https://github.com/wevm/viem/issues/1960", () => {
+	expect(() =>
+		encodeAbiParameters(
+			[
+				{
+					name: "boolz",
+					type: "bool[]",
+					internalType: "bool[]",
+				},
+			] as const,
+			// @ts-expect-error
+			[["truez"]],
+		),
+	).toThrowErrorMatchingInlineSnapshot(`
+    [ViemError: Invalid boolean value: "truez" (type: string). Expected: \`true\` or \`false\`.
 
     Version: viem@x.y.z]
-  `)
-})
+  `);
+});

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1,1813 +1,1869 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from 'vitest'
 
-import { seaportContractConfig } from "~test/src/abis.js";
-import { address } from "~test/src/constants.js";
+import { seaportContractConfig } from '~test/src/abis.js'
+import { address } from '~test/src/constants.js'
 
-import { encodeAbiParameters, getArrayComponents } from "./encodeAbiParameters.js";
-import { getAbiItem } from "./getAbiItem.js";
+import {
+  encodeAbiParameters,
+  getArrayComponents,
+} from './encodeAbiParameters.js'
+import { getAbiItem } from './getAbiItem.js'
 
-describe("static", () => {
-	test("blank", () => {
-		expect(encodeAbiParameters([], [])).toBe("0x");
-	});
+describe('static', () => {
+  test('blank', () => {
+    expect(encodeAbiParameters([], [])).toBe('0x')
+  })
 
-	test("uint", () => {
-		expect(
-			encodeAbiParameters(
-				[
-					{
-						type: "uint256",
-					},
-				],
-				[69420n],
-			),
-		).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
-	});
+  test('uint', () => {
+    expect(
+      encodeAbiParameters(
+        [
+          {
+            type: 'uint256',
+          },
+        ],
+        [69420n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000010f2c')
+  })
 
-	describe("uint8", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint8",
-						},
-					],
-					[32],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000020");
-		});
+  describe('uint8', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint8',
+            },
+          ],
+          [32],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000020',
+      )
+    })
 
-		test("invalid value", () => {
-			try {
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint8",
-						},
-					],
-					// @ts-expect-error
-					[69420n],
-				);
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint8",
-						},
-					],
-					// @ts-expect-error
-					["lol"],
-				);
-			} catch {}
-		});
-	});
+    test('invalid value', () => {
+      try {
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint8',
+            },
+          ],
+          // @ts-expect-error
+          [69420n],
+        )
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint8',
+            },
+          ],
+          // @ts-expect-error
+          ['lol'],
+        )
+      } catch {}
+    })
+  })
 
-	describe("uint32", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint32",
-						},
-					],
-					[69420],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
-		});
+  describe('uint32', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint32',
+            },
+          ],
+          [69420],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000010f2c',
+      )
+    })
 
-		test("invalid value", () => {
-			try {
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint32",
-						},
-					],
-					// @ts-expect-error
-					[69420n],
-				);
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint32",
-						},
-					],
-					// @ts-expect-error
-					["lol"],
-				);
-			} catch {}
-		});
-	});
+    test('invalid value', () => {
+      try {
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint32',
+            },
+          ],
+          // @ts-expect-error
+          [69420n],
+        )
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint32',
+            },
+          ],
+          // @ts-expect-error
+          ['lol'],
+        )
+      } catch {}
+    })
+  })
 
-	describe("int", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int256",
-						},
-					],
-					[69420n],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000010f2c");
-		});
+  describe('int', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int256',
+            },
+          ],
+          [69420n],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000010f2c',
+      )
+    })
 
-		test("negative (twos compliment)", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int256",
-						},
-					],
-					[-69420n],
-				),
-			).toBe("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffef0d4");
-		});
-	});
+    test('negative (twos compliment)', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int256',
+            },
+          ],
+          [-69420n],
+        ),
+      ).toBe(
+        '0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffef0d4',
+      )
+    })
+  })
 
-	describe("int8", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int8",
-						},
-					],
-					[127],
-				),
-			).toBe("0x000000000000000000000000000000000000000000000000000000000000007f");
-		});
+  describe('int8', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int8',
+            },
+          ],
+          [127],
+        ),
+      ).toBe(
+        '0x000000000000000000000000000000000000000000000000000000000000007f',
+      )
+    })
 
-		test("negative (twos compliment)", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int8",
-						},
-					],
-					[-128],
-				),
-			).toBe("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80");
-		});
+    test('negative (twos compliment)', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int8',
+            },
+          ],
+          [-128],
+        ),
+      ).toBe(
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80',
+      )
+    })
 
-		test("invalid value", () => {
-			try {
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int8",
-						},
-					],
-					// @ts-expect-error
-					[69420n],
-				);
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int8",
-						},
-					],
-					// @ts-expect-error
-					["lol"],
-				);
-			} catch {}
-		});
-	});
+    test('invalid value', () => {
+      try {
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int8',
+            },
+          ],
+          // @ts-expect-error
+          [69420n],
+        )
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int8',
+            },
+          ],
+          // @ts-expect-error
+          ['lol'],
+        )
+      } catch {}
+    })
+  })
 
-	describe("int32", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int32",
-						},
-					],
-					[2147483647],
-				),
-			).toBe("0x000000000000000000000000000000000000000000000000000000007fffffff");
-		});
+  describe('int32', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int32',
+            },
+          ],
+          [2147483647],
+        ),
+      ).toBe(
+        '0x000000000000000000000000000000000000000000000000000000007fffffff',
+      )
+    })
 
-		test("negative (twos compliment)", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int8",
-						},
-					],
-					[-2147483648],
-				),
-			).toBe("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000");
-		});
+    test('negative (twos compliment)', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int8',
+            },
+          ],
+          [-2147483648],
+        ),
+      ).toBe(
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000',
+      )
+    })
 
-		test("invalid value", () => {
-			try {
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int32",
-						},
-					],
-					// @ts-expect-error
-					[69420n],
-				);
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int32",
-						},
-					],
-					// @ts-expect-error
-					["lol"],
-				);
-			} catch {}
-		});
-	});
+    test('invalid value', () => {
+      try {
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int32',
+            },
+          ],
+          // @ts-expect-error
+          [69420n],
+        )
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int32',
+            },
+          ],
+          // @ts-expect-error
+          ['lol'],
+        )
+      } catch {}
+    })
+  })
 
-	describe("address", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "address",
-						},
-					],
-					["0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"],
-				),
-			).toBe("0x00000000000000000000000014dc79964da2c08b23698b3d3cc7ca32193d9955");
-		});
-	});
+  describe('address', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'address',
+            },
+          ],
+          ['0x14dC79964da2C08b23698B3D3cc7Ca32193d9955'],
+        ),
+      ).toBe(
+        '0x00000000000000000000000014dc79964da2c08b23698b3d3cc7ca32193d9955',
+      )
+    })
+  })
 
-	describe("bool", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					[true],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					[false],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
-		});
+  describe('bool', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [true],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [false],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
 
-		test("from string", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					["False" as unknown as boolean],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					["True" as unknown as boolean],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
-		});
+    test('from string', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          ['False' as unknown as boolean],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          ['True' as unknown as boolean],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+    })
 
-		test("from number", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					[23 as unknown as boolean],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					[BigInt(23) as unknown as boolean],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool",
-						},
-					],
-					[0 as unknown as boolean],
-				),
-			).toBe("0x0000000000000000000000000000000000000000000000000000000000000000");
-		});
-	});
+    test('from number', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [23 as unknown as boolean],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [BigInt(23) as unknown as boolean],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [0 as unknown as boolean],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
+  })
 
-	describe("bytes8", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes8",
-						},
-					],
-					["0x0123456789abcdef"],
-				),
-			).toBe("0x0123456789abcdef000000000000000000000000000000000000000000000000");
-		});
+  describe('bytes8', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes8',
+            },
+          ],
+          ['0x0123456789abcdef'],
+        ),
+      ).toBe(
+        '0x0123456789abcdef000000000000000000000000000000000000000000000000',
+      )
+    })
 
-		test("overflow", () => {
-			expect(() =>
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes8",
-						},
-					],
-					[
-						"0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef",
-					],
-				),
-			).toThrowErrorMatchingInlineSnapshot(
-				`
+    test('overflow', () => {
+      expect(() =>
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes8',
+            },
+          ],
+          [
+            '0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef',
+          ],
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `
         [AbiEncodingBytesSizeMismatchError: Size of bytes "0x0000000000000000000000000000000000000000000000000000000000000000000000000123456789abcdef" (bytes44) does not match expected size (bytes8).
 
         Version: viem@x.y.z]
       `,
-			);
-		});
-	});
+      )
+    })
+  })
 
-	describe("bytes16", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes16",
-						},
-					],
-					["0x42069420694201023210101231415122"],
-				),
-			).toBe("0x4206942069420102321010123141512200000000000000000000000000000000");
-		});
+  describe('bytes16', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes16',
+            },
+          ],
+          ['0x42069420694201023210101231415122'],
+        ),
+      ).toBe(
+        '0x4206942069420102321010123141512200000000000000000000000000000000',
+      )
+    })
 
-		test("overflow", () => {
-			expect(() =>
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes16",
-						},
-					],
-					["0x000000000000000000000000000000000000000000000000000000000000000420"],
-				),
-			).toThrowErrorMatchingInlineSnapshot(
-				`
+    test('overflow', () => {
+      expect(() =>
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes16',
+            },
+          ],
+          [
+            '0x000000000000000000000000000000000000000000000000000000000000000420',
+          ],
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `
         [AbiEncodingBytesSizeMismatchError: Size of bytes "0x000000000000000000000000000000000000000000000000000000000000000420" (bytes33) does not match expected size (bytes16).
 
         Version: viem@x.y.z]
       `,
-			);
-		});
-	});
+      )
+    })
+  })
 
-	describe("uint[3]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[3]",
-						},
-					],
-					[[69420n, 42069n, 420420420n]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b44"',
-			);
-		});
-	});
+  describe('uint[3]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[3]',
+            },
+          ],
+          [[69420n, 42069n, 420420420n]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b44"',
+      )
+    })
+  })
 
-	describe("int[3]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "int256[3]",
-						},
-					],
-					[[69420n, -42069n, 420420420n]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000010f2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5bab00000000000000000000000000000000000000000000000000000000190f1b44"',
-			);
-		});
-	});
+  describe('int[3]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'int256[3]',
+            },
+          ],
+          [[69420n, -42069n, 420420420n]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000010f2cffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5bab00000000000000000000000000000000000000000000000000000000190f1b44"',
+      )
+    })
+  })
 
-	describe("address[2]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "address[2]",
-						},
-					],
-					[
-						[
-							"0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b",
-							"0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-						],
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-			);
-		});
-	});
+  describe('address[2]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'address[2]',
+            },
+          ],
+          [
+            [
+              '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
+              '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            ],
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+      )
+    })
+  })
 
-	describe("bool[2]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bool[2]",
-						},
-					],
-					[[true, false]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('bool[2]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool[2]',
+            },
+          ],
+          [[true, false]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("bytes8[2]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes8[2]",
-						},
-					],
-					[["0x1211121112111211", "0x1111111111111111"]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x12111211121112110000000000000000000000000000000000000000000000001111111111111111000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('bytes8[2]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes8[2]',
+            },
+          ],
+          [['0x1211121112111211', '0x1111111111111111']],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x12111211121112110000000000000000000000000000000000000000000000001111111111111111000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("uint[3][2]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[3][2]",
-						},
-					],
-					[
-						[
-							[69420n, 42069n, 420420420n],
-							[420n, 44n, 422n],
-						],
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b4400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000001a6"',
-			);
-		});
-	});
+  describe('uint[3][2]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[3][2]',
+            },
+          ],
+          [
+            [
+              [69420n, 42069n, 420420420n],
+              [420n, 44n, 422n],
+            ],
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000010f2c000000000000000000000000000000000000000000000000000000000000a45500000000000000000000000000000000000000000000000000000000190f1b4400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000001a6"',
+      )
+    })
+  })
 
-	describe("uint[3][2][4]", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[3][2][4]",
-						},
-					],
-					[
-						[
-							[
-								[1n, 2n, 3n],
-								[4n, 5n, 6n],
-							],
-							[
-								[7n, 8n, 9n],
-								[10n, 11n, 12n],
-							],
-							[
-								[13n, 14n, 15n],
-								[16n, 17n, 18n],
-							],
-							[
-								[19n, 20n, 21n],
-								[22n, 23n, 24n],
-							],
-						],
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001300000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000015000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000018"',
-			);
-		});
-	});
+  describe('uint[3][2][4]', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[3][2][4]',
+            },
+          ],
+          [
+            [
+              [
+                [1n, 2n, 3n],
+                [4n, 5n, 6n],
+              ],
+              [
+                [7n, 8n, 9n],
+                [10n, 11n, 12n],
+              ],
+              [
+                [13n, 14n, 15n],
+                [16n, 17n, 18n],
+              ],
+              [
+                [19n, 20n, 21n],
+                [22n, 23n, 24n],
+              ],
+            ],
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001300000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000015000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000018"',
+      )
+    })
+  })
 
-	describe("struct: (uint256,bool,address)", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									name: "x",
-									type: "uint256",
-								},
-								{
-									name: "y",
-									type: "bool",
-								},
-								{
-									name: "z",
-									type: "address",
-								},
-							],
-							name: "fooIn",
-							type: "tuple",
-						},
-					],
-					[
-						{
-							x: 420n,
-							y: true,
-							z: "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-						},
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-			);
-		});
-	});
+  describe('struct: (uint256,bool,address)', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  name: 'x',
+                  type: 'uint256',
+                },
+                {
+                  name: 'y',
+                  type: 'bool',
+                },
+                {
+                  name: 'z',
+                  type: 'address',
+                },
+              ],
+              name: 'fooIn',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              x: 420n,
+              y: true,
+              z: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+      )
+    })
+  })
 
-	describe("struct: (uint256,bool,address)", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									type: "uint256",
-								},
-								{
-									type: "bool",
-								},
-								{
-									type: "address",
-								},
-							],
-							name: "fooOut",
-							type: "tuple",
-						},
-					],
-					[[420n, true, "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC"]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
-			);
-		});
-	});
+  describe('struct: (uint256,bool,address)', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a((uint256,bool,address))" "(420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC)"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'bool',
+                },
+                {
+                  type: 'address',
+                },
+              ],
+              name: 'fooOut',
+              type: 'tuple',
+            },
+          ],
+          [[420n, true, '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC']],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac"',
+      )
+    })
+  })
 
-	describe("struct: ((uint256,bool,address),(uint256,bool,address),uint8[2])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(((uint256,bool,address),(uint256,bool,address),uint8[2]))" "((420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC),(69,false,0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b),[1,2])"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									components: [
-										{
-											name: "x",
-											type: "uint256",
-										},
-										{
-											name: "y",
-											type: "bool",
-										},
-										{
-											name: "z",
-											type: "address",
-										},
-									],
-									name: "foo",
-									type: "tuple",
-								},
-								{
-									components: [
-										{
-											name: "x",
-											type: "uint256",
-										},
-										{
-											name: "y",
-											type: "bool",
-										},
-										{
-											name: "z",
-											type: "address",
-										},
-									],
-									name: "baz",
-									type: "tuple",
-								},
-								{
-									name: "x",
-									type: "uint8[2]",
-								},
-							],
-							name: "barIn",
-							type: "tuple",
-						},
-					],
-					[
-						{
-							foo: {
-								x: 420n,
-								y: true,
-								z: "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-							},
-							baz: {
-								x: 69n,
-								y: false,
-								z: "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b",
-							},
-							x: [1, 2],
-						},
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac00000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"',
-			);
-		});
-	});
+  describe('struct: ((uint256,bool,address),(uint256,bool,address),uint8[2])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(((uint256,bool,address),(uint256,bool,address),uint8[2]))" "((420,true,0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC),(69,false,0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b),[1,2])"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  components: [
+                    {
+                      name: 'x',
+                      type: 'uint256',
+                    },
+                    {
+                      name: 'y',
+                      type: 'bool',
+                    },
+                    {
+                      name: 'z',
+                      type: 'address',
+                    },
+                  ],
+                  name: 'foo',
+                  type: 'tuple',
+                },
+                {
+                  components: [
+                    {
+                      name: 'x',
+                      type: 'uint256',
+                    },
+                    {
+                      name: 'y',
+                      type: 'bool',
+                    },
+                    {
+                      name: 'z',
+                      type: 'address',
+                    },
+                  ],
+                  name: 'baz',
+                  type: 'tuple',
+                },
+                {
+                  name: 'x',
+                  type: 'uint8[2]',
+                },
+              ],
+              name: 'barIn',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              foo: {
+                x: 420n,
+                y: true,
+                z: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+              },
+              baz: {
+                x: 69n,
+                y: false,
+                z: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
+              },
+              x: [1, 2],
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac00000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"',
+      )
+    })
+  })
 
-	describe("struct: (uint8,bytes[])", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									type: "uint8",
-								},
-								{
-									type: "bytes[]",
-								},
-							],
-							type: "tuple",
-						},
-					],
-					[[69, ["0x123", "0x456"]]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024560000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
+  describe('struct: (uint8,bytes[])', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  type: 'uint8',
+                },
+                {
+                  type: 'bytes[]',
+                },
+              ],
+              type: 'tuple',
+            },
+          ],
+          [[69, ['0x123', '0x456']]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024560000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
 
-		test("empty bytes", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									type: "uint8",
-								},
-								{
-									type: "bytes[]",
-								},
-							],
-							type: "tuple",
-						},
-					],
-					[[0, []]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+    test('empty bytes', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  type: 'uint8',
+                },
+                {
+                  type: 'bytes[]',
+                },
+              ],
+              type: 'tuple',
+            },
+          ],
+          [[0, []]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(uint256[2],bool,string[])", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{ name: "xOut", type: "uint256[2]" },
-						{ name: "yOut", type: "bool" },
-						{ name: "zOut", type: "string[3]" },
-					],
-					[[420n, 69n], true, ["wagmi", "viem", "lol"]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036c6f6c0000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(uint256[2],bool,string[])', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            { name: 'xOut', type: 'uint256[2]' },
+            { name: 'yOut', type: 'bool' },
+            { name: 'zOut', type: 'string[3]' },
+          ],
+          [[420n, 69n], true, ['wagmi', 'viem', 'lol']],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036c6f6c0000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("multiple (uint,bool,address)", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256",
-						},
-						{
-							name: "yIn",
-							type: "bool",
-						},
-						{
-							name: "zIn",
-							type: "address",
-						},
-					],
-					[420n, true, "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
-			);
-		});
-	});
+  describe('multiple (uint,bool,address)', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256',
+            },
+            {
+              name: 'yIn',
+              type: 'bool',
+            },
+            {
+              name: 'zIn',
+              type: 'address',
+            },
+          ],
+          [420n, true, '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
+      )
+    })
+  })
 
-	describe("multiple params unnamed: (uint,bool,address)", () => {
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "",
-							type: "uint256",
-						},
-						{
-							name: "",
-							type: "bool",
-						},
-						{
-							name: "",
-							type: "address",
-						},
-					],
-					[420n, true, "0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
-			);
-		});
-	});
-});
+  describe('multiple params unnamed: (uint,bool,address)', () => {
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: '',
+              type: 'uint256',
+            },
+            {
+              name: '',
+              type: 'bool',
+            },
+            {
+              name: '',
+              type: 'address',
+            },
+          ],
+          [420n, true, '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b"',
+      )
+    })
+  })
+})
 
-describe("dynamic", () => {
-	describe("(string)", () => {
-		// cast abi-encode "a(string)" "wagmi"
-		test("default", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xOut",
-							type: "string",
-						},
-					],
-					["wagmi"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-			);
-		});
+describe('dynamic', () => {
+  describe('(string)', () => {
+    // cast abi-encode "a(string)" "wagmi"
+    test('default', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xOut',
+              type: 'string',
+            },
+          ],
+          ['wagmi'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+      )
+    })
 
-		// cast abi-encode "a(string)" "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet."
-		test("> 32 bytes", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xOut",
-							type: "string",
-						},
-					],
-					[
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet.",
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002da4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e204e756e63206661756369627573206c6f72656d2061206c696265726f20617563746f7220636f6e64696d656e74756d2e20446f6e6563206f726e617265206d617373612072686f6e637573206c616375732072757472756d2c20656765742070756c76696e6172206172637520656c656d656e74756d2e204e756e63206d6175726973206c6f72656d2c20736f64616c65732065676574207669766572726120696e2c20657569736d6f642071756973206d692e205072616573656e74206e656320636f6d6d6f646f206c656f2e2050686173656c6c757320636f6e64696d656e74756d206d61757269732073656420616363756d73616e20656c656966656e642e205072616573656e7420616320626c616e6469742073656d2c2065742072757472756d20697073756d2e20457469616d20696e2074656c6c757320616320656e696d20666163696c6973697320756c7472696365732e20467573636520616320766573746962756c756d207175616d2e204475697320736564207075727573207363656c657269737175652c20736f6c6c696369747564696e20657261742061632c2070756c76696e6172206e6973692e2050656c6c656e746573717565206575207075727573206e65632073617069656e207665686963756c6120636f6e76616c6c69732075742076656c20656c69742e2053757370656e6469737365206567657420657820766974616520656e696d20766f6c7574706174207363656c657269737175652e20536564207175697320656c6974207472697374697175652065726174206c756374757320656765737461732061206163206f64696f2e2044756973207665686963756c6120656e696d206163206d6574757320677261766964612c2076656c206d6178696d7573206e69736920696d706572646965742e000000000000"',
-			);
-		});
+    // cast abi-encode "a(string)" "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet."
+    test('> 32 bytes', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xOut',
+              type: 'string',
+            },
+          ],
+          [
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc faucibus lorem a libero auctor condimentum. Donec ornare massa rhoncus lacus rutrum, eget pulvinar arcu elementum. Nunc mauris lorem, sodales eget viverra in, euismod quis mi. Praesent nec commodo leo. Phasellus condimentum mauris sed accumsan eleifend. Praesent ac blandit sem, et rutrum ipsum. Etiam in tellus ac enim facilisis ultrices. Fusce ac vestibulum quam. Duis sed purus scelerisque, sollicitudin erat ac, pulvinar nisi. Pellentesque eu purus nec sapien vehicula convallis ut vel elit. Suspendisse eget ex vitae enim volutpat scelerisque. Sed quis elit tristique erat luctus egestas a ac odio. Duis vehicula enim ac metus gravida, vel maximus nisi imperdiet.',
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002da4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73656374657475722061646970697363696e6720656c69742e204e756e63206661756369627573206c6f72656d2061206c696265726f20617563746f7220636f6e64696d656e74756d2e20446f6e6563206f726e617265206d617373612072686f6e637573206c616375732072757472756d2c20656765742070756c76696e6172206172637520656c656d656e74756d2e204e756e63206d6175726973206c6f72656d2c20736f64616c65732065676574207669766572726120696e2c20657569736d6f642071756973206d692e205072616573656e74206e656320636f6d6d6f646f206c656f2e2050686173656c6c757320636f6e64696d656e74756d206d61757269732073656420616363756d73616e20656c656966656e642e205072616573656e7420616320626c616e6469742073656d2c2065742072757472756d20697073756d2e20457469616d20696e2074656c6c757320616320656e696d20666163696c6973697320756c7472696365732e20467573636520616320766573746962756c756d207175616d2e204475697320736564207075727573207363656c657269737175652c20736f6c6c696369747564696e20657261742061632c2070756c76696e6172206e6973692e2050656c6c656e746573717565206575207075727573206e65632073617069656e207665686963756c6120636f6e76616c6c69732075742076656c20656c69742e2053757370656e6469737365206567657420657820766974616520656e696d20766f6c7574706174207363656c657269737175652e20536564207175697320656c6974207472697374697175652065726174206c756374757320656765737461732061206163206f64696f2e2044756973207665686963756c6120656e696d206163206d6574757320677261766964612c2076656c206d6178696d7573206e69736920696d706572646965742e000000000000"',
+      )
+    })
 
-		// cast abi-encode "a(string)" "👨‍👨‍👦‍👦🏴‍☠️"
-		test("emojis", () => {
-			expect(
-				encodeAbiParameters(
-					[
-						{
-							name: "xOut",
-							type: "string",
-						},
-					],
-					["👨‍👨‍👦‍👦🏴‍☠️"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026f09f91a8e2808df09f91a8e2808df09f91a6e2808df09f91a6f09f8fb4e2808de298a0efb88f0000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+    // cast abi-encode "a(string)" "👨‍👨‍👦‍👦🏴‍☠️"
+    test('emojis', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xOut',
+              type: 'string',
+            },
+          ],
+          ['👨‍👨‍👦‍👦🏴‍☠️'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026f09f91a8e2808df09f91a8e2808df09f91a6e2808df09f91a6f09f8fb4e2808de298a0efb88f0000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(string,uint,bool)", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(string,uint,bool)" "wagmi" 420 true
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "string",
-						},
-						{
-							name: "yIn",
-							type: "uint256",
-						},
-						{
-							name: "zIn",
-							type: "bool",
-						},
-					],
-					["wagmi", 420n, true],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(string,uint,bool)', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(string,uint,bool)" "wagmi" 420 true
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'string',
+            },
+            {
+              name: 'yIn',
+              type: 'uint256',
+            },
+            {
+              name: 'zIn',
+              type: 'bool',
+            },
+          ],
+          ['wagmi', 420n, true],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(uint[2],bool,string)", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(uint[2],bool,string)" "[420,69]" true "wagmi"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[2]",
-						},
-						{
-							name: "yIn",
-							type: "bool",
-						},
-						{
-							name: "zIn",
-							type: "string",
-						},
-					],
-					[[420n, 69n], true, "wagmi"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(uint[2],bool,string)', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(uint[2],bool,string)" "[420,69]" true "wagmi"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[2]',
+            },
+            {
+              name: 'yIn',
+              type: 'bool',
+            },
+            {
+              name: 'zIn',
+              type: 'string',
+            },
+          ],
+          [[420n, 69n], true, 'wagmi'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d69000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(bytes)", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(bytes)" "0x42069"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes",
-						},
-					],
-					["0x042069"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030420690000000000000000000000000000000000000000000000000000000000"',
-			);
-			expect(
-				// cast abi-encode "a(bytes)" "0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes",
-						},
-					],
-					["0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020d83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"',
-			);
-			expect(
-				// cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes",
-						},
-					],
-					["0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002470a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000"',
-			);
-			expect(
-				// cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "bytes",
-						},
-					],
-					[
-						"0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004870a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000"',
-			);
-			expect(
-				// cast abi-encode "a(bytes)" "0x"
-				encodeAbiParameters([{ type: "bytes" }], ["0x"]),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(bytes)', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(bytes)" "0x42069"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes',
+            },
+          ],
+          ['0x042069'],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030420690000000000000000000000000000000000000000000000000000000000"',
+      )
+      expect(
+        // cast abi-encode "a(bytes)" "0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes',
+            },
+          ],
+          [
+            '0xd83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f',
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020d83ddc68200dd83ddc68200dd83ddc66200dd83ddc66d83cdff4200d2620fe0f"',
+      )
+      expect(
+        // cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes',
+            },
+          ],
+          [
+            '0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002470a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000"',
+      )
+      expect(
+        // cast abi-encode "a(bytes)" "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bytes',
+            },
+          ],
+          [
+            '0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004870a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604570a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000"',
+      )
+      expect(
+        // cast abi-encode "a(bytes)" "0x"
+        encodeAbiParameters([{ type: 'bytes' }], ['0x']),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(uint[])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(uint[])" "[420,69,22,55]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[]",
-						},
-					],
-					[[420n, 69n, 22n, 55n]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000037"',
-			);
-		});
+  describe('(uint[])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(uint[])" "[420,69,22,55]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[]',
+            },
+          ],
+          [[420n, 69n, 22n, 55n]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000037"',
+      )
+    })
 
-		test("empty", () => {
-			expect(
-				// cast abi-encode "a(uint[])" "[]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[]",
-						},
-					],
-					[[]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+    test('empty', () => {
+      expect(
+        // cast abi-encode "a(uint[])" "[]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[]',
+            },
+          ],
+          [[]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(uint[][])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(uint[][])" "[[420,69]]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[][]",
-						},
-					],
-					[[[420n, 69n]]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
-			);
-		});
+  describe('(uint[][])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(uint[][])" "[[420,69]]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[][]',
+            },
+          ],
+          [[[420n, 69n]]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
+      )
+    })
 
-		test("empty", () => {
-			expect(
-				// cast abi-encode "a(uint[][])" "[[]]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[][]",
-						},
-					],
-					[[[]]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
-			);
-		});
+    test('empty', () => {
+      expect(
+        // cast abi-encode "a(uint[][])" "[[]]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[][]',
+            },
+          ],
+          [[[]]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"',
+      )
+    })
 
-		test("complex", () => {
-			expect(
-				// cast abi-encode "a(uint[][])" "[[420,69],[22,55,22],[51,52,66,11]]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[][]",
-						},
-					],
-					[
-						[
-							[420n, 69n],
-							[22n, 55n, 22n],
-							[51n, 52n, 66n, 11n],
-						],
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000003700000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003300000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000b"',
-			);
-		});
-	});
+    test('complex', () => {
+      expect(
+        // cast abi-encode "a(uint[][])" "[[420,69],[22,55,22],[51,52,66,11]]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[][]',
+            },
+          ],
+          [
+            [
+              [420n, 69n],
+              [22n, 55n, 22n],
+              [51n, 52n, 66n, 11n],
+            ],
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000003700000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003300000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000000000000000b"',
+      )
+    })
+  })
 
-	describe("(uint[][][])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(uint[][][])" "[[[420,69]]]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "uint256[][][]",
-						},
-					],
-					[[[[420n, 69n]]]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
-			);
-		});
-	});
+  describe('(uint[][][])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(uint[][][])" "[[[420,69]]]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'uint256[][][]',
+            },
+          ],
+          [[[[420n, 69n]]]],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000045"',
+      )
+    })
+  })
 
-	describe("(string[2])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(string[2])" "["wagmi","viem"]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "string[2]",
-						},
-					],
-					[["wagmi", "viem"]],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(string[2])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(string[2])" "["wagmi","viem"]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'string[2]',
+            },
+          ],
+          [['wagmi', 'viem']],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(string[2][3])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(string[2][3])" "[["wagmi","viem"],["jake","tom"],["lol","haha"]]"
-				encodeAbiParameters(
-					[
-						{
-							name: "xIn",
-							type: "string[2][3]",
-						},
-					],
-					[
-						[
-							["wagmi", "viem"],
-							["jake", "tom"],
-							["lol", "haha"],
-						],
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046a616b65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003746f6d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(string[2][3])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(string[2][3])" "[["wagmi","viem"],["jake","tom"],["lol","haha"]]"
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'string[2][3]',
+            },
+          ],
+          [
+            [
+              ['wagmi', 'viem'],
+              ['jake', 'tom'],
+              ['lol', 'haha'],
+            ],
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046a616b65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003746f6d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("((uint256[],bool,string[]))", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a((uint256[],bool,string[]))" "([1,2,3,4],true,[hello,world])"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									name: "x",
-									type: "uint256[]",
-								},
-								{
-									name: "y",
-									type: "bool",
-								},
-								{
-									name: "z",
-									type: "string[]",
-								},
-							],
-							name: "bazIn",
-							type: "tuple",
-						},
-					],
-					[
-						{
-							x: [1n, 2n, 3n, 4n],
-							y: true,
-							z: ["hello", "world"],
-						},
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c64000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('((uint256[],bool,string[]))', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a((uint256[],bool,string[]))" "([1,2,3,4],true,[hello,world])"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  name: 'x',
+                  type: 'uint256[]',
+                },
+                {
+                  name: 'y',
+                  type: 'bool',
+                },
+                {
+                  name: 'z',
+                  type: 'string[]',
+                },
+              ],
+              name: 'bazIn',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              x: [1n, 2n, 3n, 4n],
+              y: true,
+              z: ['hello', 'world'],
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c64000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(((uint256[],bool,string[])),uint256,string[])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a(((uint256[],bool,string[]),uint256,string[]))" "(([1,2,3,4],true,[hello,world]),420,[wagmi,viem])"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									components: [
-										{
-											name: "x",
-											type: "uint256[]",
-										},
-										{
-											name: "y",
-											type: "bool",
-										},
-										{
-											name: "z",
-											type: "string[]",
-										},
-									],
-									name: "foo",
-									type: "tuple",
-								},
-								{
-									name: "a",
-									type: "uint256",
-								},
-								{
-									name: "b",
-									type: "string[]",
-								},
-							],
-							name: "wagmiIn",
-							type: "tuple",
-						},
-					],
-					[
-						{
-							foo: {
-								x: [1n, 2n, 3n, 4n],
-								y: true,
-								z: ["hello", "world"],
-							},
-							a: 420n,
-							b: ["wagmi", "viem"],
-						},
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c6400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
+  describe('(((uint256[],bool,string[])),uint256,string[])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a(((uint256[],bool,string[]),uint256,string[]))" "(([1,2,3,4],true,[hello,world]),420,[wagmi,viem])"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  components: [
+                    {
+                      name: 'x',
+                      type: 'uint256[]',
+                    },
+                    {
+                      name: 'y',
+                      type: 'bool',
+                    },
+                    {
+                      name: 'z',
+                      type: 'string[]',
+                    },
+                  ],
+                  name: 'foo',
+                  type: 'tuple',
+                },
+                {
+                  name: 'a',
+                  type: 'uint256',
+                },
+                {
+                  name: 'b',
+                  type: 'string[]',
+                },
+              ],
+              name: 'wagmiIn',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              foo: {
+                x: [1n, 2n, 3n, 4n],
+                y: true,
+                z: ['hello', 'world'],
+              },
+              a: 420n,
+              b: ['wagmi', 'viem'],
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c6400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d6900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047669656d00000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
 
-	describe("(((uint256[],bool,string[]))[],uint256,string[])", () => {
-		test("default", () => {
-			expect(
-				// cast abi-encode "a((uint256[],bool,string[]),(((uint256[],bool,string),uint256,string[]),((uint256[],bool,string),uint256,string[]),uint256,string[]))" "([1,2,3,4],true,[hello, world])" "((([420,69],true,[nice,haha]),420,[wagmi,allday]),(([420,420],true,[this,is,a,param]),69420,[hello,there]),4204202,[lol,haha])"
-				encodeAbiParameters(
-					[
-						{
-							components: [
-								{
-									name: "x",
-									type: "uint256[]",
-								},
-								{
-									name: "y",
-									type: "bool",
-								},
-								{
-									name: "z",
-									type: "string[]",
-								},
-							],
-							name: "bazIn",
-							type: "tuple[]",
-						},
-						{
-							components: [
-								{
-									components: [
-										{
-											components: [
-												{
-													name: "x",
-													type: "uint256[]",
-												},
-												{
-													name: "y",
-													type: "bool",
-												},
-												{
-													name: "z",
-													type: "string[]",
-												},
-											],
-											name: "foo",
-											type: "tuple",
-										},
-										{
-											name: "a",
-											type: "uint256",
-										},
-										{
-											name: "b",
-											type: "string[]",
-										},
-									],
-									name: "foo",
-									type: "tuple",
-								},
-								{
-									components: [
-										{
-											components: [
-												{
-													name: "x",
-													type: "uint256[]",
-												},
-												{
-													name: "y",
-													type: "bool",
-												},
-												{
-													name: "z",
-													type: "string[]",
-												},
-											],
-											name: "foo",
-											type: "tuple",
-										},
-										{
-											name: "a",
-											type: "uint256",
-										},
-										{
-											name: "b",
-											type: "string[]",
-										},
-									],
-									name: "bar",
-									type: "tuple",
-								},
-								{
-									name: "c",
-									type: "uint256",
-								},
-								{
-									name: "d",
-									type: "string[]",
-								},
-							],
-							name: "gmiIn",
-							type: "tuple",
-						},
-					],
-					[
-						[
-							{
-								x: [1n, 2n, 3n, 4n],
-								y: true,
-								z: ["hello", "world"],
-							},
-						],
-						{
-							bar: {
-								a: 69420n,
-								b: ["hello", "there"],
-								foo: {
-									x: [420n, 420n],
-									y: true,
-									z: ["this", "is", "a", "param"],
-								},
-							},
-							c: 4204202n,
-							d: ["lol", "haha"],
-							foo: {
-								a: 420n,
-								b: ["wagmi", "allday"],
-								foo: {
-									x: [420n, 69n],
-									y: true,
-									z: ["nice", "haha"],
-								},
-							},
-						},
-					],
-				),
-			).toMatchInlineSnapshot(
-				'"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000002600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000004026aa0000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046e696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004686168610000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d690000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006616c6c646179000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000010f2c00000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000004746869730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026973000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000161000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005706172616d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005746865726500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
-			);
-		});
-	});
-});
+  describe('(((uint256[],bool,string[]))[],uint256,string[])', () => {
+    test('default', () => {
+      expect(
+        // cast abi-encode "a((uint256[],bool,string[]),(((uint256[],bool,string),uint256,string[]),((uint256[],bool,string),uint256,string[]),uint256,string[]))" "([1,2,3,4],true,[hello, world])" "((([420,69],true,[nice,haha]),420,[wagmi,allday]),(([420,420],true,[this,is,a,param]),69420,[hello,there]),4204202,[lol,haha])"
+        encodeAbiParameters(
+          [
+            {
+              components: [
+                {
+                  name: 'x',
+                  type: 'uint256[]',
+                },
+                {
+                  name: 'y',
+                  type: 'bool',
+                },
+                {
+                  name: 'z',
+                  type: 'string[]',
+                },
+              ],
+              name: 'bazIn',
+              type: 'tuple[]',
+            },
+            {
+              components: [
+                {
+                  components: [
+                    {
+                      components: [
+                        {
+                          name: 'x',
+                          type: 'uint256[]',
+                        },
+                        {
+                          name: 'y',
+                          type: 'bool',
+                        },
+                        {
+                          name: 'z',
+                          type: 'string[]',
+                        },
+                      ],
+                      name: 'foo',
+                      type: 'tuple',
+                    },
+                    {
+                      name: 'a',
+                      type: 'uint256',
+                    },
+                    {
+                      name: 'b',
+                      type: 'string[]',
+                    },
+                  ],
+                  name: 'foo',
+                  type: 'tuple',
+                },
+                {
+                  components: [
+                    {
+                      components: [
+                        {
+                          name: 'x',
+                          type: 'uint256[]',
+                        },
+                        {
+                          name: 'y',
+                          type: 'bool',
+                        },
+                        {
+                          name: 'z',
+                          type: 'string[]',
+                        },
+                      ],
+                      name: 'foo',
+                      type: 'tuple',
+                    },
+                    {
+                      name: 'a',
+                      type: 'uint256',
+                    },
+                    {
+                      name: 'b',
+                      type: 'string[]',
+                    },
+                  ],
+                  name: 'bar',
+                  type: 'tuple',
+                },
+                {
+                  name: 'c',
+                  type: 'uint256',
+                },
+                {
+                  name: 'd',
+                  type: 'string[]',
+                },
+              ],
+              name: 'gmiIn',
+              type: 'tuple',
+            },
+          ],
+          [
+            [
+              {
+                x: [1n, 2n, 3n, 4n],
+                y: true,
+                z: ['hello', 'world'],
+              },
+            ],
+            {
+              bar: {
+                a: 69420n,
+                b: ['hello', 'there'],
+                foo: {
+                  x: [420n, 420n],
+                  y: true,
+                  z: ['this', 'is', 'a', 'param'],
+                },
+              },
+              c: 4204202n,
+              d: ['lol', 'haha'],
+              foo: {
+                a: 420n,
+                b: ['wagmi', 'allday'],
+                foo: {
+                  x: [420n, 69n],
+                  y: true,
+                  z: ['nice', 'haha'],
+                },
+              },
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(
+        '"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000002600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005776f726c640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000004026aa0000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000046e696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004686168610000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000057761676d690000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006616c6c646179000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000010f2c00000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000001a400000000000000000000000000000000000000000000000000000000000001a40000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000004746869730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026973000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000161000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005706172616d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000568656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005746865726500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036c6f6c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046861686100000000000000000000000000000000000000000000000000000000"',
+      )
+    })
+  })
+})
 
 const orderComponents = [
-	{
-		conduitKey: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-		consideration: [
-			{
-				endAmount: 420n,
-				identifierOrCriteria: 69n,
-				itemType: 10,
-				recipient: address.vitalik,
-				startAmount: 6n,
-				token: address.burn,
-			},
-			{
-				endAmount: 141n,
-				identifierOrCriteria: 55n,
-				itemType: 16,
-				recipient: address.vitalik,
-				startAmount: 15n,
-				token: address.burn,
-			},
-		],
-		counter: 1234123123n,
-		endTime: 123123123123n,
-		offer: [
-			{
-				endAmount: 420n,
-				identifierOrCriteria: 69n,
-				itemType: 10,
-				startAmount: 6n,
-				token: address.burn,
-			},
-			{
-				endAmount: 11n,
-				identifierOrCriteria: 515n,
-				itemType: 10,
-				startAmount: 6n,
-				token: address.usdcHolder,
-			},
-			{
-				endAmount: 123123n,
-				identifierOrCriteria: 55555511n,
-				itemType: 10,
-				startAmount: 111n,
-				token: address.vitalik,
-			},
-		],
-		offerer: address.vitalik,
-		orderType: 10,
-		salt: 1234123123n,
-		startTime: 123123123123n,
-		zone: address.vitalik,
-		zoneHash: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-	},
-	{
-		conduitKey: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-		consideration: [
-			{
-				endAmount: 420n,
-				identifierOrCriteria: 69n,
-				itemType: 10,
-				recipient: address.vitalik,
-				startAmount: 6n,
-				token: address.burn,
-			},
-			{
-				endAmount: 141n,
-				identifierOrCriteria: 55n,
-				itemType: 16,
-				recipient: address.vitalik,
-				startAmount: 15n,
-				token: address.burn,
-			},
-		],
-		counter: 1234123123n,
-		endTime: 123123123123n,
-		offer: [
-			{
-				endAmount: 420n,
-				identifierOrCriteria: 69n,
-				itemType: 10,
-				startAmount: 6n,
-				token: address.burn,
-			},
-			{
-				endAmount: 11n,
-				identifierOrCriteria: 515n,
-				itemType: 10,
-				startAmount: 6n,
-				token: address.usdcHolder,
-			},
-			{
-				endAmount: 123123n,
-				identifierOrCriteria: 55555511n,
-				itemType: 10,
-				startAmount: 111n,
-				token: address.vitalik,
-			},
-		],
-		offerer: address.vitalik,
-		orderType: 10,
-		salt: 1234123123n,
-		startTime: 123123123123n,
-		zone: address.vitalik,
-		zoneHash: "0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-	},
-] as const;
+  {
+    conduitKey:
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+    consideration: [
+      {
+        endAmount: 420n,
+        identifierOrCriteria: 69n,
+        itemType: 10,
+        recipient: address.vitalik,
+        startAmount: 6n,
+        token: address.burn,
+      },
+      {
+        endAmount: 141n,
+        identifierOrCriteria: 55n,
+        itemType: 16,
+        recipient: address.vitalik,
+        startAmount: 15n,
+        token: address.burn,
+      },
+    ],
+    counter: 1234123123n,
+    endTime: 123123123123n,
+    offer: [
+      {
+        endAmount: 420n,
+        identifierOrCriteria: 69n,
+        itemType: 10,
+        startAmount: 6n,
+        token: address.burn,
+      },
+      {
+        endAmount: 11n,
+        identifierOrCriteria: 515n,
+        itemType: 10,
+        startAmount: 6n,
+        token: address.usdcHolder,
+      },
+      {
+        endAmount: 123123n,
+        identifierOrCriteria: 55555511n,
+        itemType: 10,
+        startAmount: 111n,
+        token: address.vitalik,
+      },
+    ],
+    offerer: address.vitalik,
+    orderType: 10,
+    salt: 1234123123n,
+    startTime: 123123123123n,
+    zone: address.vitalik,
+    zoneHash:
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+  },
+  {
+    conduitKey:
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+    consideration: [
+      {
+        endAmount: 420n,
+        identifierOrCriteria: 69n,
+        itemType: 10,
+        recipient: address.vitalik,
+        startAmount: 6n,
+        token: address.burn,
+      },
+      {
+        endAmount: 141n,
+        identifierOrCriteria: 55n,
+        itemType: 16,
+        recipient: address.vitalik,
+        startAmount: 15n,
+        token: address.burn,
+      },
+    ],
+    counter: 1234123123n,
+    endTime: 123123123123n,
+    offer: [
+      {
+        endAmount: 420n,
+        identifierOrCriteria: 69n,
+        itemType: 10,
+        startAmount: 6n,
+        token: address.burn,
+      },
+      {
+        endAmount: 11n,
+        identifierOrCriteria: 515n,
+        itemType: 10,
+        startAmount: 6n,
+        token: address.usdcHolder,
+      },
+      {
+        endAmount: 123123n,
+        identifierOrCriteria: 55555511n,
+        itemType: 10,
+        startAmount: 111n,
+        token: address.vitalik,
+      },
+    ],
+    offerer: address.vitalik,
+    orderType: 10,
+    salt: 1234123123n,
+    startTime: 123123123123n,
+    zone: address.vitalik,
+    zoneHash:
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+  },
+] as const
 
-describe("seaport", () => {
-	test("cancel", () => {
-		const cancel = getAbiItem({
-			abi: seaportContractConfig.abi,
-			name: "cancel",
-		});
-		const data = encodeAbiParameters(cancel.inputs, [orderComponents]);
-		expect(data).toMatchInlineSnapshot(
-			'"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
-		);
-	});
+describe('seaport', () => {
+  test('cancel', () => {
+    const cancel = getAbiItem({
+      abi: seaportContractConfig.abi,
+      name: 'cancel',
+    })
+    const data = encodeAbiParameters(cancel.inputs, [orderComponents])
+    expect(data).toMatchInlineSnapshot(
+      '"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f39730000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
+    )
+  })
 
-	test("fulfillAdvancedOrder", () => {
-		const {
-			conduitKey,
-			consideration,
-			endTime,
-			offer,
-			offerer,
-			orderType,
-			salt,
-			startTime,
-			zone,
-			zoneHash,
-		} = orderComponents[0];
+  test('fulfillAdvancedOrder', () => {
+    const {
+      conduitKey,
+      consideration,
+      endTime,
+      offer,
+      offerer,
+      orderType,
+      salt,
+      startTime,
+      zone,
+      zoneHash,
+    } = orderComponents[0]
 
-		const fulfillAdvancedOrder = getAbiItem({
-			abi: seaportContractConfig.abi,
-			name: "fulfillAdvancedOrder",
-		});
-		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-			{
-				denominator: 69n,
-				extraData: "0x123123",
-				numerator: 420n,
-				parameters: {
-					conduitKey,
-					consideration,
-					endTime,
-					offer,
-					offerer,
-					orderType,
-					salt,
-					startTime,
-					totalOriginalConsiderationItems: 69420n,
-					zone,
-					zoneHash,
-				},
-				signature: "0x123123",
-			},
-			[
-				{
-					criteriaProof: ["0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"],
-					identifier: 4242n,
-					index: 1231n,
-					orderIndex: 11n,
-					side: 1,
-				},
-			],
-			"0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-			address.vitalik,
-		]);
-		expect(data).toMatchInlineSnapshot(
-			'"0x000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000006a0511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000004cf000000000000000000000000000000000000000000000000000000000000109200000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"',
-		);
-	});
+    const fulfillAdvancedOrder = getAbiItem({
+      abi: seaportContractConfig.abi,
+      name: 'fulfillAdvancedOrder',
+    })
+    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+      {
+        denominator: 69n,
+        extraData: '0x123123',
+        numerator: 420n,
+        parameters: {
+          conduitKey,
+          consideration,
+          endTime,
+          offer,
+          offerer,
+          orderType,
+          salt,
+          startTime,
+          totalOriginalConsiderationItems: 69420n,
+          zone,
+          zoneHash,
+        },
+        signature: '0x123123',
+      },
+      [
+        {
+          criteriaProof: [
+            '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+          ],
+          identifier: 4242n,
+          index: 1231n,
+          orderIndex: 11n,
+          side: 1,
+        },
+      ],
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+      address.vitalik,
+    ])
+    expect(data).toMatchInlineSnapshot(
+      '"0x000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000006a0511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000004cf000000000000000000000000000000000000000000000000000000000000109200000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"',
+    )
+  })
 
-	test("fulfillAvailableAdvancedOrders", () => {
-		const {
-			conduitKey,
-			consideration,
-			endTime,
-			offer,
-			offerer,
-			orderType,
-			salt,
-			startTime,
-			zone,
-			zoneHash,
-		} = orderComponents[0];
+  test('fulfillAvailableAdvancedOrders', () => {
+    const {
+      conduitKey,
+      consideration,
+      endTime,
+      offer,
+      offerer,
+      orderType,
+      salt,
+      startTime,
+      zone,
+      zoneHash,
+    } = orderComponents[0]
 
-		const fulfillAdvancedOrder = getAbiItem({
-			abi: seaportContractConfig.abi,
-			name: "fulfillAvailableAdvancedOrders",
-		});
-		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-			[
-				{
-					denominator: 24n,
-					extraData: "0x123123",
-					numerator: 41n,
-					parameters: {
-						conduitKey,
-						consideration,
-						endTime,
-						offer,
-						offerer,
-						orderType,
-						salt,
-						startTime,
-						totalOriginalConsiderationItems: 69420n,
-						zone,
-						zoneHash,
-					},
-					signature: "0x123123",
-				},
-			],
-			[
-				{
-					criteriaProof: ["0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a"],
-					identifier: 12n,
-					index: 1n,
-					orderIndex: 1n,
-					side: 1,
-				},
-			],
-			[[{ itemIndex: 1n, orderIndex: 1n }]],
-			[[{ itemIndex: 1n, orderIndex: 2n }]],
-			"0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a",
-			address.vitalik,
-			10n,
-		]);
-		expect(data).toMatchInlineSnapshot(
-			'"0x00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000074000000000000000000000000000000000000000000000000000000000000008600000000000000000000000000000000000000000000000000000000000000900511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000029000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001"',
-		);
-	});
+    const fulfillAdvancedOrder = getAbiItem({
+      abi: seaportContractConfig.abi,
+      name: 'fulfillAvailableAdvancedOrders',
+    })
+    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+      [
+        {
+          denominator: 24n,
+          extraData: '0x123123',
+          numerator: 41n,
+          parameters: {
+            conduitKey,
+            consideration,
+            endTime,
+            offer,
+            offerer,
+            orderType,
+            salt,
+            startTime,
+            totalOriginalConsiderationItems: 69420n,
+            zone,
+            zoneHash,
+          },
+          signature: '0x123123',
+        },
+      ],
+      [
+        {
+          criteriaProof: [
+            '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+          ],
+          identifier: 12n,
+          index: 1n,
+          orderIndex: 1n,
+          side: 1,
+        },
+      ],
+      [[{ itemIndex: 1n, orderIndex: 1n }]],
+      [[{ itemIndex: 1n, orderIndex: 2n }]],
+      '0x511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a',
+      address.vitalik,
+      10n,
+    ])
+    expect(data).toMatchInlineSnapshot(
+      '"0x00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000074000000000000000000000000000000000000000000000000000000000000008600000000000000000000000000000000000000000000000000000000000000900511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000029000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000005e0000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000000312312300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003123123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001"',
+    )
+  })
 
-	test("getCounter", () => {
-		const getCounter = getAbiItem({
-			abi: seaportContractConfig.abi,
-			name: "getCounter",
-		});
-		const data = encodeAbiParameters(getCounter.inputs, [address.vitalik]);
-		expect(data).toMatchInlineSnapshot(
-			'"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
-		);
-	});
+  test('getCounter', () => {
+    const getCounter = getAbiItem({
+      abi: seaportContractConfig.abi,
+      name: 'getCounter',
+    })
+    const data = encodeAbiParameters(getCounter.inputs, [address.vitalik])
+    expect(data).toMatchInlineSnapshot(
+      '"0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"',
+    )
+  })
 
-	test("fulfillAvailableAdvancedOrders", () => {
-		const {
-			conduitKey,
-			consideration,
-			endTime,
-			offer,
-			offerer,
-			orderType,
-			salt,
-			startTime,
-			zone,
-			zoneHash,
-		} = orderComponents[0];
+  test('fulfillAvailableAdvancedOrders', () => {
+    const {
+      conduitKey,
+      consideration,
+      endTime,
+      offer,
+      offerer,
+      orderType,
+      salt,
+      startTime,
+      zone,
+      zoneHash,
+    } = orderComponents[0]
 
-		const fulfillAdvancedOrder = getAbiItem({
-			abi: seaportContractConfig.abi,
-			name: "validate",
-		});
-		const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
-			[
-				{
-					parameters: {
-						conduitKey,
-						consideration,
-						endTime,
-						offer,
-						offerer,
-						orderType,
-						salt,
-						startTime,
-						totalOriginalConsiderationItems: 2n,
-						zone,
-						zoneHash,
-					},
-					signature: "0x123123",
-				},
-			],
-		]);
-		expect(data).toMatchInlineSnapshot(
-			'"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000031231230000000000000000000000000000000000000000000000000000000000"',
-		);
-	});
-});
+    const fulfillAdvancedOrder = getAbiItem({
+      abi: seaportContractConfig.abi,
+      name: 'validate',
+    })
+    const data = encodeAbiParameters(fulfillAdvancedOrder.inputs, [
+      [
+        {
+          parameters: {
+            conduitKey,
+            consideration,
+            endTime,
+            offer,
+            offerer,
+            orderType,
+            salt,
+            startTime,
+            totalOriginalConsiderationItems: 2n,
+            zone,
+            zoneHash,
+          },
+          signature: '0x123123',
+        },
+      ],
+    ])
+    expect(data).toMatchInlineSnapshot(
+      '"0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000540000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000001caab5c3b30000000000000000000000000000000000000000000000000000001caab5c3b3511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000498f3973511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511aaa511a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c07800000000000000000000000000000000000000000000000000000000000002030000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000034fb5b7000000000000000000000000000000000000000000000000000000000000006f000000000000000000000000000000000000000000000000000000000001e0f30000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000001a4000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000008d000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000031231230000000000000000000000000000000000000000000000000000000000"',
+    )
+  })
+})
 
-test("invalid type", () => {
-	expect(() => encodeAbiParameters([{ name: "x", type: "lol" }], [69]))
-		.toThrowErrorMatchingInlineSnapshot(`
+test('invalid type', () => {
+  expect(() =>
+    encodeAbiParameters([{ name: 'x', type: 'lol' }], [69]),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAbiEncodingType: Type "lol" is not a valid encoding type.
     Please provide a valid ABI type.
 
     Docs: https://viem.sh/docs/contract/encodeAbiParameters
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("invalid params/values lengths", () => {
-	expect(() =>
-		encodeAbiParameters(
-			[{ name: "x", type: "uint256[3]" }],
-			/* @ts-expect-error */
-			[69, 420],
-		),
-	).toThrowErrorMatchingInlineSnapshot(`
+test('invalid params/values lengths', () => {
+  expect(() =>
+    encodeAbiParameters(
+      [{ name: 'x', type: 'uint256[3]' }],
+      /* @ts-expect-error */
+      [69, 420],
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingLengthMismatchError: ABI encoding params/values length mismatch.
     Expected length (params): 1
     Given length (values): 2
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("invalid address", () => {
-	expect(() => encodeAbiParameters([{ name: "x", type: "address" }], ["0x111"]))
-		.toThrowErrorMatchingInlineSnapshot(`
+test('invalid address', () => {
+  expect(() =>
+    encodeAbiParameters([{ name: 'x', type: 'address' }], ['0x111']),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidAddressError: Address "0x111" is invalid.
 
     - Address must be a hex value of 20 bytes (40 hex characters).
     - Address must match its checksum counterpart.
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("invalid array", () => {
-	expect(() =>
-		encodeAbiParameters(
-			[{ name: "x", type: "uint256[3]" }],
-			/* @ts-expect-error */
-			[69],
-		),
-	).toThrowErrorMatchingInlineSnapshot(`
+test('invalid array', () => {
+  expect(() =>
+    encodeAbiParameters(
+      [{ name: 'x', type: 'uint256[3]' }],
+      /* @ts-expect-error */
+      [69],
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [InvalidArrayError: Value "69" is not a valid array.
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("invalid array lengths", () => {
-	expect(() =>
-		encodeAbiParameters(
-			[{ name: "x", type: "uint256[3]" }],
-			/* @ts-expect-error */
-			[[69n, 420n]],
-		),
-	).toThrowErrorMatchingInlineSnapshot(`
+test('invalid array lengths', () => {
+  expect(() =>
+    encodeAbiParameters(
+      [{ name: 'x', type: 'uint256[3]' }],
+      /* @ts-expect-error */
+      [[69n, 420n]],
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingArrayLengthMismatchError: ABI encoding array length mismatch for type uint256[3].
     Expected length: 3
     Given length: 2
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("invalid bytes", () => {
-	expect(() => encodeAbiParameters([{ name: "x", type: "bytes8" }], ["0x111"]))
-		.toThrowErrorMatchingInlineSnapshot(`
+test('invalid bytes', () => {
+  expect(() =>
+    encodeAbiParameters([{ name: 'x', type: 'bytes8' }], ['0x111']),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [AbiEncodingBytesSizeMismatchError: Size of bytes "0x111" (bytes2) does not match expected size (bytes8).
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})
 
-test("getArrayComponents", () => {
-	expect(getArrayComponents("uint256[2]")).toEqual([2, "uint256"]);
-	expect(getArrayComponents("uint256[2][3]")).toEqual([3, "uint256[2]"]);
-	expect(getArrayComponents("uint256[][3]")).toEqual([3, "uint256[]"]);
-	expect(getArrayComponents("uint256[]")).toEqual([null, "uint256"]);
-	expect(getArrayComponents("uint256[][]")).toEqual([null, "uint256[]"]);
-	expect(getArrayComponents("uint256")).toBeUndefined();
-});
+test('getArrayComponents', () => {
+  expect(getArrayComponents('uint256[2]')).toEqual([2, 'uint256'])
+  expect(getArrayComponents('uint256[2][3]')).toEqual([3, 'uint256[2]'])
+  expect(getArrayComponents('uint256[][3]')).toEqual([3, 'uint256[]'])
+  expect(getArrayComponents('uint256[]')).toEqual([null, 'uint256'])
+  expect(getArrayComponents('uint256[][]')).toEqual([null, 'uint256[]'])
+  expect(getArrayComponents('uint256')).toBeUndefined()
+})
 
-test("https://github.com/wevm/viem/issues/1960", () => {
-	expect(() =>
-		encodeAbiParameters(
-			[
-				{
-					name: "boolz",
-					type: "bool[]",
-					internalType: "bool[]",
-				},
-			] as const,
-			// @ts-expect-error
-			[["truez"]],
-		),
-	).toThrowErrorMatchingInlineSnapshot(`
+test('https://github.com/wevm/viem/issues/1960', () => {
+  expect(() =>
+    encodeAbiParameters(
+      [
+        {
+          name: 'boolz',
+          type: 'bool[]',
+          internalType: 'bool[]',
+        },
+      ] as const,
+      // @ts-expect-error
+      [['truez']],
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [ViemError: Invalid boolean value: "truez" (type: string). Expected: \`true\` or \`false\`.
 
     Version: viem@x.y.z]
-  `);
-});
+  `)
+})

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -312,6 +312,90 @@ describe('static', () => {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       )
     })
+    
+    test('from string', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          ['False'],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          ['True'],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [''],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
+    
+    test('from number', () => {
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [23],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [BigInt(23)],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      )
+      expect(
+        encodeAbiParameters(
+          [
+            {
+              name: 'xIn',
+              type: 'bool',
+            },
+          ],
+          [0],
+        ),
+      ).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
   })
 
   describe('bytes8', () => {

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -312,7 +312,7 @@ describe('static', () => {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       )
     })
-    
+
     test('from string', () => {
       expect(
         encodeAbiParameters(
@@ -322,7 +322,7 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          ['False'],
+          ['False' as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -335,7 +335,7 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          ['True'],
+          ['True' as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -348,13 +348,13 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          [''],
+          ['' as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       )
     })
-    
+
     test('from number', () => {
       expect(
         encodeAbiParameters(
@@ -364,7 +364,7 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          [23],
+          [23 as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -377,7 +377,7 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          [BigInt(23)],
+          [BigInt(23) as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -390,7 +390,7 @@ describe('static', () => {
               type: 'bool',
             },
           ],
-          [0],
+          [0 as unknown as boolean],
         ),
       ).toBe(
         '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -315,13 +315,23 @@ type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType
 
 function encodeBool(value: any): PreparedParam {
   if (typeof value === 'string')
-    return { dynamic: false, encoded: padHex(boolToHex(value.toLowerCase() !== 'false' && value !== '')) }
-  else if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
+    return {
+      dynamic: false,
+      encoded: padHex(
+        boolToHex(value.toLowerCase() !== 'false' && value !== ''),
+      ),
+    }
+  
+  if (
+    typeof value === 'number' ||
+    typeof value === 'bigint' ||
+    typeof value === 'boolean'
+  )
     return { dynamic: false, encoded: padHex(boolToHex(value)) }
-  else
-    throw new BaseError(
-      `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
-    )
+
+  throw new BaseError(
+    `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
+  )
 }
 
 type EncodeNumberErrorType = NumberToHexErrorType | ErrorType

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -1,46 +1,49 @@
 import type {
-	AbiParameter,
-	AbiParameterToPrimitiveType,
-	AbiParametersToPrimitiveTypes,
-} from "abitype";
+  AbiParameter,
+  AbiParameterToPrimitiveType,
+  AbiParametersToPrimitiveTypes,
+} from 'abitype'
 
 import {
-	AbiEncodingArrayLengthMismatchError,
-	type AbiEncodingArrayLengthMismatchErrorType,
-	AbiEncodingBytesSizeMismatchError,
-	type AbiEncodingBytesSizeMismatchErrorType,
-	AbiEncodingLengthMismatchError,
-	type AbiEncodingLengthMismatchErrorType,
-	InvalidAbiEncodingTypeError,
-	type InvalidAbiEncodingTypeErrorType,
-	InvalidArrayError,
-	type InvalidArrayErrorType,
-} from "../../errors/abi.js";
-import { InvalidAddressError, type InvalidAddressErrorType } from "../../errors/address.js";
-import { BaseError } from "../../errors/base.js";
-import type { ErrorType } from "../../errors/utils.js";
-import type { Hex } from "../../types/misc.js";
-import { type IsAddressErrorType, isAddress } from "../address/isAddress.js";
-import { type ConcatErrorType, concat } from "../data/concat.js";
-import { type PadHexErrorType, padHex } from "../data/pad.js";
-import { type SizeErrorType, size } from "../data/size.js";
-import { type SliceErrorType, slice } from "../data/slice.js";
+  AbiEncodingArrayLengthMismatchError,
+  type AbiEncodingArrayLengthMismatchErrorType,
+  AbiEncodingBytesSizeMismatchError,
+  type AbiEncodingBytesSizeMismatchErrorType,
+  AbiEncodingLengthMismatchError,
+  type AbiEncodingLengthMismatchErrorType,
+  InvalidAbiEncodingTypeError,
+  type InvalidAbiEncodingTypeErrorType,
+  InvalidArrayError,
+  type InvalidArrayErrorType,
+} from '../../errors/abi.js'
 import {
-	type BoolToHexErrorType,
-	type NumberToHexErrorType,
-	type StringToHexErrorType,
-	boolToHex,
-	numberToHex,
-	stringToHex,
-} from "../encoding/toHex.js";
+  InvalidAddressError,
+  type InvalidAddressErrorType,
+} from '../../errors/address.js'
+import { BaseError } from '../../errors/base.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { Hex } from '../../types/misc.js'
+import { type IsAddressErrorType, isAddress } from '../address/isAddress.js'
+import { type ConcatErrorType, concat } from '../data/concat.js'
+import { type PadHexErrorType, padHex } from '../data/pad.js'
+import { type SizeErrorType, size } from '../data/size.js'
+import { type SliceErrorType, slice } from '../data/slice.js'
+import {
+  type BoolToHexErrorType,
+  type NumberToHexErrorType,
+  type StringToHexErrorType,
+  boolToHex,
+  numberToHex,
+  stringToHex,
+} from '../encoding/toHex.js'
 
-export type EncodeAbiParametersReturnType = Hex;
+export type EncodeAbiParametersReturnType = Hex
 
 export type EncodeAbiParametersErrorType =
-	| AbiEncodingLengthMismatchErrorType
-	| PrepareParamsErrorType
-	| EncodeParamsErrorType
-	| ErrorType;
+  | AbiEncodingLengthMismatchErrorType
+  | PrepareParamsErrorType
+  | EncodeParamsErrorType
+  | ErrorType
 
 /**
  * @description Encodes a list of primitive values into an ABI-encoded hex value.
@@ -78,328 +81,345 @@ export type EncodeAbiParametersErrorType =
  * ```
  */
 export function encodeAbiParameters<
-	const TParams extends readonly AbiParameter[] | readonly unknown[],
+  const TParams extends readonly AbiParameter[] | readonly unknown[],
 >(
-	params: TParams,
-	values: TParams extends readonly AbiParameter[] ? AbiParametersToPrimitiveTypes<TParams> : never,
+  params: TParams,
+  values: TParams extends readonly AbiParameter[]
+    ? AbiParametersToPrimitiveTypes<TParams>
+    : never,
 ): EncodeAbiParametersReturnType {
-	if (params.length !== values.length)
-		throw new AbiEncodingLengthMismatchError({
-			expectedLength: params.length as number,
-			givenLength: values.length as any,
-		});
-	// Prepare the parameters to determine dynamic types to encode.
-	const preparedParams = prepareParams({
-		params: params as readonly AbiParameter[],
-		values: values as any,
-	});
-	const data = encodeParams(preparedParams);
-	if (data.length === 0) return "0x";
-	return data;
+  if (params.length !== values.length)
+    throw new AbiEncodingLengthMismatchError({
+      expectedLength: params.length as number,
+      givenLength: values.length as any,
+    })
+  // Prepare the parameters to determine dynamic types to encode.
+  const preparedParams = prepareParams({
+    params: params as readonly AbiParameter[],
+    values: values as any,
+  })
+  const data = encodeParams(preparedParams)
+  if (data.length === 0) return '0x'
+  return data
 }
 
 /////////////////////////////////////////////////////////////////
 
-type PreparedParam = { dynamic: boolean; encoded: Hex };
+type PreparedParam = { dynamic: boolean; encoded: Hex }
 
-type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] };
-type Tuple = AbiParameterToPrimitiveType<TupleAbiParameter>;
+type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] }
+type Tuple = AbiParameterToPrimitiveType<TupleAbiParameter>
 
-type PrepareParamsErrorType = PrepareParamErrorType | ErrorType;
+type PrepareParamsErrorType = PrepareParamErrorType | ErrorType
 
 function prepareParams<const TParams extends readonly AbiParameter[]>({
-	params,
-	values,
+  params,
+  values,
 }: {
-	params: TParams;
-	values: AbiParametersToPrimitiveTypes<TParams>;
+  params: TParams
+  values: AbiParametersToPrimitiveTypes<TParams>
 }) {
-	const preparedParams: PreparedParam[] = [];
-	for (let i = 0; i < params.length; i++) {
-		preparedParams.push(prepareParam({ param: params[i], value: values[i] }));
-	}
-	return preparedParams;
+  const preparedParams: PreparedParam[] = []
+  for (let i = 0; i < params.length; i++) {
+    preparedParams.push(prepareParam({ param: params[i], value: values[i] }))
+  }
+  return preparedParams
 }
 
 type PrepareParamErrorType =
-	| EncodeAddressErrorType
-	| EncodeArrayErrorType
-	| EncodeBytesErrorType
-	| EncodeBoolErrorType
-	| EncodeNumberErrorType
-	| EncodeStringErrorType
-	| EncodeTupleErrorType
-	| GetArrayComponentsErrorType
-	| InvalidAbiEncodingTypeErrorType
-	| ErrorType;
+  | EncodeAddressErrorType
+  | EncodeArrayErrorType
+  | EncodeBytesErrorType
+  | EncodeBoolErrorType
+  | EncodeNumberErrorType
+  | EncodeStringErrorType
+  | EncodeTupleErrorType
+  | GetArrayComponentsErrorType
+  | InvalidAbiEncodingTypeErrorType
+  | ErrorType
 
 function prepareParam<const TParam extends AbiParameter>({
-	param,
-	value,
+  param,
+  value,
 }: {
-	param: TParam;
-	value: AbiParameterToPrimitiveType<TParam>;
+  param: TParam
+  value: AbiParameterToPrimitiveType<TParam>
 }): PreparedParam {
-	const arrayComponents = getArrayComponents(param.type);
-	if (arrayComponents) {
-		const [length, type] = arrayComponents;
-		return encodeArray(value, { length, param: { ...param, type } });
-	}
-	if (param.type === "tuple") {
-		return encodeTuple(value as unknown as Tuple, {
-			param: param as TupleAbiParameter,
-		});
-	}
-	if (param.type === "address") {
-		return encodeAddress(value as unknown as Hex);
-	}
-	if (param.type === "bool") {
-		return encodeBool(value);
-	}
-	if (param.type.startsWith("uint") || param.type.startsWith("int")) {
-		const signed = param.type.startsWith("int");
-		return encodeNumber(value as unknown as number, { signed });
-	}
-	if (param.type.startsWith("bytes")) {
-		return encodeBytes(value as unknown as Hex, { param });
-	}
-	if (param.type === "string") {
-		return encodeString(value as unknown as string);
-	}
-	throw new InvalidAbiEncodingTypeError(param.type, {
-		docsPath: "/docs/contract/encodeAbiParameters",
-	});
+  const arrayComponents = getArrayComponents(param.type)
+  if (arrayComponents) {
+    const [length, type] = arrayComponents
+    return encodeArray(value, { length, param: { ...param, type } })
+  }
+  if (param.type === 'tuple') {
+    return encodeTuple(value as unknown as Tuple, {
+      param: param as TupleAbiParameter,
+    })
+  }
+  if (param.type === 'address') {
+    return encodeAddress(value as unknown as Hex)
+  }
+  if (param.type === 'bool') {
+    return encodeBool(value)
+  }
+  if (param.type.startsWith('uint') || param.type.startsWith('int')) {
+    const signed = param.type.startsWith('int')
+    return encodeNumber(value as unknown as number, { signed })
+  }
+  if (param.type.startsWith('bytes')) {
+    return encodeBytes(value as unknown as Hex, { param })
+  }
+  if (param.type === 'string') {
+    return encodeString(value as unknown as string)
+  }
+  throw new InvalidAbiEncodingTypeError(param.type, {
+    docsPath: '/docs/contract/encodeAbiParameters',
+  })
 }
 
 /////////////////////////////////////////////////////////////////
 
-type EncodeParamsErrorType = NumberToHexErrorType | SizeErrorType | ErrorType;
+type EncodeParamsErrorType = NumberToHexErrorType | SizeErrorType | ErrorType
 
 function encodeParams(preparedParams: PreparedParam[]): Hex {
-	// 1. Compute the size of the static part of the parameters.
-	let staticSize = 0;
-	for (let i = 0; i < preparedParams.length; i++) {
-		const { dynamic, encoded } = preparedParams[i];
-		if (dynamic) staticSize += 32;
-		else staticSize += size(encoded);
-	}
+  // 1. Compute the size of the static part of the parameters.
+  let staticSize = 0
+  for (let i = 0; i < preparedParams.length; i++) {
+    const { dynamic, encoded } = preparedParams[i]
+    if (dynamic) staticSize += 32
+    else staticSize += size(encoded)
+  }
 
-	// 2. Split the parameters into static and dynamic parts.
-	const staticParams: Hex[] = [];
-	const dynamicParams: Hex[] = [];
-	let dynamicSize = 0;
-	for (let i = 0; i < preparedParams.length; i++) {
-		const { dynamic, encoded } = preparedParams[i];
-		if (dynamic) {
-			staticParams.push(numberToHex(staticSize + dynamicSize, { size: 32 }));
-			dynamicParams.push(encoded);
-			dynamicSize += size(encoded);
-		} else {
-			staticParams.push(encoded);
-		}
-	}
+  // 2. Split the parameters into static and dynamic parts.
+  const staticParams: Hex[] = []
+  const dynamicParams: Hex[] = []
+  let dynamicSize = 0
+  for (let i = 0; i < preparedParams.length; i++) {
+    const { dynamic, encoded } = preparedParams[i]
+    if (dynamic) {
+      staticParams.push(numberToHex(staticSize + dynamicSize, { size: 32 }))
+      dynamicParams.push(encoded)
+      dynamicSize += size(encoded)
+    } else {
+      staticParams.push(encoded)
+    }
+  }
 
-	// 3. Concatenate static and dynamic parts.
-	return concat([...staticParams, ...dynamicParams]);
+  // 3. Concatenate static and dynamic parts.
+  return concat([...staticParams, ...dynamicParams])
 }
 
 /////////////////////////////////////////////////////////////////
 
-type EncodeAddressErrorType = InvalidAddressErrorType | IsAddressErrorType | ErrorType;
+type EncodeAddressErrorType =
+  | InvalidAddressErrorType
+  | IsAddressErrorType
+  | ErrorType
 
 function encodeAddress(value: Hex): PreparedParam {
-	if (!isAddress(value)) throw new InvalidAddressError({ address: value });
-	return { dynamic: false, encoded: padHex(value.toLowerCase() as Hex) };
+  if (!isAddress(value)) throw new InvalidAddressError({ address: value })
+  return { dynamic: false, encoded: padHex(value.toLowerCase() as Hex) }
 }
 
 type EncodeArrayErrorType =
-	| AbiEncodingArrayLengthMismatchErrorType
-	| ConcatErrorType
-	| EncodeParamsErrorType
-	| InvalidArrayErrorType
-	| NumberToHexErrorType
-	// TODO: Add back once circular type reference is resolved
-	// | PrepareParamErrorType
-	| ErrorType;
+  | AbiEncodingArrayLengthMismatchErrorType
+  | ConcatErrorType
+  | EncodeParamsErrorType
+  | InvalidArrayErrorType
+  | NumberToHexErrorType
+  // TODO: Add back once circular type reference is resolved
+  // | PrepareParamErrorType
+  | ErrorType
 
 function encodeArray<const TParam extends AbiParameter>(
-	value: AbiParameterToPrimitiveType<TParam>,
-	{
-		length,
-		param,
-	}: {
-		length: number | null;
-		param: TParam;
-	},
+  value: AbiParameterToPrimitiveType<TParam>,
+  {
+    length,
+    param,
+  }: {
+    length: number | null
+    param: TParam
+  },
 ): PreparedParam {
-	const dynamic = length === null;
+  const dynamic = length === null
 
-	if (!Array.isArray(value)) throw new InvalidArrayError(value);
-	if (!dynamic && value.length !== length)
-		throw new AbiEncodingArrayLengthMismatchError({
-			expectedLength: length!,
-			givenLength: value.length,
-			type: `${param.type}[${length}]`,
-		});
+  if (!Array.isArray(value)) throw new InvalidArrayError(value)
+  if (!dynamic && value.length !== length)
+    throw new AbiEncodingArrayLengthMismatchError({
+      expectedLength: length!,
+      givenLength: value.length,
+      type: `${param.type}[${length}]`,
+    })
 
-	let dynamicChild = false;
-	const preparedParams: PreparedParam[] = [];
-	for (let i = 0; i < value.length; i++) {
-		const preparedParam = prepareParam({ param, value: value[i] });
-		if (preparedParam.dynamic) dynamicChild = true;
-		preparedParams.push(preparedParam);
-	}
+  let dynamicChild = false
+  const preparedParams: PreparedParam[] = []
+  for (let i = 0; i < value.length; i++) {
+    const preparedParam = prepareParam({ param, value: value[i] })
+    if (preparedParam.dynamic) dynamicChild = true
+    preparedParams.push(preparedParam)
+  }
 
-	if (dynamic || dynamicChild) {
-		const data = encodeParams(preparedParams);
-		if (dynamic) {
-			const length = numberToHex(preparedParams.length, { size: 32 });
-			return {
-				dynamic: true,
-				encoded: preparedParams.length > 0 ? concat([length, data]) : length,
-			};
-		}
-		if (dynamicChild) return { dynamic: true, encoded: data };
-	}
-	return {
-		dynamic: false,
-		encoded: concat(preparedParams.map(({ encoded }) => encoded)),
-	};
+  if (dynamic || dynamicChild) {
+    const data = encodeParams(preparedParams)
+    if (dynamic) {
+      const length = numberToHex(preparedParams.length, { size: 32 })
+      return {
+        dynamic: true,
+        encoded: preparedParams.length > 0 ? concat([length, data]) : length,
+      }
+    }
+    if (dynamicChild) return { dynamic: true, encoded: data }
+  }
+  return {
+    dynamic: false,
+    encoded: concat(preparedParams.map(({ encoded }) => encoded)),
+  }
 }
 
 type EncodeBytesErrorType =
-	| AbiEncodingBytesSizeMismatchErrorType
-	| ConcatErrorType
-	| PadHexErrorType
-	| NumberToHexErrorType
-	| SizeErrorType
-	| ErrorType;
+  | AbiEncodingBytesSizeMismatchErrorType
+  | ConcatErrorType
+  | PadHexErrorType
+  | NumberToHexErrorType
+  | SizeErrorType
+  | ErrorType
 
 function encodeBytes<const TParam extends AbiParameter>(
-	value: Hex,
-	{ param }: { param: TParam },
+  value: Hex,
+  { param }: { param: TParam },
 ): PreparedParam {
-	const [, paramSize] = param.type.split("bytes");
-	const bytesSize = size(value);
-	if (!paramSize) {
-		let value_ = value;
-		// If the size is not divisible by 32 bytes, pad the end
-		// with empty bytes to the ceiling 32 bytes.
-		if (bytesSize % 32 !== 0)
-			value_ = padHex(value_, {
-				dir: "right",
-				size: Math.ceil((value.length - 2) / 2 / 32) * 32,
-			});
-		return {
-			dynamic: true,
-			encoded: concat([padHex(numberToHex(bytesSize, { size: 32 })), value_]),
-		};
-	}
-	if (bytesSize !== Number.parseInt(paramSize))
-		throw new AbiEncodingBytesSizeMismatchError({
-			expectedSize: Number.parseInt(paramSize),
-			value,
-		});
-	return { dynamic: false, encoded: padHex(value, { dir: "right" }) };
+  const [, paramSize] = param.type.split('bytes')
+  const bytesSize = size(value)
+  if (!paramSize) {
+    let value_ = value
+    // If the size is not divisible by 32 bytes, pad the end
+    // with empty bytes to the ceiling 32 bytes.
+    if (bytesSize % 32 !== 0)
+      value_ = padHex(value_, {
+        dir: 'right',
+        size: Math.ceil((value.length - 2) / 2 / 32) * 32,
+      })
+    return {
+      dynamic: true,
+      encoded: concat([padHex(numberToHex(bytesSize, { size: 32 })), value_]),
+    }
+  }
+  if (bytesSize !== Number.parseInt(paramSize))
+    throw new AbiEncodingBytesSizeMismatchError({
+      expectedSize: Number.parseInt(paramSize),
+      value,
+    })
+  return { dynamic: false, encoded: padHex(value, { dir: 'right' }) }
 }
 
-type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType;
+type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType
 
 function encodeBool(value: any): PreparedParam {
-	if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean")
-		return { dynamic: false, encoded: padHex(boolToHex(value)) };
+  if (
+    typeof value === 'number' ||
+    typeof value === 'bigint' ||
+    typeof value === 'boolean'
+  )
+    return { dynamic: false, encoded: padHex(boolToHex(value)) }
 
-	if (typeof value === "string") {
-		const v = value.toLowerCase();
-		if (v === "true" || v === "false")
-			return {
-				dynamic: false,
-				encoded: padHex(boolToHex(value.toLowerCase() !== "false")),
-			};
-	}
+  if (typeof value === 'string') {
+    const v = value.toLowerCase()
+    if (v === 'true' || v === 'false')
+      return {
+        dynamic: false,
+        encoded: padHex(boolToHex(value.toLowerCase() !== 'false')),
+      }
+  }
 
-	throw new BaseError(
-		`Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
-	);
+  throw new BaseError(
+    `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
+  )
 }
 
-type EncodeNumberErrorType = NumberToHexErrorType | ErrorType;
+type EncodeNumberErrorType = NumberToHexErrorType | ErrorType
 
-function encodeNumber(value: number, { signed }: { signed: boolean }): PreparedParam {
-	return {
-		dynamic: false,
-		encoded: numberToHex(value, {
-			size: 32,
-			signed,
-		}),
-	};
+function encodeNumber(
+  value: number,
+  { signed }: { signed: boolean },
+): PreparedParam {
+  return {
+    dynamic: false,
+    encoded: numberToHex(value, {
+      size: 32,
+      signed,
+    }),
+  }
 }
 
 type EncodeStringErrorType =
-	| ConcatErrorType
-	| NumberToHexErrorType
-	| PadHexErrorType
-	| SizeErrorType
-	| SliceErrorType
-	| StringToHexErrorType
-	| ErrorType;
+  | ConcatErrorType
+  | NumberToHexErrorType
+  | PadHexErrorType
+  | SizeErrorType
+  | SliceErrorType
+  | StringToHexErrorType
+  | ErrorType
 
 function encodeString(value: string): PreparedParam {
-	const hexValue = stringToHex(value);
-	const partsLength = Math.ceil(size(hexValue) / 32);
-	const parts: Hex[] = [];
-	for (let i = 0; i < partsLength; i++) {
-		parts.push(
-			padHex(slice(hexValue, i * 32, (i + 1) * 32), {
-				dir: "right",
-			}),
-		);
-	}
-	return {
-		dynamic: true,
-		encoded: concat([padHex(numberToHex(size(hexValue), { size: 32 })), ...parts]),
-	};
+  const hexValue = stringToHex(value)
+  const partsLength = Math.ceil(size(hexValue) / 32)
+  const parts: Hex[] = []
+  for (let i = 0; i < partsLength; i++) {
+    parts.push(
+      padHex(slice(hexValue, i * 32, (i + 1) * 32), {
+        dir: 'right',
+      }),
+    )
+  }
+  return {
+    dynamic: true,
+    encoded: concat([
+      padHex(numberToHex(size(hexValue), { size: 32 })),
+      ...parts,
+    ]),
+  }
 }
 
 type EncodeTupleErrorType =
-	| ConcatErrorType
-	| EncodeParamsErrorType
-	// TODO: Add back once circular type reference is resolved
-	// | PrepareParamErrorType
-	| ErrorType;
+  | ConcatErrorType
+  | EncodeParamsErrorType
+  // TODO: Add back once circular type reference is resolved
+  // | PrepareParamErrorType
+  | ErrorType
 
-function encodeTuple<const TParam extends AbiParameter & { components: readonly AbiParameter[] }>(
-	value: AbiParameterToPrimitiveType<TParam>,
-	{ param }: { param: TParam },
+function encodeTuple<
+  const TParam extends AbiParameter & { components: readonly AbiParameter[] },
+>(
+  value: AbiParameterToPrimitiveType<TParam>,
+  { param }: { param: TParam },
 ): PreparedParam {
-	let dynamic = false;
-	const preparedParams: PreparedParam[] = [];
-	for (let i = 0; i < param.components.length; i++) {
-		const param_ = param.components[i];
-		const index = Array.isArray(value) ? i : param_.name;
-		const preparedParam = prepareParam({
-			param: param_,
-			value: (value as any)[index!] as readonly unknown[],
-		});
-		preparedParams.push(preparedParam);
-		if (preparedParam.dynamic) dynamic = true;
-	}
-	return {
-		dynamic,
-		encoded: dynamic
-			? encodeParams(preparedParams)
-			: concat(preparedParams.map(({ encoded }) => encoded)),
-	};
+  let dynamic = false
+  const preparedParams: PreparedParam[] = []
+  for (let i = 0; i < param.components.length; i++) {
+    const param_ = param.components[i]
+    const index = Array.isArray(value) ? i : param_.name
+    const preparedParam = prepareParam({
+      param: param_,
+      value: (value as any)[index!] as readonly unknown[],
+    })
+    preparedParams.push(preparedParam)
+    if (preparedParam.dynamic) dynamic = true
+  }
+  return {
+    dynamic,
+    encoded: dynamic
+      ? encodeParams(preparedParams)
+      : concat(preparedParams.map(({ encoded }) => encoded)),
+  }
 }
 
-type GetArrayComponentsErrorType = ErrorType;
+type GetArrayComponentsErrorType = ErrorType
 
 export function getArrayComponents(
-	type: string,
+  type: string,
 ): [length: number | null, innerType: string] | undefined {
-	const matches = type.match(/^(.*)\[(\d+)?\]$/);
-	return matches
-		? // Return `null` if the array is dynamic.
-		  [matches[2] ? Number(matches[2]) : null, matches[1]]
-		: undefined;
+  const matches = type.match(/^(.*)\[(\d+)?\]$/)
+  return matches
+    ? // Return `null` if the array is dynamic.
+      [matches[2] ? Number(matches[2]) : null, matches[1]]
+    : undefined
 }

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -159,7 +159,7 @@ function prepareParam<const TParam extends AbiParameter>({
     return encodeAddress(value as unknown as Hex)
   }
   if (param.type === 'bool') {
-    return encodeBool(value as unknown as boolean)
+    return encodeBool(value)
   }
   if (param.type.startsWith('uint') || param.type.startsWith('int')) {
     const signed = param.type.startsWith('int')
@@ -313,12 +313,15 @@ function encodeBytes<const TParam extends AbiParameter>(
 
 type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType
 
-function encodeBool(value: boolean): PreparedParam {
-  if (typeof value !== 'boolean')
+function encodeBool(value: any): PreparedParam {
+  if (typeof value === 'string')
+    return { dynamic: false, encoded: padHex(boolToHex(value.toLowerCase() !== 'false' && value !== '')) }
+  else if (typeof value === 'number' || typeof value === 'boolean')
+    return { dynamic: false, encoded: padHex(boolToHex(value)) }
+  else
     throw new BaseError(
       `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
     )
-  return { dynamic: false, encoded: padHex(boolToHex(value)) }
 }
 
 type EncodeNumberErrorType = NumberToHexErrorType | ErrorType

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -321,7 +321,7 @@ function encodeBool(value: any): PreparedParam {
         boolToHex(value.toLowerCase() !== 'false' && value !== ''),
       ),
     }
-  
+
   if (
     typeof value === 'number' ||
     typeof value === 'bigint' ||

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -316,7 +316,7 @@ type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType
 function encodeBool(value: any): PreparedParam {
   if (typeof value === 'string')
     return { dynamic: false, encoded: padHex(boolToHex(value.toLowerCase() !== 'false' && value !== '')) }
-  else if (typeof value === 'number' || typeof value === 'boolean')
+  else if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
     return { dynamic: false, encoded: padHex(boolToHex(value)) }
   else
     throw new BaseError(

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -1,49 +1,46 @@
 import type {
-  AbiParameter,
-  AbiParameterToPrimitiveType,
-  AbiParametersToPrimitiveTypes,
-} from 'abitype'
+	AbiParameter,
+	AbiParameterToPrimitiveType,
+	AbiParametersToPrimitiveTypes,
+} from "abitype";
 
 import {
-  AbiEncodingArrayLengthMismatchError,
-  type AbiEncodingArrayLengthMismatchErrorType,
-  AbiEncodingBytesSizeMismatchError,
-  type AbiEncodingBytesSizeMismatchErrorType,
-  AbiEncodingLengthMismatchError,
-  type AbiEncodingLengthMismatchErrorType,
-  InvalidAbiEncodingTypeError,
-  type InvalidAbiEncodingTypeErrorType,
-  InvalidArrayError,
-  type InvalidArrayErrorType,
-} from '../../errors/abi.js'
+	AbiEncodingArrayLengthMismatchError,
+	type AbiEncodingArrayLengthMismatchErrorType,
+	AbiEncodingBytesSizeMismatchError,
+	type AbiEncodingBytesSizeMismatchErrorType,
+	AbiEncodingLengthMismatchError,
+	type AbiEncodingLengthMismatchErrorType,
+	InvalidAbiEncodingTypeError,
+	type InvalidAbiEncodingTypeErrorType,
+	InvalidArrayError,
+	type InvalidArrayErrorType,
+} from "../../errors/abi.js";
+import { InvalidAddressError, type InvalidAddressErrorType } from "../../errors/address.js";
+import { BaseError } from "../../errors/base.js";
+import type { ErrorType } from "../../errors/utils.js";
+import type { Hex } from "../../types/misc.js";
+import { type IsAddressErrorType, isAddress } from "../address/isAddress.js";
+import { type ConcatErrorType, concat } from "../data/concat.js";
+import { type PadHexErrorType, padHex } from "../data/pad.js";
+import { type SizeErrorType, size } from "../data/size.js";
+import { type SliceErrorType, slice } from "../data/slice.js";
 import {
-  InvalidAddressError,
-  type InvalidAddressErrorType,
-} from '../../errors/address.js'
-import { BaseError } from '../../errors/base.js'
-import type { ErrorType } from '../../errors/utils.js'
-import type { Hex } from '../../types/misc.js'
-import { type IsAddressErrorType, isAddress } from '../address/isAddress.js'
-import { type ConcatErrorType, concat } from '../data/concat.js'
-import { type PadHexErrorType, padHex } from '../data/pad.js'
-import { type SizeErrorType, size } from '../data/size.js'
-import { type SliceErrorType, slice } from '../data/slice.js'
-import {
-  type BoolToHexErrorType,
-  type NumberToHexErrorType,
-  type StringToHexErrorType,
-  boolToHex,
-  numberToHex,
-  stringToHex,
-} from '../encoding/toHex.js'
+	type BoolToHexErrorType,
+	type NumberToHexErrorType,
+	type StringToHexErrorType,
+	boolToHex,
+	numberToHex,
+	stringToHex,
+} from "../encoding/toHex.js";
 
-export type EncodeAbiParametersReturnType = Hex
+export type EncodeAbiParametersReturnType = Hex;
 
 export type EncodeAbiParametersErrorType =
-  | AbiEncodingLengthMismatchErrorType
-  | PrepareParamsErrorType
-  | EncodeParamsErrorType
-  | ErrorType
+	| AbiEncodingLengthMismatchErrorType
+	| PrepareParamsErrorType
+	| EncodeParamsErrorType
+	| ErrorType;
 
 /**
  * @description Encodes a list of primitive values into an ABI-encoded hex value.
@@ -81,344 +78,328 @@ export type EncodeAbiParametersErrorType =
  * ```
  */
 export function encodeAbiParameters<
-  const TParams extends readonly AbiParameter[] | readonly unknown[],
+	const TParams extends readonly AbiParameter[] | readonly unknown[],
 >(
-  params: TParams,
-  values: TParams extends readonly AbiParameter[]
-    ? AbiParametersToPrimitiveTypes<TParams>
-    : never,
+	params: TParams,
+	values: TParams extends readonly AbiParameter[] ? AbiParametersToPrimitiveTypes<TParams> : never,
 ): EncodeAbiParametersReturnType {
-  if (params.length !== values.length)
-    throw new AbiEncodingLengthMismatchError({
-      expectedLength: params.length as number,
-      givenLength: values.length as any,
-    })
-  // Prepare the parameters to determine dynamic types to encode.
-  const preparedParams = prepareParams({
-    params: params as readonly AbiParameter[],
-    values: values as any,
-  })
-  const data = encodeParams(preparedParams)
-  if (data.length === 0) return '0x'
-  return data
+	if (params.length !== values.length)
+		throw new AbiEncodingLengthMismatchError({
+			expectedLength: params.length as number,
+			givenLength: values.length as any,
+		});
+	// Prepare the parameters to determine dynamic types to encode.
+	const preparedParams = prepareParams({
+		params: params as readonly AbiParameter[],
+		values: values as any,
+	});
+	const data = encodeParams(preparedParams);
+	if (data.length === 0) return "0x";
+	return data;
 }
 
 /////////////////////////////////////////////////////////////////
 
-type PreparedParam = { dynamic: boolean; encoded: Hex }
+type PreparedParam = { dynamic: boolean; encoded: Hex };
 
-type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] }
-type Tuple = AbiParameterToPrimitiveType<TupleAbiParameter>
+type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] };
+type Tuple = AbiParameterToPrimitiveType<TupleAbiParameter>;
 
-type PrepareParamsErrorType = PrepareParamErrorType | ErrorType
+type PrepareParamsErrorType = PrepareParamErrorType | ErrorType;
 
 function prepareParams<const TParams extends readonly AbiParameter[]>({
-  params,
-  values,
+	params,
+	values,
 }: {
-  params: TParams
-  values: AbiParametersToPrimitiveTypes<TParams>
+	params: TParams;
+	values: AbiParametersToPrimitiveTypes<TParams>;
 }) {
-  const preparedParams: PreparedParam[] = []
-  for (let i = 0; i < params.length; i++) {
-    preparedParams.push(prepareParam({ param: params[i], value: values[i] }))
-  }
-  return preparedParams
+	const preparedParams: PreparedParam[] = [];
+	for (let i = 0; i < params.length; i++) {
+		preparedParams.push(prepareParam({ param: params[i], value: values[i] }));
+	}
+	return preparedParams;
 }
 
 type PrepareParamErrorType =
-  | EncodeAddressErrorType
-  | EncodeArrayErrorType
-  | EncodeBytesErrorType
-  | EncodeBoolErrorType
-  | EncodeNumberErrorType
-  | EncodeStringErrorType
-  | EncodeTupleErrorType
-  | GetArrayComponentsErrorType
-  | InvalidAbiEncodingTypeErrorType
-  | ErrorType
+	| EncodeAddressErrorType
+	| EncodeArrayErrorType
+	| EncodeBytesErrorType
+	| EncodeBoolErrorType
+	| EncodeNumberErrorType
+	| EncodeStringErrorType
+	| EncodeTupleErrorType
+	| GetArrayComponentsErrorType
+	| InvalidAbiEncodingTypeErrorType
+	| ErrorType;
 
 function prepareParam<const TParam extends AbiParameter>({
-  param,
-  value,
+	param,
+	value,
 }: {
-  param: TParam
-  value: AbiParameterToPrimitiveType<TParam>
+	param: TParam;
+	value: AbiParameterToPrimitiveType<TParam>;
 }): PreparedParam {
-  const arrayComponents = getArrayComponents(param.type)
-  if (arrayComponents) {
-    const [length, type] = arrayComponents
-    return encodeArray(value, { length, param: { ...param, type } })
-  }
-  if (param.type === 'tuple') {
-    return encodeTuple(value as unknown as Tuple, {
-      param: param as TupleAbiParameter,
-    })
-  }
-  if (param.type === 'address') {
-    return encodeAddress(value as unknown as Hex)
-  }
-  if (param.type === 'bool') {
-    return encodeBool(value)
-  }
-  if (param.type.startsWith('uint') || param.type.startsWith('int')) {
-    const signed = param.type.startsWith('int')
-    return encodeNumber(value as unknown as number, { signed })
-  }
-  if (param.type.startsWith('bytes')) {
-    return encodeBytes(value as unknown as Hex, { param })
-  }
-  if (param.type === 'string') {
-    return encodeString(value as unknown as string)
-  }
-  throw new InvalidAbiEncodingTypeError(param.type, {
-    docsPath: '/docs/contract/encodeAbiParameters',
-  })
+	const arrayComponents = getArrayComponents(param.type);
+	if (arrayComponents) {
+		const [length, type] = arrayComponents;
+		return encodeArray(value, { length, param: { ...param, type } });
+	}
+	if (param.type === "tuple") {
+		return encodeTuple(value as unknown as Tuple, {
+			param: param as TupleAbiParameter,
+		});
+	}
+	if (param.type === "address") {
+		return encodeAddress(value as unknown as Hex);
+	}
+	if (param.type === "bool") {
+		return encodeBool(value);
+	}
+	if (param.type.startsWith("uint") || param.type.startsWith("int")) {
+		const signed = param.type.startsWith("int");
+		return encodeNumber(value as unknown as number, { signed });
+	}
+	if (param.type.startsWith("bytes")) {
+		return encodeBytes(value as unknown as Hex, { param });
+	}
+	if (param.type === "string") {
+		return encodeString(value as unknown as string);
+	}
+	throw new InvalidAbiEncodingTypeError(param.type, {
+		docsPath: "/docs/contract/encodeAbiParameters",
+	});
 }
 
 /////////////////////////////////////////////////////////////////
 
-type EncodeParamsErrorType = NumberToHexErrorType | SizeErrorType | ErrorType
+type EncodeParamsErrorType = NumberToHexErrorType | SizeErrorType | ErrorType;
 
 function encodeParams(preparedParams: PreparedParam[]): Hex {
-  // 1. Compute the size of the static part of the parameters.
-  let staticSize = 0
-  for (let i = 0; i < preparedParams.length; i++) {
-    const { dynamic, encoded } = preparedParams[i]
-    if (dynamic) staticSize += 32
-    else staticSize += size(encoded)
-  }
+	// 1. Compute the size of the static part of the parameters.
+	let staticSize = 0;
+	for (let i = 0; i < preparedParams.length; i++) {
+		const { dynamic, encoded } = preparedParams[i];
+		if (dynamic) staticSize += 32;
+		else staticSize += size(encoded);
+	}
 
-  // 2. Split the parameters into static and dynamic parts.
-  const staticParams: Hex[] = []
-  const dynamicParams: Hex[] = []
-  let dynamicSize = 0
-  for (let i = 0; i < preparedParams.length; i++) {
-    const { dynamic, encoded } = preparedParams[i]
-    if (dynamic) {
-      staticParams.push(numberToHex(staticSize + dynamicSize, { size: 32 }))
-      dynamicParams.push(encoded)
-      dynamicSize += size(encoded)
-    } else {
-      staticParams.push(encoded)
-    }
-  }
+	// 2. Split the parameters into static and dynamic parts.
+	const staticParams: Hex[] = [];
+	const dynamicParams: Hex[] = [];
+	let dynamicSize = 0;
+	for (let i = 0; i < preparedParams.length; i++) {
+		const { dynamic, encoded } = preparedParams[i];
+		if (dynamic) {
+			staticParams.push(numberToHex(staticSize + dynamicSize, { size: 32 }));
+			dynamicParams.push(encoded);
+			dynamicSize += size(encoded);
+		} else {
+			staticParams.push(encoded);
+		}
+	}
 
-  // 3. Concatenate static and dynamic parts.
-  return concat([...staticParams, ...dynamicParams])
+	// 3. Concatenate static and dynamic parts.
+	return concat([...staticParams, ...dynamicParams]);
 }
 
 /////////////////////////////////////////////////////////////////
 
-type EncodeAddressErrorType =
-  | InvalidAddressErrorType
-  | IsAddressErrorType
-  | ErrorType
+type EncodeAddressErrorType = InvalidAddressErrorType | IsAddressErrorType | ErrorType;
 
 function encodeAddress(value: Hex): PreparedParam {
-  if (!isAddress(value)) throw new InvalidAddressError({ address: value })
-  return { dynamic: false, encoded: padHex(value.toLowerCase() as Hex) }
+	if (!isAddress(value)) throw new InvalidAddressError({ address: value });
+	return { dynamic: false, encoded: padHex(value.toLowerCase() as Hex) };
 }
 
 type EncodeArrayErrorType =
-  | AbiEncodingArrayLengthMismatchErrorType
-  | ConcatErrorType
-  | EncodeParamsErrorType
-  | InvalidArrayErrorType
-  | NumberToHexErrorType
-  // TODO: Add back once circular type reference is resolved
-  // | PrepareParamErrorType
-  | ErrorType
+	| AbiEncodingArrayLengthMismatchErrorType
+	| ConcatErrorType
+	| EncodeParamsErrorType
+	| InvalidArrayErrorType
+	| NumberToHexErrorType
+	// TODO: Add back once circular type reference is resolved
+	// | PrepareParamErrorType
+	| ErrorType;
 
 function encodeArray<const TParam extends AbiParameter>(
-  value: AbiParameterToPrimitiveType<TParam>,
-  {
-    length,
-    param,
-  }: {
-    length: number | null
-    param: TParam
-  },
+	value: AbiParameterToPrimitiveType<TParam>,
+	{
+		length,
+		param,
+	}: {
+		length: number | null;
+		param: TParam;
+	},
 ): PreparedParam {
-  const dynamic = length === null
+	const dynamic = length === null;
 
-  if (!Array.isArray(value)) throw new InvalidArrayError(value)
-  if (!dynamic && value.length !== length)
-    throw new AbiEncodingArrayLengthMismatchError({
-      expectedLength: length!,
-      givenLength: value.length,
-      type: `${param.type}[${length}]`,
-    })
+	if (!Array.isArray(value)) throw new InvalidArrayError(value);
+	if (!dynamic && value.length !== length)
+		throw new AbiEncodingArrayLengthMismatchError({
+			expectedLength: length!,
+			givenLength: value.length,
+			type: `${param.type}[${length}]`,
+		});
 
-  let dynamicChild = false
-  const preparedParams: PreparedParam[] = []
-  for (let i = 0; i < value.length; i++) {
-    const preparedParam = prepareParam({ param, value: value[i] })
-    if (preparedParam.dynamic) dynamicChild = true
-    preparedParams.push(preparedParam)
-  }
+	let dynamicChild = false;
+	const preparedParams: PreparedParam[] = [];
+	for (let i = 0; i < value.length; i++) {
+		const preparedParam = prepareParam({ param, value: value[i] });
+		if (preparedParam.dynamic) dynamicChild = true;
+		preparedParams.push(preparedParam);
+	}
 
-  if (dynamic || dynamicChild) {
-    const data = encodeParams(preparedParams)
-    if (dynamic) {
-      const length = numberToHex(preparedParams.length, { size: 32 })
-      return {
-        dynamic: true,
-        encoded: preparedParams.length > 0 ? concat([length, data]) : length,
-      }
-    }
-    if (dynamicChild) return { dynamic: true, encoded: data }
-  }
-  return {
-    dynamic: false,
-    encoded: concat(preparedParams.map(({ encoded }) => encoded)),
-  }
+	if (dynamic || dynamicChild) {
+		const data = encodeParams(preparedParams);
+		if (dynamic) {
+			const length = numberToHex(preparedParams.length, { size: 32 });
+			return {
+				dynamic: true,
+				encoded: preparedParams.length > 0 ? concat([length, data]) : length,
+			};
+		}
+		if (dynamicChild) return { dynamic: true, encoded: data };
+	}
+	return {
+		dynamic: false,
+		encoded: concat(preparedParams.map(({ encoded }) => encoded)),
+	};
 }
 
 type EncodeBytesErrorType =
-  | AbiEncodingBytesSizeMismatchErrorType
-  | ConcatErrorType
-  | PadHexErrorType
-  | NumberToHexErrorType
-  | SizeErrorType
-  | ErrorType
+	| AbiEncodingBytesSizeMismatchErrorType
+	| ConcatErrorType
+	| PadHexErrorType
+	| NumberToHexErrorType
+	| SizeErrorType
+	| ErrorType;
 
 function encodeBytes<const TParam extends AbiParameter>(
-  value: Hex,
-  { param }: { param: TParam },
+	value: Hex,
+	{ param }: { param: TParam },
 ): PreparedParam {
-  const [, paramSize] = param.type.split('bytes')
-  const bytesSize = size(value)
-  if (!paramSize) {
-    let value_ = value
-    // If the size is not divisible by 32 bytes, pad the end
-    // with empty bytes to the ceiling 32 bytes.
-    if (bytesSize % 32 !== 0)
-      value_ = padHex(value_, {
-        dir: 'right',
-        size: Math.ceil((value.length - 2) / 2 / 32) * 32,
-      })
-    return {
-      dynamic: true,
-      encoded: concat([padHex(numberToHex(bytesSize, { size: 32 })), value_]),
-    }
-  }
-  if (bytesSize !== Number.parseInt(paramSize))
-    throw new AbiEncodingBytesSizeMismatchError({
-      expectedSize: Number.parseInt(paramSize),
-      value,
-    })
-  return { dynamic: false, encoded: padHex(value, { dir: 'right' }) }
+	const [, paramSize] = param.type.split("bytes");
+	const bytesSize = size(value);
+	if (!paramSize) {
+		let value_ = value;
+		// If the size is not divisible by 32 bytes, pad the end
+		// with empty bytes to the ceiling 32 bytes.
+		if (bytesSize % 32 !== 0)
+			value_ = padHex(value_, {
+				dir: "right",
+				size: Math.ceil((value.length - 2) / 2 / 32) * 32,
+			});
+		return {
+			dynamic: true,
+			encoded: concat([padHex(numberToHex(bytesSize, { size: 32 })), value_]),
+		};
+	}
+	if (bytesSize !== Number.parseInt(paramSize))
+		throw new AbiEncodingBytesSizeMismatchError({
+			expectedSize: Number.parseInt(paramSize),
+			value,
+		});
+	return { dynamic: false, encoded: padHex(value, { dir: "right" }) };
 }
 
-type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType
+type EncodeBoolErrorType = PadHexErrorType | BoolToHexErrorType | ErrorType;
 
 function encodeBool(value: any): PreparedParam {
-  if (typeof value === 'string')
-    return {
-      dynamic: false,
-      encoded: padHex(
-        boolToHex(value.toLowerCase() !== 'false' && value !== ''),
-      ),
-    }
+	if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean")
+		return { dynamic: false, encoded: padHex(boolToHex(value)) };
 
-  if (
-    typeof value === 'number' ||
-    typeof value === 'bigint' ||
-    typeof value === 'boolean'
-  )
-    return { dynamic: false, encoded: padHex(boolToHex(value)) }
+	if (typeof value === "string") {
+		const v = value.toLowerCase();
+		if (v === "true" || v === "false")
+			return {
+				dynamic: false,
+				encoded: padHex(boolToHex(value.toLowerCase() !== "false")),
+			};
+	}
 
-  throw new BaseError(
-    `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
-  )
+	throw new BaseError(
+		`Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`,
+	);
 }
 
-type EncodeNumberErrorType = NumberToHexErrorType | ErrorType
+type EncodeNumberErrorType = NumberToHexErrorType | ErrorType;
 
-function encodeNumber(
-  value: number,
-  { signed }: { signed: boolean },
-): PreparedParam {
-  return {
-    dynamic: false,
-    encoded: numberToHex(value, {
-      size: 32,
-      signed,
-    }),
-  }
+function encodeNumber(value: number, { signed }: { signed: boolean }): PreparedParam {
+	return {
+		dynamic: false,
+		encoded: numberToHex(value, {
+			size: 32,
+			signed,
+		}),
+	};
 }
 
 type EncodeStringErrorType =
-  | ConcatErrorType
-  | NumberToHexErrorType
-  | PadHexErrorType
-  | SizeErrorType
-  | SliceErrorType
-  | StringToHexErrorType
-  | ErrorType
+	| ConcatErrorType
+	| NumberToHexErrorType
+	| PadHexErrorType
+	| SizeErrorType
+	| SliceErrorType
+	| StringToHexErrorType
+	| ErrorType;
 
 function encodeString(value: string): PreparedParam {
-  const hexValue = stringToHex(value)
-  const partsLength = Math.ceil(size(hexValue) / 32)
-  const parts: Hex[] = []
-  for (let i = 0; i < partsLength; i++) {
-    parts.push(
-      padHex(slice(hexValue, i * 32, (i + 1) * 32), {
-        dir: 'right',
-      }),
-    )
-  }
-  return {
-    dynamic: true,
-    encoded: concat([
-      padHex(numberToHex(size(hexValue), { size: 32 })),
-      ...parts,
-    ]),
-  }
+	const hexValue = stringToHex(value);
+	const partsLength = Math.ceil(size(hexValue) / 32);
+	const parts: Hex[] = [];
+	for (let i = 0; i < partsLength; i++) {
+		parts.push(
+			padHex(slice(hexValue, i * 32, (i + 1) * 32), {
+				dir: "right",
+			}),
+		);
+	}
+	return {
+		dynamic: true,
+		encoded: concat([padHex(numberToHex(size(hexValue), { size: 32 })), ...parts]),
+	};
 }
 
 type EncodeTupleErrorType =
-  | ConcatErrorType
-  | EncodeParamsErrorType
-  // TODO: Add back once circular type reference is resolved
-  // | PrepareParamErrorType
-  | ErrorType
+	| ConcatErrorType
+	| EncodeParamsErrorType
+	// TODO: Add back once circular type reference is resolved
+	// | PrepareParamErrorType
+	| ErrorType;
 
-function encodeTuple<
-  const TParam extends AbiParameter & { components: readonly AbiParameter[] },
->(
-  value: AbiParameterToPrimitiveType<TParam>,
-  { param }: { param: TParam },
+function encodeTuple<const TParam extends AbiParameter & { components: readonly AbiParameter[] }>(
+	value: AbiParameterToPrimitiveType<TParam>,
+	{ param }: { param: TParam },
 ): PreparedParam {
-  let dynamic = false
-  const preparedParams: PreparedParam[] = []
-  for (let i = 0; i < param.components.length; i++) {
-    const param_ = param.components[i]
-    const index = Array.isArray(value) ? i : param_.name
-    const preparedParam = prepareParam({
-      param: param_,
-      value: (value as any)[index!] as readonly unknown[],
-    })
-    preparedParams.push(preparedParam)
-    if (preparedParam.dynamic) dynamic = true
-  }
-  return {
-    dynamic,
-    encoded: dynamic
-      ? encodeParams(preparedParams)
-      : concat(preparedParams.map(({ encoded }) => encoded)),
-  }
+	let dynamic = false;
+	const preparedParams: PreparedParam[] = [];
+	for (let i = 0; i < param.components.length; i++) {
+		const param_ = param.components[i];
+		const index = Array.isArray(value) ? i : param_.name;
+		const preparedParam = prepareParam({
+			param: param_,
+			value: (value as any)[index!] as readonly unknown[],
+		});
+		preparedParams.push(preparedParam);
+		if (preparedParam.dynamic) dynamic = true;
+	}
+	return {
+		dynamic,
+		encoded: dynamic
+			? encodeParams(preparedParams)
+			: concat(preparedParams.map(({ encoded }) => encoded)),
+	};
 }
 
-type GetArrayComponentsErrorType = ErrorType
+type GetArrayComponentsErrorType = ErrorType;
 
 export function getArrayComponents(
-  type: string,
+	type: string,
 ): [length: number | null, innerType: string] | undefined {
-  const matches = type.match(/^(.*)\[(\d+)?\]$/)
-  return matches
-    ? // Return `null` if the array is dynamic.
-      [matches[2] ? Number(matches[2]) : null, matches[1]]
-    : undefined
+	const matches = type.match(/^(.*)\[(\d+)?\]$/);
+	return matches
+		? // Return `null` if the array is dynamic.
+		  [matches[2] ? Number(matches[2]) : null, matches[1]]
+		: undefined;
 }

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -1,28 +1,23 @@
-import {
-  IntegerOutOfRangeError,
-  type IntegerOutOfRangeErrorType,
-} from '../../errors/encoding.js'
-import type { ErrorType } from '../../errors/utils.js'
-import type { ByteArray, Hex } from '../../types/misc.js'
-import { type PadErrorType, pad } from '../data/pad.js'
+import { IntegerOutOfRangeError, type IntegerOutOfRangeErrorType } from "../../errors/encoding.js";
+import type { ErrorType } from "../../errors/utils.js";
+import type { ByteArray, Hex } from "../../types/misc.js";
+import { type PadErrorType, pad } from "../data/pad.js";
 
-import { type AssertSizeErrorType, assertSize } from './fromHex.js'
+import { type AssertSizeErrorType, assertSize } from "./fromHex.js";
 
-const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (_v, i) =>
-  i.toString(16).padStart(2, '0'),
-)
+const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (_v, i) => i.toString(16).padStart(2, "0"));
 
 export type ToHexParameters = {
-  /** The size (in bytes) of the output hex value. */
-  size?: number | undefined
-}
+	/** The size (in bytes) of the output hex value. */
+	size?: number | undefined;
+};
 
 export type ToHexErrorType =
-  | BoolToHexErrorType
-  | BytesToHexErrorType
-  | NumberToHexErrorType
-  | StringToHexErrorType
-  | ErrorType
+	| BoolToHexErrorType
+	| BytesToHexErrorType
+	| NumberToHexErrorType
+	| StringToHexErrorType
+	| ErrorType;
 
 /**
  * Encodes a string, number, bigint, or ByteArray into a hex string
@@ -50,24 +45,23 @@ export type ToHexErrorType =
  * // '0x48656c6c6f20776f726c64210000000000000000000000000000000000000000'
  */
 export function toHex(
-  value: string | number | bigint | boolean | ByteArray,
-  opts: ToHexParameters = {},
+	value: string | number | bigint | boolean | ByteArray,
+	opts: ToHexParameters = {},
 ): Hex {
-  if (typeof value === 'number' || typeof value === 'bigint')
-    return numberToHex(value, opts)
-  if (typeof value === 'string') {
-    return stringToHex(value, opts)
-  }
-  if (typeof value === 'boolean') return boolToHex(value, opts)
-  return bytesToHex(value, opts)
+	if (typeof value === "number" || typeof value === "bigint") return numberToHex(value, opts);
+	if (typeof value === "string") {
+		return stringToHex(value, opts);
+	}
+	if (typeof value === "boolean") return boolToHex(value, opts);
+	return bytesToHex(value, opts);
 }
 
 export type BoolToHexOpts = {
-  /** The size (in bytes) of the output hex value. */
-  size?: number | undefined
-}
+	/** The size (in bytes) of the output hex value. */
+	size?: number | undefined;
+};
 
-export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
+export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType;
 
 /**
  * Encodes a boolean into a hex string
@@ -93,24 +87,21 @@ export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
  * const data = boolToHex(true, { size: 32 })
  * // '0x0000000000000000000000000000000000000000000000000000000000000001'
  */
-export function boolToHex(
-  value: Parameters<typeof Number>[0],
-  opts: BoolToHexOpts = {},
-): Hex {
-  const hex: Hex = `0x${Number(value)}`
-  if (typeof opts.size === 'number') {
-    assertSize(hex, { size: opts.size })
-    return pad(hex, { size: opts.size })
-  }
-  return hex
+export function boolToHex(value: Parameters<typeof Number>[0], opts: BoolToHexOpts = {}): Hex {
+	const hex: Hex = `0x${Number(!!value)}`;
+	if (typeof opts.size === "number") {
+		assertSize(hex, { size: opts.size });
+		return pad(hex, { size: opts.size });
+	}
+	return hex;
 }
 
 export type BytesToHexOpts = {
-  /** The size (in bytes) of the output hex value. */
-  size?: number | undefined
-}
+	/** The size (in bytes) of the output hex value. */
+	size?: number | undefined;
+};
 
-export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
+export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType;
 
 /**
  * Encodes a bytes array into a hex string
@@ -132,36 +123,33 @@ export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
  * // '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000'
  */
 export function bytesToHex(value: ByteArray, opts: BytesToHexOpts = {}): Hex {
-  let string = ''
-  for (let i = 0; i < value.length; i++) {
-    string += hexes[value[i]]
-  }
-  const hex = `0x${string}` as const
+	let string = "";
+	for (let i = 0; i < value.length; i++) {
+		string += hexes[value[i]];
+	}
+	const hex = `0x${string}` as const;
 
-  if (typeof opts.size === 'number') {
-    assertSize(hex, { size: opts.size })
-    return pad(hex, { dir: 'right', size: opts.size })
-  }
-  return hex
+	if (typeof opts.size === "number") {
+		assertSize(hex, { size: opts.size });
+		return pad(hex, { dir: "right", size: opts.size });
+	}
+	return hex;
 }
 
 export type NumberToHexOpts =
-  | {
-      /** Whether or not the number of a signed representation. */
-      signed?: boolean | undefined
-      /** The size (in bytes) of the output hex value. */
-      size: number
-    }
-  | {
-      signed?: undefined
-      /** The size (in bytes) of the output hex value. */
-      size?: number | undefined
-    }
+	| {
+			/** Whether or not the number of a signed representation. */
+			signed?: boolean | undefined;
+			/** The size (in bytes) of the output hex value. */
+			size: number;
+	  }
+	| {
+			signed?: undefined;
+			/** The size (in bytes) of the output hex value. */
+			size?: number | undefined;
+	  };
 
-export type NumberToHexErrorType =
-  | IntegerOutOfRangeErrorType
-  | PadErrorType
-  | ErrorType
+export type NumberToHexErrorType = IntegerOutOfRangeErrorType | PadErrorType | ErrorType;
 
 /**
  * Encodes a number or bigint into a hex string
@@ -182,51 +170,48 @@ export type NumberToHexErrorType =
  * const data = numberToHex(420, { size: 32 })
  * // '0x00000000000000000000000000000000000000000000000000000000000001a4'
  */
-export function numberToHex(
-  value_: number | bigint,
-  opts: NumberToHexOpts = {},
-): Hex {
-  const { signed, size } = opts
+export function numberToHex(value_: number | bigint, opts: NumberToHexOpts = {}): Hex {
+	const { signed, size } = opts;
 
-  const value = BigInt(value_)
+	const value = BigInt(value_);
 
-  let maxValue: bigint | number | undefined
-  if (size) {
-    if (signed) maxValue = (1n << (BigInt(size) * 8n - 1n)) - 1n
-    else maxValue = 2n ** (BigInt(size) * 8n) - 1n
-  } else if (typeof value_ === 'number') {
-    maxValue = BigInt(Number.MAX_SAFE_INTEGER)
-  }
+	let maxValue: bigint | number | undefined;
+	if (size) {
+		if (signed) maxValue = (1n << (BigInt(size) * 8n - 1n)) - 1n;
+		else maxValue = 2n ** (BigInt(size) * 8n) - 1n;
+	} else if (typeof value_ === "number") {
+		maxValue = BigInt(Number.MAX_SAFE_INTEGER);
+	}
 
-  const minValue = typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
+	const minValue = typeof maxValue === "bigint" && signed ? -maxValue - 1n : 0;
 
-  if ((maxValue && value > maxValue) || value < minValue) {
-    const suffix = typeof value_ === 'bigint' ? 'n' : ''
-    throw new IntegerOutOfRangeError({
-      max: maxValue ? `${maxValue}${suffix}` : undefined,
-      min: `${minValue}${suffix}`,
-      signed,
-      size,
-      value: `${value_}${suffix}`,
-    })
-  }
+	if ((maxValue && value > maxValue) || value < minValue) {
+		const suffix = typeof value_ === "bigint" ? "n" : "";
+		throw new IntegerOutOfRangeError({
+			max: maxValue ? `${maxValue}${suffix}` : undefined,
+			min: `${minValue}${suffix}`,
+			signed,
+			size,
+			value: `${value_}${suffix}`,
+		});
+	}
 
-  const hex = `0x${(signed && value < 0
-    ? (1n << BigInt(size * 8)) + BigInt(value)
-    : value
-  ).toString(16)}` as Hex
-  if (size) return pad(hex, { size }) as Hex
-  return hex
+	const hex = `0x${(signed && value < 0
+		? (1n << BigInt(size * 8)) + BigInt(value)
+		: value
+	).toString(16)}` as Hex;
+	if (size) return pad(hex, { size }) as Hex;
+	return hex;
 }
 
 export type StringToHexOpts = {
-  /** The size (in bytes) of the output hex value. */
-  size?: number | undefined
-}
+	/** The size (in bytes) of the output hex value. */
+	size?: number | undefined;
+};
 
-export type StringToHexErrorType = BytesToHexErrorType | ErrorType
+export type StringToHexErrorType = BytesToHexErrorType | ErrorType;
 
-const encoder = /*#__PURE__*/ new TextEncoder()
+const encoder = /*#__PURE__*/ new TextEncoder();
 
 /**
  * Encodes a UTF-8 string into a hex string
@@ -248,6 +233,6 @@ const encoder = /*#__PURE__*/ new TextEncoder()
  * // '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000'
  */
 export function stringToHex(value_: string, opts: StringToHexOpts = {}): Hex {
-  const value = encoder.encode(value_)
-  return bytesToHex(value, opts)
+	const value = encoder.encode(value_);
+	return bytesToHex(value, opts);
 }

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -93,7 +93,10 @@ export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
  * const data = boolToHex(true, { size: 32 })
  * // '0x0000000000000000000000000000000000000000000000000000000000000001'
  */
-export function boolToHex(value: Parameters<typeof Number>[0], opts: BoolToHexOpts = {}): Hex {
+export function boolToHex(
+  value: Parameters<typeof Number>[0],
+  opts: BoolToHexOpts = {},
+): Hex {
   const hex: Hex = `0x${Number(value)}`
   if (typeof opts.size === 'number') {
     assertSize(hex, { size: opts.size })

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -93,7 +93,7 @@ export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
  * const data = boolToHex(true, { size: 32 })
  * // '0x0000000000000000000000000000000000000000000000000000000000000001'
  */
-export function boolToHex(value: boolean, opts: BoolToHexOpts = {}): Hex {
+export function boolToHex(value: Parameters<typeof Number>[0], opts: BoolToHexOpts = {}): Hex {
   const hex: Hex = `0x${Number(value)}`
   if (typeof opts.size === 'number') {
     assertSize(hex, { size: opts.size })

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -1,23 +1,28 @@
-import { IntegerOutOfRangeError, type IntegerOutOfRangeErrorType } from "../../errors/encoding.js";
-import type { ErrorType } from "../../errors/utils.js";
-import type { ByteArray, Hex } from "../../types/misc.js";
-import { type PadErrorType, pad } from "../data/pad.js";
+import {
+  IntegerOutOfRangeError,
+  type IntegerOutOfRangeErrorType,
+} from '../../errors/encoding.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { ByteArray, Hex } from '../../types/misc.js'
+import { type PadErrorType, pad } from '../data/pad.js'
 
-import { type AssertSizeErrorType, assertSize } from "./fromHex.js";
+import { type AssertSizeErrorType, assertSize } from './fromHex.js'
 
-const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (_v, i) => i.toString(16).padStart(2, "0"));
+const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (_v, i) =>
+  i.toString(16).padStart(2, '0'),
+)
 
 export type ToHexParameters = {
-	/** The size (in bytes) of the output hex value. */
-	size?: number | undefined;
-};
+  /** The size (in bytes) of the output hex value. */
+  size?: number | undefined
+}
 
 export type ToHexErrorType =
-	| BoolToHexErrorType
-	| BytesToHexErrorType
-	| NumberToHexErrorType
-	| StringToHexErrorType
-	| ErrorType;
+  | BoolToHexErrorType
+  | BytesToHexErrorType
+  | NumberToHexErrorType
+  | StringToHexErrorType
+  | ErrorType
 
 /**
  * Encodes a string, number, bigint, or ByteArray into a hex string
@@ -45,23 +50,24 @@ export type ToHexErrorType =
  * // '0x48656c6c6f20776f726c64210000000000000000000000000000000000000000'
  */
 export function toHex(
-	value: string | number | bigint | boolean | ByteArray,
-	opts: ToHexParameters = {},
+  value: string | number | bigint | boolean | ByteArray,
+  opts: ToHexParameters = {},
 ): Hex {
-	if (typeof value === "number" || typeof value === "bigint") return numberToHex(value, opts);
-	if (typeof value === "string") {
-		return stringToHex(value, opts);
-	}
-	if (typeof value === "boolean") return boolToHex(value, opts);
-	return bytesToHex(value, opts);
+  if (typeof value === 'number' || typeof value === 'bigint')
+    return numberToHex(value, opts)
+  if (typeof value === 'string') {
+    return stringToHex(value, opts)
+  }
+  if (typeof value === 'boolean') return boolToHex(value, opts)
+  return bytesToHex(value, opts)
 }
 
 export type BoolToHexOpts = {
-	/** The size (in bytes) of the output hex value. */
-	size?: number | undefined;
-};
+  /** The size (in bytes) of the output hex value. */
+  size?: number | undefined
+}
 
-export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType;
+export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
 
 /**
  * Encodes a boolean into a hex string
@@ -87,21 +93,24 @@ export type BoolToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType;
  * const data = boolToHex(true, { size: 32 })
  * // '0x0000000000000000000000000000000000000000000000000000000000000001'
  */
-export function boolToHex(value: Parameters<typeof Number>[0], opts: BoolToHexOpts = {}): Hex {
-	const hex: Hex = `0x${Number(!!value)}`;
-	if (typeof opts.size === "number") {
-		assertSize(hex, { size: opts.size });
-		return pad(hex, { size: opts.size });
-	}
-	return hex;
+export function boolToHex(
+  value: Parameters<typeof Number>[0],
+  opts: BoolToHexOpts = {},
+): Hex {
+  const hex: Hex = `0x${Number(!!value)}`
+  if (typeof opts.size === 'number') {
+    assertSize(hex, { size: opts.size })
+    return pad(hex, { size: opts.size })
+  }
+  return hex
 }
 
 export type BytesToHexOpts = {
-	/** The size (in bytes) of the output hex value. */
-	size?: number | undefined;
-};
+  /** The size (in bytes) of the output hex value. */
+  size?: number | undefined
+}
 
-export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType;
+export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
 
 /**
  * Encodes a bytes array into a hex string
@@ -123,33 +132,36 @@ export type BytesToHexErrorType = AssertSizeErrorType | PadErrorType | ErrorType
  * // '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000'
  */
 export function bytesToHex(value: ByteArray, opts: BytesToHexOpts = {}): Hex {
-	let string = "";
-	for (let i = 0; i < value.length; i++) {
-		string += hexes[value[i]];
-	}
-	const hex = `0x${string}` as const;
+  let string = ''
+  for (let i = 0; i < value.length; i++) {
+    string += hexes[value[i]]
+  }
+  const hex = `0x${string}` as const
 
-	if (typeof opts.size === "number") {
-		assertSize(hex, { size: opts.size });
-		return pad(hex, { dir: "right", size: opts.size });
-	}
-	return hex;
+  if (typeof opts.size === 'number') {
+    assertSize(hex, { size: opts.size })
+    return pad(hex, { dir: 'right', size: opts.size })
+  }
+  return hex
 }
 
 export type NumberToHexOpts =
-	| {
-			/** Whether or not the number of a signed representation. */
-			signed?: boolean | undefined;
-			/** The size (in bytes) of the output hex value. */
-			size: number;
-	  }
-	| {
-			signed?: undefined;
-			/** The size (in bytes) of the output hex value. */
-			size?: number | undefined;
-	  };
+  | {
+      /** Whether or not the number of a signed representation. */
+      signed?: boolean | undefined
+      /** The size (in bytes) of the output hex value. */
+      size: number
+    }
+  | {
+      signed?: undefined
+      /** The size (in bytes) of the output hex value. */
+      size?: number | undefined
+    }
 
-export type NumberToHexErrorType = IntegerOutOfRangeErrorType | PadErrorType | ErrorType;
+export type NumberToHexErrorType =
+  | IntegerOutOfRangeErrorType
+  | PadErrorType
+  | ErrorType
 
 /**
  * Encodes a number or bigint into a hex string
@@ -170,48 +182,51 @@ export type NumberToHexErrorType = IntegerOutOfRangeErrorType | PadErrorType | E
  * const data = numberToHex(420, { size: 32 })
  * // '0x00000000000000000000000000000000000000000000000000000000000001a4'
  */
-export function numberToHex(value_: number | bigint, opts: NumberToHexOpts = {}): Hex {
-	const { signed, size } = opts;
+export function numberToHex(
+  value_: number | bigint,
+  opts: NumberToHexOpts = {},
+): Hex {
+  const { signed, size } = opts
 
-	const value = BigInt(value_);
+  const value = BigInt(value_)
 
-	let maxValue: bigint | number | undefined;
-	if (size) {
-		if (signed) maxValue = (1n << (BigInt(size) * 8n - 1n)) - 1n;
-		else maxValue = 2n ** (BigInt(size) * 8n) - 1n;
-	} else if (typeof value_ === "number") {
-		maxValue = BigInt(Number.MAX_SAFE_INTEGER);
-	}
+  let maxValue: bigint | number | undefined
+  if (size) {
+    if (signed) maxValue = (1n << (BigInt(size) * 8n - 1n)) - 1n
+    else maxValue = 2n ** (BigInt(size) * 8n) - 1n
+  } else if (typeof value_ === 'number') {
+    maxValue = BigInt(Number.MAX_SAFE_INTEGER)
+  }
 
-	const minValue = typeof maxValue === "bigint" && signed ? -maxValue - 1n : 0;
+  const minValue = typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
 
-	if ((maxValue && value > maxValue) || value < minValue) {
-		const suffix = typeof value_ === "bigint" ? "n" : "";
-		throw new IntegerOutOfRangeError({
-			max: maxValue ? `${maxValue}${suffix}` : undefined,
-			min: `${minValue}${suffix}`,
-			signed,
-			size,
-			value: `${value_}${suffix}`,
-		});
-	}
+  if ((maxValue && value > maxValue) || value < minValue) {
+    const suffix = typeof value_ === 'bigint' ? 'n' : ''
+    throw new IntegerOutOfRangeError({
+      max: maxValue ? `${maxValue}${suffix}` : undefined,
+      min: `${minValue}${suffix}`,
+      signed,
+      size,
+      value: `${value_}${suffix}`,
+    })
+  }
 
-	const hex = `0x${(signed && value < 0
-		? (1n << BigInt(size * 8)) + BigInt(value)
-		: value
-	).toString(16)}` as Hex;
-	if (size) return pad(hex, { size }) as Hex;
-	return hex;
+  const hex = `0x${(signed && value < 0
+    ? (1n << BigInt(size * 8)) + BigInt(value)
+    : value
+  ).toString(16)}` as Hex
+  if (size) return pad(hex, { size }) as Hex
+  return hex
 }
 
 export type StringToHexOpts = {
-	/** The size (in bytes) of the output hex value. */
-	size?: number | undefined;
-};
+  /** The size (in bytes) of the output hex value. */
+  size?: number | undefined
+}
 
-export type StringToHexErrorType = BytesToHexErrorType | ErrorType;
+export type StringToHexErrorType = BytesToHexErrorType | ErrorType
 
-const encoder = /*#__PURE__*/ new TextEncoder();
+const encoder = /*#__PURE__*/ new TextEncoder()
 
 /**
  * Encodes a UTF-8 string into a hex string
@@ -233,6 +248,6 @@ const encoder = /*#__PURE__*/ new TextEncoder();
  * // '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000'
  */
 export function stringToHex(value_: string, opts: StringToHexOpts = {}): Hex {
-	const value = encoder.encode(value_);
-	return bytesToHex(value, opts);
+  const value = encoder.encode(value_)
+  return bytesToHex(value, opts)
 }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

This PR expands the functionaly of the `encodeAbiParameter` utility function to accept `string`, `number`, and `bigint` as encodable types for ABI `boolean`. In particular, a string with value '`false'` will be interpreted as ABI `false` as that is the likely intent of such a string input.

Currently, all other basic types of values in an ABI (uint/int, address, bytes, strings themselves) are able to be passed in as a string in Javascript, despite the types not officially allowing for this.

We recently identified a difficulty arising from this issue with our tooling, [Cannon](https://usecannon.com/). Our tool only allows interpolation of strings as a means for value injection, but we noticed that interpolation was not possible for ABI arguments which were of type `boolean`. After exploring various options for resolution, we identified that upstreaming a change seems most appropriate since the type handling for booleans seemed unusually strict compared to other types and any fixes we attempt on our end would simply be a workaround for this restriction.

Notes:
* I considered editing the type for `AbiToParameter`, to account for more broad types to match those accepted by `encodeAbiParameters` after this change, but this type is likely used by other structures (such as decodeAbiParameters) for type resolution and therefore carried a risk for side effects. Additionally, other types which accept strings or others (ex. uint) do not officially allow those types in the encode function, so I chose not to edit the type. Please let me know if it would be better to edit.
* Any non-zero numeric value will be treated as true. This most closely matches the behavior or most programming languages, but should an error be thrown if a number other than 0 or 1 is provided?
* in https://github.com/wevm/viem/issues/1960, it was reported tha-t supplying a string accidentally to boolean values would yield a NaN, so this issue was fixed by (it appears) restricting the supply of non-boolean values and adding a test case. I updated this test case to supply an invalid string (`"truez"`) which would be like a typo and fail in the same way, so the issue should not relapse.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `boolToHex` function and its usage in encoding boolean values for ABI parameters.

### Detailed summary
- Updated `boolToHex` to handle various input types
- Improved encoding of boolean values in ABI parameters
- Added tests for encoding boolean values from strings, numbers, and BigInts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->