### PR TITLE
feat(chains): Add Mode Testnet contracts

### DIFF
--- a/.changeset/old-pans-tickle.md
+++ b/.changeset/old-pans-tickle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added OP Stack contract addresses for Mode Testnet chain.

--- a/src/chains/definitions/modeTestnet.ts
+++ b/src/chains/definitions/modeTestnet.ts
@@ -1,11 +1,14 @@
+import { chainConfig } from '../../op-stack/chainConfig.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 const sourceId = 11_155_111 // sepolia
 
 export const modeTestnet = /*#__PURE__*/ defineChain({
+  ...chainConfig,
   id: 919,
+  network: 'mode-testnet',
   name: 'Mode Testnet',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://sepolia.mode.network'],
@@ -19,6 +22,25 @@ export const modeTestnet = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ...chainConfig.contracts,
+    l2OutputOracle: {
+      [sourceId]: {
+        address: '0x2634BD65ba27AB63811c74A63118ACb312701Bfa',
+        blockCreated: 3778393
+      }
+    },
+    portal: {
+      [sourceId]: {
+        address: '0x320e1580effF37E008F1C92700d1eBa47c1B23fD',
+        blockCreated: 3778395
+      }
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0xbC5C679879B2965296756CD959C3C739769995E2',
+        blockCreated: 3778392
+      }
+    },
     multicall3: {
       address: '0xBAba8373113Fb7a68f195deF18732e01aF8eDfCF',
       blockCreated: 3019007,

--- a/src/chains/definitions/modeTestnet.ts
+++ b/src/chains/definitions/modeTestnet.ts
@@ -6,9 +6,8 @@ const sourceId = 11_155_111 // sepolia
 export const modeTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 919,
-  network: 'mode-testnet',
   name: 'Mode Testnet',
-  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://sepolia.mode.network'],


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Add Mode Testnet contracts so that they can be used for wallet clients.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds OP Stack contract addresses for Mode Testnet chain.

### Detailed summary
- Added OP Stack contract addresses for Mode Testnet chain in `modeTestnet.ts` file.
- Added `l2OutputOracle`, `portal`, and `l1StandardBridge` contracts with addresses and block numbers.
- Updated `multicall3` contract address for Mode Testnet chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->