### PR TITLE
Add multicall3 contract to Berachain bArtio

### DIFF
--- a/.changeset/strong-beds-drive.md
+++ b/.changeset/strong-beds-drive.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract to Berachain bArtio.

--- a/src/chains/definitions/berachainTestnetbArtio.ts
+++ b/src/chains/definitions/berachainTestnetbArtio.ts
@@ -8,6 +8,12 @@ export const berachainTestnetbArtio = /*#__PURE__*/ defineChain({
     name: 'BERA Token',
     symbol: 'BERA',
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11', 
+      blockCreated: 109269
+    },
+  },
   rpcUrls: {
     default: { http: ['https://bartio.rpc.berachain.com'] },
   },


### PR DESCRIPTION
Multicall3 contract address was missing in the chain definition but listed on https://www.multicall3.com/deployments.

Contract has been verified as requested by contributing guidelines. You can check it on the block explorer https://bartio.beratrail.io/address/0xcA11bde05977b3631167028862bE2a173976CA11

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `multicall3` contract to Berachain bArtio.

### Detailed summary
- Added `multicall3` contract to Berachain bArtio in `berachainTestnetbArtio.ts` definition file.
- Defined address and block created information for `multicall3` contract.
- Updated RPC URLs for Berachain bArtio with new endpoint.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->