### PR TITLE
[WIP] update: Abstract testnet EIP712 domain

### DIFF
--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -21,7 +21,7 @@ export const getAbstractEip712Domain: EIP712DomainFn<
 
   return {
     domain: {
-      name: 'Abstract',
+      name: 'Abstract', // Use 'Abstract' rather than 'zkSync'
       version: '2',
       chainId: transaction.chainId,
     },
@@ -67,6 +67,6 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
   },
   testnet: true,
   custom: {
-    getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
+    getEip712Domain: getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
   },
 })

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -1,5 +1,51 @@
+import { transactionToMessage } from '../..//zksync/utils/getEip712Domain.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../../zksync/chainConfig.js'
+import type { EIP712DomainFn } from '../../zksync/types/eip712.js'
+import type {
+  ZksyncEIP712TransactionSignable,
+  ZksyncTransactionSerializable,
+  ZksyncTransactionSerializableEIP712,
+} from '../../zksync/types/transaction.js'
+import { assertEip712Transaction } from '../../zksync/utils/assertEip712Transaction.js'
+
+export const getAbstractEip712Domain: EIP712DomainFn<
+  ZksyncTransactionSerializable,
+  ZksyncEIP712TransactionSignable
+> = (transaction) => {
+  assertEip712Transaction(transaction)
+
+  const message = transactionToMessage(
+    transaction as ZksyncTransactionSerializableEIP712,
+  )
+
+  return {
+    domain: {
+      name: 'Abstract',
+      version: '2',
+      chainId: transaction.chainId,
+    },
+    types: {
+      Transaction: [
+        { name: 'txType', type: 'uint256' },
+        { name: 'from', type: 'uint256' },
+        { name: 'to', type: 'uint256' },
+        { name: 'gasLimit', type: 'uint256' },
+        { name: 'gasPerPubdataByteLimit', type: 'uint256' },
+        { name: 'maxFeePerGas', type: 'uint256' },
+        { name: 'maxPriorityFeePerGas', type: 'uint256' },
+        { name: 'paymaster', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'factoryDeps', type: 'bytes32[]' },
+        { name: 'paymasterInput', type: 'bytes' },
+      ],
+    },
+    primaryType: 'Transaction',
+    message: message,
+  }
+}
 
 export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
@@ -20,4 +66,7 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  custom: {
+    getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
+  },
 })

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -50,7 +50,7 @@ export const getEip712Domain: EIP712DomainFn<
 //////////////////////////////////////////////////////////////////////////////
 // Utilities
 
-function transactionToMessage(
+export function transactionToMessage(
   transaction: ZksyncTransactionSerializableEIP712,
 ): ZksyncEIP712TransactionSignable {
   const {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->
The default domain name for zk stack chains right now is `zkSync`. However, on Abstract, we want the domain name to be `Abstract`. This PR changes the network configuration to default to `Abstract`.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new function `getAbstractEip712Domain` and update `abstractTestnet` chain configuration with a custom EIP712 domain.

### Detailed summary
- Added `getAbstractEip712Domain` function to generate EIP712 domain for Abstract chain
- Updated `abstractTestnet` chain configuration to use the new EIP712 domain function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->