### PR TITLE
Add holesky apiUrl

### DIFF
--- a/.changeset/new-ravens-beg.md
+++ b/.changeset/new-ravens-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Holesky API URL.

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -13,6 +13,7 @@ export const holesky = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://holesky.etherscan.io',
+      apiUrl: 'https://api-holesky.etherscan.io/api',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Holesky has etherscan URL but is missing etherscan API URL - probably should be added
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the Holesky API URL to the Etherscan definition.

### Detailed summary
- Added Holesky API URL to the Etherscan definition in `holesky.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->