### PR TITLE
fix(docs): fix expirationTime pointing to localhost

### DIFF
--- a/site/pages/docs/siwe/actions/verifySiweMessage.md
+++ b/site/pages/docs/siwe/actions/verifySiweMessage.md
@@ -229,7 +229,7 @@ const valid = await publicClient.verifySiweMessage({
 - **Type:** `Date`
 - **Default:** `new Date()`
 
-Current time to check optional [`expirationTime`](http://localhost:5173/docs/siwe/utilities/createSiweMessage#expirationtime-optional) and [`notBefore`](/docs/siwe/utilities/createSiweMessage#notbefore-optional) message fields.
+Current time to check optional [`expirationTime`](/docs/siwe/utilities/createSiweMessage#expirationtime-optional) and [`notBefore`](/docs/siwe/utilities/createSiweMessage#notbefore-optional) message fields.
 
 ```ts twoslash
 // [!include ~/snippets/publicClient.ts]


### PR DESCRIPTION
`expirationTime` under [verifySiweMessage](https://viem.sh/docs/siwe/actions/verifySiweMessage#time-optional) => time, pointing to localhost

<img width="762" alt="Screenshot 2024-07-19 at 4 43 46 PM" src="https://github.com/user-attachments/assets/019ca98c-de2f-4621-a3c7-fb7e4198181c">

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a documentation file to correct a broken link pointing to the `notBefore` field in the `verifySiweMessage` function.

### Detailed summary
- Updated broken link pointing to `notBefore` field in `verifySiweMessage` function documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->