### PR TITLE
Fix typo

### DIFF
--- a/site/pages/docs/faq.mdx
+++ b/site/pages/docs/faq.mdx
@@ -77,7 +77,7 @@ client.writeContract({
 })
 ```
 
-This can get even more complicated when a function has overrides:
+This can get even more complicated when a function has overloads:
 
 ```solidity
 function safeTransferFrom(address, address, uint256) {}


### PR DESCRIPTION
Just fix simple typo I ran into while reading

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the word "overrides" to "overloads" in the `faq.mdx` file.

### Detailed summary
- Replaced "overrides" with "overloads" in the `faq.mdx` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->