### PR TITLE
Fix chain details for btr mainnet and testnet

### DIFF
--- a/.changeset/silent-penguins-own.md
+++ b/.changeset/silent-penguins-own.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 and fixed native currency, block explorers for btr mainnet and testnet.

--- a/src/chains/definitions/btr.ts
+++ b/src/chains/definitions/btr.ts
@@ -4,8 +4,8 @@ export const btr = /*#__PURE__*/ defineChain({
   id: 200901,
   name: 'Bitlayer',
   nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
+    name: 'Bitcoin',
+    symbol: 'BTC',
     decimals: 18,
   },
   rpcUrls: {
@@ -20,9 +20,15 @@ export const btr = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'btrscan',
+      name: 'Bitlayer(BTR) Scan',
       url: 'https://www.btrscan.com',
       apiUrl: 'https://www.btrscan.com/apis',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x5b256fe9e993902ece49d138a5b1162cbb529474',
+      blockCreated: 2421963,
     },
   },
 })

--- a/src/chains/definitions/btrTestnet.ts
+++ b/src/chains/definitions/btrTestnet.ts
@@ -4,8 +4,8 @@ export const btrTestnet = /*#__PURE__*/ defineChain({
   id: 200810,
   name: 'Bitlayer Testnet',
   nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
+    name: 'Bitcoin',
+    symbol: 'BTC',
     decimals: 18,
   },
   rpcUrls: {
@@ -19,9 +19,15 @@ export const btrTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'btrscan',
-      url: 'https://testnet-scan.bitlayer.org',
-      apiUrl: 'https://testnet-scan.bitlayer.org/apis',
+      name: 'Bitlayer(BTR) Scan',
+      url: 'https://testnet.btrscan.com/',
+      apiUrl: 'https://testnet.btrscan.com/apis',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x5b256fe9e993902ece49d138a5b1162cbb529474',
+      blockCreated: 4135671,
     },
   },
   testnet: true,


### PR DESCRIPTION
This PR updates some details for the Bitlayer mainnet and testnet.

1. Fixed the native currency name and symbol.
2. Fixed the default block explorer URL for testnet.
3. Added the multicall3 contract.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `multicall3` contracts and updating native currency and block explorers for the Bitlayer mainnet and testnet.

### Detailed summary
- Added `multicall3` contracts for Bitlayer mainnet and testnet
- Updated native currency to Bitcoin (BTC)
- Updated block explorers for Bitlayer mainnet and testnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->