### PR TITLE
chore: adjust sophon native token symbol

### DIFF
--- a/.changeset/three-fireants-beg.md
+++ b/.changeset/three-fireants-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Adjusted sophon native token symbol.

--- a/src/chains/definitions/sophonTestnet.ts
+++ b/src/chains/definitions/sophonTestnet.ts
@@ -6,7 +6,7 @@ export const sophonTestnet = /*#__PURE__*/ defineChain({
   nativeCurrency: {
     decimals: 18,
     name: 'Sophon',
-    symbol: 'ETH',
+    symbol: 'SOPH',
   },
   rpcUrls: {
     default: {


### PR DESCRIPTION
I noticed that the `SOPH` symbol was changed to `ETH` after the PR I put up a few days ago, then I realized it was probably done to keep the chain configuration in line with chainlist https://chainlist.org/chain/531050104 

However that was never intended to state ETH, we created a PR that was merged into `ethereum-lists/chains` earlier today to get that corrected https://github.com/ethereum-lists/chains/pull/5746 , would love to see the same in viem!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adjusts the native token symbol in the Sophon Testnet from 'ETH' to 'SOPH'.

### Detailed summary
- Adjusted the native token symbol from 'ETH' to 'SOPH' in `src/chains/definitions/sophonTestnet.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->