### PR TITLE
feat: add ws keepalive support

### DIFF
--- a/.changeset/brave-rivers-scream.md
+++ b/.changeset/brave-rivers-scream.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `keepAliveInterval` to ws transport

--- a/.changeset/brave-rivers-scream.md
+++ b/.changeset/brave-rivers-scream.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added `keepAliveInterval` to ws transport
+Added `keepAlive` property to `webSocket` transport to send keep-alive ping messages (defaults to `true`).

--- a/site/pages/docs/clients/transports/websocket.md
+++ b/site/pages/docs/clients/transports/websocket.md
@@ -38,6 +38,21 @@ import { webSocket } from 'viem'
 const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...')
 ```
 
+### keepAlive (optional)
+
+- **Type:** `boolean | { interval?: number }`
+- **Default:** `true`
+
+Whether or not to send keep-alive ping messages.
+
+```ts twoslash
+import { webSocket } from 'viem'
+// ---cut---
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  keepAlive: { interval: 1_000 }, // [!code focus]
+})
+```
+
 ### key (optional)
 
 - **Type:** `string`
@@ -80,21 +95,6 @@ import { webSocket } from 'viem'
 // ---cut---
 const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
   reconnect: false, // [!code focus]
-})
-```
-
-### keepAliveInterval (optional)
-
-- **Type:** `number`
-- **Default:** `30_000`
-
-The interval (in ms) to send keep-alive ping message.
-
-```ts twoslash
-import { webSocket } from 'viem'
-// ---cut---
-const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
-  keepAliveInterval: 10_000, // [!code focus]
 })
 ```
 

--- a/site/pages/docs/clients/transports/websocket.md
+++ b/site/pages/docs/clients/transports/websocket.md
@@ -83,6 +83,21 @@ const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
 })
 ```
 
+### keepAliveInterval (optional)
+
+- **Type:** `number`
+- **Default:** `30_000`
+
+The interval (in ms) to send keep-alive ping message.
+
+```ts twoslash
+import { webSocket } from 'viem'
+// ---cut---
+const transport = webSocket('wss://eth-mainnet.g.alchemy.com/v2/...', {
+  keepAliveInterval: 10_000, // [!code focus]
+})
+```
+
 #### reconnect.attempts (optional)
 
 - **Type:** `number`

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -42,6 +42,11 @@ type WebSocketTransportSubscribe = {
 }
 
 export type WebSocketTransportConfig = {
+  /**
+   * Whether or not to send keep-alive ping messages.
+   * @default true
+   */
+  keepAlive?: GetWebSocketRpcClientOptions['keepAlive'] | undefined
   /** The key of the WebSocket transport. */
   key?: TransportConfig['key'] | undefined
   /** The name of the WebSocket transport. */
@@ -51,13 +56,6 @@ export type WebSocketTransportConfig = {
    * @default true
    */
   reconnect?: GetWebSocketRpcClientOptions['reconnect'] | undefined
-  /**
-   * The interval (in ms) to send keep-alive ping message.
-   * @default 30_000
-   */
-  keepAliveInterval?:
-    | GetWebSocketRpcClientOptions['keepAliveInterval']
-    | undefined
   /** The max number of times to retry. */
   retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
@@ -92,10 +90,10 @@ export function webSocket(
   config: WebSocketTransportConfig = {},
 ): WebSocketTransport {
   const {
+    keepAlive,
     key = 'webSocket',
     name = 'WebSocket JSON-RPC',
     reconnect,
-    keepAliveInterval = 30_000,
     retryDelay,
   } = config
   return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
@@ -110,8 +108,8 @@ export function webSocket(
         async request({ method, params }) {
           const body = { method, params }
           const rpcClient = await getWebSocketRpcClient(url_, {
+            keepAlive,
             reconnect,
-            keepAliveInterval,
           })
           const { error, result } = await rpcClient.requestAsync({
             body,

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -51,6 +51,13 @@ export type WebSocketTransportConfig = {
    * @default true
    */
   reconnect?: GetWebSocketRpcClientOptions['reconnect'] | undefined
+  /**
+   * The interval (in ms) to send keep-alive ping message.
+   * @default 30_000
+   */
+  keepAliveInterval?:
+    | GetWebSocketRpcClientOptions['keepAliveInterval']
+    | undefined
   /** The max number of times to retry. */
   retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
@@ -88,6 +95,7 @@ export function webSocket(
     key = 'webSocket',
     name = 'WebSocket JSON-RPC',
     reconnect,
+    keepAliveInterval = 30_000,
     retryDelay,
   } = config
   return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
@@ -101,7 +109,10 @@ export function webSocket(
         name,
         async request({ method, params }) {
           const body = { method, params }
-          const rpcClient = await getWebSocketRpcClient(url_, { reconnect })
+          const rpcClient = await getWebSocketRpcClient(url_, {
+            reconnect,
+            keepAliveInterval,
+          })
           const { error, result } = await rpcClient.requestAsync({
             body,
             timeout,

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -11,7 +11,7 @@ import { wait } from '../wait.js'
 import { getWebSocketRpcClient } from './webSocket.js'
 
 const client = anvilMainnet.getClient()
-
+anvilMainnet.start()
 describe('getWebSocketRpcClient', () => {
   test('creates WebSocket instance', async () => {
     const socketClient = await getWebSocketRpcClient(anvilMainnet.rpcUrl.ws)
@@ -53,6 +53,10 @@ describe('getWebSocketRpcClient', () => {
     expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
     setTimeout(() => {
       expect(spy).toHaveBeenCalled()
+    }, 5)
+    await anvilMainnet.restart()
+    setTimeout(() => {
+      expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
     }, 5)
   })
 })

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -11,7 +11,7 @@ import { wait } from '../wait.js'
 import { getWebSocketRpcClient } from './webSocket.js'
 
 const client = anvilMainnet.getClient()
-anvilMainnet.start()
+
 describe('getWebSocketRpcClient', () => {
   test('creates WebSocket instance', async () => {
     const socketClient = await getWebSocketRpcClient(anvilMainnet.rpcUrl.ws)
@@ -32,32 +32,24 @@ describe('getWebSocketRpcClient', () => {
     expect(client1).toEqual(client4)
   })
 
-  test('reconnect after Connection ended', async () => {
+  test('reconnect', async () => {
     const socketClient = await getWebSocketRpcClient(anvilMainnet.rpcUrl.ws, {
-      reconnect: { delay: 0 },
+      reconnect: { delay: 100 },
     })
     expect(socketClient).toBeDefined()
     expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
-    await anvilMainnet.restart()
-    setTimeout(() => {
-      expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
-    }, 10)
+    socketClient.socket.close()
+    await wait(500)
+    expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
   })
 
   test('keepalive', async () => {
     const socketClient = await getWebSocketRpcClient(anvilMainnet.rpcUrl.ws, {
-      keepAliveInterval: 1,
+      keepAlive: { interval: 100 },
     })
     const spy = vi.spyOn(socketClient.socket, 'ping')
-    expect(socketClient).toBeDefined()
-    expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-    }, 5)
-    await anvilMainnet.restart()
-    setTimeout(() => {
-      expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
-    }, 5)
+    await wait(500)
+    expect(spy).toHaveBeenCalledTimes(4)
   })
 })
 
@@ -388,7 +380,7 @@ describe('request', () => {
           "code": -32602,
           "message": "data did not match any variant of untagged enum EthRpcCall",
         },
-        "id": 7,
+        "id": 9,
         "jsonrpc": "2.0",
       }
     `,
@@ -416,7 +408,7 @@ describe('request', () => {
       [WebSocketRequestError: WebSocket request failed.
 
       URL: http://localhost
-      Request body: {"jsonrpc":"2.0","id":9,"method":"wagmi_lol"}
+      Request body: {"jsonrpc":"2.0","id":11,"method":"wagmi_lol"}
 
       Details: Socket is closed.
       Version: viem@x.y.z]
@@ -445,7 +437,7 @@ describe('request', () => {
       [WebSocketRequestError: WebSocket request failed.
 
       URL: http://localhost
-      Request body: {"jsonrpc":"2.0","id":11,"method":"wagmi_lol"}
+      Request body: {"jsonrpc":"2.0","id":13,"method":"wagmi_lol"}
 
       Details: Socket is closed.
       Version: viem@x.y.z]
@@ -578,7 +570,7 @@ describe('request (subscription)', () => {
           "code": -32602,
           "message": "data did not match any variant of untagged enum EthRpcCall",
         },
-        "id": 31,
+        "id": 33,
         "jsonrpc": "2.0",
       }
     `)
@@ -952,7 +944,7 @@ describe('requestAsync', () => {
           "code": -32602,
           "message": "data did not match any variant of untagged enum EthRpcCall",
         },
-        "id": 151,
+        "id": 153,
         "jsonrpc": "2.0",
       }
     `,

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -56,9 +56,18 @@ export async function getWebSocketRpcClient(
           close_.bind(socket)()
           onClose()
         },
-        ping() {
-          if (socket.readyState === socket.CLOSED) return
-          socket.send('ping')
+        ping(data = 'ping') {
+          try {
+            if (socket.readyState === socket.CLOSED) {
+              throw new Error('Socket is closed: readyState === CLOSED')
+            }
+            if (socket.readyState === socket.CONNECTING) {
+              return
+            }
+            socket.send(data)
+          } catch (error) {
+            onError(error as Error)
+          }
         },
         request({ body }) {
           if (

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -10,14 +10,14 @@ import {
 
 export type GetWebSocketRpcClientOptions = Pick<
   GetSocketRpcClientParameters,
-  'reconnect'
+  'reconnect' | 'keepAliveInterval'
 >
 
 export async function getWebSocketRpcClient(
   url: string,
   options: GetWebSocketRpcClientOptions | undefined = {},
 ): Promise<SocketRpcClient<WebSocket>> {
-  const { reconnect } = options
+  const { reconnect, keepAliveInterval } = options
 
   return getSocketRpcClient({
     async getSocket({ onError, onOpen, onResponse }) {
@@ -56,6 +56,10 @@ export async function getWebSocketRpcClient(
           close_.bind(socket)()
           onClose()
         },
+        ping() {
+          if (socket.readyState === socket.CLOSED) return
+          socket.send('ping')
+        },
         request({ body }) {
           if (
             socket.readyState === socket.CLOSED ||
@@ -72,6 +76,7 @@ export async function getWebSocketRpcClient(
       } as Socket<WebSocket>)
     },
     reconnect,
+    keepAliveInterval,
     url,
   })
 }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `keepAlive` property to the `webSocket` transport for sending ping messages and improve reconnect behavior.

### Detailed summary
- Added `keepAlive` property to `webSocket` transport
- Implemented sending keep-alive ping messages
- Improved reconnect behavior on socket closure

> The following files were skipped due to too many changes: `src/utils/rpc/socket.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->