### PR TITLE
add movement devnet

### DIFF
--- a/.changeset/.famous-trains-collect.md
+++ b/.changeset/.famous-trains-collect.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added movement devnet

--- a/.changeset/.lucky-actors-smell.md
+++ b/.changeset/.lucky-actors-smell.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Added Crab and Koi chain

--- a/src/chains/definitions/movementDevnet.ts
+++ b/src/chains/definitions/movementDevnet.ts
@@ -1,0 +1,12 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const movementDevnet = /*#__PURE__*/ defineChain({
+  id: 30730,
+  name: 'Movement Devnet',
+  nativeCurrency: { name: 'Move', symbol: 'MOVE', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://mevm.devnet.m1.movementlabs.xyz'],
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -178,6 +178,7 @@ export { moonbeamDev } from './definitions/moonbeamDev.js'
 export { moonriver } from './definitions/moonriver.js'
 export { morphHolesky } from './definitions/morphHolesky.js'
 export { morphSepolia } from './definitions/morphSepolia.js'
+export { movementDevnet } from "./definitions/movementDevnet.js"
 export { nautilus } from './definitions/nautilus.js'
 export { neonDevnet } from './definitions/neonDevnet.js'
 export { neonMainnet } from './definitions/neonMainnet.js'


### PR DESCRIPTION
This PR adds the Movement Devnet to Viem



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new chain definition called `movementDevnet` with the Move currency to the project.

### Detailed summary
- Added `movementDevnet` chain definition with Move currency
- Updated `chains/index.ts` to export `movementDevnet`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->