### PR TITLE
test: demonstrate callstack in extended client action

### DIFF
--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -5,7 +5,7 @@ import { getChainId } from '../actions/public/getChainId.js'
 import { localhost, mainnet } from '../chains/index.js'
 import type { EIP1193RequestFn, EIP1474Methods } from '../types/eip1193.js'
 import { getAction } from '../utils/getAction.js'
-import { createClient } from './createClient.js'
+import { type Client, createClient } from './createClient.js'
 import { publicActions } from './decorators/public.js'
 import { createTransport } from './transports/createTransport.js'
 import { custom } from './transports/custom.js'
@@ -577,29 +577,62 @@ describe('extends', () => {
   })
 
   test('action composition', async () => {
-    const calls: string[] = []
-    const extended = anvilMainnet
-      .getClient()
+    let calls: string[] = []
+
+    async function getChainId(_client: Client) {
+      calls.push('getChainId:base')
+      return 1337
+    }
+
+    async function estimateGas(client: Client) {
+      calls.push('estimateGas:base')
+      await getAction(client, getChainId, 'getChainId')({})
+      return 1000n
+    }
+
+    const extended = createClient({
+      chain: localhost,
+      transport: http(),
+    })
+      .extend((client) => ({
+        getChainId: () => getChainId(client),
+        estimateGas: () => estimateGas(client),
+      }))
       .extend((client) => ({
         async getChainId() {
-          calls.push('first')
+          calls.push('getChainId:first')
           return getAction(client, getChainId, 'getChainId')({})
+        },
+        async estimateGas() {
+          calls.push('estimateGas:first')
+          return getAction(client, estimateGas, 'estimateGas')({})
         },
       }))
       .extend((client) => ({
         async getChainId() {
-          calls.push('second')
+          calls.push('getChainId:second')
           return getAction(client, getChainId, 'getChainId')({})
         },
-      }))
-      .extend((client) => ({
-        async getChainId() {
-          calls.push('third')
-          return getAction(client, getChainId, 'getChainId')({})
+        async estimateGas() {
+          calls.push('estimateGas:second')
+          return getAction(client, estimateGas, 'estimateGas')({})
         },
       }))
 
-    expect(await extended.getChainId()).toBe(anvilMainnet.chain.id)
-    expect(calls).toEqual(['third', 'second', 'first'])
+    expect(await extended.getChainId()).toBe(1337)
+    expect(calls).toEqual([
+      'getChainId:second',
+      'getChainId:first',
+      'getChainId:base',
+    ])
+
+    calls = []
+    expect(await extended.estimateGas()).toBe(1000n)
+    expect(calls).toEqual([
+      'estimateGas:second',
+      'estimateGas:first',
+      'estimateGas:base',
+      'getChainId:base',
+    ])
   })
 })

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -1,7 +1,6 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { anvilMainnet } from '../../test/src/anvil.js'
-import { getChainId } from '../actions/public/getChainId.js'
 import { localhost, mainnet } from '../chains/index.js'
 import type { EIP1193RequestFn, EIP1474Methods } from '../types/eip1193.js'
 import { getAction } from '../utils/getAction.js'


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

Continued from https://github.com/wevm/viem/pull/2675

- replaces base actions to avoid RPC calls
- demonstrates callstack of inner action calls

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor and extend action composition in the `createClient` module.

### Detailed summary
- Added type definition for `Client`
- Refactored action composition logic in `createClient`
- Added new actions `getChainId` and `estimateGas`
- Updated tests to reflect changes in action composition logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->