### PR TITLE
fix: Always use maxUint256 instead of 2n ** 256n - 1n

### DIFF
--- a/.changeset/seven-emus-fetch.md
+++ b/.changeset/seven-emus-fetch.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaced instances of `2n ** 256n - 1n` with the `maxUint256` constant.

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -34,6 +34,7 @@ import {
   createClient,
   decodeFunctionResult,
   encodeAbiParameters,
+  maxUint256,
   multicall3Abi,
   pad,
   parseEther,
@@ -247,7 +248,7 @@ describe('errors', () => {
         data: `${mintWithParams4bytes}${fourTwenty}`,
         account: sourceAccount.address,
         to: wagmiContractAddress,
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [CallExecutionError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).

--- a/src/actions/public/estimateGas.test.ts
+++ b/src/actions/public/estimateGas.test.ts
@@ -329,7 +329,7 @@ describe('errors', () => {
         account: accounts[0].address,
         to: accounts[1].address,
         value: parseEther('1'),
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [EstimateGasExecutionError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -24,6 +24,7 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { mine } from '../test/mine.js'
 
+import { maxUint256 } from '~viem/constants/number.js'
 import { simulateContract } from './simulateContract.js'
 
 const client = anvilMainnet
@@ -545,7 +546,7 @@ describe('node errors', () => {
         account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [13371337n],
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [ContractFunctionExecutionError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -6,6 +6,7 @@ import { anvilMainnet } from '../../../test/src/anvil.js'
 import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
 import { celo, localhost, mainnet, optimism } from '../../chains/index.js'
 
+import { maxUint256 } from '~viem/constants/number.js'
 import { BatchCallInvoker } from '../../../contracts/generated.js'
 import { getSmartAccounts_07 } from '../../../test/src/account-abstraction.js'
 import { deploy } from '../../../test/src/utils.js'
@@ -1174,7 +1175,7 @@ describe('errors', () => {
       sendTransaction(client, {
         to: targetAccount.address,
         value: parseEther('1'),
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [AccountNotFoundError: Could not find an Account to execute with this Action.
@@ -1193,7 +1194,7 @@ describe('errors', () => {
         account: sourceAccount.address,
         to: targetAccount.address,
         value: parseEther('1'),
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [TransactionExecutionError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).

--- a/src/celo/serializers.ts
+++ b/src/celo/serializers.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from '~viem/constants/number.js'
 import { InvalidAddressError } from '../errors/address.js'
 import { BaseError } from '../errors/base.js'
 import { InvalidChainIdError } from '../errors/chain.js'
@@ -75,8 +76,8 @@ function serializeTransactionCIP64(
   ]) as SerializeTransactionCIP64ReturnType
 }
 
-// maxFeePerGas must be less than 2^256 - 1
-const MAX_MAX_FEE_PER_GAS = 2n ** 256n - 1n
+// maxFeePerGas must be less than maxUint256
+const MAX_MAX_FEE_PER_GAS = maxUint256
 
 export function assertTransactionCIP42(
   transaction: TransactionSerializableCIP42,

--- a/src/utils/transaction/assertRequest.test.ts
+++ b/src/utils/transaction/assertRequest.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 
 import { parseGwei } from '../unit/parseGwei.js'
 
+import { maxUint256 } from '~viem/constants/number.js'
 import { assertRequest } from './assertRequest.js'
 
 test('invalid address', () => {
@@ -19,7 +20,7 @@ test('invalid address', () => {
 
 test('fee cap too high', () => {
   expect(() =>
-    assertRequest({ maxFeePerGas: 2n ** 256n - 1n + 1n }),
+    assertRequest({ maxFeePerGas: maxUint256 + 1n }),
   ).toThrowErrorMatchingInlineSnapshot(`
     [FeeCapTooHighError: The fee cap (\`maxFeePerGas\` = 115792089237316195423570985008687907853269984665640564039457584007913.129639936 gwei) cannot be higher than the maximum allowed value (2^256-1).
 

--- a/src/utils/transaction/assertRequest.ts
+++ b/src/utils/transaction/assertRequest.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from '~viem/constants/number.js'
 import {
   type ParseAccountErrorType,
   parseAccount,
@@ -53,7 +54,7 @@ export function assertRequest(args: AssertRequestParameters) {
   )
     throw new FeeConflictError()
 
-  if (maxFeePerGas && maxFeePerGas > 2n ** 256n - 1n)
+  if (maxFeePerGas && maxFeePerGas > maxUint256)
     throw new FeeCapTooHighError({ maxFeePerGas })
   if (
     maxPriorityFeePerGas &&

--- a/src/utils/transaction/assertTransaction.test.ts
+++ b/src/utils/transaction/assertTransaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import { parseGwei } from '../unit/parseGwei.js'
 
+import { maxUint256 } from '~viem/constants/number.js'
 import {
   assertTransactionEIP1559,
   assertTransactionEIP2930,
@@ -71,7 +72,7 @@ describe('eip7702', () => {
             yParity: 0,
           },
         ],
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
@@ -136,7 +137,7 @@ describe('eip4844', () => {
         blobVersionedHashes: [
           '0x01febabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe',
         ],
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
@@ -151,7 +152,7 @@ describe('eip1559', () => {
   test('fee cap too high', () => {
     expect(() =>
       assertTransactionEIP1559({
-        maxFeePerGas: 2n ** 256n - 1n + 1n,
+        maxFeePerGas: maxUint256 + 1n,
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
@@ -203,7 +204,7 @@ describe('eip2930', () => {
   test('fee cap too high', () => {
     expect(() =>
       assertTransactionEIP2930({
-        gasPrice: 2n ** 256n - 1n + 1n,
+        gasPrice: maxUint256 + 1n,
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
@@ -254,7 +255,7 @@ describe('legacy', () => {
   test('fee cap too high', () => {
     expect(() =>
       assertTransactionLegacy({
-        gasPrice: 2n ** 256n - 1n + 1n,
+        gasPrice: maxUint256 + 1n,
         chainId: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`

--- a/src/utils/transaction/assertTransaction.ts
+++ b/src/utils/transaction/assertTransaction.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from '~viem/constants/number.js'
 import { versionedHashVersionKzg } from '../../constants/kzg.js'
 import {
   InvalidAddressError,
@@ -99,7 +100,7 @@ export function assertTransactionEIP1559(
   const { chainId, maxPriorityFeePerGas, maxFeePerGas, to } = transaction
   if (chainId <= 0) throw new InvalidChainIdError({ chainId })
   if (to && !isAddress(to)) throw new InvalidAddressError({ address: to })
-  if (maxFeePerGas && maxFeePerGas > 2n ** 256n - 1n)
+  if (maxFeePerGas && maxFeePerGas > maxUint256)
     throw new FeeCapTooHighError({ maxFeePerGas })
   if (
     maxPriorityFeePerGas &&
@@ -128,7 +129,7 @@ export function assertTransactionEIP2930(
     throw new BaseError(
       '`maxFeePerGas`/`maxPriorityFeePerGas` is not a valid EIP-2930 Transaction attribute.',
     )
-  if (gasPrice && gasPrice > 2n ** 256n - 1n)
+  if (gasPrice && gasPrice > maxUint256)
     throw new FeeCapTooHighError({ maxFeePerGas: gasPrice })
 }
 
@@ -152,6 +153,6 @@ export function assertTransactionLegacy(
     throw new BaseError(
       '`maxFeePerGas`/`maxPriorityFeePerGas` is not a valid Legacy Transaction attribute.',
     )
-  if (gasPrice && gasPrice > 2n ** 256n - 1n)
+  if (gasPrice && gasPrice > maxUint256)
     throw new FeeCapTooHighError({ maxFeePerGas: gasPrice })
 }


### PR DESCRIPTION
### Overview
This PR improves the readability of code that uses `2n ** 256n - 1n`. It also fixes a crash in JavaScript caused by using these big numbers directly inside `if` statements.
![Screenshot 2024-09-05 at 12 00 47](https://github.com/user-attachments/assets/4dc81d5d-b49d-4e59-8854-4b94a4a9bc5d)

### Summary

- Fixed a crash related to big numbers in conditional logic.
- Improved overall code readability for better maintenance and understanding.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces hard-coded values with a `maxUint256` constant for fee calculations.

### Detailed summary
- Replaced hard-coded values with `maxUint256` constant in fee calculations across multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->