### PR TITLE
#2542 fix

### DIFF
--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -43,6 +43,7 @@ export async function getChainId<
 >(client: Client<Transport, chain, account>): Promise<GetChainIdReturnType> {
   const chainIdHex = await client.request(
     {
+      jsonrpc: '2.0',
       method: 'eth_chainId',
     },
     { dedupe: true },


### PR DESCRIPTION
fixes #2542
`getChainId` makes malformatted rpc requests


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `getChainId` function in `getChainId.ts` to use the `eth_chainId` method with JSON-RPC 2.0.

### Detailed summary
- Updated method to `eth_chainId`
- Added JSON-RPC version 2.0

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->