### PR TITLE
Fix WebSocket Ping message

### DIFF
--- a/.changeset/rude-onions-draw.md
+++ b/.changeset/rude-onions-draw.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed websocket ping request not conforming to jsonrpc schema.

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -4,13 +4,13 @@ import {
   SocketClosedError,
   WebSocketRequestError,
 } from '../../errors/request.js'
+import type { RpcRequest } from '../../types/rpc.js'
 import {
   type GetSocketRpcClientParameters,
   type Socket,
   type SocketRpcClient,
   getSocketRpcClient,
 } from './socket.js'
-import type { RpcRequest } from '../../types/rpc.js'
 
 export type GetWebSocketRpcClientOptions = Pick<
   GetSocketRpcClientParameters,
@@ -72,7 +72,11 @@ export async function getWebSocketRpcClient(
                 cause: new SocketClosedError({ url: socket.url }),
               })
 
-            const body = <RpcRequest>({ jsonrpc: "2.0", method: "net_version", params: [] })
+            const body = <RpcRequest>{
+              jsonrpc: '2.0',
+              method: 'net_version',
+              params: [],
+            }
             socket.send(JSON.stringify(body))
           } catch (error) {
             onError(error as Error)

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -72,7 +72,7 @@ export async function getWebSocketRpcClient(
                 cause: new SocketClosedError({ url: socket.url }),
               })
 
-            const body = <RpcRequest>{
+            const body: RpcRequest = {
               jsonrpc: '2.0',
               method: 'net_version',
               params: [],

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -10,6 +10,7 @@ import {
   type SocketRpcClient,
   getSocketRpcClient,
 } from './socket.js'
+import type { RpcRequest } from '../../types/rpc.js'
 
 export type GetWebSocketRpcClientOptions = Pick<
   GetSocketRpcClientParameters,
@@ -71,7 +72,8 @@ export async function getWebSocketRpcClient(
                 cause: new SocketClosedError({ url: socket.url }),
               })
 
-            socket.send('net_version')
+            const body = <RpcRequest>({ jsonrpc: "2.0", method: "net_version", params: [] })
+            socket.send(JSON.stringify(body))
           } catch (error) {
             onError(error as Error)
           }


### PR DESCRIPTION
Fix WebSocket ping request not complying with jsonrpc schema. The problem leads to client disconnection with code 1006 when using some rpc rpoviders.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the websocket ping request to adhere to the jsonrpc schema.

### Detailed summary
- Fixed websocket ping request to conform to jsonrpc schema
- Added import for `RpcRequest`
- Replaced direct `socket.send` with structured JSON request body

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->