### PR TITLE
fix: sophon testnet chain

### DIFF
--- a/.changeset/rude-maps-play.md
+++ b/.changeset/rude-maps-play.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Sophon testnet chain.

--- a/.changeset/rude-maps-play.md
+++ b/.changeset/rude-maps-play.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed Sophon testnet chain.
+Added ZKsync config to Sophon testnet chain.

--- a/src/chains/definitions/sophonTestnet.ts
+++ b/src/chains/definitions/sophonTestnet.ts
@@ -1,6 +1,8 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
 
 export const sophonTestnet = /*#__PURE__*/ defineChain({
+  ...chainConfig,
   id: 531_050_104,
   name: 'Sophon Testnet',
   nativeCurrency: {


### PR DESCRIPTION
This PR fixes the Sophon Tesnet chain definition by adding the required configuration for zkSync chains.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds ZKSync config to the Sophon Testnet chain definition.

### Detailed summary
- Added ZKSync config to Sophon Testnet chain definition in `sophonTestnet.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->