### PR TITLE
docs: Fix the 'to' field type to 'Address'

### DIFF
--- a/site/pages/docs/accounts/local/signTransaction.md
+++ b/site/pages/docs/accounts/local/signTransaction.md
@@ -240,7 +240,7 @@ const signature = await account.signTransaction({
 
 ### to (optional)
 
-- **Type:** `number`
+- **Type:** `Address`
 
 The transaction recipient.
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Type` from `number` to `Address` in the `signTransaction.md` file under `site/pages/docs/accounts/local`.

### Detailed summary
- Changed the `Type` from `number` to `Address` for the transaction recipient in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->