### PR TITLE
feat: make `getNonce` optional on Smart Account implementations.

### DIFF
--- a/.changeset/hip-starfishes-speak.md
+++ b/.changeset/hip-starfishes-speak.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Made `getNonce` optional on `SmartAccountImplementation`.

--- a/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
+++ b/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
@@ -1,4 +1,4 @@
-import { type Address, type TypedData, parseAbi } from 'abitype'
+import type { Address, TypedData } from 'abitype'
 import {
   type WebAuthnData,
   parseSignature as parseP256Signature,
@@ -130,19 +130,6 @@ export async function toCoinbaseSmartAccount(
         args: [owners_bytes, nonce],
       })
       return { factory: factory.address, factoryData }
-    },
-
-    async getNonce({ key = 0n } = {}) {
-      const address = await this.getAddress()
-      const nonce = await readContract(client, {
-        abi: parseAbi([
-          'function getNonce(address, uint192) pure returns (uint256)',
-        ]),
-        address: entryPoint.address,
-        functionName: 'getNonce',
-        args: [address, key],
-      })
-      return nonce
     },
 
     async getStubSignature() {

--- a/src/account-abstraction/accounts/implementations/toSoladySmartAccount.ts
+++ b/src/account-abstraction/accounts/implementations/toSoladySmartAccount.ts
@@ -1,4 +1,4 @@
-import { type Abi, type Address, type TypedData, parseAbi } from 'abitype'
+import type { Abi, Address, TypedData } from 'abitype'
 
 import { parseAccount } from '../../../accounts/utils/parseAccount.js'
 import { readContract } from '../../../actions/public/readContract.js'
@@ -34,6 +34,7 @@ export type ToSoladySmartAccountParameters<
       }
     | undefined
   factoryAddress?: Address | undefined
+  getNonce?: SmartAccountImplementation['getNonce'] | undefined
   owner: Address | Account
   salt?: Hex | undefined
 }
@@ -86,6 +87,7 @@ export async function toSoladySmartAccount<
       version: '0.7',
     },
     factoryAddress = '0x5d82735936c6Cd5DE57cC3c1A799f6B2E6F933Df',
+    getNonce,
     salt = '0x0',
   } = parameters
 
@@ -103,6 +105,7 @@ export async function toSoladySmartAccount<
   return toSmartAccount({
     client,
     entryPoint,
+    getNonce,
 
     extend: { abi, factory },
 
@@ -142,19 +145,6 @@ export async function toSoladySmartAccount<
         args: [owner.address, pad(salt)],
       })
       return { factory: factory.address, factoryData }
-    },
-
-    async getNonce({ key = 0n } = {}) {
-      const address = await this.getAddress()
-      const nonce = await readContract(client, {
-        abi: parseAbi([
-          'function getNonce(address, uint192) pure returns (uint256)',
-        ]),
-        address: entryPoint.address,
-        functionName: 'getNonce',
-        args: [address, key],
-      })
-      return nonce
     },
 
     async getStubSignature() {

--- a/src/account-abstraction/accounts/toSmartAccount.test.ts
+++ b/src/account-abstraction/accounts/toSmartAccount.test.ts
@@ -966,3 +966,28 @@ test('return value: `getFactoryArgs`', async () => {
     }
   `)
 })
+
+test('return value: `getNonce`', async () => {
+  const { factoryAddress } = await deploySoladyAccount_07()
+
+  const account = await toSoladySmartAccount({
+    client,
+    factoryAddress,
+    owner: accounts[1].address,
+  })
+  expect(await account.getNonce()).toBeDefined()
+})
+
+test('return value: `getNonce` (implementation override)', async () => {
+  const { factoryAddress } = await deploySoladyAccount_07()
+
+  const account = await toSoladySmartAccount({
+    client,
+    factoryAddress,
+    owner: accounts[1].address,
+    async getNonce() {
+      return 69n
+    },
+  })
+  expect(await account.getNonce()).toBe(69n)
+})

--- a/src/account-abstraction/accounts/toSmartAccount.ts
+++ b/src/account-abstraction/accounts/toSmartAccount.ts
@@ -1,13 +1,13 @@
-import { parseAbi, type Abi } from 'abitype'
+import { type Abi, parseAbi } from 'abitype'
 
 import { getCode } from '../../actions/public/getCode.js'
+import { readContract } from '../../actions/public/readContract.js'
 import type { Prettify } from '../../types/utils.js'
 import { getAction } from '../../utils/getAction.js'
 import { createNonceManager } from '../../utils/nonceManager.js'
 import { serializeErc6492Signature } from '../../utils/signature/serializeErc6492Signature.js'
 import type { EntryPointVersion } from '../types/entryPointVersion.js'
 import type { SmartAccount, SmartAccountImplementation } from './types.js'
-import { readContract } from '../../actions/public/readContract.js'
 
 export type ToSmartAccountParameters<
   entryPointAbi extends Abi | readonly unknown[] = Abi,

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -88,9 +88,11 @@ export type SmartAccountImplementation<
    * // 1n
    * ```
    */
-  getNonce: (
-    parameters?: { key?: bigint | undefined } | undefined,
-  ) => Promise<bigint>
+  getNonce?:
+    | ((
+        parameters?: { key?: bigint | undefined } | undefined,
+      ) => Promise<bigint>)
+    | undefined
   /**
    * Retrieves the User Operation "stub" signature for gas estimation.
    *
@@ -184,6 +186,16 @@ export type SmartAccount<
     {
       /** Address of the Smart Account. */
       address: Address
+      /**
+       * Retrieves the nonce of the Account.
+       *
+       * @example
+       * ```ts
+       * const nonce = await account.getNonce()
+       * // 1n
+       * ```
+       */
+      getNonce: NonNullable<SmartAccountImplementation['getNonce']>
       /** Whether or not the Smart Account has been deployed. */
       isDeployed: () => Promise<boolean>
       /** Type of account. */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds optional `getNonce` functionality to `SmartAccountImplementation` and updates related test cases and implementations.

### Detailed summary
- Made `getNonce` optional on `SmartAccountImplementation`
- Updated test cases for `getNonce` return value
- Updated `types.ts` to reflect optional `getNonce` function
- Updated `toSmartAccount.ts` and implementations to handle optional `getNonce` functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->