### PR TITLE
chore: add multicall3 to Sophon Testnet

### DIFF
--- a/.changeset/tiny-dots-cry.md
+++ b/.changeset/tiny-dots-cry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 to Sophon Testnet.

--- a/src/chains/definitions/sophonTestnet.ts
+++ b/src/chains/definitions/sophonTestnet.ts
@@ -20,5 +20,11 @@ export const sophonTestnet = /*#__PURE__*/ defineChain({
       url: 'https://explorer.testnet.sophon.xyz',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0x83c04d112adedA2C6D9037bb6ecb42E7f0b108Af',
+      blockCreated: 15_642
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Hi!

Here's a small PR to add the recently deployed multicall3 contract to the Sophon Testnet config, the verified contract can be found in the explorer [[link](https://explorer.testnet.sophon.xyz/address/0x83c04d112adedA2C6D9037bb6ecb42E7f0b108Af)], and the block in which it was deployed in can be found [here](https://explorer.testnet.sophon.xyz/block/15642)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `multicall3` contract to the Sophon Testnet.

### Detailed summary
- Added `multicall3` contract with address and block creation information to Sophon Testnet definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->