### PR TITLE
feat: configurable base errors

### DIFF
--- a/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.test.ts
+++ b/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.test.ts
@@ -500,7 +500,7 @@ describe('sign', async () => {
         hash: keccak256('0xdeadbeef'),
       }),
     ).rejects.toMatchInlineSnapshot(`
-      [ViemError: \`owner\` does not support raw sign.
+      [BaseError: \`owner\` does not support raw sign.
 
       Version: viem@x.y.z]
     `)

--- a/src/account-abstraction/errors/bundler.ts
+++ b/src/account-abstraction/errors/bundler.ts
@@ -7,7 +7,6 @@ export type AccountNotDeployedErrorType = AccountNotDeployedError & {
 }
 export class AccountNotDeployedError extends BaseError {
   static message = /aa20/
-  override name = 'AccountNotDeployedError'
   constructor({
     cause,
   }: {
@@ -20,6 +19,7 @@ export class AccountNotDeployedError extends BaseError {
         '- No `factory`/`factoryData` or `initCode` properties are provided for Smart Account deployment.',
         '- An incorrect `sender` address is provided.',
       ],
+      name: 'AccountNotDeployedError',
     })
   }
 }
@@ -31,8 +31,6 @@ export type ExecutionRevertedErrorType = ExecutionRevertedError & {
 export class ExecutionRevertedError extends BaseError {
   static code = -32521
   static message = /execution reverted/
-
-  override name = 'ExecutionRevertedError'
 
   constructor({
     cause,
@@ -47,6 +45,7 @@ export class ExecutionRevertedError extends BaseError {
       }.`,
       {
         cause,
+        name: 'ExecutionRevertedError',
       },
     )
   }
@@ -58,7 +57,6 @@ export type FailedToSendToBeneficiaryErrorType =
   }
 export class FailedToSendToBeneficiaryError extends BaseError {
   static message = /aa91/
-  override name = 'FailedToSendToBeneficiaryError'
   constructor({
     cause,
   }: {
@@ -66,6 +64,7 @@ export class FailedToSendToBeneficiaryError extends BaseError {
   }) {
     super('Failed to send funds to beneficiary.', {
       cause,
+      name: 'FailedToSendToBeneficiaryError',
     })
   }
 }
@@ -75,7 +74,6 @@ export type GasValuesOverflowErrorType = GasValuesOverflowError & {
 }
 export class GasValuesOverflowError extends BaseError {
   static message = /aa94/
-  override name = 'GasValuesOverflowError'
   constructor({
     cause,
   }: {
@@ -87,6 +85,7 @@ export class GasValuesOverflowError extends BaseError {
         'This could arise when:',
         '- one of the gas values exceeded 2**120 (uint120)',
       ].filter(Boolean) as string[],
+      name: 'GasValuesOverflowError',
     })
   }
 }
@@ -96,7 +95,6 @@ export type HandleOpsOutOfGasErrorType = HandleOpsOutOfGasError & {
 }
 export class HandleOpsOutOfGasError extends BaseError {
   static message = /aa95/
-  override name = 'HandleOpsOutOfGasError'
   constructor({
     cause,
   }: {
@@ -106,6 +104,7 @@ export class HandleOpsOutOfGasError extends BaseError {
       'The `handleOps` function was called by the Bundler with a gas limit too low.',
       {
         cause,
+        name: 'HandleOpsOutOfGasError',
       },
     )
   }
@@ -116,7 +115,6 @@ export type InitCodeFailedErrorType = InitCodeFailedError & {
 }
 export class InitCodeFailedError extends BaseError {
   static message = /aa13/
-  override name = 'InitCodeFailedError'
   constructor({
     cause,
     factory,
@@ -139,6 +137,7 @@ export class InitCodeFailedError extends BaseError {
         factoryData && `factoryData: ${factoryData}`,
         initCode && `initCode: ${initCode}`,
       ].filter(Boolean) as string[],
+      name: 'InitCodeFailedError',
     })
   }
 }
@@ -149,7 +148,6 @@ export type InitCodeMustCreateSenderErrorType =
   }
 export class InitCodeMustCreateSenderError extends BaseError {
   static message = /aa15/
-  override name = 'InitCodeMustCreateSenderError'
   constructor({
     cause,
     factory,
@@ -173,6 +171,7 @@ export class InitCodeMustCreateSenderError extends BaseError {
           factoryData && `factoryData: ${factoryData}`,
           initCode && `initCode: ${initCode}`,
         ].filter(Boolean) as string[],
+        name: 'InitCodeMustCreateSenderError',
       },
     )
   }
@@ -184,7 +183,6 @@ export type InitCodeMustReturnSenderErrorType =
   }
 export class InitCodeMustReturnSenderError extends BaseError {
   static message = /aa14/
-  override name = 'InitCodeMustReturnSenderError'
   constructor({
     cause,
     factory,
@@ -210,6 +208,7 @@ export class InitCodeMustReturnSenderError extends BaseError {
           initCode && `initCode: ${initCode}`,
           sender && `sender: ${sender}`,
         ].filter(Boolean) as string[],
+        name: 'InitCodeMustReturnSenderError',
       },
     )
   }
@@ -220,7 +219,6 @@ export type InsufficientPrefundErrorType = InsufficientPrefundError & {
 }
 export class InsufficientPrefundError extends BaseError {
   static message = /aa21/
-  override name = 'InsufficientPrefundError'
   constructor({
     cause,
   }: {
@@ -235,6 +233,7 @@ export class InsufficientPrefundError extends BaseError {
           '- the Smart Account does not have sufficient funds to cover the required prefund, or',
           '- a Paymaster was not provided',
         ].filter(Boolean) as string[],
+        name: 'InsufficientPrefundError',
       },
     )
   }
@@ -245,7 +244,6 @@ export type InternalCallOnlyErrorType = InternalCallOnlyError & {
 }
 export class InternalCallOnlyError extends BaseError {
   static message = /aa92/
-  override name = 'InternalCallOnlyError'
   constructor({
     cause,
   }: {
@@ -253,6 +251,7 @@ export class InternalCallOnlyError extends BaseError {
   }) {
     super('Bundler attempted to call an invalid function on the EntryPoint.', {
       cause,
+      name: 'InternalCallOnlyError',
     })
   }
 }
@@ -262,7 +261,6 @@ export type InvalidAggregatorErrorType = InvalidAggregatorError & {
 }
 export class InvalidAggregatorError extends BaseError {
   static message = /aa96/
-  override name = 'InvalidAggregatorError'
   constructor({
     cause,
   }: {
@@ -272,6 +270,7 @@ export class InvalidAggregatorError extends BaseError {
       'Bundler used an invalid aggregator for handling aggregated User Operations.',
       {
         cause,
+        name: 'InvalidAggregatorError',
       },
     )
   }
@@ -282,7 +281,6 @@ export type InvalidAccountNonceErrorType = InvalidAccountNonceError & {
 }
 export class InvalidAccountNonceError extends BaseError {
   static message = /aa25/
-  override name = 'InvalidAccountNonceError'
   constructor({
     cause,
     nonce,
@@ -293,6 +291,7 @@ export class InvalidAccountNonceError extends BaseError {
     super('Invalid Smart Account nonce used for User Operation.', {
       cause,
       metaMessages: [nonce && `nonce: ${nonce}`].filter(Boolean) as string[],
+      name: 'InvalidAccountNonceError',
     })
   }
 }
@@ -302,7 +301,6 @@ export type InvalidBeneficiaryErrorType = InvalidBeneficiaryError & {
 }
 export class InvalidBeneficiaryError extends BaseError {
   static message = /aa90/
-  override name = 'InvalidBeneficiaryError'
   constructor({
     cause,
   }: {
@@ -310,6 +308,7 @@ export class InvalidBeneficiaryError extends BaseError {
   }) {
     super('Bundler has not set a beneficiary address.', {
       cause,
+      name: 'InvalidBeneficiaryError',
     })
   }
 }
@@ -320,8 +319,6 @@ export type InvalidFieldsErrorType = InvalidFieldsError & {
 export class InvalidFieldsError extends BaseError {
   static code = -32602
 
-  override name = 'InvalidFieldsError'
-
   constructor({
     cause,
   }: {
@@ -329,6 +326,7 @@ export class InvalidFieldsError extends BaseError {
   }) {
     super('Invalid fields set on User Operation.', {
       cause,
+      name: 'InvalidFieldsError',
     })
   }
 }
@@ -338,7 +336,6 @@ export type InvalidPaymasterAndDataErrorType = InvalidPaymasterAndDataError & {
 }
 export class InvalidPaymasterAndDataError extends BaseError {
   static message = /aa93/
-  override name = 'InvalidPaymasterAndDataError'
   constructor({
     cause,
     paymasterAndData,
@@ -353,6 +350,7 @@ export class InvalidPaymasterAndDataError extends BaseError {
         '- the `paymasterAndData` property is of an incorrect length\n',
         paymasterAndData && `paymasterAndData: ${paymasterAndData}`,
       ].filter(Boolean) as string[],
+      name: 'InvalidPaymasterAndDataError',
     })
   }
 }
@@ -365,8 +363,6 @@ export class PaymasterDepositTooLowError extends BaseError {
   static code = -32508
   static message = /aa31/
 
-  override name = 'PaymasterDepositTooLowError'
-
   constructor({
     cause,
   }: {
@@ -378,6 +374,7 @@ export class PaymasterDepositTooLowError extends BaseError {
         'This could arise when:',
         '- the Paymaster has deposited less than the expected amount via the `deposit` function',
       ].filter(Boolean) as string[],
+      name: 'PaymasterDepositTooLowError',
     })
   }
 }
@@ -388,7 +385,6 @@ export type PaymasterFunctionRevertedErrorType =
   }
 export class PaymasterFunctionRevertedError extends BaseError {
   static message = /aa33/
-  override name = 'PaymasterFunctionRevertedError'
   constructor({
     cause,
   }: {
@@ -396,6 +392,7 @@ export class PaymasterFunctionRevertedError extends BaseError {
   }) {
     super('The `validatePaymasterUserOp` function on the Paymaster reverted.', {
       cause,
+      name: 'PaymasterFunctionRevertedError',
     })
   }
 }
@@ -405,7 +402,6 @@ export type PaymasterNotDeployedErrorType = PaymasterNotDeployedError & {
 }
 export class PaymasterNotDeployedError extends BaseError {
   static message = /aa30/
-  override name = 'PaymasterNotDeployedError'
   constructor({
     cause,
   }: {
@@ -413,6 +409,7 @@ export class PaymasterNotDeployedError extends BaseError {
   }) {
     super('The Paymaster contract has not been deployed.', {
       cause,
+      name: 'PaymasterNotDeployedError',
     })
   }
 }
@@ -424,13 +421,12 @@ export type PaymasterRateLimitErrorType = PaymasterRateLimitError & {
 export class PaymasterRateLimitError extends BaseError {
   static code = -32504
 
-  override name = 'PaymasterRateLimitError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       'UserOperation rejected because paymaster (or signature aggregator) is throttled/banned.',
       {
         cause,
+        name: 'PaymasterRateLimitError',
       },
     )
   }
@@ -443,13 +439,12 @@ export type PaymasterStakeTooLowErrorType = PaymasterStakeTooLowError & {
 export class PaymasterStakeTooLowError extends BaseError {
   static code = -32505
 
-  override name = 'PaymasterStakeTooLowError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       'UserOperation rejected because paymaster (or signature aggregator) is throttled/banned.',
       {
         cause,
+        name: 'PaymasterStakeTooLowError',
       },
     )
   }
@@ -461,7 +456,6 @@ export type PaymasterPostOpFunctionRevertedErrorType =
   }
 export class PaymasterPostOpFunctionRevertedError extends BaseError {
   static message = /aa50/
-  override name = 'PaymasterPostOpFunctionRevertedError'
   constructor({
     cause,
   }: {
@@ -469,6 +463,7 @@ export class PaymasterPostOpFunctionRevertedError extends BaseError {
   }) {
     super('Paymaster `postOp` function reverted.', {
       cause,
+      name: 'PaymasterPostOpFunctionRevertedError',
     })
   }
 }
@@ -479,7 +474,6 @@ export type SenderAlreadyConstructedErrorType =
   }
 export class SenderAlreadyConstructedError extends BaseError {
   static message = /aa10/
-  override name = 'SenderAlreadyConstructedError'
   constructor({
     cause,
     factory,
@@ -499,6 +493,7 @@ export class SenderAlreadyConstructedError extends BaseError {
         factoryData && '`factoryData`',
         initCode && '`initCode`',
       ].filter(Boolean) as string[],
+      name: 'SenderAlreadyConstructedError',
     })
   }
 }
@@ -510,13 +505,12 @@ export type SignatureCheckFailedErrorType = SignatureCheckFailedError & {
 export class SignatureCheckFailedError extends BaseError {
   static code = -32507
 
-  override name = 'SignatureCheckFailedError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       'UserOperation rejected because account signature check failed (or paymaster signature, if the paymaster uses its data as signature).',
       {
         cause,
+        name: 'SignatureCheckFailedError',
       },
     )
   }
@@ -528,7 +522,6 @@ export type SmartAccountFunctionRevertedErrorType =
   }
 export class SmartAccountFunctionRevertedError extends BaseError {
   static message = /aa23/
-  override name = 'SmartAccountFunctionRevertedError'
   constructor({
     cause,
   }: {
@@ -536,6 +529,7 @@ export class SmartAccountFunctionRevertedError extends BaseError {
   }) {
     super('The `validateUserOp` function on the Smart Account reverted.', {
       cause,
+      name: 'SmartAccountFunctionRevertedError',
     })
   }
 }
@@ -548,13 +542,12 @@ export type UnsupportedSignatureAggregatorErrorType =
 export class UnsupportedSignatureAggregatorError extends BaseError {
   static code = -32506
 
-  override name = 'UnsupportedSignatureAggregatorError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       'UserOperation rejected because account specified unsupported signature aggregator.',
       {
         cause,
+        name: 'UnsupportedSignatureAggregatorError',
       },
     )
   }
@@ -565,7 +558,6 @@ export type UserOperationExpiredErrorType = UserOperationExpiredError & {
 }
 export class UserOperationExpiredError extends BaseError {
   static message = /aa22/
-  override name = 'UserOperationExpiredError'
   constructor({
     cause,
   }: {
@@ -577,6 +569,7 @@ export class UserOperationExpiredError extends BaseError {
         'This could arise when:',
         '- the `validAfter` or `validUntil` values returned from `validateUserOp` on the Smart Account are not satisfied',
       ].filter(Boolean) as string[],
+      name: 'UserOperationExpiredError',
     })
   }
 }
@@ -587,7 +580,6 @@ export type UserOperationPaymasterExpiredErrorType =
   }
 export class UserOperationPaymasterExpiredError extends BaseError {
   static message = /aa32/
-  override name = 'UserOperationPaymasterExpiredError'
   constructor({
     cause,
   }: {
@@ -599,6 +591,7 @@ export class UserOperationPaymasterExpiredError extends BaseError {
         'This could arise when:',
         '- the `validAfter` or `validUntil` values returned from `validatePaymasterUserOp` on the Paymaster are not satisfied',
       ].filter(Boolean) as string[],
+      name: 'UserOperationPaymasterExpiredError',
     })
   }
 }
@@ -608,7 +601,6 @@ export type UserOperationSignatureErrorType = UserOperationSignatureError & {
 }
 export class UserOperationSignatureError extends BaseError {
   static message = /aa24/
-  override name = 'UserOperationSignatureError'
   constructor({
     cause,
   }: {
@@ -620,6 +612,7 @@ export class UserOperationSignatureError extends BaseError {
         'This could arise when:',
         '- the `signature` for the User Operation is incorrectly computed, and unable to be verified by the Smart Account',
       ].filter(Boolean) as string[],
+      name: 'UserOperationSignatureError',
     })
   }
 }
@@ -630,7 +623,6 @@ export type UserOperationPaymasterSignatureErrorType =
   }
 export class UserOperationPaymasterSignatureError extends BaseError {
   static message = /aa34/
-  override name = 'UserOperationPaymasterSignatureError'
   constructor({
     cause,
   }: {
@@ -642,6 +634,7 @@ export class UserOperationPaymasterSignatureError extends BaseError {
         'This could arise when:',
         '- the `signature` for the User Operation is incorrectly computed, and unable to be verified by the Paymaster',
       ].filter(Boolean) as string[],
+      name: 'UserOperationPaymasterSignatureError',
     })
   }
 }
@@ -654,13 +647,12 @@ export type UserOperationRejectedByEntryPointErrorType =
 export class UserOperationRejectedByEntryPointError extends BaseError {
   static code = -32500
 
-  override name = 'UserOperationRejectedByEntryPointError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       "User Operation rejected by EntryPoint's `simulateValidation` during account creation or validation.",
       {
         cause,
+        name: 'UserOperationRejectedByEntryPointError',
       },
     )
   }
@@ -674,11 +666,10 @@ export type UserOperationRejectedByPaymasterErrorType =
 export class UserOperationRejectedByPaymasterError extends BaseError {
   static code = -32501
 
-  override name = 'UserOperationRejectedByPaymasterError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super("User Operation rejected by Paymaster's `validatePaymasterUserOp`.", {
       cause,
+      name: 'UserOperationRejectedByPaymasterError',
     })
   }
 }
@@ -691,11 +682,10 @@ export type UserOperationRejectedByOpCodeErrorType =
 export class UserOperationRejectedByOpCodeError extends BaseError {
   static code = -32502
 
-  override name = 'UserOperationRejectedByOpCodeError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super('User Operation rejected with op code validation error.', {
       cause,
+      name: 'UserOperationRejectedByOpCodeError',
     })
   }
 }
@@ -708,13 +698,12 @@ export type UserOperationOutOfTimeRangeErrorType =
 export class UserOperationOutOfTimeRangeError extends BaseError {
   static code = -32503
 
-  override name = 'UserOperationOutOfTimeRangeError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       'UserOperation out of time-range: either wallet or paymaster returned a time-range, and it is already expired (or will expire soon).',
       {
         cause,
+        name: 'UserOperationOutOfTimeRangeError',
       },
     )
   }
@@ -724,13 +713,12 @@ export type UnknownBundlerErrorType = UnknownBundlerError & {
   name: 'UnknownBundlerError'
 }
 export class UnknownBundlerError extends BaseError {
-  override name = 'UnknownBundlerError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(
       `An error occurred while executing user operation: ${cause?.shortMessage}`,
       {
         cause,
+        name: 'UnknownBundlerError',
       },
     )
   }
@@ -742,7 +730,6 @@ export type VerificationGasLimitExceededErrorType =
   }
 export class VerificationGasLimitExceededError extends BaseError {
   static message = /aa40/
-  override name = 'VerificationGasLimitExceededError'
   constructor({
     cause,
   }: {
@@ -754,6 +741,7 @@ export class VerificationGasLimitExceededError extends BaseError {
         'This could arise when:',
         '- the gas used for verification exceeded the `verificationGasLimit`',
       ].filter(Boolean) as string[],
+      name: 'VerificationGasLimitExceededError',
     })
   }
 }
@@ -764,7 +752,6 @@ export type VerificationGasLimitTooLowErrorType =
   }
 export class VerificationGasLimitTooLowError extends BaseError {
   static message = /aa41/
-  override name = 'VerificationGasLimitTooLowError'
   constructor({
     cause,
   }: {
@@ -776,6 +763,7 @@ export class VerificationGasLimitTooLowError extends BaseError {
         'This could arise when:',
         '- the `verificationGasLimit` is too low to verify the User Operation',
       ].filter(Boolean) as string[],
+      name: 'VerificationGasLimitTooLowError',
     })
   }
 }

--- a/src/account-abstraction/errors/userOperation.ts
+++ b/src/account-abstraction/errors/userOperation.ts
@@ -10,8 +10,6 @@ export type UserOperationExecutionErrorType = UserOperationExecutionError & {
 export class UserOperationExecutionError extends BaseError {
   override cause: BaseError
 
-  override name = 'UserOperationExecutionError'
-
   constructor(
     cause: BaseError,
     {
@@ -69,6 +67,7 @@ export class UserOperationExecutionError extends BaseError {
         'Request Arguments:',
         prettyArgs,
       ].filter(Boolean) as string[],
+      name: 'UserOperationExecutionError',
     })
     this.cause = cause
   }
@@ -79,10 +78,10 @@ export type UserOperationReceiptNotFoundErrorType =
     name: 'UserOperationReceiptNotFoundError'
   }
 export class UserOperationReceiptNotFoundError extends BaseError {
-  override name = 'UserOperationReceiptNotFoundError'
   constructor({ hash }: { hash: Hash }) {
     super(
       `User Operation receipt with hash "${hash}" could not be found. The User Operation may not have been processed yet.`,
+      { name: 'UserOperationReceiptNotFoundError' },
     )
   }
 }
@@ -91,9 +90,10 @@ export type UserOperationNotFoundErrorType = UserOperationNotFoundError & {
   name: 'UserOperationNotFoundError'
 }
 export class UserOperationNotFoundError extends BaseError {
-  override name = 'UserOperationNotFoundError'
   constructor({ hash }: { hash: Hash }) {
-    super(`User Operation with hash "${hash}" could not be found.`)
+    super(`User Operation with hash "${hash}" could not be found.`, {
+      name: 'UserOperationNotFoundError',
+    })
   }
 }
 
@@ -102,10 +102,10 @@ export type WaitForUserOperationReceiptTimeoutErrorType =
     name: 'WaitForUserOperationReceiptTimeoutError'
   }
 export class WaitForUserOperationReceiptTimeoutError extends BaseError {
-  override name = 'WaitForUserOperationReceiptTimeoutError'
   constructor({ hash }: { hash: Hash }) {
     super(
       `Timed out while waiting for User Operation with hash "${hash}" to be confirmed.`,
+      { name: 'WaitForUserOperationReceiptTimeoutError' },
     )
   }
 }

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -587,7 +587,7 @@ describe('errors', () => {
         factory: wagmiContractConfig.address,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: Cannot provide both \`code\` & \`factory\`/\`factoryData\` as parameters.
+      [BaseError: Cannot provide both \`code\` & \`factory\`/\`factoryData\` as parameters.
 
       Version: viem@x.y.z]
     `)
@@ -600,7 +600,7 @@ describe('errors', () => {
         to: '0x0000000000000000000000000000000000000000',
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: Cannot provide both \`code\` & \`to\` as parameters.
+      [BaseError: Cannot provide both \`code\` & \`to\` as parameters.
 
       Version: viem@x.y.z]
     `)

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -1031,7 +1031,7 @@ describe('errors', () => {
       [AccountNotFoundError: Could not find an Account to execute with this Action.
       Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-      Docs: https://viem.sh/docs/actions/wallet/sendTransaction#account
+      Docs: https://viem.sh/docs/actions/wallet/sendTransaction
       Version: viem@x.y.z]
     `)
   })

--- a/src/actions/wallet/signMessage.test.ts
+++ b/src/actions/wallet/signMessage.test.ts
@@ -89,7 +89,7 @@ test('error: no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/docs/actions/wallet/signMessage#account
+    Docs: https://viem.sh/docs/actions/wallet/signMessage
     Version: viem@x.y.z]
   `,
   )

--- a/src/actions/wallet/signTransaction.test.ts
+++ b/src/actions/wallet/signTransaction.test.ts
@@ -412,7 +412,7 @@ describe('errors', () => {
       [AccountNotFoundError: Could not find an Account to execute with this Action.
       Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-      Docs: https://viem.sh/docs/actions/wallet/signTransaction#account
+      Docs: https://viem.sh/docs/actions/wallet/signTransaction
       Version: viem@x.y.z]
     `)
   })

--- a/src/actions/wallet/signTypedData.test.ts
+++ b/src/actions/wallet/signTypedData.test.ts
@@ -467,7 +467,7 @@ test('no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/docs/actions/wallet/signTypedData#account
+    Docs: https://viem.sh/docs/actions/wallet/signTypedData
     Version: viem@x.y.z]
   `)
 })

--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -506,7 +506,7 @@ describe('request', () => {
 test('no url', () => {
   expect(() => http()({})).toThrowErrorMatchingInlineSnapshot(
     `
-    [ViemError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
+    [UrlRequiredError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
 
     Docs: https://viem.sh/docs/clients/intro
     Version: viem@x.y.z]

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -238,7 +238,7 @@ test('throws on bogus subscription', async () => {
 
 test('no url', () => {
   expect(() => webSocket()({})).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
+    [UrlRequiredError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
 
     Docs: https://viem.sh/docs/clients/intro
     Version: viem@x.y.z]

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -10,7 +10,6 @@ export type AbiConstructorNotFoundErrorType = AbiConstructorNotFoundError & {
   name: 'AbiConstructorNotFoundError'
 }
 export class AbiConstructorNotFoundError extends BaseError {
-  override name = 'AbiConstructorNotFoundError'
   constructor({ docsPath }: { docsPath: string }) {
     super(
       [
@@ -19,6 +18,7 @@ export class AbiConstructorNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiConstructorNotFoundError',
       },
     )
   }
@@ -30,7 +30,6 @@ export type AbiConstructorParamsNotFoundErrorType =
   }
 
 export class AbiConstructorParamsNotFoundError extends BaseError {
-  override name = 'AbiConstructorParamsNotFoundError'
   constructor({ docsPath }: { docsPath: string }) {
     super(
       [
@@ -39,6 +38,7 @@ export class AbiConstructorParamsNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiConstructorParamsNotFoundError',
       },
     )
   }
@@ -49,14 +49,16 @@ export type AbiDecodingDataSizeInvalidErrorType =
     name: 'AbiDecodingDataSizeInvalidError'
   }
 export class AbiDecodingDataSizeInvalidError extends BaseError {
-  override name = 'AbiDecodingDataSizeInvalidError'
   constructor({ data, size }: { data: Hex; size: number }) {
     super(
       [
         `Data size of ${size} bytes is invalid.`,
         'Size must be in increments of 32 bytes (size % 32 === 0).',
       ].join('\n'),
-      { metaMessages: [`Data: ${data} (${size} bytes)`] },
+      {
+        metaMessages: [`Data: ${data} (${size} bytes)`],
+        name: 'AbiDecodingDataSizeInvalidError',
+      },
     )
   }
 }
@@ -66,8 +68,6 @@ export type AbiDecodingDataSizeTooSmallErrorType =
     name: 'AbiDecodingDataSizeTooSmallError'
   }
 export class AbiDecodingDataSizeTooSmallError extends BaseError {
-  override name = 'AbiDecodingDataSizeTooSmallError'
-
   data: Hex
   params: readonly AbiParameter[]
   size: number
@@ -86,6 +86,7 @@ export class AbiDecodingDataSizeTooSmallError extends BaseError {
           `Params: (${formatAbiParams(params, { includeName: true })})`,
           `Data:   ${data} (${size} bytes)`,
         ],
+        name: 'AbiDecodingDataSizeTooSmallError',
       },
     )
 
@@ -99,9 +100,10 @@ export type AbiDecodingZeroDataErrorType = AbiDecodingZeroDataError & {
   name: 'AbiDecodingZeroDataError'
 }
 export class AbiDecodingZeroDataError extends BaseError {
-  override name = 'AbiDecodingZeroDataError'
   constructor() {
-    super('Cannot decode zero data ("0x") with ABI parameters.')
+    super('Cannot decode zero data ("0x") with ABI parameters.', {
+      name: 'AbiDecodingZeroDataError',
+    })
   }
 }
 
@@ -110,7 +112,6 @@ export type AbiEncodingArrayLengthMismatchErrorType =
     name: 'AbiEncodingArrayLengthMismatchError'
   }
 export class AbiEncodingArrayLengthMismatchError extends BaseError {
-  override name = 'AbiEncodingArrayLengthMismatchError'
   constructor({
     expectedLength,
     givenLength,
@@ -122,6 +123,7 @@ export class AbiEncodingArrayLengthMismatchError extends BaseError {
         `Expected length: ${expectedLength}`,
         `Given length: ${givenLength}`,
       ].join('\n'),
+      { name: 'AbiEncodingArrayLengthMismatchError' },
     )
   }
 }
@@ -131,12 +133,12 @@ export type AbiEncodingBytesSizeMismatchErrorType =
     name: 'AbiEncodingBytesSizeMismatchError'
   }
 export class AbiEncodingBytesSizeMismatchError extends BaseError {
-  override name = 'AbiEncodingBytesSizeMismatchError'
   constructor({ expectedSize, value }: { expectedSize: number; value: Hex }) {
     super(
       `Size of bytes "${value}" (bytes${size(
         value,
       )}) does not match expected size (bytes${expectedSize}).`,
+      { name: 'AbiEncodingBytesSizeMismatchError' },
     )
   }
 }
@@ -146,7 +148,6 @@ export type AbiEncodingLengthMismatchErrorType =
     name: 'AbiEncodingLengthMismatchError'
   }
 export class AbiEncodingLengthMismatchError extends BaseError {
-  override name = 'AbiEncodingLengthMismatchError'
   constructor({
     expectedLength,
     givenLength,
@@ -157,6 +158,7 @@ export class AbiEncodingLengthMismatchError extends BaseError {
         `Expected length (params): ${expectedLength}`,
         `Given length (values): ${givenLength}`,
       ].join('\n'),
+      { name: 'AbiEncodingLengthMismatchError' },
     )
   }
 }
@@ -165,7 +167,6 @@ export type AbiErrorInputsNotFoundErrorType = AbiErrorInputsNotFoundError & {
   name: 'AbiErrorInputsNotFoundError'
 }
 export class AbiErrorInputsNotFoundError extends BaseError {
-  override name = 'AbiErrorInputsNotFoundError'
   constructor(errorName: string, { docsPath }: { docsPath: string }) {
     super(
       [
@@ -175,6 +176,7 @@ export class AbiErrorInputsNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiErrorInputsNotFoundError',
       },
     )
   }
@@ -184,7 +186,6 @@ export type AbiErrorNotFoundErrorType = AbiErrorNotFoundError & {
   name: 'AbiErrorNotFoundError'
 }
 export class AbiErrorNotFoundError extends BaseError {
-  override name = 'AbiErrorNotFoundError'
   constructor(
     errorName?: string | undefined,
     { docsPath }: { docsPath?: string | undefined } = {},
@@ -196,6 +197,7 @@ export class AbiErrorNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiErrorNotFoundError',
       },
     )
   }
@@ -206,8 +208,6 @@ export type AbiErrorSignatureNotFoundErrorType =
     name: 'AbiErrorSignatureNotFoundError'
   }
 export class AbiErrorSignatureNotFoundError extends BaseError {
-  override name = 'AbiErrorSignatureNotFoundError'
-
   signature: Hex
 
   constructor(signature: Hex, { docsPath }: { docsPath: string }) {
@@ -219,6 +219,7 @@ export class AbiErrorSignatureNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiErrorSignatureNotFoundError',
       },
     )
     this.signature = signature
@@ -230,10 +231,10 @@ export type AbiEventSignatureEmptyTopicsErrorType =
     name: 'AbiEventSignatureEmptyTopicsError'
   }
 export class AbiEventSignatureEmptyTopicsError extends BaseError {
-  override name = 'AbiEventSignatureEmptyTopicsError'
   constructor({ docsPath }: { docsPath: string }) {
     super('Cannot extract event signature from empty topics.', {
       docsPath,
+      name: 'AbiEventSignatureEmptyTopicsError',
     })
   }
 }
@@ -243,7 +244,6 @@ export type AbiEventSignatureNotFoundErrorType =
     name: 'AbiEventSignatureNotFoundError'
   }
 export class AbiEventSignatureNotFoundError extends BaseError {
-  override name = 'AbiEventSignatureNotFoundError'
   constructor(signature: Hex, { docsPath }: { docsPath: string }) {
     super(
       [
@@ -253,6 +253,7 @@ export class AbiEventSignatureNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiEventSignatureNotFoundError',
       },
     )
   }
@@ -262,7 +263,6 @@ export type AbiEventNotFoundErrorType = AbiEventNotFoundError & {
   name: 'AbiEventNotFoundError'
 }
 export class AbiEventNotFoundError extends BaseError {
-  override name = 'AbiEventNotFoundError'
   constructor(
     eventName?: string | undefined,
     { docsPath }: { docsPath?: string | undefined } = {},
@@ -274,6 +274,7 @@ export class AbiEventNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiEventNotFoundError',
       },
     )
   }
@@ -283,7 +284,6 @@ export type AbiFunctionNotFoundErrorType = AbiFunctionNotFoundError & {
   name: 'AbiFunctionNotFoundError'
 }
 export class AbiFunctionNotFoundError extends BaseError {
-  override name = 'AbiFunctionNotFoundError'
   constructor(
     functionName?: string | undefined,
     { docsPath }: { docsPath?: string | undefined } = {},
@@ -295,6 +295,7 @@ export class AbiFunctionNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiFunctionNotFoundError',
       },
     )
   }
@@ -305,7 +306,6 @@ export type AbiFunctionOutputsNotFoundErrorType =
     name: 'AbiFunctionOutputsNotFoundError'
   }
 export class AbiFunctionOutputsNotFoundError extends BaseError {
-  override name = 'AbiFunctionOutputsNotFoundError'
   constructor(functionName: string, { docsPath }: { docsPath: string }) {
     super(
       [
@@ -315,6 +315,7 @@ export class AbiFunctionOutputsNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiFunctionOutputsNotFoundError',
       },
     )
   }
@@ -325,7 +326,6 @@ export type AbiFunctionSignatureNotFoundErrorType =
     name: 'AbiFunctionSignatureNotFoundError'
   }
 export class AbiFunctionSignatureNotFoundError extends BaseError {
-  override name = 'AbiFunctionSignatureNotFoundError'
   constructor(signature: Hex, { docsPath }: { docsPath: string }) {
     super(
       [
@@ -335,6 +335,7 @@ export class AbiFunctionSignatureNotFoundError extends BaseError {
       ].join('\n'),
       {
         docsPath,
+        name: 'AbiFunctionSignatureNotFoundError',
       },
     )
   }
@@ -344,7 +345,6 @@ export type AbiItemAmbiguityErrorType = AbiItemAmbiguityError & {
   name: 'AbiItemAmbiguityError'
 }
 export class AbiItemAmbiguityError extends BaseError {
-  override name = 'AbiItemAmbiguityError'
   constructor(
     x: { abiItem: Abi[number]; type: string },
     y: { abiItem: Abi[number]; type: string },
@@ -357,6 +357,7 @@ export class AbiItemAmbiguityError extends BaseError {
         'These types encode differently and cannot be distinguished at runtime.',
         'Remove one of the ambiguous items in the ABI.',
       ],
+      name: 'AbiItemAmbiguityError',
     })
   }
 }
@@ -365,12 +366,13 @@ export type BytesSizeMismatchErrorType = BytesSizeMismatchError & {
   name: 'BytesSizeMismatchError'
 }
 export class BytesSizeMismatchError extends BaseError {
-  override name = 'BytesSizeMismatchError'
   constructor({
     expectedSize,
     givenSize,
   }: { expectedSize: number; givenSize: number }) {
-    super(`Expected bytes${expectedSize}, got bytes${givenSize}.`)
+    super(`Expected bytes${expectedSize}, got bytes${givenSize}.`, {
+      name: 'BytesSizeMismatchError',
+    })
   }
 }
 
@@ -378,8 +380,6 @@ export type DecodeLogDataMismatchErrorType = DecodeLogDataMismatch & {
   name: 'DecodeLogDataMismatch'
 }
 export class DecodeLogDataMismatch extends BaseError {
-  override name = 'DecodeLogDataMismatch'
-
   abiItem: AbiEvent
   data: Hex
   params: readonly AbiParameter[]
@@ -405,6 +405,7 @@ export class DecodeLogDataMismatch extends BaseError {
           `Params: (${formatAbiParams(params, { includeName: true })})`,
           `Data:   ${data} (${size} bytes)`,
         ],
+        name: 'DecodeLogDataMismatch',
       },
     )
 
@@ -419,8 +420,6 @@ export type DecodeLogTopicsMismatchErrorType = DecodeLogTopicsMismatch & {
   name: 'DecodeLogTopicsMismatch'
 }
 export class DecodeLogTopicsMismatch extends BaseError {
-  override name = 'DecodeLogTopicsMismatch'
-
   abiItem: AbiEvent
 
   constructor({
@@ -436,6 +435,7 @@ export class DecodeLogTopicsMismatch extends BaseError {
           param.name ? ` "${param.name}"` : ''
         } on event "${formatAbiItem(abiItem, { includeName: true })}".`,
       ].join('\n'),
+      { name: 'DecodeLogTopicsMismatch' },
     )
 
     this.abiItem = abiItem
@@ -446,14 +446,13 @@ export type InvalidAbiEncodingTypeErrorType = InvalidAbiEncodingTypeError & {
   name: 'InvalidAbiEncodingTypeError'
 }
 export class InvalidAbiEncodingTypeError extends BaseError {
-  override name = 'InvalidAbiEncodingType'
   constructor(type: string, { docsPath }: { docsPath: string }) {
     super(
       [
         `Type "${type}" is not a valid encoding type.`,
         'Please provide a valid ABI type.',
       ].join('\n'),
-      { docsPath },
+      { docsPath, name: 'InvalidAbiEncodingType' },
     )
   }
 }
@@ -462,14 +461,13 @@ export type InvalidAbiDecodingTypeErrorType = InvalidAbiDecodingTypeError & {
   name: 'InvalidAbiDecodingTypeError'
 }
 export class InvalidAbiDecodingTypeError extends BaseError {
-  override name = 'InvalidAbiDecodingType'
   constructor(type: string, { docsPath }: { docsPath: string }) {
     super(
       [
         `Type "${type}" is not a valid decoding type.`,
         'Please provide a valid ABI type.',
       ].join('\n'),
-      { docsPath },
+      { docsPath, name: 'InvalidAbiDecodingType' },
     )
   }
 }
@@ -478,9 +476,10 @@ export type InvalidArrayErrorType = InvalidArrayError & {
   name: 'InvalidArrayError'
 }
 export class InvalidArrayError extends BaseError {
-  override name = 'InvalidArrayError'
   constructor(value: unknown) {
-    super([`Value "${value}" is not a valid array.`].join('\n'))
+    super([`Value "${value}" is not a valid array.`].join('\n'), {
+      name: 'InvalidArrayError',
+    })
   }
 }
 
@@ -488,13 +487,13 @@ export type InvalidDefinitionTypeErrorType = InvalidDefinitionTypeError & {
   name: 'InvalidDefinitionTypeError'
 }
 export class InvalidDefinitionTypeError extends BaseError {
-  override name = 'InvalidDefinitionTypeError'
   constructor(type: string) {
     super(
       [
         `"${type}" is not a valid definition type.`,
         'Valid types: "function", "event", "error"',
       ].join('\n'),
+      { name: 'InvalidDefinitionTypeError' },
     )
   }
 }
@@ -503,8 +502,9 @@ export type UnsupportedPackedAbiTypeErrorType = UnsupportedPackedAbiType & {
   name: 'UnsupportedPackedAbiType'
 }
 export class UnsupportedPackedAbiType extends BaseError {
-  override name = 'UnsupportedPackedAbiType'
   constructor(type: unknown) {
-    super(`Type "${type}" is not supported for packed encoding.`)
+    super(`Type "${type}" is not supported for packed encoding.`, {
+      name: 'UnsupportedPackedAbiType',
+    })
   }
 }

--- a/src/errors/account.ts
+++ b/src/errors/account.ts
@@ -4,7 +4,6 @@ export type AccountNotFoundErrorType = AccountNotFoundError & {
   name: 'AccountNotFoundError'
 }
 export class AccountNotFoundError extends BaseError {
-  override name = 'AccountNotFoundError'
   constructor({ docsPath }: { docsPath?: string | undefined } = {}) {
     super(
       [
@@ -14,6 +13,7 @@ export class AccountNotFoundError extends BaseError {
       {
         docsPath,
         docsSlug: 'account',
+        name: 'AccountNotFoundError',
       },
     )
   }
@@ -23,7 +23,6 @@ export type AccountTypeNotSupportedErrorType = AccountTypeNotSupportedError & {
   name: 'AccountTypeNotSupportedError'
 }
 export class AccountTypeNotSupportedError extends BaseError {
-  override name = 'AccountTypeNotSupportedError'
   constructor({
     docsPath,
     metaMessages,
@@ -36,6 +35,7 @@ export class AccountTypeNotSupportedError extends BaseError {
     super(`Account type "${type}" is not supported.`, {
       docsPath,
       metaMessages,
+      name: 'AccountTypeNotSupportedError',
     })
   }
 }

--- a/src/errors/address.ts
+++ b/src/errors/address.ts
@@ -4,13 +4,13 @@ export type InvalidAddressErrorType = InvalidAddressError & {
   name: 'InvalidAddressError'
 }
 export class InvalidAddressError extends BaseError {
-  override name = 'InvalidAddressError'
   constructor({ address }: { address: string }) {
     super(`Address "${address}" is invalid.`, {
       metaMessages: [
         '- Address must be a hex value of 20 bytes (40 hex characters).',
         '- Address must match its checksum counterpart.',
       ],
+      name: 'InvalidAddressError',
     })
   }
 }

--- a/src/errors/blob.ts
+++ b/src/errors/blob.ts
@@ -7,10 +7,10 @@ export type BlobSizeTooLargeErrorType = BlobSizeTooLargeError & {
   name: 'BlobSizeTooLargeError'
 }
 export class BlobSizeTooLargeError extends BaseError {
-  override name = 'BlobSizeTooLargeError'
   constructor({ maxSize, size }: { maxSize: number; size: number }) {
     super('Blob size is too large.', {
       metaMessages: [`Max: ${maxSize} bytes`, `Given: ${size} bytes`],
+      name: 'BlobSizeTooLargeError',
     })
   }
 }
@@ -19,9 +19,8 @@ export type EmptyBlobErrorType = EmptyBlobError & {
   name: 'EmptyBlobError'
 }
 export class EmptyBlobError extends BaseError {
-  override name = 'EmptyBlobError'
   constructor() {
-    super('Blob data must not be empty.')
+    super('Blob data must not be empty.', { name: 'EmptyBlobError' })
   }
 }
 
@@ -30,7 +29,6 @@ export type InvalidVersionedHashSizeErrorType =
     name: 'InvalidVersionedHashSizeError'
   }
 export class InvalidVersionedHashSizeError extends BaseError {
-  override name = 'InvalidVersionedHashSizeError'
   constructor({
     hash,
     size,
@@ -40,6 +38,7 @@ export class InvalidVersionedHashSizeError extends BaseError {
   }) {
     super(`Versioned hash "${hash}" size is invalid.`, {
       metaMessages: ['Expected: 32', `Received: ${size}`],
+      name: 'InvalidVersionedHashSizeError',
     })
   }
 }
@@ -49,7 +48,6 @@ export type InvalidVersionedHashVersionErrorType =
     name: 'InvalidVersionedHashVersionError'
   }
 export class InvalidVersionedHashVersionError extends BaseError {
-  override name = 'InvalidVersionedHashVersionError'
   constructor({
     hash,
     version,
@@ -62,6 +60,7 @@ export class InvalidVersionedHashVersionError extends BaseError {
         `Expected: ${versionedHashVersionKzg}`,
         `Received: ${version}`,
       ],
+      name: 'InvalidVersionedHashVersionError',
     })
   }
 }

--- a/src/errors/block.ts
+++ b/src/errors/block.ts
@@ -6,7 +6,6 @@ export type BlockNotFoundErrorType = BlockNotFoundError & {
   name: 'BlockNotFoundError'
 }
 export class BlockNotFoundError extends BaseError {
-  override name = 'BlockNotFoundError'
   constructor({
     blockHash,
     blockNumber,
@@ -17,6 +16,6 @@ export class BlockNotFoundError extends BaseError {
     let identifier = 'Block'
     if (blockHash) identifier = `Block at hash "${blockHash}"`
     if (blockNumber) identifier = `Block at number "${blockNumber}"`
-    super(`${identifier} could not be found.`)
+    super(`${identifier} could not be found.`, { name: 'BlockNotFoundError' })
   }
 }

--- a/src/errors/ccip.ts
+++ b/src/errors/ccip.ts
@@ -10,7 +10,6 @@ export type OffchainLookupErrorType = OffchainLookupError & {
   name: 'OffchainLookupError'
 }
 export class OffchainLookupError extends BaseError {
-  override name = 'OffchainLookupError'
   constructor({
     callbackSelector,
     cause,
@@ -44,6 +43,7 @@ export class OffchainLookupError extends BaseError {
           `  Callback selector: ${callbackSelector}`,
           `  Extra data: ${extraData}`,
         ].flat(),
+        name: 'OffchainLookupError',
       },
     )
   }
@@ -54,7 +54,6 @@ export type OffchainLookupResponseMalformedErrorType =
     name: 'OffchainLookupResponseMalformedError'
   }
 export class OffchainLookupResponseMalformedError extends BaseError {
-  override name = 'OffchainLookupResponseMalformedError'
   constructor({ result, url }: { result: any; url: string }) {
     super(
       'Offchain gateway response is malformed. Response data must be a hex value.',
@@ -63,6 +62,7 @@ export class OffchainLookupResponseMalformedError extends BaseError {
           `Gateway URL: ${getUrl(url)}`,
           `Response: ${stringify(result)}`,
         ],
+        name: 'OffchainLookupResponseMalformedError',
       },
     )
   }
@@ -74,7 +74,6 @@ export type OffchainLookupSenderMismatchErrorType =
     name: 'OffchainLookupSenderMismatchError'
   }
 export class OffchainLookupSenderMismatchError extends BaseError {
-  override name = 'OffchainLookupSenderMismatchError'
   constructor({ sender, to }: { sender: Address; to: Address }) {
     super(
       'Reverted sender address does not match target contract address (`to`).',
@@ -83,6 +82,7 @@ export class OffchainLookupSenderMismatchError extends BaseError {
           `Contract address: ${to}`,
           `OffchainLookup sender address: ${sender}`,
         ],
+        name: 'OffchainLookupSenderMismatchError',
       },
     )
   }

--- a/src/errors/chain.ts
+++ b/src/errors/chain.ts
@@ -7,7 +7,6 @@ export type ChainDoesNotSupportContractErrorType =
     name: 'ChainDoesNotSupportContract'
   }
 export class ChainDoesNotSupportContract extends BaseError {
-  override name = 'ChainDoesNotSupportContract'
   constructor({
     blockNumber,
     chain,
@@ -32,6 +31,7 @@ export class ChainDoesNotSupportContract extends BaseError {
                 `- The chain does not have the contract "${contract.name}" configured.`,
               ]),
         ],
+        name: 'ChainDoesNotSupportContract',
       },
     )
   }
@@ -41,8 +41,6 @@ export type ChainMismatchErrorType = ChainMismatchError & {
   name: 'ChainMismatchError'
 }
 export class ChainMismatchError extends BaseError {
-  override name = 'ChainMismatchError'
-
   constructor({
     chain,
     currentChainId,
@@ -57,6 +55,7 @@ export class ChainMismatchError extends BaseError {
           `Current Chain ID:  ${currentChainId}`,
           `Expected Chain ID: ${chain.id} – ${chain.name}`,
         ],
+        name: 'ChainMismatchError',
       },
     )
   }
@@ -66,14 +65,15 @@ export type ChainNotFoundErrorType = ChainNotFoundError & {
   name: 'ChainNotFoundError'
 }
 export class ChainNotFoundError extends BaseError {
-  override name = 'ChainNotFoundError'
-
   constructor() {
     super(
       [
         'No chain was provided to the request.',
         'Please provide a chain with the `chain` argument on the Action, or by supplying a `chain` to WalletClient.',
       ].join('\n'),
+      {
+        name: 'ChainNotFoundError',
+      },
     )
   }
 }
@@ -83,10 +83,10 @@ export type ClientChainNotConfiguredErrorType =
     name: 'ClientChainNotConfiguredError'
   }
 export class ClientChainNotConfiguredError extends BaseError {
-  override name = 'ClientChainNotConfiguredError'
-
   constructor() {
-    super('No chain was provided to the Client.')
+    super('No chain was provided to the Client.', {
+      name: 'ClientChainNotConfiguredError',
+    })
   }
 }
 
@@ -94,13 +94,12 @@ export type InvalidChainIdErrorType = InvalidChainIdError & {
   name: 'InvalidChainIdError'
 }
 export class InvalidChainIdError extends BaseError {
-  override name = 'InvalidChainIdError'
-
   constructor({ chainId }: { chainId?: number | undefined }) {
     super(
       typeof chainId === 'number'
         ? `Chain ID "${chainId}" is invalid.`
         : 'Chain ID is invalid.',
+      { name: 'InvalidChainIdError' },
     )
   }
 }

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -27,8 +27,6 @@ export type CallExecutionErrorType = CallExecutionError & {
 export class CallExecutionError extends BaseError {
   override cause: BaseError
 
-  override name = 'CallExecutionError'
-
   constructor(
     cause: BaseError,
     {
@@ -81,6 +79,7 @@ export class CallExecutionError extends BaseError {
         'Raw Call Arguments:',
         prettyArgs,
       ].filter(Boolean) as string[],
+      name: 'CallExecutionError',
     })
     this.cause = cause
   }
@@ -98,8 +97,6 @@ export class ContractFunctionExecutionError extends BaseError {
   formattedArgs?: string | undefined
   functionName: string
   sender?: Address | undefined
-
-  override name = 'ContractFunctionExecutionError'
 
   constructor(
     cause: BaseError,
@@ -155,6 +152,7 @@ export class ContractFunctionExecutionError extends BaseError {
           prettyArgs && 'Contract Call:',
           prettyArgs,
         ].filter(Boolean) as string[],
+        name: 'ContractFunctionExecutionError',
       },
     )
     this.abi = abi
@@ -171,8 +169,6 @@ export type ContractFunctionRevertedErrorType =
     name: 'ContractFunctionRevertedError'
   }
 export class ContractFunctionRevertedError extends BaseError {
-  override name = 'ContractFunctionRevertedError'
-
   data?: DecodeErrorResultReturnType | undefined
   reason?: string | undefined
   signature?: Hex | undefined
@@ -251,6 +247,7 @@ export class ContractFunctionRevertedError extends BaseError {
       {
         cause,
         metaMessages,
+        name: 'ContractFunctionRevertedError',
       },
     )
 
@@ -265,7 +262,6 @@ export type ContractFunctionZeroDataErrorType =
     name: 'ContractFunctionZeroDataError'
   }
 export class ContractFunctionZeroDataError extends BaseError {
-  override name = 'ContractFunctionZeroDataError'
   constructor({ functionName }: { functionName: string }) {
     super(`The contract function "${functionName}" returned no data ("0x").`, {
       metaMessages: [
@@ -274,6 +270,7 @@ export class ContractFunctionZeroDataError extends BaseError {
         '  - The parameters passed to the contract function may be invalid, or',
         '  - The address is not a contract.',
       ],
+      name: 'ContractFunctionZeroDataError',
     })
   }
 }
@@ -283,7 +280,6 @@ export type CounterfactualDeploymentFailedErrorType =
     name: 'CounterfactualDeploymentFailedError'
   }
 export class CounterfactualDeploymentFailedError extends BaseError {
-  override name = 'CounterfactualDeploymentFailedError'
   constructor({ factory }: { factory?: Address | undefined }) {
     super(
       `Deployment for counterfactual contract call failed${
@@ -295,6 +291,7 @@ export class CounterfactualDeploymentFailedError extends BaseError {
           '- The `factory` is a valid contract deployment factory (ie. Create2 Factory, ERC-4337 Factory, etc).',
           '- The `factoryData` is a valid encoded function call for contract deployment function on the factory.',
         ],
+        name: 'CounterfactualDeploymentFailedError',
       },
     )
   }
@@ -305,7 +302,6 @@ export type RawContractErrorType = RawContractError & {
 }
 export class RawContractError extends BaseError {
   code = 3
-  override name = 'RawContractError'
 
   data?: Hex | { data?: Hex | undefined } | undefined
 
@@ -316,7 +312,7 @@ export class RawContractError extends BaseError {
     data?: Hex | { data?: Hex | undefined } | undefined
     message?: string | undefined
   }) {
-    super(message || '')
+    super(message || '', { name: 'RawContractError' })
     this.data = data
   }
 }

--- a/src/errors/cursor.ts
+++ b/src/errors/cursor.ts
@@ -4,9 +4,10 @@ export type NegativeOffsetErrorType = NegativeOffsetError & {
   name: 'NegativeOffsetError'
 }
 export class NegativeOffsetError extends BaseError {
-  override name = 'NegativeOffsetError'
   constructor({ offset }: { offset: number }) {
-    super(`Offset \`${offset}\` cannot be negative.`)
+    super(`Offset \`${offset}\` cannot be negative.`, {
+      name: 'NegativeOffsetError',
+    })
   }
 }
 
@@ -14,10 +15,10 @@ export type PositionOutOfBoundsErrorType = PositionOutOfBoundsError & {
   name: 'PositionOutOfBoundsError'
 }
 export class PositionOutOfBoundsError extends BaseError {
-  override name = 'PositionOutOfBoundsError'
   constructor({ length, position }: { length: number; position: number }) {
     super(
       `Position \`${position}\` is out of bounds (\`0 < position < ${length}\`).`,
+      { name: 'PositionOutOfBoundsError' },
     )
   }
 }
@@ -27,10 +28,10 @@ export type RecursiveReadLimitExceededErrorType =
     name: 'RecursiveReadLimitExceededError'
   }
 export class RecursiveReadLimitExceededError extends BaseError {
-  override name = 'RecursiveReadLimitExceededError'
   constructor({ count, limit }: { count: number; limit: number }) {
     super(
       `Recursive read limit of \`${limit}\` exceeded (recursive read count: \`${count}\`).`,
+      { name: 'RecursiveReadLimitExceededError' },
     )
   }
 }

--- a/src/errors/data.ts
+++ b/src/errors/data.ts
@@ -4,7 +4,6 @@ export type SliceOffsetOutOfBoundsErrorType = SliceOffsetOutOfBoundsError & {
   name: 'SliceOffsetOutOfBoundsError'
 }
 export class SliceOffsetOutOfBoundsError extends BaseError {
-  override name = 'SliceOffsetOutOfBoundsError'
   constructor({
     offset,
     position,
@@ -14,6 +13,7 @@ export class SliceOffsetOutOfBoundsError extends BaseError {
       `Slice ${
         position === 'start' ? 'starting' : 'ending'
       } at offset "${offset}" is out-of-bounds (size: ${size}).`,
+      { name: 'SliceOffsetOutOfBoundsError' },
     )
   }
 }
@@ -22,7 +22,6 @@ export type SizeExceedsPaddingSizeErrorType = SizeExceedsPaddingSizeError & {
   name: 'SizeExceedsPaddingSizeError'
 }
 export class SizeExceedsPaddingSizeError extends BaseError {
-  override name = 'SizeExceedsPaddingSizeError'
   constructor({
     size,
     targetSize,
@@ -36,6 +35,7 @@ export class SizeExceedsPaddingSizeError extends BaseError {
       `${type.charAt(0).toUpperCase()}${type
         .slice(1)
         .toLowerCase()} size (${size}) exceeds padding size (${targetSize}).`,
+      { name: 'SizeExceedsPaddingSizeError' },
     )
   }
 }
@@ -44,7 +44,6 @@ export type InvalidBytesLengthErrorType = InvalidBytesLengthError & {
   name: 'InvalidBytesLengthError'
 }
 export class InvalidBytesLengthError extends BaseError {
-  override name = 'InvalidBytesLengthError'
   constructor({
     size,
     targetSize,
@@ -58,6 +57,7 @@ export class InvalidBytesLengthError extends BaseError {
       `${type.charAt(0).toUpperCase()}${type
         .slice(1)
         .toLowerCase()} is expected to be ${targetSize} ${type} long, but is ${size} ${type} long.`,
+      { name: 'InvalidBytesLengthError' },
     )
   }
 }

--- a/src/errors/eip712.ts
+++ b/src/errors/eip712.ts
@@ -5,7 +5,6 @@ export type Eip712DomainNotFoundErrorType = Eip712DomainNotFoundError & {
   name: 'Eip712DomainNotFoundError'
 }
 export class Eip712DomainNotFoundError extends BaseError {
-  override name = 'Eip712DomainNotFoundError'
   constructor({ address }: { address: Address }) {
     super(`No EIP-712 domain found on contract "${address}".`, {
       metaMessages: [
@@ -14,6 +13,7 @@ export class Eip712DomainNotFoundError extends BaseError {
         '- `eip712Domain()` function exists on the contract.',
         '- `eip712Domain()` function matches signature to ERC-5267 specification.',
       ],
+      name: 'Eip712DomainNotFoundError',
     })
   }
 }

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -6,7 +6,6 @@ export type IntegerOutOfRangeErrorType = IntegerOutOfRangeError & {
   name: 'IntegerOutOfRangeError'
 }
 export class IntegerOutOfRangeError extends BaseError {
-  override name = 'IntegerOutOfRangeError'
   constructor({
     max,
     min,
@@ -24,6 +23,7 @@ export class IntegerOutOfRangeError extends BaseError {
       `Number "${value}" is not in safe ${
         size ? `${size * 8}-bit ${signed ? 'signed' : 'unsigned'} ` : ''
       }integer range ${max ? `(${min} to ${max})` : `(above ${min})`}`,
+      { name: 'IntegerOutOfRangeError' },
     )
   }
 }
@@ -32,10 +32,12 @@ export type InvalidBytesBooleanErrorType = InvalidBytesBooleanError & {
   name: 'InvalidBytesBooleanError'
 }
 export class InvalidBytesBooleanError extends BaseError {
-  override name = 'InvalidBytesBooleanError'
   constructor(bytes: ByteArray) {
     super(
       `Bytes value "${bytes}" is not a valid boolean. The bytes array must contain a single byte of either a 0 or 1 value.`,
+      {
+        name: 'InvalidBytesBooleanError',
+      },
     )
   }
 }
@@ -44,10 +46,10 @@ export type InvalidHexBooleanErrorType = InvalidHexBooleanError & {
   name: 'InvalidHexBooleanError'
 }
 export class InvalidHexBooleanError extends BaseError {
-  override name = 'InvalidHexBooleanError'
   constructor(hex: Hex) {
     super(
       `Hex value "${hex}" is not a valid boolean. The hex value must be "0x0" (false) or "0x1" (true).`,
+      { name: 'InvalidHexBooleanError' },
     )
   }
 }
@@ -56,10 +58,10 @@ export type InvalidHexValueErrorType = InvalidHexValueError & {
   name: 'InvalidHexValueError'
 }
 export class InvalidHexValueError extends BaseError {
-  override name = 'InvalidHexValueError'
   constructor(value: Hex) {
     super(
       `Hex value "${value}" is an odd length (${value.length}). It must be an even length.`,
+      { name: 'InvalidHexValueError' },
     )
   }
 }
@@ -68,10 +70,10 @@ export type SizeOverflowErrorType = SizeOverflowError & {
   name: 'SizeOverflowError'
 }
 export class SizeOverflowError extends BaseError {
-  override name = 'SizeOverflowError' as const
   constructor({ givenSize, maxSize }: { givenSize: number; maxSize: number }) {
     super(
       `Size cannot exceed ${maxSize} bytes. Given size: ${givenSize} bytes.`,
+      { name: 'SizeOverflowError' },
     )
   }
 }

--- a/src/errors/ens.ts
+++ b/src/errors/ens.ts
@@ -5,7 +5,6 @@ export type EnsAvatarInvalidMetadataErrorType =
     name: 'EnsAvatarInvalidMetadataError'
   }
 export class EnsAvatarInvalidMetadataError extends BaseError {
-  override name = 'EnsAvatarInvalidMetadataError'
   constructor({ data }: { data: any }) {
     super(
       'Unable to extract image from metadata. The metadata may be malformed or invalid.',
@@ -15,6 +14,7 @@ export class EnsAvatarInvalidMetadataError extends BaseError {
           '',
           `Provided data: ${JSON.stringify(data)}`,
         ],
+        name: 'EnsAvatarInvalidMetadataError',
       },
     )
   }
@@ -24,9 +24,10 @@ export type EnsAvatarInvalidNftUriErrorType = EnsAvatarInvalidNftUriError & {
   name: 'EnsAvatarInvalidNftUriError'
 }
 export class EnsAvatarInvalidNftUriError extends BaseError {
-  override name = 'EnsAvatarInvalidNftUriError'
   constructor({ reason }: { reason: string }) {
-    super(`ENS NFT avatar URI is invalid. ${reason}`)
+    super(`ENS NFT avatar URI is invalid. ${reason}`, {
+      name: 'EnsAvatarInvalidNftUriError',
+    })
   }
 }
 
@@ -34,10 +35,10 @@ export type EnsAvatarUriResolutionErrorType = EnsAvatarUriResolutionError & {
   name: 'EnsAvatarUriResolutionError'
 }
 export class EnsAvatarUriResolutionError extends BaseError {
-  override name = 'EnsAvatarUriResolutionError'
   constructor({ uri }: { uri: string }) {
     super(
       `Unable to resolve ENS avatar URI "${uri}". The URI may be malformed, invalid, or does not respond with a valid image.`,
+      { name: 'EnsAvatarUriResolutionError' },
     )
   }
 }
@@ -47,10 +48,10 @@ export type EnsAvatarUnsupportedNamespaceErrorType =
     name: 'EnsAvatarUnsupportedNamespaceError'
   }
 export class EnsAvatarUnsupportedNamespaceError extends BaseError {
-  override name = 'EnsAvatarUnsupportedNamespaceError'
   constructor({ namespace }: { namespace: string }) {
     super(
       `ENS NFT avatar namespace "${namespace}" is not supported. Must be "erc721" or "erc1155".`,
+      { name: 'EnsAvatarUnsupportedNamespaceError' },
     )
   }
 }

--- a/src/errors/estimateGas.ts
+++ b/src/errors/estimateGas.ts
@@ -13,8 +13,6 @@ export type EstimateGasExecutionErrorType = EstimateGasExecutionError & {
 export class EstimateGasExecutionError extends BaseError {
   override cause: BaseError
 
-  override name = 'EstimateGasExecutionError'
-
   constructor(
     cause: BaseError,
     {
@@ -62,6 +60,7 @@ export class EstimateGasExecutionError extends BaseError {
         'Estimate Gas Arguments:',
         prettyArgs,
       ].filter(Boolean) as string[],
+      name: 'EstimateGasExecutionError',
     })
     this.cause = cause
   }

--- a/src/errors/fee.ts
+++ b/src/errors/fee.ts
@@ -5,9 +5,10 @@ export type BaseFeeScalarErrorType = BaseFeeScalarError & {
   name: 'BaseFeeScalarError'
 }
 export class BaseFeeScalarError extends BaseError {
-  override name = 'BaseFeeScalarError'
   constructor() {
-    super('`baseFeeMultiplier` must be greater than 1.')
+    super('`baseFeeMultiplier` must be greater than 1.', {
+      name: 'BaseFeeScalarError',
+    })
   }
 }
 
@@ -15,9 +16,10 @@ export type Eip1559FeesNotSupportedErrorType = Eip1559FeesNotSupportedError & {
   name: 'Eip1559FeesNotSupportedError'
 }
 export class Eip1559FeesNotSupportedError extends BaseError {
-  override name = 'Eip1559FeesNotSupportedError'
   constructor() {
-    super('Chain does not support EIP-1559 fees.')
+    super('Chain does not support EIP-1559 fees.', {
+      name: 'Eip1559FeesNotSupportedError',
+    })
   }
 }
 
@@ -25,12 +27,12 @@ export type MaxFeePerGasTooLowErrorType = MaxFeePerGasTooLowError & {
   name: 'MaxFeePerGasTooLowError'
 }
 export class MaxFeePerGasTooLowError extends BaseError {
-  override name = 'MaxFeePerGasTooLowError'
   constructor({ maxPriorityFeePerGas }: { maxPriorityFeePerGas: bigint }) {
     super(
       `\`maxFeePerGas\` cannot be less than the \`maxPriorityFeePerGas\` (${formatGwei(
         maxPriorityFeePerGas,
       )} gwei).`,
+      { name: 'MaxFeePerGasTooLowError' },
     )
   }
 }

--- a/src/errors/log.ts
+++ b/src/errors/log.ts
@@ -4,8 +4,9 @@ export type FilterTypeNotSupportedErrorType = FilterTypeNotSupportedError & {
   name: 'FilterTypeNotSupportedError'
 }
 export class FilterTypeNotSupportedError extends BaseError {
-  override name = 'FilterTypeNotSupportedError'
   constructor(type: string) {
-    super(`Filter type "${type}" is not supported.`)
+    super(`Filter type "${type}" is not supported.`, {
+      name: 'FilterTypeNotSupportedError',
+    })
   }
 }

--- a/src/errors/node.test.ts
+++ b/src/errors/node.test.ts
@@ -25,14 +25,14 @@ test('FeeCapTooHighError', () => {
     ),
   })
   expect(error).toMatchInlineSnapshot(`
-    [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 420124124012041204024020140124120401281273891237128937128937128737912371283791 gwei) cannot be higher than the maximum allowed value (2^256-1).
+    [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 420124124012041204024020140124120401281273891237128937128937128737912371283791 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
     Version: viem@x.y.z]
   `)
 
   error = new FeeCapTooHighError({ cause: new BaseError('foo') })
   expect(error).toMatchInlineSnapshot(`
-    [FeeCapTooHigh: The fee cap (\`maxFeePerGas\`) cannot be higher than the maximum allowed value (2^256-1).
+    [FeeCapTooHighError: The fee cap (\`maxFeePerGas\`) cannot be higher than the maximum allowed value (2^256-1).
 
     Version: viem@x.y.z]
   `)
@@ -44,14 +44,14 @@ test('FeeCapTooLowError', () => {
     maxFeePerGas: parseGwei('1'),
   })
   expect(error).toMatchInlineSnapshot(`
-    [FeeCapTooLow: The fee cap (\`maxFeePerGas\` = 1 gwei) cannot be lower than the block base fee.
+    [FeeCapTooLowError: The fee cap (\`maxFeePerGas\` = 1 gwei) cannot be lower than the block base fee.
 
     Version: viem@x.y.z]
   `)
 
   error = new FeeCapTooLowError({ cause: new BaseError('foo') })
   expect(error).toMatchInlineSnapshot(`
-    [FeeCapTooLow: The fee cap (\`maxFeePerGas\` gwei) cannot be lower than the block base fee.
+    [FeeCapTooLowError: The fee cap (\`maxFeePerGas\` gwei) cannot be lower than the block base fee.
 
     Version: viem@x.y.z]
   `)

--- a/src/errors/node.ts
+++ b/src/errors/node.ts
@@ -19,8 +19,6 @@ export class ExecutionRevertedError extends BaseError {
   static code = 3
   static nodeMessage = /execution reverted/
 
-  override name = 'ExecutionRevertedError'
-
   constructor({
     cause,
     message,
@@ -34,6 +32,7 @@ export class ExecutionRevertedError extends BaseError {
       }.`,
       {
         cause,
+        name: 'ExecutionRevertedError',
       },
     )
   }
@@ -45,7 +44,6 @@ export type FeeCapTooHighErrorType = FeeCapTooHighError & {
 export class FeeCapTooHighError extends BaseError {
   static nodeMessage =
     /max fee per gas higher than 2\^256-1|fee cap higher than 2\^256-1/
-  override name = 'FeeCapTooHigh'
   constructor({
     cause,
     maxFeePerGas,
@@ -59,6 +57,7 @@ export class FeeCapTooHighError extends BaseError {
       }) cannot be higher than the maximum allowed value (2^256-1).`,
       {
         cause,
+        name: 'FeeCapTooHighError',
       },
     )
   }
@@ -70,7 +69,6 @@ export type FeeCapTooLowErrorType = FeeCapTooLowError & {
 export class FeeCapTooLowError extends BaseError {
   static nodeMessage =
     /max fee per gas less than block base fee|fee cap less than block base fee|transaction is outdated/
-  override name = 'FeeCapTooLow'
   constructor({
     cause,
     maxFeePerGas,
@@ -84,6 +82,7 @@ export class FeeCapTooLowError extends BaseError {
       } gwei) cannot be lower than the block base fee.`,
       {
         cause,
+        name: 'FeeCapTooLowError',
       },
     )
   }
@@ -94,7 +93,6 @@ export type NonceTooHighErrorType = NonceTooHighError & {
 }
 export class NonceTooHighError extends BaseError {
   static nodeMessage = /nonce too high/
-  override name = 'NonceTooHighError'
   constructor({
     cause,
     nonce,
@@ -103,7 +101,7 @@ export class NonceTooHighError extends BaseError {
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
       }is higher than the next one expected.`,
-      { cause },
+      { cause, name: 'NonceTooHighError' },
     )
   }
 }
@@ -114,7 +112,6 @@ export type NonceTooLowErrorType = NonceTooLowError & {
 export class NonceTooLowError extends BaseError {
   static nodeMessage =
     /nonce too low|transaction already imported|already known/
-  override name = 'NonceTooLowError'
   constructor({
     cause,
     nonce,
@@ -126,7 +123,7 @@ export class NonceTooLowError extends BaseError {
         }is lower than the current nonce of the account.`,
         'Try increasing the nonce or find the latest nonce with `getTransactionCount`.',
       ].join('\n'),
-      { cause },
+      { cause, name: 'NonceTooLowError' },
     )
   }
 }
@@ -136,7 +133,6 @@ export type NonceMaxValueErrorType = NonceMaxValueError & {
 }
 export class NonceMaxValueError extends BaseError {
   static nodeMessage = /nonce has max value/
-  override name = 'NonceMaxValueError'
   constructor({
     cause,
     nonce,
@@ -145,7 +141,7 @@ export class NonceMaxValueError extends BaseError {
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
       }exceeds the maximum allowed nonce.`,
-      { cause },
+      { cause, name: 'NonceMaxValueError' },
     )
   }
 }
@@ -155,7 +151,6 @@ export type InsufficientFundsErrorType = InsufficientFundsError & {
 }
 export class InsufficientFundsError extends BaseError {
   static nodeMessage = /insufficient funds/
-  override name = 'InsufficientFundsError'
   constructor({ cause }: { cause?: BaseError | undefined } = {}) {
     super(
       [
@@ -173,6 +168,7 @@ export class InsufficientFundsError extends BaseError {
           ' - `gas fee` is the gas fee,',
           ' - `value` is the amount of ether to send to the recipient.',
         ],
+        name: 'InsufficientFundsError',
       },
     )
   }
@@ -183,7 +179,6 @@ export type IntrinsicGasTooHighErrorType = IntrinsicGasTooHighError & {
 }
 export class IntrinsicGasTooHighError extends BaseError {
   static nodeMessage = /intrinsic gas too high|gas limit reached/
-  override name = 'IntrinsicGasTooHighError'
   constructor({
     cause,
     gas,
@@ -194,6 +189,7 @@ export class IntrinsicGasTooHighError extends BaseError {
       }provided for the transaction exceeds the limit allowed for the block.`,
       {
         cause,
+        name: 'IntrinsicGasTooHighError',
       },
     )
   }
@@ -204,7 +200,6 @@ export type IntrinsicGasTooLowErrorType = IntrinsicGasTooLowError & {
 }
 export class IntrinsicGasTooLowError extends BaseError {
   static nodeMessage = /intrinsic gas too low/
-  override name = 'IntrinsicGasTooLowError'
   constructor({
     cause,
     gas,
@@ -215,6 +210,7 @@ export class IntrinsicGasTooLowError extends BaseError {
       }provided for the transaction is too low.`,
       {
         cause,
+        name: 'IntrinsicGasTooLowError',
       },
     )
   }
@@ -226,10 +222,10 @@ export type TransactionTypeNotSupportedErrorType =
   }
 export class TransactionTypeNotSupportedError extends BaseError {
   static nodeMessage = /transaction type not valid/
-  override name = 'TransactionTypeNotSupportedError'
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super('The transaction type is not supported for this chain.', {
       cause,
+      name: 'TransactionTypeNotSupportedError',
     })
   }
 }
@@ -240,7 +236,6 @@ export type TipAboveFeeCapErrorType = TipAboveFeeCapError & {
 export class TipAboveFeeCapError extends BaseError {
   static nodeMessage =
     /max priority fee per gas higher than max fee per gas|tip higher than fee cap/
-  override name = 'TipAboveFeeCapError'
   constructor({
     cause,
     maxPriorityFeePerGas,
@@ -262,6 +257,7 @@ export class TipAboveFeeCapError extends BaseError {
       ].join('\n'),
       {
         cause,
+        name: 'TipAboveFeeCapError',
       },
     )
   }
@@ -271,11 +267,10 @@ export type UnknownNodeErrorType = UnknownNodeError & {
   name: 'UnknownNodeError'
 }
 export class UnknownNodeError extends BaseError {
-  override name = 'UnknownNodeError'
-
   constructor({ cause }: { cause?: BaseError | undefined }) {
     super(`An error occurred while executing: ${cause?.shortMessage}`, {
       cause,
+      name: 'UnknownNodeError',
     })
   }
 }

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -7,8 +7,6 @@ export type HttpRequestErrorType = HttpRequestError & {
   name: 'HttpRequestError'
 }
 export class HttpRequestError extends BaseError {
-  override name = 'HttpRequestError'
-
   body?: { [x: string]: unknown } | { [y: string]: unknown }[] | undefined
   headers?: Headers | undefined
   status?: number | undefined
@@ -37,6 +35,7 @@ export class HttpRequestError extends BaseError {
         `URL: ${getUrl(url)}`,
         body && `Request body: ${stringify(body)}`,
       ].filter(Boolean) as string[],
+      name: 'HttpRequestError',
     })
     this.body = body
     this.headers = headers
@@ -49,8 +48,6 @@ export type WebSocketRequestErrorType = WebSocketRequestError & {
   name: 'WebSocketRequestError'
 }
 export class WebSocketRequestError extends BaseError {
-  override name = 'WebSocketRequestError'
-
   constructor({
     body,
     cause,
@@ -69,6 +66,7 @@ export class WebSocketRequestError extends BaseError {
         `URL: ${getUrl(url)}`,
         body && `Request body: ${stringify(body)}`,
       ].filter(Boolean) as string[],
+      name: 'WebSocketRequestError',
     })
   }
 }
@@ -77,8 +75,6 @@ export type RpcRequestErrorType = RpcRequestError & {
   name: 'RpcRequestError'
 }
 export class RpcRequestError extends BaseError {
-  override name = 'RpcRequestError'
-
   code: number
 
   constructor({
@@ -94,6 +90,7 @@ export class RpcRequestError extends BaseError {
       cause: error as any,
       details: error.message,
       metaMessages: [`URL: ${getUrl(url)}`, `Request body: ${stringify(body)}`],
+      name: 'RpcRequestError',
     })
     this.code = error.code
   }
@@ -103,8 +100,6 @@ export type SocketClosedErrorType = SocketClosedError & {
   name: 'SocketClosedError'
 }
 export class SocketClosedError extends BaseError {
-  override name = 'SocketClosedError'
-
   constructor({
     url,
   }: {
@@ -112,6 +107,7 @@ export class SocketClosedError extends BaseError {
   } = {}) {
     super('The socket has been closed.', {
       metaMessages: [url && `URL: ${getUrl(url)}`].filter(Boolean) as string[],
+      name: 'SocketClosedError',
     })
   }
 }
@@ -120,8 +116,6 @@ export type TimeoutErrorType = TimeoutError & {
   name: 'TimeoutError'
 }
 export class TimeoutError extends BaseError {
-  override name = 'TimeoutError'
-
   constructor({
     body,
     url,
@@ -132,6 +126,7 @@ export class TimeoutError extends BaseError {
     super('The request took too long to respond.', {
       details: 'The request timed out.',
       metaMessages: [`URL: ${getUrl(url)}`, `Request body: ${stringify(body)}`],
+      name: 'TimeoutError',
     })
   }
 }

--- a/src/errors/rpc.test.ts
+++ b/src/errors/rpc.test.ts
@@ -87,7 +87,7 @@ test('ProviderRpcError', () => {
       },
     ),
   ).toMatchInlineSnapshot(`
-    [ProviderRpcError: An internal error was received.
+    [RpcRequestError: An internal error was received.
 
     URL: http://localhost
     Request body: {"foo":"bar"}

--- a/src/errors/rpc.ts
+++ b/src/errors/rpc.ts
@@ -24,6 +24,7 @@ type RpcErrorOptions<code extends number = RpcErrorCode> = {
   code?: code | (number & {}) | undefined
   docsPath?: string | undefined
   metaMessages?: string[] | undefined
+  name?: string | undefined
   shortMessage: string
 }
 
@@ -34,21 +35,26 @@ type RpcErrorOptions<code extends number = RpcErrorCode> = {
  */
 export type RpcErrorType = RpcError & { name: 'RpcError' }
 export class RpcError<code_ extends number = RpcErrorCode> extends BaseError {
-  override name = 'RpcError'
-
   code: code_ | (number & {})
 
   constructor(
     cause: Error,
-    { code, docsPath, metaMessages, shortMessage }: RpcErrorOptions<code_>,
+    {
+      code,
+      docsPath,
+      metaMessages,
+      name,
+      shortMessage,
+    }: RpcErrorOptions<code_>,
   ) {
     super(shortMessage, {
       cause,
       docsPath,
       metaMessages:
         metaMessages || (cause as { metaMessages?: string[] })?.metaMessages,
+      name: name || 'RpcError',
     })
-    this.name = cause.name
+    this.name = name || cause.name
     this.code = (
       cause instanceof RpcRequestError ? cause.code : code ?? unknownErrorCode
     ) as code_
@@ -74,8 +80,6 @@ export type ProviderRpcErrorType = ProviderRpcError & {
 export class ProviderRpcError<
   T = undefined,
 > extends RpcError<ProviderRpcErrorCode> {
-  override name = 'ProviderRpcError'
-
   data?: T | undefined
 
   constructor(
@@ -102,12 +106,12 @@ export type ParseRpcErrorType = ParseRpcError & {
   name: 'ParseRpcError'
 }
 export class ParseRpcError extends RpcError {
-  override name = 'ParseRpcError'
   static code = -32700 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: ParseRpcError.code,
+      name: 'ParseRpcError',
       shortMessage:
         'Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.',
     })
@@ -124,12 +128,12 @@ export type InvalidRequestRpcErrorType = InvalidRequestRpcError & {
   name: 'InvalidRequestRpcError'
 }
 export class InvalidRequestRpcError extends RpcError {
-  override name = 'InvalidRequestRpcError'
   static code = -32600 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: InvalidRequestRpcError.code,
+      name: 'InvalidRequestRpcError',
       shortMessage: 'JSON is not a valid request object.',
     })
   }
@@ -145,12 +149,12 @@ export type MethodNotFoundRpcErrorType = MethodNotFoundRpcError & {
   name: 'MethodNotFoundRpcError'
 }
 export class MethodNotFoundRpcError extends RpcError {
-  override name = 'MethodNotFoundRpcError'
   static code = -32601 as const
 
   constructor(cause: Error, { method }: { method?: string } = {}) {
     super(cause, {
       code: MethodNotFoundRpcError.code,
+      name: 'MethodNotFoundRpcError',
       shortMessage: `The method${method ? ` "${method}"` : ''} does not exist / is not available.`,
     })
   }
@@ -166,12 +170,12 @@ export type InvalidParamsRpcErrorType = InvalidParamsRpcError & {
   name: 'InvalidParamsRpcError'
 }
 export class InvalidParamsRpcError extends RpcError {
-  override name = 'InvalidParamsRpcError'
   static code = -32602 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: InvalidParamsRpcError.code,
+      name: 'InvalidParamsRpcError',
       shortMessage: [
         'Invalid parameters were provided to the RPC method.',
         'Double check you have provided the correct parameters.',
@@ -190,12 +194,12 @@ export type InternalRpcErrorType = InternalRpcError & {
   name: 'InternalRpcError'
 }
 export class InternalRpcError extends RpcError {
-  override name = 'InternalRpcError'
   static code = -32603 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: InternalRpcError.code,
+      name: 'InternalRpcError',
       shortMessage: 'An internal error was received.',
     })
   }
@@ -211,12 +215,12 @@ export type InvalidInputRpcErrorType = InvalidInputRpcError & {
   name: 'InvalidInputRpcError'
 }
 export class InvalidInputRpcError extends RpcError {
-  override name = 'InvalidInputRpcError'
   static code = -32000 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: InvalidInputRpcError.code,
+      name: 'InvalidInputRpcError',
       shortMessage: [
         'Missing or invalid parameters.',
         'Double check you have provided the correct parameters.',
@@ -232,7 +236,6 @@ export class InvalidInputRpcError extends RpcError {
  */
 export type ResourceNotFoundRpcErrorType = ResourceNotFoundRpcError & {
   code: -32001
-  name: 'ResourceNotFoundRpcError'
 }
 export class ResourceNotFoundRpcError extends RpcError {
   override name = 'ResourceNotFoundRpcError'
@@ -241,6 +244,7 @@ export class ResourceNotFoundRpcError extends RpcError {
   constructor(cause: Error) {
     super(cause, {
       code: ResourceNotFoundRpcError.code,
+      name: 'ResourceNotFoundRpcError',
       shortMessage: 'Requested resource not found.',
     })
   }
@@ -256,12 +260,12 @@ export type ResourceUnavailableRpcErrorType = ResourceUnavailableRpcError & {
   name: 'ResourceUnavailableRpcError'
 }
 export class ResourceUnavailableRpcError extends RpcError {
-  override name = 'ResourceUnavailableRpcError'
   static code = -32002 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: ResourceUnavailableRpcError.code,
+      name: 'ResourceUnavailableRpcError',
       shortMessage: 'Requested resource not available.',
     })
   }
@@ -277,12 +281,12 @@ export type TransactionRejectedRpcErrorType = TransactionRejectedRpcError & {
   name: 'TransactionRejectedRpcError'
 }
 export class TransactionRejectedRpcError extends RpcError {
-  override name = 'TransactionRejectedRpcError'
   static code = -32003 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: TransactionRejectedRpcError.code,
+      name: 'TransactionRejectedRpcError',
       shortMessage: 'Transaction creation failed.',
     })
   }
@@ -298,12 +302,12 @@ export type MethodNotSupportedRpcErrorType = MethodNotSupportedRpcError & {
   name: 'MethodNotSupportedRpcError'
 }
 export class MethodNotSupportedRpcError extends RpcError {
-  override name = 'MethodNotSupportedRpcError'
   static code = -32004 as const
 
   constructor(cause: Error, { method }: { method?: string } = {}) {
     super(cause, {
       code: MethodNotSupportedRpcError.code,
+      name: 'MethodNotSupportedRpcError',
       shortMessage: `Method${method ? ` "${method}"` : ''} is not implemented.`,
     })
   }
@@ -319,12 +323,12 @@ export type LimitExceededRpcErrorType = LimitExceededRpcError & {
   name: 'LimitExceededRpcError'
 }
 export class LimitExceededRpcError extends RpcError {
-  override name = 'LimitExceededRpcError'
   static code = -32005 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: LimitExceededRpcError.code,
+      name: 'LimitExceededRpcError',
       shortMessage: 'Request exceeds defined limit.',
     })
   }
@@ -341,12 +345,12 @@ export type JsonRpcVersionUnsupportedErrorType =
     name: 'JsonRpcVersionUnsupportedError'
   }
 export class JsonRpcVersionUnsupportedError extends RpcError {
-  override name = 'JsonRpcVersionUnsupportedError'
   static code = -32006 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: JsonRpcVersionUnsupportedError.code,
+      name: 'JsonRpcVersionUnsupportedError',
       shortMessage: 'Version of JSON-RPC protocol is not supported.',
     })
   }
@@ -362,12 +366,12 @@ export type UserRejectedRequestErrorType = UserRejectedRequestError & {
   name: 'UserRejectedRequestError'
 }
 export class UserRejectedRequestError extends ProviderRpcError {
-  override name = 'UserRejectedRequestError'
   static code = 4001 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: UserRejectedRequestError.code,
+      name: 'UserRejectedRequestError',
       shortMessage: 'User rejected the request.',
     })
   }
@@ -383,12 +387,12 @@ export type UnauthorizedProviderErrorType = UnauthorizedProviderError & {
   name: 'UnauthorizedProviderError'
 }
 export class UnauthorizedProviderError extends ProviderRpcError {
-  override name = 'UnauthorizedProviderError'
   static code = 4100 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: UnauthorizedProviderError.code,
+      name: 'UnauthorizedProviderError',
       shortMessage:
         'The requested method and/or account has not been authorized by the user.',
     })
@@ -406,12 +410,12 @@ export type UnsupportedProviderMethodErrorType =
     name: 'UnsupportedProviderMethodError'
   }
 export class UnsupportedProviderMethodError extends ProviderRpcError {
-  override name = 'UnsupportedProviderMethodError'
   static code = 4200 as const
 
   constructor(cause: Error, { method }: { method?: string } = {}) {
     super(cause, {
       code: UnsupportedProviderMethodError.code,
+      name: 'UnsupportedProviderMethodError',
       shortMessage: `The Provider does not support the requested method${method ? ` " ${method}"` : ''}.`,
     })
   }
@@ -427,12 +431,12 @@ export type ProviderDisconnectedErrorType = ProviderDisconnectedError & {
   name: 'ProviderDisconnectedError'
 }
 export class ProviderDisconnectedError extends ProviderRpcError {
-  override name = 'ProviderDisconnectedError'
   static code = 4900 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: ProviderDisconnectedError.code,
+      name: 'ProviderDisconnectedError',
       shortMessage: 'The Provider is disconnected from all chains.',
     })
   }
@@ -448,12 +452,12 @@ export type ChainDisconnectedErrorType = ChainDisconnectedError & {
   name: 'ChainDisconnectedError'
 }
 export class ChainDisconnectedError extends ProviderRpcError {
-  override name = 'ChainDisconnectedError'
   static code = 4901 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: ChainDisconnectedError.code,
+      name: 'ChainDisconnectedError',
       shortMessage: 'The Provider is not connected to the requested chain.',
     })
   }
@@ -469,12 +473,12 @@ export type SwitchChainErrorType = SwitchChainError & {
   name: 'SwitchChainError'
 }
 export class SwitchChainError extends ProviderRpcError {
-  override name = 'SwitchChainError'
   static code = 4902 as const
 
   constructor(cause: Error) {
     super(cause, {
       code: SwitchChainError.code,
+      name: 'SwitchChainError',
       shortMessage: 'An error occurred when attempting to switch chain.',
     })
   }
@@ -487,10 +491,9 @@ export type UnknownRpcErrorType = UnknownRpcError & {
   name: 'UnknownRpcError'
 }
 export class UnknownRpcError extends RpcError {
-  override name = 'UnknownRpcError'
-
   constructor(cause: Error) {
     super(cause, {
+      name: 'UnknownRpcError',
       shortMessage: 'An unknown RPC error occurred.',
     })
   }

--- a/src/errors/siwe.ts
+++ b/src/errors/siwe.ts
@@ -4,7 +4,6 @@ export type SiweInvalidMessageFieldErrorType = SiweInvalidMessageFieldError & {
   name: 'SiweInvalidMessageFieldError'
 }
 export class SiweInvalidMessageFieldError extends BaseError {
-  override name = 'SiweInvalidMessageFieldError'
   constructor(parameters: {
     docsPath?: string | undefined
     field: string
@@ -13,8 +12,8 @@ export class SiweInvalidMessageFieldError extends BaseError {
     const { docsPath, field, metaMessages } = parameters
     super(`Invalid Sign-In with Ethereum message field "${field}".`, {
       docsPath,
-      docsSlug: 'TODO',
       metaMessages,
+      name: 'SiweInvalidMessageFieldError',
     })
   }
 }

--- a/src/errors/stateOverride.ts
+++ b/src/errors/stateOverride.ts
@@ -6,9 +6,10 @@ export type AccountStateConflictErrorType = AccountStateConflictError & {
 }
 
 export class AccountStateConflictError extends BaseError {
-  override name = 'AccountStateConflictError'
   constructor({ address }: { address: string }) {
-    super(`State for account "${address}" is set multiple times.`)
+    super(`State for account "${address}" is set multiple times.`, {
+      name: 'AccountStateConflictError',
+    })
   }
 }
 
@@ -17,9 +18,10 @@ export type StateAssignmentConflictErrorType = StateAssignmentConflictError & {
 }
 
 export class StateAssignmentConflictError extends BaseError {
-  override name = 'StateAssignmentConflictError'
   constructor() {
-    super('state and stateDiff are set on the same account.')
+    super('state and stateDiff are set on the same account.', {
+      name: 'StateAssignmentConflictError',
+    })
   }
 }
 

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -28,13 +28,13 @@ export type FeeConflictErrorType = FeeConflictError & {
   name: 'FeeConflictError'
 }
 export class FeeConflictError extends BaseError {
-  override name = 'FeeConflictError'
   constructor() {
     super(
       [
         'Cannot specify both a `gasPrice` and a `maxFeePerGas`/`maxPriorityFeePerGas`.',
         'Use `maxFeePerGas`/`maxPriorityFeePerGas` for EIP-1559 compatible networks, and `gasPrice` for others.',
       ].join('\n'),
+      { name: 'FeeConflictError' },
     )
   }
 }
@@ -43,10 +43,10 @@ export type InvalidLegacyVErrorType = InvalidLegacyVError & {
   name: 'InvalidLegacyVError'
 }
 export class InvalidLegacyVError extends BaseError {
-  override name = 'InvalidLegacyVError'
-
   constructor({ v }: { v: bigint }) {
-    super(`Invalid \`v\` value "${v}". Expected 27 or 28.`)
+    super(`Invalid \`v\` value "${v}". Expected 27 or 28.`, {
+      name: 'InvalidLegacyVError',
+    })
   }
 }
 
@@ -55,8 +55,6 @@ export type InvalidSerializableTransactionErrorType =
     name: 'InvalidSerializableTransactionError'
   }
 export class InvalidSerializableTransactionError extends BaseError {
-  override name = 'InvalidSerializableTransactionError'
-
   constructor({ transaction }: { transaction: Record<string, unknown> }) {
     super('Cannot infer a transaction type from provided transaction.', {
       metaMessages: [
@@ -72,6 +70,7 @@ export class InvalidSerializableTransactionError extends BaseError {
         '- an EIP-4844 Transaction with `blobs`, `blobVersionedHashes`, `sidecars`, or',
         '- a Legacy Transaction with `gasPrice`',
       ],
+      name: 'InvalidSerializableTransactionError',
     })
   }
 }
@@ -81,12 +80,12 @@ export type InvalidSerializedTransactionTypeErrorType =
     name: 'InvalidSerializedTransactionTypeError'
   }
 export class InvalidSerializedTransactionTypeError extends BaseError {
-  override name = 'InvalidSerializedTransactionType'
-
   serializedType: Hex
 
   constructor({ serializedType }: { serializedType: Hex }) {
-    super(`Serialized transaction type "${serializedType}" is invalid.`)
+    super(`Serialized transaction type "${serializedType}" is invalid.`, {
+      name: 'InvalidSerializedTransactionType',
+    })
 
     this.serializedType = serializedType
   }
@@ -97,8 +96,6 @@ export type InvalidSerializedTransactionErrorType =
     name: 'InvalidSerializedTransactionError'
   }
 export class InvalidSerializedTransactionError extends BaseError {
-  override name = 'InvalidSerializedTransactionError'
-
   serializedTransaction: Hex
   type: TransactionType
 
@@ -119,6 +116,7 @@ export class InvalidSerializedTransactionError extends BaseError {
         `Serialized Transaction: "${serializedTransaction}"`,
         missing.length > 0 ? `Missing Attributes: ${missing.join(', ')}` : '',
       ].filter(Boolean),
+      name: 'InvalidSerializedTransactionError',
     })
 
     this.serializedTransaction = serializedTransaction
@@ -130,13 +128,12 @@ export type InvalidStorageKeySizeErrorType = InvalidStorageKeySizeError & {
   name: 'InvalidStorageKeySizeError'
 }
 export class InvalidStorageKeySizeError extends BaseError {
-  override name = 'InvalidStorageKeySizeError'
-
   constructor({ storageKey }: { storageKey: Hex }) {
     super(
       `Size for storage key "${storageKey}" is invalid. Expected 32 bytes. Got ${Math.floor(
         (storageKey.length - 2) / 2,
       )} bytes.`,
+      { name: 'InvalidStorageKeySizeError' },
     )
   }
 }
@@ -146,8 +143,6 @@ export type TransactionExecutionErrorType = TransactionExecutionError & {
 }
 export class TransactionExecutionError extends BaseError {
   override cause: BaseError
-
-  override name = 'TransactionExecutionError'
 
   constructor(
     cause: BaseError,
@@ -197,6 +192,7 @@ export class TransactionExecutionError extends BaseError {
         'Request Arguments:',
         prettyArgs,
       ].filter(Boolean) as string[],
+      name: 'TransactionExecutionError',
     })
     this.cause = cause
   }
@@ -206,7 +202,6 @@ export type TransactionNotFoundErrorType = TransactionNotFoundError & {
   name: 'TransactionNotFoundError'
 }
 export class TransactionNotFoundError extends BaseError {
-  override name = 'TransactionNotFoundError'
   constructor({
     blockHash,
     blockNumber,
@@ -228,7 +223,9 @@ export class TransactionNotFoundError extends BaseError {
     if (blockNumber && index !== undefined)
       identifier = `Transaction at block number "${blockNumber}" at index "${index}"`
     if (hash) identifier = `Transaction with hash "${hash}"`
-    super(`${identifier} could not be found.`)
+    super(`${identifier} could not be found.`, {
+      name: 'TransactionNotFoundError',
+    })
   }
 }
 
@@ -237,10 +234,12 @@ export type TransactionReceiptNotFoundErrorType =
     name: 'TransactionReceiptNotFoundError'
   }
 export class TransactionReceiptNotFoundError extends BaseError {
-  override name = 'TransactionReceiptNotFoundError'
   constructor({ hash }: { hash: Hash }) {
     super(
       `Transaction receipt with hash "${hash}" could not be found. The Transaction may not be processed on a block yet.`,
+      {
+        name: 'TransactionReceiptNotFoundError',
+      },
     )
   }
 }
@@ -250,10 +249,10 @@ export type WaitForTransactionReceiptTimeoutErrorType =
     name: 'WaitForTransactionReceiptTimeoutError'
   }
 export class WaitForTransactionReceiptTimeoutError extends BaseError {
-  override name = 'WaitForTransactionReceiptTimeoutError'
   constructor({ hash }: { hash: Hash }) {
     super(
       `Timed out while waiting for transaction with hash "${hash}" to be confirmed.`,
+      { name: 'WaitForTransactionReceiptTimeoutError' },
     )
   }
 }

--- a/src/errors/transport.test.ts
+++ b/src/errors/transport.test.ts
@@ -4,7 +4,7 @@ import { UrlRequiredError } from './transport.js'
 
 test('UrlRequiredError', () => {
   expect(new UrlRequiredError()).toMatchInlineSnapshot(`
-    [ViemError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
+    [UrlRequiredError: No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.
 
     Docs: https://viem.sh/docs/clients/intro
     Version: viem@x.y.z]

--- a/src/errors/transport.ts
+++ b/src/errors/transport.ts
@@ -9,6 +9,7 @@ export class UrlRequiredError extends BaseError {
       'No URL was provided to the Transport. Please provide a valid RPC URL to the Transport.',
       {
         docsPath: '/docs/clients/intro',
+        name: 'UrlRequiredError',
       },
     )
   }

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -1,9 +1,6 @@
 import type { Address } from 'abitype'
 
-import { version } from './version.js'
-
 export type ErrorType<name extends string = 'Error'> = Error & { name: name }
 
 export const getContractAddress = (address: Address) => address
 export const getUrl = (url: string) => url
-export const getVersion = () => `viem@${version}`

--- a/src/experimental/eip5792/actions/sendCalls.test.ts
+++ b/src/experimental/eip5792/actions/sendCalls.test.ts
@@ -167,7 +167,7 @@ test('error: no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/experimental/eip5792/sendCalls#account
+    Docs: https://viem.sh/experimental/eip5792/sendCalls
     Version: viem@x.y.z]
   `)
 })

--- a/src/experimental/solady/actions/signMessage.test.ts
+++ b/src/experimental/solady/actions/signMessage.test.ts
@@ -188,7 +188,7 @@ test('no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/experimental/solady/signMessage#account
+    Docs: https://viem.sh/experimental/solady/signMessage
     Version: viem@x.y.z]
   `,
   )

--- a/src/experimental/solady/actions/signTypedData.test.ts
+++ b/src/experimental/solady/actions/signTypedData.test.ts
@@ -371,7 +371,7 @@ test('no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/experimental/solady/signTypedData#account
+    Docs: https://viem.sh/experimental/solady/signTypedData
     Version: viem@x.y.z]
   `)
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -170,6 +170,7 @@ test('exports', () => {
       "InvalidDefinitionTypeError",
       "UnsupportedPackedAbiType",
       "BaseError",
+      "setErrorConfig",
       "BlockNotFoundError",
       "CallExecutionError",
       "ContractFunctionExecutionError",

--- a/src/index.ts
+++ b/src/index.ts
@@ -710,7 +710,7 @@ export {
   UnsupportedPackedAbiType,
   type UnsupportedPackedAbiTypeErrorType,
 } from './errors/abi.js'
-export { BaseError, type BaseErrorType } from './errors/base.js'
+export { BaseError, type BaseErrorType, setErrorConfig } from './errors/base.js'
 export {
   BlockNotFoundError,
   type BlockNotFoundErrorType,

--- a/src/op-stack/errors/withdrawal.ts
+++ b/src/op-stack/errors/withdrawal.ts
@@ -5,9 +5,8 @@ export type GameNotFoundErrorType = GameNotFoundError & {
   name: 'GameNotFoundError'
 }
 export class GameNotFoundError extends BaseError {
-  override name = 'GameNotFoundError'
   constructor() {
-    super('Dispute game not found.')
+    super('Dispute game not found.', { name: 'GameNotFoundError' })
   }
 }
 
@@ -16,10 +15,10 @@ export type ReceiptContainsNoWithdrawalsErrorType =
     name: 'ReceiptContainsNoWithdrawalsError'
   }
 export class ReceiptContainsNoWithdrawalsError extends BaseError {
-  override name = 'ReceiptContainsNoWithdrawalsError'
   constructor({ hash }: { hash: Hex }) {
     super(
       `The provided transaction receipt with hash "${hash}" contains no withdrawals.`,
+      { name: 'ReceiptContainsNoWithdrawalsError' },
     )
   }
 }

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1790,7 +1790,7 @@ test('https://github.com/wevm/viem/issues/1960', () => {
       [['true']],
     ),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: Invalid boolean value: "true" (type: string). Expected: \`true\` or \`false\`.
+    [BaseError: Invalid boolean value: "true" (type: string). Expected: \`true\` or \`false\`.
 
     Version: viem@x.y.z]
   `)

--- a/src/utils/buildRequest.test.ts
+++ b/src/utils/buildRequest.test.ts
@@ -192,7 +192,7 @@ describe('behavior', () => {
           Promise.reject(new BaseError('foo', { details: 'bar' })),
         )({ method: 'eth_test' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [ViemError: foo
+        [BaseError: foo
 
         Details: bar
         Version: viem@x.y.z]

--- a/src/utils/encoding/fromHex.test.ts
+++ b/src/utils/encoding/fromHex.test.ts
@@ -348,7 +348,7 @@ describe('converts hex to bytes', () => {
     expect(() =>
       fromHex('0x420fggf11a', 'bytes'),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: Invalid byte sequence ("gg" in "420fggf11a").
+      [BaseError: Invalid byte sequence ("gg" in "420fggf11a").
 
       Version: viem@x.y.z]
     `)

--- a/src/utils/encoding/toBytes.test.ts
+++ b/src/utils/encoding/toBytes.test.ts
@@ -1002,7 +1002,7 @@ describe('converts hex to bytes', () => {
 
   test('error: invalid hex', () => {
     expect(() => hexToBytes('0xabcdefgh')).toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: Invalid byte sequence ("gh" in "abcdefgh").
+      [BaseError: Invalid byte sequence ("gh" in "abcdefgh").
 
       Version: viem@x.y.z]
     `)

--- a/src/utils/errors/getContractError.test.ts
+++ b/src/utils/errors/getContractError.test.ts
@@ -238,7 +238,7 @@ describe('getContractError', () => {
       Version: viem@x.y.z]
     `)
     expect(error.cause).toMatchInlineSnapshot(`
-      [ViemError: An RPC error occurred
+      [BaseError: An RPC error occurred
 
       Details: rarararar i am an error lmaoaoo
       Version: viem@x.y.z]
@@ -261,7 +261,7 @@ describe('getContractError', () => {
       Version: viem@x.y.z]
     `)
     expect(error2.cause).toMatchInlineSnapshot(`
-      [ViemError: An RPC error occurred
+      [BaseError: An RPC error occurred
 
       Version: viem@x.y.z]
     `)
@@ -283,7 +283,7 @@ describe('getContractError', () => {
       Version: viem@x.y.z]
     `)
     expect(error3.cause).toMatchInlineSnapshot(`
-      [ViemError: An error occurred.
+      [BaseError: An error occurred.
 
       Version: viem@x.y.z]
     `)

--- a/src/utils/errors/getNodeError.test.ts
+++ b/src/utils/errors/getNodeError.test.ts
@@ -40,7 +40,7 @@ test('FeeCapTooHigh', () => {
     ),
   })
   expect(result).toMatchInlineSnapshot(`
-    [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 1231287389123781293712897312893791283921738912378912 gwei) cannot be higher than the maximum allowed value (2^256-1).
+    [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 1231287389123781293712897312893791283921738912378912 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
     Details: fee cap higher than 2^256-1
     Version: viem@x.y.z]
@@ -64,7 +64,7 @@ test('FeeCapTooLow', () => {
     maxFeePerGas: parseGwei('1'),
   })
   expect(result).toMatchInlineSnapshot(`
-    [FeeCapTooLow: The fee cap (\`maxFeePerGas\` = 1 gwei) cannot be lower than the block base fee.
+    [FeeCapTooLowError: The fee cap (\`maxFeePerGas\` = 1 gwei) cannot be lower than the block base fee.
 
     Details: max fee per gas less than block base fee
     Version: viem@x.y.z]

--- a/src/utils/hash/normalizeSignature.test.ts
+++ b/src/utils/hash/normalizeSignature.test.ts
@@ -126,7 +126,7 @@ test('trim spaces', () => {
 test('error: invalid signatures', () => {
   expect(() => normalizeSignature('bar')).toThrowErrorMatchingInlineSnapshot(
     `
-    [ViemError: Unable to normalize signature.
+    [BaseError: Unable to normalize signature.
 
     Version: viem@x.y.z]
   `,
@@ -135,7 +135,7 @@ test('error: invalid signatures', () => {
   expect(() =>
     normalizeSignature('bar(uint foo'),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: Unable to normalize signature.
+    [BaseError: Unable to normalize signature.
 
     Version: viem@x.y.z]
   `)
@@ -143,7 +143,7 @@ test('error: invalid signatures', () => {
   expect(() =>
     normalizeSignature('baruint foo)'),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: Unable to normalize signature.
+    [BaseError: Unable to normalize signature.
 
     Version: viem@x.y.z]
   `)
@@ -151,7 +151,7 @@ test('error: invalid signatures', () => {
   expect(() =>
     normalizeSignature('bar(uint foo, (uint baz)'),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: Unable to normalize signature.
+    [BaseError: Unable to normalize signature.
 
     Version: viem@x.y.z]
   `)

--- a/src/utils/transaction/assertRequest.test.ts
+++ b/src/utils/transaction/assertRequest.test.ts
@@ -21,7 +21,7 @@ test('fee cap too high', () => {
   expect(() =>
     assertRequest({ maxFeePerGas: 2n ** 256n - 1n + 1n }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
+    [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
     Version: viem@x.y.z]
   `)

--- a/src/utils/transaction/assertTransaction.test.ts
+++ b/src/utils/transaction/assertTransaction.test.ts
@@ -67,7 +67,7 @@ describe('eip4844', () => {
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
+      [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
       Version: viem@x.y.z]
     `)
@@ -82,7 +82,7 @@ describe('eip1559', () => {
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
+      [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
       Version: viem@x.y.z]
     `)
@@ -134,7 +134,7 @@ describe('eip2930', () => {
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
+      [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
       Version: viem@x.y.z]
     `)
@@ -170,7 +170,7 @@ describe('eip2930', () => {
         maxPriorityFeePerGas: parseGwei('1') as unknown as undefined,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [ViemError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid EIP-2930 Transaction attribute.
+      [BaseError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid EIP-2930 Transaction attribute.
 
       Version: viem@x.y.z]
     `)
@@ -185,7 +185,7 @@ describe('legacy', () => {
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [FeeCapTooHigh: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
+      [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 
       Version: viem@x.y.z]
     `)
@@ -222,7 +222,7 @@ test('invalid transaction type', () => {
       maxPriorityFeePerGas: parseGwei('1') as unknown as undefined,
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid EIP-2930 Transaction attribute.
+    [BaseError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid EIP-2930 Transaction attribute.
 
     Version: viem@x.y.z]
   `)
@@ -232,7 +232,7 @@ test('invalid transaction type', () => {
       maxFeePerGas: parseGwei('1') as unknown as undefined,
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid Legacy Transaction attribute.
+    [BaseError: \`maxFeePerGas\`/\`maxPriorityFeePerGas\` is not a valid Legacy Transaction attribute.
 
     Version: viem@x.y.z]
   `)
@@ -242,7 +242,7 @@ test('invalid transaction type', () => {
       accessList: [] as unknown as undefined,
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`accessList\` is not a valid Legacy Transaction attribute.
+    [BaseError: \`accessList\` is not a valid Legacy Transaction attribute.
 
     Version: viem@x.y.z]
   `)

--- a/src/zksync/actions/sendEip712Transaction.test.ts
+++ b/src/zksync/actions/sendEip712Transaction.test.ts
@@ -45,7 +45,7 @@ test('errors: no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/docs/actions/wallet/sendTransaction#account
+    Docs: https://viem.sh/docs/actions/wallet/sendTransaction
     Version: viem@x.y.z]
   `)
 })

--- a/src/zksync/actions/signEip712Transaction.test.ts
+++ b/src/zksync/actions/signEip712Transaction.test.ts
@@ -38,7 +38,7 @@ test('errors: no eip712 domain fn', async () => {
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `
-    [ViemError: \`getEip712Domain\` not found on chain.
+    [BaseError: \`getEip712Domain\` not found on chain.
 
     Version: viem@x.y.z]
   `,
@@ -54,7 +54,7 @@ test('errors: no serializer fn', async () => {
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `
-    [ViemError: transaction serializer not found on chain.
+    [BaseError: transaction serializer not found on chain.
 
     Version: viem@x.y.z]
   `,
@@ -70,7 +70,7 @@ test('errors: no account', async () => {
     [AccountNotFoundError: Could not find an Account to execute with this Action.
     Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
 
-    Docs: https://viem.sh/docs/actions/wallet/signTransaction#account
+    Docs: https://viem.sh/docs/actions/wallet/signTransaction
     Version: viem@x.y.z]
   `,
   )

--- a/src/zksync/errors/bytecode.ts
+++ b/src/zksync/errors/bytecode.ts
@@ -6,13 +6,13 @@ export type BytecodeLengthExceedsMaxSizeErrorType =
   }
 
 export class BytecodeLengthExceedsMaxSizeError extends BaseError {
-  override name = 'BytecodeLengthExceedsMaxSizeError'
   constructor({
     givenLength,
     maxBytecodeSize,
   }: { givenLength: number; maxBytecodeSize: bigint }) {
     super(
       `Bytecode cannot be longer than ${maxBytecodeSize} bytes. Given length: ${givenLength}`,
+      { name: 'BytecodeLengthExceedsMaxSizeError' },
     )
   }
 }
@@ -23,10 +23,10 @@ export type BytecodeLengthInWordsMustBeOddErrorType =
   }
 
 export class BytecodeLengthInWordsMustBeOddError extends BaseError {
-  override name = 'BytecodeLengthInWordsMustBeOddError'
   constructor({ givenLengthInWords }: { givenLengthInWords: number }) {
     super(
       `Bytecode length in 32-byte words must be odd. Given length in words: ${givenLengthInWords}`,
+      { name: 'BytecodeLengthInWordsMustBeOddError' },
     )
   }
 }
@@ -37,10 +37,10 @@ export type BytecodeLengthMustBeDivisibleBy32ErrorType =
   }
 
 export class BytecodeLengthMustBeDivisibleBy32Error extends BaseError {
-  override name = 'BytecodeLengthMustBeDivisibleBy32Error'
   constructor({ givenLength }: { givenLength: number }) {
     super(
       `The bytecode length in bytes must be divisible by 32. Given length: ${givenLength}`,
+      { name: 'BytecodeLengthMustBeDivisibleBy32Error' },
     )
   }
 }

--- a/src/zksync/errors/token-is-eth.ts
+++ b/src/zksync/errors/token-is-eth.ts
@@ -4,13 +4,12 @@ export type TokenIsEthErrorType = TokenIsEthError & {
   name: 'TokenIsEthError'
 }
 export class TokenIsEthError extends BaseError {
-  override name = 'TokenIsEthError'
-
   constructor() {
     super(
       ['Token is an ETH token.', '', 'ETH token cannot be retrieved.'].join(
         '\n',
       ),
+      { name: 'TokenIsEthError' },
     )
   }
 }

--- a/src/zksync/errors/transaction.ts
+++ b/src/zksync/errors/transaction.ts
@@ -5,8 +5,6 @@ export type InvalidEip712TransactionErrorType =
     name: 'InvalidEip712TransactionError'
   }
 export class InvalidEip712TransactionError extends BaseError {
-  override name = 'InvalidEip712TransactionError'
-
   constructor() {
     super(
       [
@@ -16,6 +14,7 @@ export class InvalidEip712TransactionError extends BaseError {
         '  - include `type: "eip712"`',
         '  - include one of the following: `customSignature`, `paymaster`, `paymasterInput`, `gasPerPubdata`, `factoryDeps`',
       ].join('\n'),
+      { name: 'InvalidEip712TransactionError' },
     )
   }
 }

--- a/src/zksync/utils/assertEip712Transaction.test.ts
+++ b/src/zksync/utils/assertEip712Transaction.test.ts
@@ -90,7 +90,7 @@ test('default', () => {
       type: 'eip712',
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`paymasterInput\` must be provided when \`paymaster\` is defined
+    [BaseError: \`paymasterInput\` must be provided when \`paymaster\` is defined
 
     Version: viem@x.y.z]
   `)
@@ -102,7 +102,7 @@ test('default', () => {
       type: 'eip712',
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [ViemError: \`paymaster\` must be provided when \`paymasterInput\` is defined
+    [BaseError: \`paymaster\` must be provided when \`paymasterInput\` is defined
 
     Version: viem@x.y.z]
   `)

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,17 +5,25 @@ import { cleanupCache, listenersCache } from '~viem/utils/observe.js'
 import { promiseCache, responseCache } from '~viem/utils/promise/withCache.js'
 import { socketClientCache } from '~viem/utils/rpc/socket.js'
 
+import { setErrorConfig } from '../src/errors/base.js'
 import * as instances from './src/anvil.js'
 
 const client = instances.anvilMainnet.getClient()
 
 beforeAll(() => {
+  setErrorConfig({
+    getDocsUrl({ docsBaseUrl, docsPath }) {
+      return docsPath
+        ? `${docsBaseUrl ?? 'https://viem.sh'}${docsPath}`
+        : undefined
+    },
+    version: 'viem@x.y.z',
+  })
   vi.mock('../src/errors/utils.ts', () => ({
     getContractAddress: vi
       .fn()
       .mockReturnValue('0x0000000000000000000000000000000000000000'),
     getUrl: vi.fn().mockReturnValue('http://localhost'),
-    getVersion: vi.fn().mockReturnValue('viem@x.y.z'),
   }))
 })
 


### PR DESCRIPTION
Adds ability for consumer (libraries built on-top of Viem) to globally configure `BaseError` properties.

```ts
import { setErrorConfig } from 'viem'

setErrorConfig({
  getDocsUrl({ name }) {
    return `https://examplelib.com?error=${name}`
  }
  version: 'examplelib@1.2.3'
}) 
```