### PR TITLE
add movement imola net

### DIFF
--- a/.changeset/.lucky-actors-smell.md
+++ b/.changeset/.lucky-actors-smell.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added Crab and Koi chain
+Added Movement Imola Devnet

--- a/src/chains/definitions/movementImola.ts
+++ b/src/chains/definitions/movementImola.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const movementImola = /*#__PURE__*/ defineChain({
+  id: 30732,
+  name: 'Movement Imola Devnet',
+  nativeCurrency: { name: 'Move', symbol: 'MOVE', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://mevm.devnet.imola.movementlabs.xyz/'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Movement Imola Explorer',
+      url: 'https://explorer.devnet.imola.movementlabs.xyz/',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -183,6 +183,7 @@ export { moonbeamDev } from './definitions/moonbeamDev.js'
 export { moonriver } from './definitions/moonriver.js'
 export { morphHolesky } from './definitions/morphHolesky.js'
 export { morphSepolia } from './definitions/morphSepolia.js'
+export { movementImola } from "./definitions/movementImola.js"
 export { nautilus } from './definitions/nautilus.js'
 export { neonDevnet } from './definitions/neonDevnet.js'
 export { neonMainnet } from './definitions/neonMainnet.js'


### PR DESCRIPTION
This PR adds support for Movement Labs Imola Network 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the `Movement Imola Devnet` chain with its definition in the `movementImola.ts` file.

### Detailed summary
- Added `Movement Imola Devnet` chain definition
- Included chain details such as ID, name, native currency, RPC URLs, block explorers
- Set `testnet` flag to true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->