### PR TITLE
Add Sei Testnet

### DIFF
--- a/.changeset/gentle-walls-knock.md
+++ b/.changeset/gentle-walls-knock.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add Sei testnet chain

--- a/.changeset/gentle-walls-knock.md
+++ b/.changeset/gentle-walls-knock.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Add Sei testnet chain
+Added Sei testnet chain.

--- a/src/chains/definitions/seiTestnet.ts
+++ b/src/chains/definitions/seiTestnet.ts
@@ -7,7 +7,7 @@ export const seiTestnet = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
         http: ['https://evm-rpc-testnet.sei-apis.com'],
-        webSocket: ['wss://evm-ws-testnet.sei-apis.com/']
+        webSocket: ['wss://evm-ws-testnet.sei-apis.com']
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/seiTestnet.ts
+++ b/src/chains/definitions/seiTestnet.ts
@@ -1,0 +1,20 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const seiTestnet = /*#__PURE__*/ defineChain({
+  id: 1328,
+  name: 'Sei Testnet',
+  nativeCurrency: { name: 'Sei', symbol: 'SEI', decimals: 18 },
+  rpcUrls: {
+    default: {
+        http: ['https://evm-rpc-testnet.sei-apis.com'],
+        webSocket: ['wss://evm-ws-testnet.sei-apis.com/']
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Seitrace',
+      url: 'https://seitrace.com',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Add Sei Testnet chain

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for the Sei Testnet chain.

### Detailed summary
- Added `Sei Testnet` chain definition in `seiTestnet.ts`
- Includes chain ID, name, native currency details, RPC URLs, block explorer information, and testnet flag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->