### PR TITLE
Add missing API URL to Immutable ZKEVM

### DIFF
--- a/src/chains/definitions/immutableZkEvm.ts
+++ b/src/chains/definitions/immutableZkEvm.ts
@@ -17,6 +17,7 @@ export const immutableZkEvm = /*#__PURE__*/ defineChain({
     default: {
       name: 'Immutable Explorer',
       url: 'https://explorer.immutable.com',
+      apiUrl: 'https://explorer.immutable.com/api',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

API URL was missing

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an `apiUrl` property to the `Immutable Explorer` definition in `immutableZkEvm.ts`.

### Detailed summary
- Added `apiUrl` property with value `'https://explorer.immutable.com/api'` to the `Immutable Explorer` definition in `immutableZkEvm.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->