### PR TITLE
Update withdrawals.md

### DIFF
--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -80,7 +80,7 @@ const proveReceipt = await publicClientL1.waitForTransactionReceipt({
 
 // Wait until the withdrawal is ready to finalize.
 await publicClientL1.waitToFinalize({
-  targetChain: walletClientL2.chain
+  targetChain: walletClientL2.chain,
   withdrawalHash: withdrawal.withdrawalHash,
 })
 


### PR DESCRIPTION
Add comma before `withdrawalHash` in `waitToFinalize` step

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR is solving a syntax error in the OP Stack Withdrawal example, specifically the part where we wait for transaction to finalize on L1.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `withdrawals.md` file in the `op-stack` directory to fix a syntax error in the `waitToFinalize` function call.

### Detailed summary
- Fixed syntax error by adding a comma after `walletClientL2.chain` in the `waitToFinalize` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->