### PR TITLE
fix: add export of paymaster actions

### DIFF
--- a/.changeset/cyan-insects-invite.md
+++ b/.changeset/cyan-insects-invite.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `getPaymasterData` and `getPaymasterStubData`.

--- a/src/account-abstraction/index.ts
+++ b/src/account-abstraction/index.ts
@@ -79,6 +79,19 @@ export {
 } from './actions/bundler/waitForUserOperationReceipt.js'
 
 export {
+  type GetPaymasterDataParameters,
+  type GetPaymasterDataReturnType,
+  type GetPaymasterDataErrorType,
+  getPaymasterData,
+} from './actions/paymaster/getPaymasterData.js'
+export {
+  type GetPaymasterStubDataParameters,
+  type GetPaymasterStubDataReturnType,
+  type GetPaymasterStubDataErrorType,
+  getPaymasterStubData,
+} from './actions/paymaster/getPaymasterStubData.js'
+
+export {
   type BundlerActions,
   bundlerActions,
 } from './clients/decorators/bundler.js'


### PR DESCRIPTION
Just added the export of the the paymaster actions `getPaymasterData` and `getPaymasterStubData` from the `viem/account-abstraction/actions/paymaster` folder.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting `getPaymasterData` and `getPaymasterStubData` functions. 

### Detailed summary
- Exported `getPaymasterData` functions with types.
- Exported `getPaymasterStubData` functions with types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->