### PR TITLE
chore: make websocket can be used in service worker

### DIFF
--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -1,4 +1,4 @@
-import type { MessageEvent } from 'isows'
+import { type MessageEvent, WebSocket } from 'isows'
 
 import {
   SocketClosedError,
@@ -24,7 +24,6 @@ export async function getWebSocketRpcClient(
 
   return getSocketRpcClient({
     async getSocket({ onClose, onError, onOpen, onResponse }) {
-      const WebSocket = await import('isows').then((module) => module.WebSocket)
       const socket = new WebSocket(url)
 
       function onClose_() {


### PR DESCRIPTION
import() is disallowed on ServiceWorkerGlobalScope by the HTML specification. See https://github.com/w3c/ServiceWorker/issues/1356.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the WebSocket import in `webSocket.ts` file to use `isows`. 

### Detailed summary
- Updated WebSocket import to use `isows`
- Removed dynamic import for WebSocket

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->