### PR TITLE
add ENS addresses to to `root` and `rootPorcini` chains

### DIFF
--- a/.changeset/lemon-camels-dress.md
+++ b/.changeset/lemon-camels-dress.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+added ENS addresses to root and rootPorcini chains

--- a/src/chains/definitions/root.ts
+++ b/src/chains/definitions/root.ts
@@ -25,5 +25,10 @@ export const root = /*#__PURE__*/ defineChain({
       address: '0xc9C2E2429AeC354916c476B30d729deDdC94988d',
       blockCreated: 9218338,
     },
+    ensRegistry: { address: '0xEC58C26B8E0A4bc0fe1ad21D216e4ecAd9e037A8' },
+    ensUniversalResolver: {
+      address: '0x7808dF0A1F1d58c6Ad0F3bA07E749D730F02f13A',
+      blockCreated: 12_519_044,
+    },
   },
 })

--- a/src/chains/definitions/rootPorcini.ts
+++ b/src/chains/definitions/rootPorcini.ts
@@ -25,6 +25,11 @@ export const rootPorcini = /*#__PURE__*/ defineChain({
       address: '0xc9C2E2429AeC354916c476B30d729deDdC94988d',
       blockCreated: 10555692,
     },
+    ensRegistry: { address: '0xA931c1F9621ECa562c258B81bF9fA8401f12241B' },
+    ensUniversalResolver: {
+      address: '0xB3c0AE882b35E72B7b84F7A1E0cF01fBDC617170',
+      blockCreated: 11_983_898,
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->
## Overview
This PR adds the `ensRegistry` and `ensUniversalResolver` addresses for the `root` and `rootPorcini` chains. The contract addresses are sourced from the [rootnameservice package](https://github.com/rootnameservice/rootnameservice/blob/main/src/addresses.ts)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add ENS addresses to the `root` and `rootPorcini` chains.

### Detailed summary
- Added ENS addresses to `root` chain definitions
- Added ENS addresses to `rootPorcini` chain definitions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->