### PR TITLE
Fix Abstract testnet definition

### DIFF
--- a/.changeset/kind-yaks-dress.md
+++ b/.changeset/kind-yaks-dress.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix Abstract testnet config

--- a/.changeset/kind-yaks-dress.md
+++ b/.changeset/kind-yaks-dress.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fix Abstract testnet config
+Added ZKsync config to Abstract Testnet chain.

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -5,7 +5,6 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 11_124,
   name: 'Abstract Testnet',
-  network: 'abstract-testnet',
   nativeCurrency: {
     decimals: 18,
     name: 'ETH',

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -5,6 +5,7 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 11_124,
   name: 'Abstract Testnet',
+  network: 'abstract-testnet',
   nativeCurrency: {
     decimals: 18,
     name: 'ETH',

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -1,6 +1,8 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
 
 export const abstractTestnet = /*#__PURE__*/ defineChain({
+  ...chainConfig,
   id: 11_124,
   name: 'Abstract Testnet',
   nativeCurrency: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Because Abstract is based on zkSync's rollup stack, we need to inherit zksync's chain config.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds ZKsync config to the Abstract Testnet chain definition.

### Detailed summary
- Added ZKsync config to Abstract Testnet chain
- Defined chain ID as 11_124
- Set chain name as 'Abstract Testnet'
- Added native currency definition

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->