### PR TITLE
feat: added dispute game factory address for Base Sepolia

### DIFF
--- a/.changeset/nervous-buttons-relax.md
+++ b/.changeset/nervous-buttons-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added dispute game factory address for Base Sepolia.

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -23,6 +23,11 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
   },
   contracts: {
     ...chainConfig.contracts,
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1',
+      },
+    },
     l2OutputOracle: {
       [sourceId]: {
         address: '0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254',


### PR DESCRIPTION
To support Fault Proofs w/ Base Sepolia.

See https://github.com/ethereum-optimism/superchain-ops/pull/261

Related to https://github.com/wevm/viem/pull/1994

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the dispute game factory address for Base Sepolia in the chain definitions.

### Detailed summary
- Added dispute game factory address for Base Sepolia in `baseSepolia.ts` chain definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->