### PR TITLE
Fix: Wrong link used in PublicClient multicall docs

### DIFF
--- a/.changeset/early-stingrays-lie.md
+++ b/.changeset/early-stingrays-lie.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix wrong link used in multicall docs

--- a/.changeset/early-stingrays-lie.md
+++ b/.changeset/early-stingrays-lie.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Fix wrong link used in multicall docs

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -59,7 +59,7 @@ const publicClient = createPublicClient({
 })
 ```
 
-> You can also [customize the `multicall` options](#batch-multicall-batchsize-optional).
+> You can also [customize the `multicall` options](#batchmulticallbatchsize-optional).
 
 Now, when you start to utilize `readContract` Actions, the Public Client will batch and send over those requests at the end of the message queue (or custom time period) in a single `eth_call` multicall request:
 


### PR DESCRIPTION
This PR fixes a link that was incorrect in the docs of the PublicClient multicall config.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix a typo in a link anchor in the `public.md` file related to customizing `multicall` options.

### Detailed summary
- Fixed a typo in a link anchor from `#batch-multicall-batchsize-optional` to `#batchmulticallbatchsize-optional` in `public.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->