### PR TITLE
Add: bitTorrent Multicall3

### DIFF
--- a/.changeset/forty-moles-jam.md
+++ b/.changeset/forty-moles-jam.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract to BitTorrent chain.

--- a/src/chains/definitions/bitTorrent.ts
+++ b/src/chains/definitions/bitTorrent.ts
@@ -16,4 +16,10 @@ export const bitTorrent = /*#__PURE__*/ defineChain({
       apiUrl: 'https://api.bttcscan.com/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11"
+      blockCreated: 31078552,
+    }
+  },
 })

--- a/src/chains/definitions/bitTorrent.ts
+++ b/src/chains/definitions/bitTorrent.ts
@@ -18,7 +18,7 @@ export const bitTorrent = /*#__PURE__*/ defineChain({
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11"
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
       blockCreated: 31078552,
     }
   },


### PR DESCRIPTION
Official address: https://www.multicall3.com/deployments
Contract: https://bttcscan.com/address/0xca11bde05977b3631167028862be2a173976ca11#code

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `multicall3` contract to the BitTorrent chain.

### Detailed summary
- Added `multicall3` contract to BitTorrent chain with address and block creation details.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->