### PR TITLE
Add Gravity Alpha Mainnet chain definitiion

### DIFF
--- a/src/chains/definitions/gravity.ts
+++ b/src/chains/definitions/gravity.ts
@@ -1,0 +1,25 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const arbitrum = /*#__PURE__*/ defineChain({
+  id: 1625,
+  name: 'Gravity Alpha Mainnet',
+  nativeCurrency: { name: 'G', symbol: 'G', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.gravity.xyz'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Gravity Alpha Mainnet explorer',
+      url: 'https://explorer.gravity.xyz/',
+      apiUrl: 'https://explorer.gravity.xyz/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xf8ac4BEB2F75d2cFFb588c63251347fdD629B92c',
+      blockCreated: 16851,
+    },
+  },
+})


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Adds missing chain definition for Gravity Alpha Mainnet
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new chain definition for Gravity Alpha Mainnet on Arbitrum.

### Detailed summary
- Added a new chain definition for Gravity Alpha Mainnet on Arbitrum
- Defined chain ID, name, native currency, RPC URLs, block explorers, and contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->