### PR TITLE
Update estimateGas.md

### DIFF
--- a/site/pages/docs/actions/public/estimateGas.md
+++ b/site/pages/docs/actions/public/estimateGas.md
@@ -39,7 +39,7 @@ export const publicClient = createPublicClient({
 
 `bigint`
 
-The gas estimate (in wei).
+The gas estimate (in gas).
 
 ## Parameters
 


### PR DESCRIPTION
Co-worker got confused by the docs saying the units of `estimateGas` were in `wei`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the unit of the gas estimate from wei to gas in the `estimateGas.md` file.

### Detailed summary
- Changed the unit of the gas estimate from wei to gas.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->