### PR TITLE
fix: getPaymasterData api request & response

### DIFF
--- a/.changeset/plenty-kings-hope.md
+++ b/.changeset/plenty-kings-hope.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add paymasterPostOpGasLimit and paymasterVerificationGasLimit to getPaymasterData request & make them as optional in getPaymasterData response per ERC-7677 standard.

--- a/src/account-abstraction/actions/paymaster/getPaymasterData.ts
+++ b/src/account-abstraction/actions/paymaster/getPaymasterData.ts
@@ -46,6 +46,8 @@ export type GetPaymasterDataParameters = OneOf<
         | 'sender'
         | 'preVerificationGas'
         | 'verificationGasLimit'
+        | 'paymasterPostOpGasLimit'
+        | 'paymasterVerificationGasLimit'
       >,
       | 'callGasLimit'
       | 'factory'
@@ -67,8 +69,8 @@ export type GetPaymasterDataReturnType = Prettify<
     | {
         paymaster: Address
         paymasterData: Hex
-        paymasterVerificationGasLimit: bigint
-        paymasterPostOpGasLimit: bigint
+        paymasterVerificationGasLimit?: bigint
+        paymasterPostOpGasLimit?: bigint
       }
   >
 >
@@ -125,11 +127,17 @@ export async function getPaymasterData(
     })
   return {
     ...rest,
-    ...(paymasterPostOpGasLimit && {
-      paymasterPostOpGasLimit: hexToBigInt(paymasterPostOpGasLimit),
-    }),
-    ...(paymasterVerificationGasLimit && {
-      paymasterVerificationGasLimit: hexToBigInt(paymasterVerificationGasLimit),
-    }),
+    ...(paymasterPostOpGasLimit
+      ? {
+          paymasterPostOpGasLimit: hexToBigInt(paymasterPostOpGasLimit),
+        }
+      : {}),
+    ...(paymasterVerificationGasLimit
+      ? {
+          paymasterVerificationGasLimit: hexToBigInt(
+            paymasterVerificationGasLimit,
+          ),
+        }
+      : {}),
   } as unknown as GetPaymasterDataReturnType
 }

--- a/src/account-abstraction/actions/paymaster/getPaymasterData.ts
+++ b/src/account-abstraction/actions/paymaster/getPaymasterData.ts
@@ -127,17 +127,11 @@ export async function getPaymasterData(
     })
   return {
     ...rest,
-    ...(paymasterPostOpGasLimit
-      ? {
-          paymasterPostOpGasLimit: hexToBigInt(paymasterPostOpGasLimit),
-        }
-      : {}),
-    ...(paymasterVerificationGasLimit
-      ? {
-          paymasterVerificationGasLimit: hexToBigInt(
-            paymasterVerificationGasLimit,
-          ),
-        }
-      : {}),
+    ...(paymasterPostOpGasLimit && {
+      paymasterPostOpGasLimit: hexToBigInt(paymasterPostOpGasLimit),
+    }),
+    ...(paymasterVerificationGasLimit && {
+      paymasterVerificationGasLimit: hexToBigInt(paymasterVerificationGasLimit),
+    }),
   } as unknown as GetPaymasterDataReturnType
 }


### PR DESCRIPTION
Per ERC-7677 [standard](https://www.erc7677.xyz/reference/paymasters/getPaymasterData#example-usage-1): `paymasterPostOpGasLimit` and `paymasterVerificationGasLimit` are two optional fields in getPaymasterData's request, and they are optional in getPaymasterData's returning response.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `getPaymasterData` functionality by adding `paymasterPostOpGasLimit` and `paymasterVerificationGasLimit` as optional fields per ERC-7677 standard.

### Detailed summary
- Added `paymasterPostOpGasLimit` and `paymasterVerificationGasLimit` as optional fields in `getPaymasterData` response
- Updated `GetPaymasterDataReturnType` type


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->