### PR TITLE
fix: add export of `PaymasterRpcSchema`

### DIFF
--- a/.changeset/odd-dolphins-own.md
+++ b/.changeset/odd-dolphins-own.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added export of `PaymasterRpcSchema` from `types/eip1193.ts`

--- a/.changeset/odd-dolphins-own.md
+++ b/.changeset/odd-dolphins-own.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added export of `PaymasterRpcSchema` from `types/eip1193.ts`
+Exported `PaymasterRpcSchema`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1049,6 +1049,7 @@ export type {
   ProviderConnectInfo,
   ProviderMessage,
   PublicRpcSchema,
+  PaymasterRpcSchema,
   NetworkSync,
   RpcSchema,
   RpcSchemaOverride,


### PR DESCRIPTION
Just added the export of the `PaymasterRpcSchema` from the eip1193 rpc schema definitions file.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `PaymasterRpcSchema` export and includes it in the list of exports in `src/index.ts`.

### Detailed summary
- Added export of `PaymasterRpcSchema` in `src/index.ts`
- Updated `.changeset/odd-dolphins-own.md` to reflect the export of `PaymasterRpcSchema`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->