### PR TITLE
fix: metis chainid in api route

### DIFF
--- a/.changeset/four-pugs-greet.md
+++ b/.changeset/four-pugs-greet.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Metis Explorer API URL.

--- a/src/chains/definitions/metis.ts
+++ b/src/chains/definitions/metis.ts
@@ -16,7 +16,7 @@ export const metis = /*#__PURE__*/ defineChain({
       name: 'Metis Explorer',
       url: 'https://explorer.metis.io',
       apiUrl:
-        'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api',
+        'https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan/api',
     },
     blockscout: {
       name: 'Andromeda Explorer',


### PR DESCRIPTION
metis was using wrong chainid

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the Metis Explorer API URL by updating the chain definitions for Metis and Andromeda Explorer.

### Detailed summary
- Updated Metis Explorer API URL in `metis.ts` file
- Changed the EVM network number from 43114 to 1088
- Updated the name of the block explorer to 'Andromeda Explorer'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->