### PR TITLE
chore: export `encodeDeployData` and `hashBytecode` from zksync entrypoint

### DIFF
--- a/.changeset/spotty-shirts-turn.md
+++ b/.changeset/spotty-shirts-turn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Export `encodeDeployData` and `hashBytecode` from `viem/zksync`

--- a/.changeset/spotty-shirts-turn.md
+++ b/.changeset/spotty-shirts-turn.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Export `encodeDeployData` and `hashBytecode` from `viem/zksync`
+**Extension (ZKsync):** Exported `encodeDeployData` and `hashBytecode`.

--- a/src/zksync/index.ts
+++ b/src/zksync/index.ts
@@ -20,6 +20,15 @@ export {
   deployContract,
 } from './actions/deployContract.js'
 export {
+  type EncodeDeployDataParameters,
+  type EncodeDeployDataErrorType,
+  encodeDeployData,
+} from './utils/abi/encodeDeployData.js'
+export {
+  type HashBytecodeErrorType,
+  hashBytecode,
+} from './utils/hashBytecode.js'
+export {
   type EstimateFeeParameters,
   type EstimateFeeReturnType,
   estimateFee,


### PR DESCRIPTION
Exporting `encodeDeployData` and `hashBytecode` from `viem/zksync` - would like to use these for our zksync deployment flows rather than rewrite our own version!

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to extend the ZKsync extension by exporting `encodeDeployData` and `hashBytecode` functions.

### Detailed summary
- Exported `encodeDeployData` and `hashBytecode` functions in ZKsync extension.
- Added types for `encodeDeployData` and `hashBytecode`.
- Updated exports in `index.ts` for the new functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->