### PR TITLE
Add missing Kaia blockexplorer API URL

### DIFF
--- a/src/chains/definitions/kaia.ts
+++ b/src/chains/definitions/kaia.ts
@@ -15,6 +15,7 @@ export const kaia = /*#__PURE__*/ defineChain({
     default: {
       name: 'KaiaScope',
       url: 'https://kaiascope.com',
+      apiUrl: 'https://api-cypress.klaytnscope.com/api',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `apiUrl` for the `KaiaScope` in the `kaia.ts` file.

### Detailed summary
- Updated `apiUrl` to 'https://api-cypress.klaytnscope.com/api' for `KaiaScope` in `kaia.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->