### PR TITLE
add cannon to chains list

### DIFF
--- a/src/chains/definitions/cannon.js
+++ b/src/chains/definitions/cannon.js
@@ -1,0 +1,14 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const cannon = /*#__PURE__*/ defineChain({
+  id: 13_370,
+  name: 'Cannon',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: { http: ['http://127.0.0.1:8545'] },
+  },
+})


### PR DESCRIPTION

This PR adds support for the chain ID used by [Cannon](https://usecannon.com/), used by cannon CLI when hosting a local testnet. chain with its definitions and configurations.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new chain definition for `Cannon`.

### Detailed summary
- Added a new chain definition for `Cannon` with ID 13_370
- Set the name as 'Cannon' and native currency as Ether (ETH)
- Defined default RPC URL for the chain with http://127.0.0.1:8545

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->