### PR TITLE
Fixed prepareTransactionRequest usage documentation to use a correct example

### DIFF
--- a/site/pages/docs/actions/wallet/prepareTransactionRequest.md
+++ b/site/pages/docs/actions/wallet/prepareTransactionRequest.md
@@ -29,8 +29,8 @@ const request = await walletClient.prepareTransactionRequest({ // [!code focus:1
 // @log: }
 
 
-const signature = await walletClient.signTransaction(request)
-const hash = await walletClient.sendRawTransaction(signature)
+const serializedTransaction = await walletClient.signTransaction(request)
+const hash = await walletClient.sendRawTransaction({ serializedTransaction })
 ```
 
 ```ts twoslash [config.ts] filename="config.ts"
@@ -80,8 +80,8 @@ const request = await walletClient.prepareTransactionRequest({ // [!code focus:1
 // @log: }
 
 
-const signature = await walletClient.signTransaction(request)
-const hash = await walletClient.sendRawTransaction(signature)
+const sendRawTransaction = await walletClient.signTransaction(request)
+const hash = await walletClient.sendRawTransaction({ sendRawTransaction })
 ```
 
 ```ts [config.ts (JSON-RPC Account)]

--- a/site/pages/docs/actions/wallet/prepareTransactionRequest.md
+++ b/site/pages/docs/actions/wallet/prepareTransactionRequest.md
@@ -80,8 +80,8 @@ const request = await walletClient.prepareTransactionRequest({ // [!code focus:1
 // @log: }
 
 
-const sendRawTransaction = await walletClient.signTransaction(request)
-const hash = await walletClient.sendRawTransaction({ sendRawTransaction })
+const serializedTransaction = await walletClient.signTransaction(request)
+const hash = await walletClient.sendRawTransaction({ serializedTransaction })
 ```
 
 ```ts [config.ts (JSON-RPC Account)]


### PR DESCRIPTION
Simple fix for the usage example of the [preparetransactionrequest](https://viem.sh/docs/actions/wallet/prepareTransactionRequest#preparetransactionrequest) method in the docs.

Current:
![image](https://github.com/wevm/viem/assets/5667907/1862b1ec-c4ec-46f8-9ac9-5509ea94c667)

This usage example is incorrect, see the [sendRawTransaction](https://viem.sh/docs/actions/wallet/sendRawTransaction) method page:
![image](https://github.com/wevm/viem/assets/5667907/1af10760-faa0-401c-8042-ed58ef9c0767)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the way transaction data is handled in the wallet actions. 

### Detailed summary
- Renamed `signature` variable to `serializedTransaction` for clarity.
- Modified `sendRawTransaction` to accept an object with `serializedTransaction` property.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->