### PR TITLE
Fix: Added missing `http` import in the config file example

### DIFF
--- a/site/pages/docs/contract/writeContract.md
+++ b/site/pages/docs/contract/writeContract.md
@@ -52,7 +52,7 @@ export const wagmiAbi = [
 ```
 
 ```ts [config.ts]
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, custom, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 
@@ -113,7 +113,7 @@ export const wagmiAbi = [
 ```
 
 ```ts [config.ts]
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, custom, http} from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 
@@ -168,7 +168,7 @@ export const wagmiAbi = [
 ```
 
 ```ts [config.ts]
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, custom, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 


### PR DESCRIPTION
The `http` was used in the config file example, but the import is missing, which might confuse beginners.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `http` import to the `viem` library in the `config.ts` file.

### Detailed summary
- Added `http` import to `viem` library in `config.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->