### PR TITLE
fix: typo within `recoverPublicKey.md`

### DIFF
--- a/site/pages/docs/utilities/recoverPublicKey.md
+++ b/site/pages/docs/utilities/recoverPublicKey.md
@@ -11,7 +11,7 @@ Recovers the original signing 64-byte public key from a hash & signature.
 ```ts [example.ts]
 import { recoverPublicKey } from 'viem'
  
-const address = await recoverPublicKey({
+const publicKey = await recoverPublicKey({
   hash: '0xd9eba16ed0ecae432b71fe008c98cc872bb4cc214d3220a36f365326cf807d68',
   signature: '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c'
 })


### PR DESCRIPTION
Fixes a small typo where the variable name is written as `address` instead of `publicKey`, as should be because the returned value is that of the recovered public key.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the variable name from `address` to `publicKey` in the `recoverPublicKey` function call.

### Detailed summary
- Renamed the variable from `address` to `publicKey` in the `recoverPublicKey` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->