### PR TITLE
Add altar testnet

### DIFF
--- a/src/chains/definitions/altarTestnet.ts
+++ b/src/chains/definitions/altarTestnet.ts
@@ -1,0 +1,22 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const altarTestnet = /*#__PURE__*/ defineChain({
+  id: 444444,
+  name: 'Altar Testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: { http: ['https://altar-rpc.ceremonies.ai'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Altar Explorer',
+      url: 'https://altar-explorer.ceremonies.ai/',
+      apiUrl: 'https://altar-explorer.ceremonies.ai/api/v2/',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -2,6 +2,7 @@ export type { Chain } from '../types/chain.js'
 
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export { acala } from './definitions/acala.js'
+export { altarTestnet } from './definitions/altarTestnet.js'
 export { ancient8 } from './definitions/ancient8.js'
 export { ancient8Sepolia } from './definitions/ancient8Sepolia.js'
 export { anvil } from './definitions/anvil.js'


### PR DESCRIPTION
Added testnet for Altar chain
https://ceremonies.gitbook.io/ceremonies/altar



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new chain definition for `Altar Testnet`.

### Detailed summary
- Added `altarTestnet` chain definition in `chains/definitions/altarTestnet.ts`
- Defines Altar Testnet with ID 444444, native currency Ether (ETH), RPC URL, block explorer, and testnet flag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->