### PR TITLE
[docs] fix call of estimateInitiateWithdrawalGas

### DIFF
--- a/site/pages/op-stack/actions/estimateInitiateWithdrawalGas.md
+++ b/site/pages/op-stack/actions/estimateInitiateWithdrawalGas.md
@@ -13,9 +13,9 @@ Estimates gas required to initiate a [withdrawal](https://github.com/ethereum-op
 
 ```ts [example.ts]
 import { base } from 'viem/chains'
-import { account, walletClientL2 } from './config'
+import { account, publicClientL2 } from './config'
  
-const gas = await walletClientL2.estimateInitiateWithdrawalGas({
+const gas = await publicClientL2.estimateInitiateWithdrawalGas({
   account,
   request: {
     gas: 21_000n,
@@ -29,12 +29,12 @@ const gas = await walletClientL2.estimateInitiateWithdrawalGas({
 import { createWalletClient, custom } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
-import { walletActionsL2 } from 'viem/op-stack'
+import { publicActionsL2 } from 'viem/op-stack'
 
-export const walletClientL2 = createWalletClient({
+export const publicClientL2 = createPublicClient({
   chain: mainnet,
   transport: custom(window.ethereum)
-}).extend(walletActionsL2())
+}).extend(publicActionsL2())
 
 // JSON-RPC Account
 export const [account] = await walletClientL2.getAddresses()


### PR DESCRIPTION

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

While playing around with the viem op extensions i noticed the docs show estimateInitiateWithdrawalGas being called on walletClient, but it seems to be a public action and not available on wallet client. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the client and actions in the `estimateInitiateWithdrawalGas` function for better clarity and consistency.

### Detailed summary
- Updated `walletClientL2` to `publicClientL2` in `estimateInitiateWithdrawalGas` function
- Renamed `walletClientL2` to `publicClientL2` and `walletActionsL2` to `publicActionsL2`
- Updated client creation method from `createWalletClient` to `createPublicClient`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->