### PR TITLE
refactor: use getAction internally

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -130,6 +130,7 @@ export {
   type GetChainIdErrorType,
   type GetChainIdReturnType,
   getChainId,
+  _getChainId,
 } from './public/getChainId.js'
 export {
   /** @deprecated Use `GetCodeErrorType` instead */

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -113,6 +113,7 @@ export {
   type GetBlockParameters,
   type GetBlockReturnType,
   getBlock,
+  _getBlock,
 } from './public/getBlock.js'
 export {
   type GetBlockNumberErrorType,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -119,6 +119,7 @@ export {
   type GetBlockNumberParameters,
   type GetBlockNumberReturnType,
   getBlockNumber,
+  _getBlockNumber,
 } from './public/getBlockNumber.js'
 export {
   type GetBlockTransactionCountErrorType,

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -25,7 +25,7 @@ import {
   type EstimateMaxPriorityFeePerGasErrorType,
   internal_estimateMaxPriorityFeePerGas,
 } from './estimateMaxPriorityFeePerGas.js'
-import { getBlock } from './getBlock.js'
+import { type GetBlockErrorType, getBlock } from './getBlock.js'
 import { type GetGasPriceErrorType, getGasPrice } from './getGasPrice.js'
 
 export type EstimateFeesPerGasParameters<
@@ -52,6 +52,7 @@ export type EstimateFeesPerGasReturnType<
 
 export type EstimateFeesPerGasErrorType =
   | BaseFeeScalarErrorType
+  | GetBlockErrorType
   | EstimateMaxPriorityFeePerGasErrorType
   | GetGasPriceErrorType
   | Eip1559FeesNotSupportedErrorType
@@ -126,9 +127,7 @@ export async function internal_estimateFeesPerGas<
     (base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) /
     BigInt(denominator)
 
-  const block = block_
-    ? block_
-    : await getAction(client, getBlock, 'getBlock')({})
+  const block = block_ ? block_ : await getBlock(client)
 
   if (typeof chain?.fees?.estimateFeesPerGas === 'function') {
     const fees = (await chain.fees.estimateFeesPerGas({

--- a/src/actions/public/estimateMaxPriorityFeePerGas.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.ts
@@ -30,7 +30,6 @@ export type EstimateMaxPriorityFeePerGasErrorType =
   | GetBlockErrorType
   | HexToBigIntErrorType
   | RequestErrorType
-  | GetBlockErrorType
   | GetGasPriceErrorType
   | Eip1559FeesNotSupportedErrorType
   | ErrorType
@@ -87,7 +86,7 @@ export async function internal_estimateMaxPriorityFeePerGas<
 ): Promise<EstimateMaxPriorityFeePerGasReturnType> {
   const { block: block_, chain = client.chain, request } = args || {}
   if (typeof chain?.fees?.defaultPriorityFee === 'function') {
-    const block = block_ || (await getAction(client, getBlock, 'getBlock')({}))
+    const block = block_ || (await getBlock(client))
     return chain.fees.defaultPriorityFee({
       block,
       client,

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -20,6 +20,7 @@ import {
   type FormattedBlock,
   formatBlock,
 } from '../../utils/formatters/block.js'
+import { getAction } from '../../utils/getAction.js'
 
 export type GetBlockParameters<
   includeTransactions extends boolean = false,
@@ -88,6 +89,18 @@ export type GetBlockErrorType =
  * const block = await getBlock(client)
  */
 export async function getBlock<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+  includeTransactions extends boolean = false,
+  blockTag extends BlockTag = 'latest',
+>(
+  client: Client<Transport, chain, account>,
+  params: GetBlockParameters<includeTransactions, blockTag> = {},
+): Promise<GetBlockReturnType<chain, includeTransactions, blockTag>> {
+  return getAction(client, _getBlock, 'getBlock')(params)
+}
+
+export async function _getBlock<
   chain extends Chain | undefined,
   account extends Account | undefined,
   includeTransactions extends boolean = false,

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -3,6 +3,7 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type GetCacheErrorType,
   getCache,
@@ -52,6 +53,13 @@ export function getBlockNumberCache(id: string) {
  * // 69420n
  */
 export async function getBlockNumber<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  params: GetBlockNumberParameters = {},
+): Promise<GetBlockNumberReturnType> {
+  return getAction(client, _getBlockNumber, 'getBlockNumber')(params)
+}
+
+export async function _getBlockNumber<chain extends Chain | undefined>(
   client: Client<Transport, chain>,
   { cacheTime = client.cacheTime }: GetBlockNumberParameters = {},
 ): Promise<GetBlockNumberReturnType> {

--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -8,6 +8,7 @@ import {
   type HexToNumberErrorType,
   hexToNumber,
 } from '../../utils/encoding/fromHex.js'
+import { getAction } from '../../utils/getAction.js'
 
 export type GetChainIdReturnType = number
 
@@ -38,6 +39,13 @@ export type GetChainIdErrorType =
  * // 1
  */
 export async function getChainId<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(client: Client<Transport, chain, account>): Promise<GetChainIdReturnType> {
+  return getAction(client, _getChainId, 'getChainId')({})
+}
+
+export async function _getChainId<
   chain extends Chain | undefined,
   account extends Account | undefined,
 >(client: Client<Transport, chain, account>): Promise<GetChainIdReturnType> {

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -67,7 +67,7 @@ export async function getTransactionConfirmations<
   { hash, transactionReceipt }: GetTransactionConfirmationsParameters<chain>,
 ): Promise<GetTransactionConfirmationsReturnType> {
   const [blockNumber, transaction] = await Promise.all([
-    getAction(client, getBlockNumber, 'getBlockNumber')({}),
+    getBlockNumber(client),
     hash
       ? getAction(client, getTransaction, 'getTransaction')({ hash })
       : undefined,

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -259,11 +259,7 @@ export async function waitForTransactionReceipt<
                   retrying = true
                   const block = await withRetry(
                     () =>
-                      getAction(
-                        client,
-                        getBlock,
-                        'getBlock',
-                      )({
+                      getBlock(client, {
                         blockNumber,
                         includeTransactions: true,
                       }),

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -4,7 +4,6 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { HasTransportType } from '../../types/transport.js'
 import { hexToBigInt } from '../../utils/encoding/fromHex.js'
-import { getAction } from '../../utils/getAction.js'
 import { observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
 import { stringify } from '../../utils/stringify.js'
@@ -117,11 +116,7 @@ export function watchBlockNumber<
       poll(
         async () => {
           try {
-            const blockNumber = await getAction(
-              client,
-              getBlockNumber,
-              'getBlockNumber',
-            )({ cacheTime: 0 })
+            const blockNumber = await getBlockNumber(client, { cacheTime: 0 })
 
             if (prevBlockNumber) {
               // If the current block number is the same as the previous,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -145,11 +145,7 @@ export function watchBlocks<
       poll(
         async () => {
           try {
-            const block = await getAction(
-              client,
-              getBlock,
-              'getBlock',
-            )({
+            const block = await getBlock(client, {
               blockTag,
               includeTransactions,
             })

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -220,11 +220,7 @@ export function watchContractEvent<
               // The fall back exists because some RPC Providers do not support filters.
 
               // Fetch the block number to use for `getLogs`.
-              const blockNumber = await getAction(
-                client,
-                getBlockNumber,
-                'getBlockNumber',
-              )({})
+              const blockNumber = await getBlockNumber(client)
 
               // If the block number has changed, we will need to fetch the logs.
               // If the block number doesn't exist, we are yet to reach the first poll interval,

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -243,11 +243,7 @@ export function watchEvent<
               // The fall back exists because some RPC Providers do not support filters.
 
               // Fetch the block number to use for `getLogs`.
-              const blockNumber = await getAction(
-                client,
-                getBlockNumber,
-                'getBlockNumber',
-              )({})
+              const blockNumber = await getBlockNumber(client)
 
               // If the block number has changed, we will need to fetch the logs.
               // If the block number doesn't exist, we are yet to reach the first poll interval,

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -271,7 +271,7 @@ export async function prepareTransactionRequest<
     if (chainId) return chainId
     if (chain) return chain.id
     if (typeof args.chainId !== 'undefined') return args.chainId
-    const chainId_ = await getAction(client, getChainId_, 'getChainId')({})
+    const chainId_ = await getChainId_(client)
     chainId = chainId_
     return chainId
   }

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -258,11 +258,7 @@ export async function prepareTransactionRequest<
   let block: Block | undefined
   async function getBlock(): Promise<Block> {
     if (block) return block
-    block = await getAction(
-      client,
-      getBlock_,
-      'getBlock',
-    )({ blockTag: 'latest' })
+    block = await getBlock_(client, { blockTag: 'latest' })
     return block
   }
 


### PR DESCRIPTION
As an author of custom actions and action overrides, I will use viem actions internally but sometimes forget to call them `getAction` so that the actions can compose on one another.

For example, maybe I'll use `getChainId` internally in my custom action, but I want this to be composable with an action that overrides `getChainId` to cache the RPC's chain ID. If I don't call this with `getAction`, I'll accidentally bypass this cache and viem will do the underlying RPC call.

I've seen this pattern in both in my code, other SDKs, and within viem itself.

I am curious if, instead of requiring all action authors to use `getAction`, that viem itself exports by default the `getAction`-wrapped variant of each of these actions, while also exporting the internal implementation in case it's useful to make an explicit, direct call.

I'm mocking this up here to see if this approach seems reasonable before doing more because its quite a big refactor.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring functions in various action files to directly call `getBlock`, `getBlockNumber`, and `getChainId` functions instead of using `getAction`.

### Detailed summary
- Replaced `getAction` calls with direct calls to `getBlock`, `getBlockNumber`, and `getChainId` functions in multiple files.
- Updated function signatures and parameters accordingly.
- Removed unnecessary `getAction` imports from specific files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->