### PR TITLE
Update Polygon's native token from MATIC to POL

### DIFF
--- a/.changeset/slimy-crabs-nail.md
+++ b/.changeset/slimy-crabs-nail.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Polygon's native token from MATIC to POL

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const polygon = /*#__PURE__*/ defineChain({
   id: 137,
   name: 'Polygon',
-  nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
+  nativeCurrency: { name: 'POL', symbol: 'POL', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://polygon-rpc.com'],


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Polygons upgrade is complete and the native token is now POL instead of MATIC

more information here: https://polygon.technology/blog/matic-to-pol-migration-is-now-live-everything-you-need-to-know

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the native token of Polygon chain from MATIC to POL.

### Detailed summary
- Updated native token of Polygon chain to POL from MATIC.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->