### PR TITLE
feat: add ability to pass fully formed UserOperations to AA Actions.

### DIFF
--- a/.changeset/cyan-crabs-dream.md
+++ b/.changeset/cyan-crabs-dream.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added \`nonceKeyManager\` as a property to \`toSmartAccount\`.

--- a/.changeset/heavy-knives-shop.md
+++ b/.changeset/heavy-knives-shop.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ability to pass full-formed User Operations to `sendUserOperation` and `estimateUserOperationGas`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3225,7 +3225,6 @@ packages:
 
   bun@1.1.12:
     resolution: {integrity: sha512-NZzeZuZk7VwCs8VAXnXUHCPOlTS/IyHCscChtT1M1FLSwhBcVMsGVStYlXaaoqsinBKgp0CGJdhnJw2gR3NkDw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -6765,6 +6764,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.19.9:
+    resolution: {integrity: sha512-KFPSfewr8tFaSYcLAC+sgkYXdZ1llX8rJrBjd/OMg1D+T4eeQyYy5S6iJTSnwYpjz8hrjSlL30RuFf4BF3jtMw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -8447,7 +8454,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.19.8(typescript@5.5.2)(zod@3.22.4)
+      viem: 2.19.9(typescript@5.5.2)(zod@3.22.4)
       yargs: 17.7.2
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
@@ -14357,24 +14364,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.19.8(typescript@5.5.2)(zod@3.22.4):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.5.2)(zod@3.22.4)
-      isows: 1.0.4(ws@8.17.1)
-      webauthn-p256: 0.0.5
-      ws: 8.17.1
-    optionalDependencies:
-      typescript: 5.5.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.19.8(typescript@5.5.4)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
@@ -14388,6 +14377,24 @@ snapshots:
       ws: 8.17.1
     optionalDependencies:
       typescript: 5.5.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.19.9(typescript@5.5.2)(zod@3.22.4):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+      abitype: 1.0.5(typescript@5.5.2)(zod@3.22.4)
+      isows: 1.0.4(ws@8.17.1)
+      webauthn-p256: 0.0.5
+      ws: 8.17.1
+    optionalDependencies:
+      typescript: 5.5.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/src/account-abstraction/accounts/toSmartAccount.ts
+++ b/src/account-abstraction/accounts/toSmartAccount.ts
@@ -31,20 +31,22 @@ export async function toSmartAccount<
 >(
   implementation: implementation,
 ): Promise<ToSmartAccountReturnType<implementation>> {
-  const { extend, ...rest } = implementation
+  const {
+    extend,
+    nonceKeyManager = createNonceManager({
+      source: {
+        get() {
+          return Date.now()
+        },
+        set() {},
+      },
+    }),
+    ...rest
+  } = implementation
 
   let deployed = false
 
   const address = await implementation.getAddress()
-
-  const nonceKeyManager = createNonceManager({
-    source: {
-      get() {
-        return Date.now()
-      },
-      set() {},
-    },
-  })
 
   return {
     ...extend,

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -5,13 +5,13 @@ import type { Client } from '../../clients/createClient.js'
 import type { Hash, Hex, SignableMessage } from '../../types/misc.js'
 import type { TypedDataDefinition } from '../../types/typedData.js'
 import type { Assign, ExactPartial, UnionPartialBy } from '../../types/utils.js'
+import type { NonceManager } from '../../utils/nonceManager.js'
 import type { EntryPointVersion } from '../types/entryPointVersion.js'
 import type {
   EstimateUserOperationGasReturnType,
   UserOperation,
   UserOperationRequest,
 } from '../types/userOperation.js'
-import type { NonceManager } from '../../utils/nonceManager.js'
 
 type Call = {
   to: Hex

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -11,6 +11,7 @@ import type {
   UserOperation,
   UserOperationRequest,
 } from '../types/userOperation.js'
+import type { NonceManager } from '../../utils/nonceManager.js'
 
 type Call = {
   to: Hex
@@ -102,6 +103,8 @@ export type SmartAccountImplementation<
    * ```
    */
   getStubSignature: () => Promise<Hex>
+  /** Custom nonce key manager. */
+  nonceKeyManager?: NonceManager | undefined
   /**
    * Signs a hash via the Smart Account's owner.
    *

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 import { ErrorsExample } from '../../../../contracts/generated.js'
 import { wagmiContractConfig } from '../../../../test/src/abis.js'
 import {
@@ -16,6 +16,8 @@ import { http } from '../../../clients/transports/http.js'
 import { pad, parseEther, parseGwei } from '../../../utils/index.js'
 import { createPaymasterClient } from '../../clients/createPaymasterClient.js'
 import { estimateUserOperationGas } from './estimateUserOperationGas.js'
+import { prepareUserOperation } from './prepareUserOperation.js'
+import type { UserOperation } from '../../types/userOperation.js'
 
 const client = anvilMainnet.getClient({ account: true })
 const bundlerClient = bundlerMainnet.getBundlerClient()
@@ -139,6 +141,39 @@ describe('entryPointVersion: 0.7', async () => {
     `)
   })
 
+  test('behavior: prepared user operation', async () => {
+    const request = {
+      ...(await prepareUserOperation(bundlerClient, {
+        account,
+        calls: [
+          {
+            to: '0x0000000000000000000000000000000000000000',
+            value: parseEther('1'),
+          },
+        ],
+        ...fees,
+      })),
+      account: undefined,
+    } as const
+
+    expectTypeOf(request).toMatchTypeOf<UserOperation>()
+
+    expect(
+      await estimateUserOperationGas(bundlerClient, {
+        ...request,
+        entryPointAddress: account.entryPoint?.address,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "callGasLimit": 80000n,
+        "paymasterPostOpGasLimit": 0n,
+        "paymasterVerificationGasLimit": 0n,
+        "preVerificationGas": 51722n,
+        "verificationGasLimit": 259060n,
+      }
+    `)
+  })
+
   test('error: insufficient funds', async () => {
     await expect(() =>
       estimateUserOperationGas(bundlerClient, {
@@ -160,7 +195,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761076688711039842254848
+        nonce:                 30902162761095135455113551806464
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -198,7 +233,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761095135455113551806464
+        nonce:                 30902162761113582199187261358080
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -235,7 +270,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761113582199187261358080
+        nonce:                 30902162761132028943260970909696
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -273,7 +308,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761132028943260970909696
+        nonce:                 30902162761150475687334680461312
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -314,7 +349,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761150475687334680461312
+        nonce:                 30902162761168922431408390012928
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -355,7 +390,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761168922431408390012928
+        nonce:                 30902162761187369175482099564544
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -396,7 +431,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761187369175482099564544
+        nonce:                 30902162761205815919555809116160
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -437,7 +472,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761205815919555809116160
+        nonce:                 30902162761224262663629518667776
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -478,7 +513,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761224262663629518667776
+        nonce:                 30902162761242709407703228219392
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -521,7 +556,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761242709407703228219392
+        nonce:                 30902162761261156151776937771008
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -564,7 +599,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761261156151776937771008
+        nonce:                 30902162761279602895850647322624
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -642,7 +677,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0x
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761279602895850647322624
+        nonce:                 30902162761298049639924356874240
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -689,7 +724,7 @@ describe('entryPointVersion: 0.7', async () => {
         factoryData:           0xf14ddffc000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000002
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761298049639924356874240
+        nonce:                 30902162761316496383998066425856
         sender:                0xE911628bF8428C23f179a07b081325cAe376DE1f
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
 
@@ -723,6 +758,37 @@ describe('entryPointVersion: 0.6', async () => {
     `)
   })
 
+  test('behavior: prepared user operation', async () => {
+    const request = {
+      ...(await prepareUserOperation(bundlerClient, {
+        account,
+        calls: [
+          {
+            to: '0x0000000000000000000000000000000000000000',
+            value: parseEther('1'),
+          },
+        ],
+        ...fees,
+      })),
+      account: undefined,
+    } as const
+
+    expectTypeOf(request).toMatchTypeOf<UserOperation>()
+
+    expect(
+      await estimateUserOperationGas(bundlerClient, {
+        ...request,
+        entryPointAddress: account.entryPoint.address,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "callGasLimit": 80000n,
+        "preVerificationGas": 55233n,
+        "verificationGasLimit": 258801n,
+      }
+    `)
+  })
+
   test('error: aa13', async () => {
     await expect(() =>
       estimateUserOperationGas(bundlerClient, {
@@ -746,7 +812,7 @@ describe('entryPointVersion: 0.6', async () => {
         initCode:              0x0000000000000000000000000000000000000000deadbeef
         maxFeePerGas:          15 gwei
         maxPriorityFeePerGas:  2 gwei
-        nonce:                 30902162761039795222892423151616
+        nonce:                 30902162761058241966966132703232
         paymasterAndData:      0x
         sender:                0x6edf7db791fC4D438D4A683E857B2fE1a84947Ce
         signature:             0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c
@@ -760,8 +826,8 @@ describe('entryPointVersion: 0.6', async () => {
 test('error: account not defined', async () => {
   await expect(() =>
     estimateUserOperationGas(bundlerClient, {
-      // @ts-expect-error
       account: undefined,
+      // @ts-expect-error
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
       ...fees,
     }),

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
@@ -825,9 +825,9 @@ describe('entryPointVersion: 0.6', async () => {
 
 test('error: account not defined', async () => {
   await expect(() =>
+    // @ts-expect-error
     estimateUserOperationGas(bundlerClient, {
       account: undefined,
-      // @ts-expect-error
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
       ...fees,
     }),

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
@@ -15,9 +15,9 @@ import { mine, writeContract } from '../../../actions/index.js'
 import { http } from '../../../clients/transports/http.js'
 import { pad, parseEther, parseGwei } from '../../../utils/index.js'
 import { createPaymasterClient } from '../../clients/createPaymasterClient.js'
+import type { UserOperation } from '../../types/userOperation.js'
 import { estimateUserOperationGas } from './estimateUserOperationGas.js'
 import { prepareUserOperation } from './prepareUserOperation.js'
-import type { UserOperation } from '../../types/userOperation.js'
 
 const client = anvilMainnet.getClient({ account: true })
 const bundlerClient = bundlerMainnet.getBundlerClient()

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
@@ -61,37 +61,34 @@ export type EstimateUserOperationGasParameters<
   _derivedVersion extends
     EntryPointVersion = DeriveEntryPointVersion<_derivedAccount>,
 > = GetSmartAccountParameter<account, accountOverride, false> &
-  OneOf<
-    // Accept a full-formed User Operation.
-    | UserOperation
-    // Accept a partially-formed User Operation (UserOperationRequest) to be filled.
-    | (_derivedAccount extends SmartAccount
-        ? Assign<
-            UserOperationRequest<_derivedVersion>,
-            OneOf<
-              { calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }
-            > & {
-              paymaster?:
-                | Address
-                | true
-                | {
-                    /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
-                    getPaymasterData?:
-                      | PaymasterActions['getPaymasterData']
-                      | undefined
-                    /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
-                    getPaymasterStubData?:
-                      | PaymasterActions['getPaymasterStubData']
-                      | undefined
-                  }
-                | undefined
-              /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
-              paymasterContext?: unknown | undefined
-            }
-          >
-        : {})
-  > &
-  // Allow the EntryPoint address to be overridden, if not Account is provided, it will need to be required.
+  (
+    | UserOperation // Accept a full-formed User Operation.
+    | Assign<
+        // Accept a partially-formed User Operation (UserOperationRequest) to be filled.
+        UserOperationRequest<_derivedVersion>,
+        OneOf<
+          { calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }
+        > & {
+          paymaster?:
+            | Address
+            | true
+            | {
+                /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
+                getPaymasterData?:
+                  | PaymasterActions['getPaymasterData']
+                  | undefined
+                /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
+                getPaymasterStubData?:
+                  | PaymasterActions['getPaymasterStubData']
+                  | undefined
+              }
+            | undefined
+          /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
+          paymasterContext?: unknown | undefined
+        }
+      >
+  ) &
+  // Allow the EntryPoint address to be overridden, if no Account is provided, it will need to be required.
   MaybeRequired<
     { entryPointAddress?: Address },
     _derivedAccount extends undefined ? true : false

--- a/src/account-abstraction/actions/bundler/sendUserOperation.test.ts
+++ b/src/account-abstraction/actions/bundler/sendUserOperation.test.ts
@@ -24,9 +24,9 @@ import { pad, parseEther, parseGwei } from '../../../utils/index.js'
 import { toCoinbaseSmartAccount } from '../../accounts/implementations/toCoinbaseSmartAccount.js'
 import { createBundlerClient } from '../../clients/createBundlerClient.js'
 import { createPaymasterClient } from '../../clients/createPaymasterClient.js'
-import { sendUserOperation } from './sendUserOperation.js'
-import { prepareUserOperation } from './prepareUserOperation.js'
 import type { UserOperation } from '../../types/userOperation.js'
+import { prepareUserOperation } from './prepareUserOperation.js'
+import { sendUserOperation } from './sendUserOperation.js'
 
 const client = anvilMainnet.getClient({ account: true })
 const bundlerClient = bundlerMainnet.getBundlerClient({ client })

--- a/src/account-abstraction/actions/bundler/sendUserOperation.test.ts
+++ b/src/account-abstraction/actions/bundler/sendUserOperation.test.ts
@@ -205,8 +205,8 @@ describe('entryPointVersion: 0.7', async () => {
 
   test('error: no account', async () => {
     await expect(() =>
+      // @ts-expect-error
       sendUserOperation(bundlerClient, {
-        // @ts-expect-error
         calls: [
           {
             to: '0x0000000000000000000000000000000000000000',

--- a/src/account-abstraction/actions/bundler/sendUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/sendUserOperation.ts
@@ -48,37 +48,34 @@ export type SendUserOperationParameters<
   _derivedVersion extends
     EntryPointVersion = DeriveEntryPointVersion<_derivedAccount>,
 > = GetSmartAccountParameter<account, accountOverride, false> &
-  OneOf<
-    // Accept a full-formed User Operation.
-    | UserOperation
-    // Accept a partially-formed User Operation (UserOperationRequest) to be filled.
-    | (_derivedAccount extends SmartAccount
-        ? Assign<
-            UserOperationRequest<_derivedVersion>,
-            OneOf<
-              { calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }
-            > & {
-              paymaster?:
-                | Address
-                | true
-                | {
-                    /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
-                    getPaymasterData?:
-                      | PaymasterActions['getPaymasterData']
-                      | undefined
-                    /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
-                    getPaymasterStubData?:
-                      | PaymasterActions['getPaymasterStubData']
-                      | undefined
-                  }
-                | undefined
-              /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
-              paymasterContext?: unknown | undefined
-            }
-          >
-        : {})
-  > &
-  // Allow the EntryPoint address to be overridden, if not Account is provided, it will need to be required.
+  (
+    | UserOperation // Accept a full-formed User Operation.
+    | Assign<
+        // Accept a partially-formed User Operation (UserOperationRequest) to be filled.
+        UserOperationRequest<_derivedVersion>,
+        OneOf<
+          { calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }
+        > & {
+          paymaster?:
+            | Address
+            | true
+            | {
+                /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
+                getPaymasterData?:
+                  | PaymasterActions['getPaymasterData']
+                  | undefined
+                /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
+                getPaymasterStubData?:
+                  | PaymasterActions['getPaymasterStubData']
+                  | undefined
+              }
+            | undefined
+          /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
+          paymasterContext?: unknown | undefined
+        }
+      >
+  ) &
+  // Allow the EntryPoint address to be overridden, if no Account is provided, it will need to be required.
   MaybeRequired<
     { entryPointAddress?: Address },
     _derivedAccount extends undefined ? true : false

--- a/src/account-abstraction/actions/bundler/sendUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/sendUserOperation.ts
@@ -7,7 +7,7 @@ import type { BaseError } from '../../../errors/base.js'
 import type { ErrorType } from '../../../errors/utils.js'
 import type { Chain } from '../../../types/chain.js'
 import type { Hex } from '../../../types/misc.js'
-import type { Assign, OneOf } from '../../../types/utils.js'
+import type { Assign, MaybeRequired, OneOf } from '../../../types/utils.js'
 import type { RequestErrorType } from '../../../utils/buildRequest.js'
 import { getAction } from '../../../utils/getAction.js'
 import type { SmartAccount } from '../../accounts/types.js'
@@ -47,27 +47,42 @@ export type SendUserOperationParameters<
   >,
   _derivedVersion extends
     EntryPointVersion = DeriveEntryPointVersion<_derivedAccount>,
-> = Assign<
-  UserOperationRequest<_derivedVersion>,
-  OneOf<{ calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }> & {
-    paymaster?:
-      | Address
-      | true
-      | {
-          /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
-          getPaymasterData?: PaymasterActions['getPaymasterData'] | undefined
-          /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
-          getPaymasterStubData?:
-            | PaymasterActions['getPaymasterStubData']
-            | undefined
-        }
-      | undefined
-    /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
-    paymasterContext?: unknown
-  }
-> &
-  GetSmartAccountParameter<account, accountOverride>
-
+> = GetSmartAccountParameter<account, accountOverride, false> &
+  OneOf<
+    // Accept a full-formed User Operation.
+    | UserOperation
+    // Accept a partially-formed User Operation (UserOperationRequest) to be filled.
+    | (_derivedAccount extends SmartAccount
+        ? Assign<
+            UserOperationRequest<_derivedVersion>,
+            OneOf<
+              { calls: UserOperationCalls<Narrow<calls>> } | { callData: Hex }
+            > & {
+              paymaster?:
+                | Address
+                | true
+                | {
+                    /** Retrieves paymaster-related User Operation properties to be used for sending the User Operation. */
+                    getPaymasterData?:
+                      | PaymasterActions['getPaymasterData']
+                      | undefined
+                    /** Retrieves paymaster-related User Operation properties to be used for gas estimation. */
+                    getPaymasterStubData?:
+                      | PaymasterActions['getPaymasterStubData']
+                      | undefined
+                  }
+                | undefined
+              /** Paymaster context to pass to `getPaymasterData` and `getPaymasterStubData` calls. */
+              paymasterContext?: unknown | undefined
+            }
+          >
+        : {})
+  > &
+  // Allow the EntryPoint address to be overridden, if not Account is provided, it will need to be required.
+  MaybeRequired<
+    { entryPointAddress?: Address },
+    _derivedAccount extends undefined ? true : false
+  >
 export type SendUserOperationReturnType = Hex
 
 export type SendUserOperationErrorType =
@@ -111,20 +126,21 @@ export async function sendUserOperation<
   client: Client<Transport, Chain | undefined, account>,
   parameters: SendUserOperationParameters<account, accountOverride, calls>,
 ) {
-  const { account: account_ = client.account } = parameters
+  const { account: account_ = client.account, entryPointAddress } = parameters
 
-  if (!account_) throw new AccountNotFoundError()
-  const account = parseAccount(account_)
+  if (!account_ && !parameters.sender) throw new AccountNotFoundError()
+  const account = account_ ? parseAccount(account_) : undefined
 
-  const request = await getAction(
-    client,
-    prepareUserOperation,
-    'prepareUserOperation',
-  )(parameters as unknown as PrepareUserOperationParameters)
+  const request = account
+    ? await getAction(
+        client,
+        prepareUserOperation,
+        'prepareUserOperation',
+      )(parameters as unknown as PrepareUserOperationParameters)
+    : parameters
 
-  const signature =
-    parameters.signature ||
-    (await account.signUserOperation(request as UserOperation))
+  const signature = (parameters.signature ||
+    (await account?.signUserOperation(request as UserOperation)))!
 
   const rpcParameters = formatUserOperationRequest({
     ...request,
@@ -135,14 +151,18 @@ export async function sendUserOperation<
     return await client.request(
       {
         method: 'eth_sendUserOperation',
-        params: [rpcParameters, account.entryPoint.address],
+        params: [
+          rpcParameters,
+          (entryPointAddress ?? account?.entryPoint.address)!,
+        ],
       },
       { retryCount: 0 },
     )
   } catch (error) {
+    const calls = (parameters as any).calls
     throw getUserOperationError(error as BaseError, {
       ...(request as UserOperation),
-      calls: parameters.calls,
+      ...(calls ? { calls } : {}),
       signature,
     })
   }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `toSmartAccount` function by adding a `nonceKeyManager` property and allows passing full-formed User Operations to `sendUserOperation` and `estimateUserOperationGas`.

### Detailed summary
- Added `nonceKeyManager` property to `toSmartAccount`
- Enhanced `sendUserOperation` to accept full-formed User Operations

> The following files were skipped due to too many changes: `src/account-abstraction/actions/bundler/sendUserOperation.ts`, `src/account-abstraction/actions/bundler/estimateUserOperationGas.ts`, `src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->