### PR TITLE
fix: default nonce manager resets previous nonce

### DIFF
--- a/src/utils/nonceManager.ts
+++ b/src/utils/nonceManager.ts
@@ -96,6 +96,7 @@ export function createNonceManager(
       const key = getKey({ address, chainId })
       deltaMap.delete(key)
       promiseMap.delete(key)
+      nonceMap.delete(key)
     },
   }
 }

--- a/src/utils/nonceManager.ts
+++ b/src/utils/nonceManager.ts
@@ -96,7 +96,6 @@ export function createNonceManager(
       const key = getKey({ address, chainId })
       deltaMap.delete(key)
       promiseMap.delete(key)
-      nonceMap.delete(key)
     },
   }
 }


### PR DESCRIPTION
I am using the default nonce manager to trigger a bunch of transactions in a queue to ensure they land in the mempool in order. If any transaction fails to submit to the mempool, I call `nonceManager.reset()`.

For example:

```
tx:1 -> nonce:1
tx:2 -> nonce:2
tx:3 -> nonce:3
```

If `tx:1` fails, I call `nonceManager.reset()` and retry it. However, the logic that looks up the nonce after reset also takes into account the previously cached nonce in the nonce manager:

https://github.com/wevm/viem/blob/5f350ecf63b2da861c8dcb60e77fbcae3e7192ab/src/utils/nonceManager.ts#L79-L84

Since the queue is blocked on `tx:1`, our nonce at the source should still be `nonce:1`. But because of the logic above, the nonce returned will actually be `nonce:4` (because of our previously queued txs).

IMO `.reset` should reset the state of the nonce manager back to the source, including the cached nonce value.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add tests for the `nonceManager` reset functionality and ensure correct nonce handling during transactions.

### Detailed summary
- Added a test for `nonceManager` reset functionality
- Implemented handling of nonce increment and reset during transactions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->