### PR TITLE
test: extended client action composition

### DIFF
--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -1,8 +1,10 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { anvilMainnet } from '../../test/src/anvil.js'
+import { getChainId } from '../actions/public/getChainId.js'
 import { localhost, mainnet } from '../chains/index.js'
 import type { EIP1193RequestFn, EIP1474Methods } from '../types/eip1193.js'
+import { getAction } from '../utils/getAction.js'
 import { createClient } from './createClient.js'
 import { publicActions } from './decorators/public.js'
 import { createTransport } from './transports/createTransport.js'
@@ -572,5 +574,34 @@ describe('extends', () => {
       // @ts-expect-error
       expect(extended.chain.id).toEqual(client.chain.id)
     })
+  })
+
+  test('action composition', async () => {
+    const calls: string[] = []
+    const extended = createClient({
+      chain: localhost,
+      transport: http(),
+    })
+      .extend((client) => ({
+        async getChainId() {
+          calls.push('first')
+          return getAction(client, getChainId, 'getChainId')({})
+        },
+      }))
+      .extend((client) => ({
+        async getChainId() {
+          calls.push('second')
+          return getAction(client, getChainId, 'getChainId')({})
+        },
+      }))
+      .extend((client) => ({
+        async getChainId() {
+          calls.push('third')
+          return getAction(client, getChainId, 'getChainId')({})
+        },
+      }))
+
+    expect(await extended.getChainId()).toBe(localhost.id)
+    expect(calls).toEqual(['third', 'second', 'first'])
   })
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

I wanted to know how client extending/action composition was meant to work, so I wrote a test to demonstrate since it doesn't seem to be documented anywhere.

(This is my assumed behavior and the test confirms it!)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a test for action composition in the `createClient` function.

### Detailed summary
- Added a test for action composition in `createClient`
- Imported `getChainId` function for testing
- Added `getAction` utility function for action composition in tests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->