### PR TITLE
fix: wrong native currency and symbol dogechain

### DIFF
--- a/src/chains/definitions/dogechain.ts
+++ b/src/chains/definitions/dogechain.ts
@@ -5,8 +5,8 @@ export const dogechain = /*#__PURE__*/ defineChain({
   name: 'Dogechain',
   nativeCurrency: {
     decimals: 18,
-    name: 'Dogechain',
-    symbol: 'DC',
+    name: 'Wrapped Dogecoin',
+    symbol: 'WDOGE',
   },
   rpcUrls: {
     default: { http: ['https://rpc.dogechain.dog'] },


### PR DESCRIPTION
fixed incorrect native currency and symbol on Dogechain network

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the native currency name and symbol in the Dogechain definition.

### Detailed summary
- Updated native currency name to 'Wrapped Dogecoin'
- Updated native currency symbol to 'WDOGE'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->