### PR TITLE
Add IOTA, IOTA Testnet and CHIPS

### DIFF
--- a/.changeset/grumpy-cows-speak.md
+++ b/.changeset/grumpy-cows-speak.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add IOTA, IOTA Testnet and CHIPS

--- a/src/chains/definitions/chips.ts
+++ b/src/chains/definitions/chips.ts
@@ -1,0 +1,17 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const chips = /*#__PURE__*/ defineChain({
+  id: 2882,
+  name: 'Chips Network',
+  network: 'CHIPS',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'IOTA',
+    symbol: 'IOTA',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://node.chips.ooo/wasp/api/v1/chains/iota1pp3d3mnap3ufmgqnjsnw344sqmf5svjh26y2khnmc89sv6788y3r207a8fn/evm'],
+    },
+  },
+})

--- a/src/chains/definitions/iota.ts
+++ b/src/chains/definitions/iota.ts
@@ -1,0 +1,25 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const iota = /*#__PURE__*/ defineChain({
+  id: 8822,
+  name: 'IOTA EVM',
+  network: 'iotaevm',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'IOTA',
+    symbol: 'IOTA',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://json-rpc.evm.iotaledger.net'],
+      webSocket: ['wss://ws.json-rpc.evm.iotaledger.net']
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Explorer',
+      url: 'https://explorer.evm.iota.org',
+      apiUrl: 'https://iota-mainnet-evm.public.blastapi.io ',
+    },
+  },
+})

--- a/src/chains/definitions/iotaTestnet.ts
+++ b/src/chains/definitions/iotaTestnet.ts
@@ -1,0 +1,26 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const iotaTestnet = /*#__PURE__*/ defineChain({
+  id: 1075,
+  name: 'IOTA EVM Testnet',
+  network: 'iotaevm-testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'IOTA',
+    symbol: 'IOTA',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://json-rpc.evm.testnet.iotaledger.net'],
+      webSocket: ['wss://ws.json-rpc.evm.testnet.iotaledger.net']
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Explorer',
+      url: 'https://explorer.evm.testnet.iotaledger.net',
+      apiUrl: 'https://iota-testnet-evm.public.blastapi.io',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Adding the iotaEVM, iotaEVM Testnet and CHIPS EVM Chains.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for IOTA, IOTA Testnet, and CHIPS network chains.

### Detailed summary
- Added `chips.ts` defining Chips Network chain
- Added `iota.ts` defining IOTA EVM chain
- Added `iotaTestnet.ts` defining IOTA EVM Testnet chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->