### PR TITLE
docs: add opaqueDataToDepositData page

### DIFF
--- a/site/pages/op-stack/utilities/opaqueDataToDepositData.md
+++ b/site/pages/op-stack/utilities/opaqueDataToDepositData.md
@@ -1,0 +1,51 @@
+---
+description: Converts opaque data into a structured deposit data format.
+---
+
+# opaqueDataToDepositData
+
+Converts an opaque data into a structured deposit data object. This includes extracting and converting the `mint`, `value`, `gas`, `isCreation` flag, and `data` from a hex string.
+
+## Import
+
+```ts
+import { opaqueDataToDepositData } from "viem";
+```
+
+## Usage
+
+```ts
+import { opaqueDataToDepositData } from "viem";
+
+const opaqueData =
+  "0x00000000000000000000000000000000000000000000000000470DE4DF82000000000000000000000000000000000000000000000000000000470DE4DF82000000000000000186A00001";
+
+const depositData = opaqueDataToDepositData(opaqueData);
+// {
+//   mint: 20000000000000000n,
+//   value: 20000000000000000n,
+//   gas: 100000n,
+//   isCreation: false,
+//   data: '0x01',
+// }
+```
+
+## Returns
+
+`OpaqueDataToDepositDataReturnType`
+
+An object containing the parsed deposit data.
+
+## Parameters
+
+### opaqueData
+
+- **Type:** `Hex`
+
+The opaque hex-encoded data.
+
+## Errors
+
+`OpaqueDataToDepositDataErrorType`
+
+An error type that includes potential slice, size, and generic errors encountered during the parsing process.


### PR DESCRIPTION
## Fix Broken Link: opaqueDataToDepositData Page

### What's Fixed
Added the missing opaqueDataToDepositData doc in the Op-Stack section.

Before
- Broken Link: https://viem.sh/op-stack/utilities/opaqueDataToDepositData

After
![image](https://github.com/user-attachments/assets/e742ca63-9253-4943-a8e9-5370a26967d3)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new utility function `opaqueDataToDepositData` to convert opaque hex-encoded data into a structured deposit data object in a TypeScript project.

### Detailed summary
- Added `opaqueDataToDepositData` utility function
- Converts opaque data to structured deposit data
- Handles extraction and conversion of `mint`, `value`, `gas`, `isCreation`, and `data`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->