### PR TITLE
feat: Add support for client mode to createClient

### DIFF
--- a/.changeset/six-timers-change.md
+++ b/.changeset/six-timers-change.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for setting `mode` on base client. Setting `mode` allows a client to be used with tree shakable test actions.

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -573,4 +573,14 @@ describe('extends', () => {
       expect(extended.chain.id).toEqual(client.chain.id)
     })
   })
+
+  test('supports test mode', () => {
+    const client = createClient({
+      chain: localhost,
+      transport: http(),
+      mode: 'hardhat',
+    })
+    assertType<{ mode: 'hardhat' }>(client)
+    expect(client.mode).toEqual('hardhat')
+  })
 })

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -149,7 +149,7 @@ export type Client<
       Prettify<client> & (extended extends Extended ? extended : unknown),
       mode
     >
-  } & (mode extends TestClientMode ? { mode: mode } : {mode?: never})
+  } & (mode extends TestClientMode ? { mode: mode } : { mode?: never })
 
 type Client_Base<
   transport extends Transport = Transport,

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -149,7 +149,7 @@ export type Client<
       Prettify<client> & (extended extends Extended ? extended : unknown),
       mode
     >
-  } & (mode extends TestClientMode ? { mode: mode } : {})
+  } & (mode extends TestClientMode ? { mode: mode } : {mode?: never})
 
 type Client_Base<
   transport extends Transport = Transport,
@@ -231,7 +231,7 @@ export function createClient(parameters: ClientConfig): Client {
     name = 'Base Client',
     pollingInterval = 4_000,
     type = 'base',
-    mode = undefined,
+    mode,
   } = parameters
 
   const chain = parameters.chain

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -117,9 +117,9 @@ export function createTestClient(parameters: TestClientConfig): TestClient {
     key,
     name,
     type: 'testClient',
+    mode,
   })
   return client.extend((config) => ({
-    mode,
     ...testActions({ mode })(config),
   }))
 }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
It's awkward to use tree shakable test actions

```typescript
import { createClient } from "viem";
import { mine } from "viem/actions";
import { optimism } from "tevm/common";
import { createTevmTransport } from "tevm/memory-client";

const client = createClient({
  transport: createTevmTransport(),
  chain: optimism,
 });

 await mine({ ...client, mode: "anvil" }, { blocks: 1 });
```

This change adds `mode` as an optional property to `createClient`.

```typescript
import { createClient } from "viem";
import { mine } from "viem/actions";
import { optimism } from "tevm/common";
import { createTevmTransport } from "tevm/memory-client";

const client = createClient({
  transport: createTevmTransport(),
  chain: optimism,
  mode: 'anvil',
 });

 await mine(client, { blocks: 1 });
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for setting `mode` on the base client for test actions.

### Detailed summary
- Added `mode` property to `ClientConfig` and `Client` types
- Updated `createClient` function to accept and handle `mode` parameter
- Added `mode` property to the base client object
- Extended `Client` type with `mode` parameter
- Added support for setting `mode` in `createTestClient.ts` and `createClient.test.ts` files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->