### PR TITLE
Documentation: Fix missing event parameter name in `getLogs` scoping example

### DIFF
--- a/site/pages/docs/actions/public/getLogs.md
+++ b/site/pages/docs/actions/public/getLogs.md
@@ -43,7 +43,7 @@ import { publicClient } from './client'
 
 const logs = await publicClient.getLogs({  // [!code focus:99]
   address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-  event: parseAbiItem('event Transfer(address indexed, address indexed, uint256)'),
+  event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256)'),
   args: {
     from: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
     to: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'


### PR DESCRIPTION
The example in the documentation was missing the parameter names

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the event parameter in `getLogs` function to include specific address fields.

### Detailed summary
- Updated the event parameter in `getLogs` function to include `from` and `to` address fields.
- Changed the address values for `from` and `to` in the `args` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->