### PR TITLE
feat: add Blockscout urls

### DIFF
--- a/.changeset/four-flies-bake.md
+++ b/.changeset/four-flies-bake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Blockscout explorer URLs

--- a/src/chains/definitions/arbitrum.ts
+++ b/src/chains/definitions/arbitrum.ts
@@ -15,6 +15,11 @@ export const arbitrum = /*#__PURE__*/ defineChain({
       url: 'https://arbiscan.io',
       apiUrl: 'https://api.arbiscan.io/api',
     },
+    blockscout: {
+      name: 'Arbitrum One Blockscout',
+      url: 'https://arbitrum.blockscout.com',
+      apiUrl: 'https://arbitrum.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/arbitrumNova.ts
+++ b/src/chains/definitions/arbitrumNova.ts
@@ -15,6 +15,11 @@ export const arbitrumNova = /*#__PURE__*/ defineChain({
       url: 'https://nova.arbiscan.io',
       apiUrl: 'https://api-nova.arbiscan.io/api',
     },
+    blockscout: {
+      name: 'Arbitrum Nova Blockscout',
+      url: 'https://nova-explorer.arbitrum.io',
+      apiUrl: 'https://nova-explorer.arbitrum.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -19,6 +19,11 @@ export const arbitrumSepolia = /*#__PURE__*/ defineChain({
       url: 'https://sepolia.arbiscan.io',
       apiUrl: 'https://api-sepolia.arbiscan.io/api',
     },
+    blockscout: {
+      name: 'Arbitrum Sepolia Blockscout',
+      url: 'https://sepolia-explorer.arbitrum.io',
+      apiUrl: 'https://sepolia-explorer.arbitrum.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/astar.ts
+++ b/src/chains/definitions/astar.ts
@@ -17,6 +17,11 @@ export const astar = /*#__PURE__*/ defineChain({
       name: 'Astar Subscan',
       url: 'https://astar.subscan.io',
     },
+    blockscout: {
+      name: 'Astar Blockscout',
+      url: 'https://astar.blockscout.com',
+      apiUrl: 'https://astar.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -19,6 +19,11 @@ export const base = /*#__PURE__*/ defineChain({
       url: 'https://basescan.org',
       apiUrl: 'https://api.basescan.org/api',
     },
+    blockscout: {
+      name: 'Base Blockscout',
+      url: 'https://base.blockscout.com',
+      apiUrl: 'https://base.blockscout.com/api',
+    },
   },
   contracts: {
     ...chainConfig.contracts,

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -20,6 +20,11 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
       url: 'https://sepolia.basescan.org',
       apiUrl: 'https://api-sepolia.basescan.org/api',
     },
+    blockscout: {
+      name: 'Base Sepolia Blockscout',
+      url: 'https://base-sepolia.blockscout.com',
+      apiUrl: 'https://base-sepolia.blockscout.com/api',
+    },
   },
   contracts: {
     ...chainConfig.contracts,

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -19,6 +19,11 @@ export const blast = /*#__PURE__*/ defineChain({
       url: 'https://blastscan.io',
       apiUrl: 'https://api.blastscan.io/api',
     },
+    blockscout: {
+      name: 'Blast Blockscout',
+      url: 'https://blast.blockscout.com',
+      apiUrl: 'https://blast.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/blastSepolia.ts
+++ b/src/chains/definitions/blastSepolia.ts
@@ -21,6 +21,11 @@ export const blastSepolia = /*#__PURE__*/ defineChain({
       url: 'https://sepolia.blastscan.io',
       apiUrl: 'https://api-sepolia.blastscan.io/api',
     },
+    blockscout: {
+      name: 'Blast Sepolia Blockscout',
+      url: 'https://blast-testnet.blockscout.com',
+      apiUrl: 'https://blast-testnet.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/bxn.ts
+++ b/src/chains/definitions/bxn.ts
@@ -15,5 +15,10 @@ export const bxn = /*#__PURE__*/ defineChain({
       url: 'https://explorer.blackfort.network',
       apiUrl: 'https://explorer.blackfort.network/api',
     },
+    blockscout: {
+      name: 'BlackFort Exchange Network Blockscout',
+      url: 'https://blackfort.blockscout.com',
+      apiUrl: 'https://blackfort.blockscout.com/api',
+    },
   },
 })

--- a/src/chains/definitions/bxnTestnet.ts
+++ b/src/chains/definitions/bxnTestnet.ts
@@ -19,6 +19,11 @@ export const bxnTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet-explorer.blackfort.network',
       apiUrl: 'https://testnet-explorer.blackfort.network/api',
     },
+    blockscout: {
+      name: 'BlackFort Exchange Network Testnet Blockscout',
+      url: 'https://blackfort-testnet.blockscout.com',
+      apiUrl: 'https://blackfort-testnet.blockscout.com/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/celo.ts
+++ b/src/chains/definitions/celo.ts
@@ -19,6 +19,11 @@ export const celo = /*#__PURE__*/ defineChain({
       url: 'https://celoscan.io',
       apiUrl: 'https://api.celoscan.io/api',
     },
+    blockscout: {
+      name: 'Celo Blockscout',
+      url: 'https://explorer.celo.org/mainnet',
+      apiUrl: 'https://explorer.celo.org/mainnet/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/classic.ts
+++ b/src/chains/definitions/classic.ts
@@ -16,5 +16,10 @@ export const classic = /*#__PURE__*/ defineChain({
       name: 'Blockscout',
       url: 'https://blockscout.com/etc/mainnet',
     },
+    blockscout: {
+      name: 'Ethereum Classic Blockscout',
+      url: 'https://etc.blockscout.com',
+      apiUrl: 'https://etc.blockscout.com/api',
+    },
   },
 })

--- a/src/chains/definitions/filecoin.ts
+++ b/src/chains/definitions/filecoin.ts
@@ -16,6 +16,11 @@ export const filecoin = /*#__PURE__*/ defineChain({
       name: 'Filfox',
       url: 'https://filfox.info/en',
     },
+    blockscout: {
+      name: 'Filecoin Mainnet Blockscout',
+      url: 'https://filecoin.blockscout.com',
+      apiUrl: 'https://filecoin.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -20,6 +20,11 @@ export const gnosis = /*#__PURE__*/ defineChain({
       url: 'https://gnosisscan.io',
       apiUrl: 'https://api.gnosisscan.io/api',
     },
+    blockscout: {
+      name: 'Gnosis Blockscout',
+      url: 'https://gnosis.blockscout.com',
+      apiUrl: 'https://gnosis.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/goerli.ts
+++ b/src/chains/definitions/goerli.ts
@@ -15,6 +15,11 @@ export const goerli = /*#__PURE__*/ defineChain({
       url: 'https://goerli.etherscan.io',
       apiUrl: 'https://api-goerli.etherscan.io/api',
     },
+    blockscout: {
+      name: 'Goerli Blockscout',
+      url: 'https://explorer.ammer.network',
+      apiUrl: 'https://explorer.ammer.network/api',
+    },
   },
   contracts: {
     ensRegistry: {

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -14,6 +14,11 @@ export const holesky = /*#__PURE__*/ defineChain({
       name: 'Etherscan',
       url: 'https://holesky.etherscan.io',
     },
+    blockscout: {
+      name: 'Holesky Blockscout',
+      url: 'https://eth-holesky.blockscout.com',
+      apiUrl: 'https://eth-holesky.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/jbc.ts
+++ b/src/chains/definitions/jbc.ts
@@ -19,6 +19,11 @@ export const jbc = /*#__PURE__*/ defineChain({
       url: 'https://exp-l1.jibchain.net',
       apiUrl: 'https://exp-l1.jibchain.net/api',
     },
+    blockscout: {
+      name: 'JIBCHAIN L1 Blockscout',
+      url: 'https://exp-l1-ng.jibchain.net',
+      apiUrl: 'https://exp-l1-ng.jibchain.net/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/kcc.ts
+++ b/src/chains/definitions/kcc.ts
@@ -19,6 +19,11 @@ export const kcc = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: { name: 'KCC Explorer', url: 'https://explorer.kcc.io' },
+    blockscout: {
+      name: 'KCC Mainnet Blockscout',
+      url: 'https://scan.kcc.io',
+      apiUrl: 'https://scan.kcc.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/klaytnBaobab.ts
+++ b/src/chains/definitions/klaytnBaobab.ts
@@ -17,6 +17,11 @@ export const klaytnBaobab = /*#__PURE__*/ defineChain({
       name: 'KlaytnScope',
       url: 'https://baobab.klaytnscope.com',
     },
+    blockscout: {
+      name: 'Klaytn Baobab Testnet Blockscout',
+      url: 'https://scan.daofinance.me',
+      apiUrl: 'https://scan.daofinance.me/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/linea.ts
+++ b/src/chains/definitions/linea.ts
@@ -16,6 +16,11 @@ export const linea = /*#__PURE__*/ defineChain({
       url: 'https://lineascan.build',
       apiUrl: 'https://api.lineascan.build/api',
     },
+    blockscout: {
+      name: 'Linea Mainnet Blockscout',
+      url: 'https://explorer.linea.build',
+      apiUrl: 'https://explorer.linea.build/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/lineaGoerli.ts
+++ b/src/chains/definitions/lineaGoerli.ts
@@ -16,6 +16,11 @@ export const lineaGoerli = /*#__PURE__*/ defineChain({
       url: 'https://goerli.lineascan.build',
       apiUrl: 'https://api-goerli.lineascan.build/api',
     },
+    blockscout: {
+      name: 'Linea Goerli Testnet Blockscout',
+      url: 'https://explorer.goerli.linea.build',
+      apiUrl: 'https://explorer.goerli.linea.build/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/lineaTestnet.ts
+++ b/src/chains/definitions/lineaTestnet.ts
@@ -16,6 +16,11 @@ export const lineaTestnet = /*#__PURE__*/ defineChain({
       url: 'https://goerli.lineascan.build',
       apiUrl: 'https://goerli.lineascan.build/api',
     },
+    blockscout: {
+      name: 'Linea Goerli Testnet Blockscout',
+      url: 'https://explorer.goerli.linea.build',
+      apiUrl: 'https://explorer.goerli.linea.build/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -15,6 +15,11 @@ export const mainnet = /*#__PURE__*/ defineChain({
       url: 'https://etherscan.io',
       apiUrl: 'https://api.etherscan.io/api',
     },
+    blockscout: {
+      name: 'Ethereum Blockscout',
+      url: 'https://eth.blockscout.com',
+      apiUrl: 'https://eth.blockscout.com/api',
+    },
   },
   contracts: {
     ensRegistry: {

--- a/src/chains/definitions/mode.ts
+++ b/src/chains/definitions/mode.ts
@@ -16,6 +16,11 @@ export const mode = /*#__PURE__*/ defineChain({
       name: 'Modescan',
       url: 'https://modescan.io',
     },
+    blockscout: {
+      name: 'Mode Mainnet Blockscout',
+      url: 'https://explorer.mode.network',
+      apiUrl: 'https://explorer.mode.network/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/neonDevnet.ts
+++ b/src/chains/definitions/neonDevnet.ts
@@ -14,6 +14,11 @@ export const neonDevnet = /*#__PURE__*/ defineChain({
       name: 'Neonscan',
       url: 'https://devnet.neonscan.org',
     },
+    blockscout: {
+      name: 'Neon EVM DevNet Blockscout',
+      url: 'https://neon-devnet.blockscout.com',
+      apiUrl: 'https://neon-devnet.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/neonMainnet.ts
+++ b/src/chains/definitions/neonMainnet.ts
@@ -15,6 +15,11 @@ export const neonMainnet = /*#__PURE__*/ defineChain({
       name: 'Neonscan',
       url: 'https://neonscan.org',
     },
+    blockscout: {
+      name: 'Neon EVM MainNet Blockscout',
+      url: 'https://neon.blockscout.com',
+      apiUrl: 'https://neon.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/oasys.ts
+++ b/src/chains/definitions/oasys.ts
@@ -15,5 +15,10 @@ export const oasys = /*#__PURE__*/ defineChain({
       url: 'https://scan.oasys.games',
       apiUrl: 'https://scan.oasys.games/api',
     },
+    blockscout: {
+      name: 'Oasys Blockscout',
+      url: 'https://explorer.oasys.games',
+      apiUrl: 'https://explorer.oasys.games/api',
+    },
   },
 })

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -19,6 +19,11 @@ export const optimism = /*#__PURE__*/ defineChain({
       url: 'https://optimistic.etherscan.io',
       apiUrl: 'https://api-optimistic.etherscan.io/api',
     },
+    blockscout: {
+      name: 'OP Mainnet Blockscout',
+      url: 'https://optimism.blockscout.com',
+      apiUrl: 'https://optimism.blockscout.com/api',
+    },
   },
   contracts: {
     ...chainConfig.contracts,

--- a/src/chains/definitions/plumeTestnet.ts
+++ b/src/chains/definitions/plumeTestnet.ts
@@ -22,6 +22,11 @@ export const plumeTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet-explorer.plumenetwork.xyz',
       apiUrl: 'https://testnet-explorer.plumenetwork.xyz/api',
     },
+    blockscout: {
+      name: 'Plume Testnet Blockscout',
+      url: 'https://plume-testnet.explorer.caldera.xyz',
+      apiUrl: 'https://plume-testnet.explorer.caldera.xyz/api',
+    },
   },
   testnet: true,
   sourceId,

--- a/src/chains/definitions/polygonZkEvm.ts
+++ b/src/chains/definitions/polygonZkEvm.ts
@@ -15,6 +15,11 @@ export const polygonZkEvm = /*#__PURE__*/ defineChain({
       url: 'https://zkevm.polygonscan.com',
       apiUrl: 'https://api-zkevm.polygonscan.com/api',
     },
+    blockscout: {
+      name: 'Polygon zkEVM Blockscout',
+      url: 'https://zkevm.blockscout.com',
+      apiUrl: 'https://zkevm.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/polygonZkEvmCardona.ts
+++ b/src/chains/definitions/polygonZkEvmCardona.ts
@@ -15,6 +15,11 @@ export const polygonZkEvmCardona = /*#__PURE__*/ defineChain({
       url: 'https://cardona-zkevm.polygonscan.com',
       apiUrl: 'https://cardona-zkevm.polygonscan.com/api',
     },
+    blockscout: {
+      name: 'Polygon zkEVM Cardona Blockscout',
+      url: 'https://explorer-ui.cardona.zkevm-rpc.com',
+      apiUrl: 'https://explorer-ui.cardona.zkevm-rpc.com/api',
+    },
   },
   testnet: true,
   contracts: {

--- a/src/chains/definitions/redstone.ts
+++ b/src/chains/definitions/redstone.ts
@@ -16,5 +16,10 @@ export const redstone = defineChain({
   },
   blockExplorers: {
     default: { name: 'Explorer', url: '	https://explorer.redstone.xyz' },
+    blockscout: {
+      name: 'Redstone Blockscout',
+      url: 'https://explorer.redstone.xyz',
+      apiUrl: 'https://explorer.redstone.xyz/api',
+    },
   },
 })

--- a/src/chains/definitions/rootstock.ts
+++ b/src/chains/definitions/rootstock.ts
@@ -17,6 +17,11 @@ export const rootstock = /*#__PURE__*/ defineChain({
       name: 'RSK Explorer',
       url: 'https://explorer.rsk.co',
     },
+    blockscout: {
+      name: 'Rootstock Mainnet Blockscout',
+      url: 'https://rootstock.blockscout.com',
+      apiUrl: 'https://rootstock.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/rootstockTestnet.ts
+++ b/src/chains/definitions/rootstockTestnet.ts
@@ -17,6 +17,11 @@ export const rootstockTestnet = /*#__PURE__*/ defineChain({
       name: 'RSK Explorer',
       url: 'https://explorer.testnet.rootstock.io',
     },
+    blockscout: {
+      name: 'Rootstock Testnet Blockscout',
+      url: 'https://rootstock-testnet.blockscout.com',
+      apiUrl: 'https://rootstock-testnet.blockscout.com/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/saigon.ts
+++ b/src/chains/definitions/saigon.ts
@@ -14,6 +14,11 @@ export const saigon = /*#__PURE__*/ defineChain({
       name: 'Saigon Explorer',
       url: 'https://saigon-app.roninchain.com',
     },
+    blockscout: {
+      name: 'Saigon Testnet Blockscout',
+      url: 'https://edgscan.live',
+      apiUrl: 'https://edgscan.live/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -15,6 +15,11 @@ export const sepolia = /*#__PURE__*/ defineChain({
       url: 'https://sepolia.etherscan.io',
       apiUrl: 'https://api-sepolia.etherscan.io/api',
     },
+    blockscout: {
+      name: 'Sepolia Blockscout',
+      url: 'https://eth-sepolia.blockscout.com',
+      apiUrl: 'https://eth-sepolia.blockscout.com/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/shibarium.ts
+++ b/src/chains/definitions/shibarium.ts
@@ -15,6 +15,11 @@ export const shibarium = /*#__PURE__*/ defineChain({
       name: 'Blockscout',
       url: 'https://shibariumscan.io',
     },
+    blockscout: {
+      name: 'Shibarium Blockscout',
+      url: 'https://www.shibariumscan.io',
+      apiUrl: 'https://www.shibariumscan.io/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/taiko.ts
+++ b/src/chains/definitions/taiko.ts
@@ -20,6 +20,11 @@ export const taiko = /*#__PURE__*/ defineChain({
       url: 'https://taikoscan.network',
       apiUrl: 'https://taikoscan.network/api',
     },
+    blockscout: {
+      name: 'Taiko Mainnet Blockscout',
+      url: 'https://blockscoutapi.mainnet.taiko.xyz',
+      apiUrl: 'https://blockscoutapi.mainnet.taiko.xyz/api',
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/zetachain.ts
+++ b/src/chains/definitions/zetachain.ts
@@ -24,6 +24,11 @@ export const zetachain = /*#__PURE__*/ defineChain({
       name: 'ZetaScan',
       url: 'https://explorer.zetachain.com',
     },
+    blockscout: {
+      name: 'ZetaChain Blockscout',
+      url: 'https://zetachain.blockscout.com',
+      apiUrl: 'https://zetachain.blockscout.com/api',
+    },
   },
   testnet: false,
 })

--- a/src/chains/definitions/zetachainAthensTestnet.ts
+++ b/src/chains/definitions/zetachainAthensTestnet.ts
@@ -24,6 +24,11 @@ export const zetachainAthensTestnet = /*#__PURE__*/ defineChain({
       name: 'ZetaScan',
       url: 'https://athens.explorer.zetachain.com',
     },
+    blockscout: {
+      name: 'ZetaChain Athens Testnet Blockscout',
+      url: 'https://zetachain-athens-3.blockscout.com',
+      apiUrl: 'https://zetachain-athens-3.blockscout.com/api',
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/zkSync.ts
+++ b/src/chains/definitions/zkSync.ts
@@ -23,6 +23,11 @@ export const zkSync = /*#__PURE__*/ defineChain({
       url: 'https://era.zksync.network/',
       apiUrl: 'https://api-era.zksync.network/api',
     },
+    blockscout: {
+      name: 'zkSync Era Blockscout',
+      url: 'https://zksync.blockscout.com',
+      apiUrl: 'https://zksync.blockscout.com/api',
+    },
     native: {
       name: 'zkSync Explorer',
       url: 'https://explorer.zksync.io/',

--- a/src/chains/definitions/zkSyncSepoliaTestnet.ts
+++ b/src/chains/definitions/zkSyncSepoliaTestnet.ts
@@ -18,6 +18,11 @@ export const zkSyncSepoliaTestnet = /*#__PURE__*/ defineChain({
       name: 'Etherscan',
       url: 'https://sepolia-era.zksync.network/',
     },
+    blockscout: {
+      name: 'zkSync Sepolia Testnet Blockscout',
+      url: 'https://zksync-sepolia.blockscout.com',
+      apiUrl: 'https://zksync-sepolia.blockscout.com/api',
+    },
     native: {
       name: 'zkSync Explorer',
       url: 'https://sepolia.explorer.zksync.io/',


### PR DESCRIPTION
Adds Blockscout explorer urls for redundancy on chains that don't specify them

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add Blockscout explorer URLs for various chains.

### Detailed summary
- Added Blockscout explorer URLs for different chains like Oasys, Ethereum Classic, Astar, and more.
- Each chain now has a designated Blockscout explorer with unique URLs.
- Enhanced visibility and accessibility for blockchain explorers across multiple networks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->