### PR TITLE
feat: abstract testnet 712 domain

### DIFF
--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -21,7 +21,7 @@ export const getAbstractEip712Domain: EIP712DomainFn<
 
   return {
     domain: {
-      name: 'Abstract',
+      name: 'Abstract', // Use 'Abstract' rather than 'zkSync'
       version: '2',
       chainId: transaction.chainId,
     },
@@ -67,6 +67,6 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
   },
   testnet: true,
   custom: {
-    getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
+    getEip712Domain: getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
   },
 })

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -1,5 +1,51 @@
+import { transactionToMessage } from '../..//zksync/utils/getEip712Domain.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../../zksync/chainConfig.js'
+import type { EIP712DomainFn } from '../../zksync/types/eip712.js'
+import type {
+  ZksyncEIP712TransactionSignable,
+  ZksyncTransactionSerializable,
+  ZksyncTransactionSerializableEIP712,
+} from '../../zksync/types/transaction.js'
+import { assertEip712Transaction } from '../../zksync/utils/assertEip712Transaction.js'
+
+export const getAbstractEip712Domain: EIP712DomainFn<
+  ZksyncTransactionSerializable,
+  ZksyncEIP712TransactionSignable
+> = (transaction) => {
+  assertEip712Transaction(transaction)
+
+  const message = transactionToMessage(
+    transaction as ZksyncTransactionSerializableEIP712,
+  )
+
+  return {
+    domain: {
+      name: 'Abstract',
+      version: '2',
+      chainId: transaction.chainId,
+    },
+    types: {
+      Transaction: [
+        { name: 'txType', type: 'uint256' },
+        { name: 'from', type: 'uint256' },
+        { name: 'to', type: 'uint256' },
+        { name: 'gasLimit', type: 'uint256' },
+        { name: 'gasPerPubdataByteLimit', type: 'uint256' },
+        { name: 'maxFeePerGas', type: 'uint256' },
+        { name: 'maxPriorityFeePerGas', type: 'uint256' },
+        { name: 'paymaster', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'factoryDeps', type: 'bytes32[]' },
+        { name: 'paymasterInput', type: 'bytes' },
+      ],
+    },
+    primaryType: 'Transaction',
+    message: message,
+  }
+}
 
 export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
@@ -20,4 +66,7 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  custom: {
+    getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
+  },
 })

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -1,51 +1,7 @@
-import { transactionToMessage } from '../..//zksync/utils/getEip712Domain.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../../zksync/chainConfig.js'
-import type { EIP712DomainFn } from '../../zksync/types/eip712.js'
-import type {
-  ZksyncEIP712TransactionSignable,
-  ZksyncTransactionSerializable,
-  ZksyncTransactionSerializableEIP712,
-} from '../../zksync/types/transaction.js'
-import { assertEip712Transaction } from '../../zksync/utils/assertEip712Transaction.js'
-
-export const getAbstractEip712Domain: EIP712DomainFn<
-  ZksyncTransactionSerializable,
-  ZksyncEIP712TransactionSignable
-> = (transaction) => {
-  assertEip712Transaction(transaction)
-
-  const message = transactionToMessage(
-    transaction as ZksyncTransactionSerializableEIP712,
-  )
-
-  return {
-    domain: {
-      name: 'Abstract', // Use 'Abstract' rather than 'zkSync'
-      version: '2',
-      chainId: transaction.chainId,
-    },
-    types: {
-      Transaction: [
-        { name: 'txType', type: 'uint256' },
-        { name: 'from', type: 'uint256' },
-        { name: 'to', type: 'uint256' },
-        { name: 'gasLimit', type: 'uint256' },
-        { name: 'gasPerPubdataByteLimit', type: 'uint256' },
-        { name: 'maxFeePerGas', type: 'uint256' },
-        { name: 'maxPriorityFeePerGas', type: 'uint256' },
-        { name: 'paymaster', type: 'uint256' },
-        { name: 'nonce', type: 'uint256' },
-        { name: 'value', type: 'uint256' },
-        { name: 'data', type: 'bytes' },
-        { name: 'factoryDeps', type: 'bytes32[]' },
-        { name: 'paymasterInput', type: 'bytes' },
-      ],
-    },
-    primaryType: 'Transaction',
-    message: message,
-  }
-}
+import type { ZksyncTransactionSerializableEIP712 } from '../../zksync/types/transaction.js'
+import { transactionToMessage } from '../../zksync/utils/getEip712Domain.js'
 
 export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
@@ -67,6 +23,35 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
   },
   testnet: true,
   custom: {
-    getEip712Domain: getAbstractEip712Domain, // Use Abstract's specific EIP712 domain
+    getEip712Domain(transaction: ZksyncTransactionSerializableEIP712) {
+      const message = transactionToMessage(transaction)
+
+      return {
+        domain: {
+          name: 'Abstract', // Use 'Abstract' rather than 'zkSync'
+          version: '2',
+          chainId: transaction.chainId,
+        },
+        types: {
+          Transaction: [
+            { name: 'txType', type: 'uint256' },
+            { name: 'from', type: 'uint256' },
+            { name: 'to', type: 'uint256' },
+            { name: 'gasLimit', type: 'uint256' },
+            { name: 'gasPerPubdataByteLimit', type: 'uint256' },
+            { name: 'maxFeePerGas', type: 'uint256' },
+            { name: 'maxPriorityFeePerGas', type: 'uint256' },
+            { name: 'paymaster', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'value', type: 'uint256' },
+            { name: 'data', type: 'bytes' },
+            { name: 'factoryDeps', type: 'bytes32[]' },
+            { name: 'paymasterInput', type: 'bytes' },
+          ],
+        },
+        primaryType: 'Transaction',
+        message: message,
+      }
+    },
   },
 })

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -50,7 +50,7 @@ export const getEip712Domain: EIP712DomainFn<
 //////////////////////////////////////////////////////////////////////////////
 // Utilities
 
-function transactionToMessage(
+export function transactionToMessage(
   transaction: ZksyncTransactionSerializableEIP712,
 ): ZksyncEIP712TransactionSignable {
   const {

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -6,15 +6,12 @@ import type {
   ZksyncTransactionSerializable,
   ZksyncTransactionSerializableEIP712,
 } from '../types/transaction.js'
-import { assertEip712Transaction } from './assertEip712Transaction.js'
 import { hashBytecode } from './hashBytecode.js'
 
 export const getEip712Domain: EIP712DomainFn<
   ZksyncTransactionSerializable,
   ZksyncEIP712TransactionSignable
 > = (transaction) => {
-  assertEip712Transaction(transaction)
-
   const message = transactionToMessage(
     transaction as ZksyncTransactionSerializableEIP712,
   )

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -6,12 +6,15 @@ import type {
   ZksyncTransactionSerializable,
   ZksyncTransactionSerializableEIP712,
 } from '../types/transaction.js'
+import { assertEip712Transaction } from './assertEip712Transaction.js'
 import { hashBytecode } from './hashBytecode.js'
 
 export const getEip712Domain: EIP712DomainFn<
   ZksyncTransactionSerializable,
   ZksyncEIP712TransactionSignable
 > = (transaction) => {
+  assertEip712Transaction(transaction)
+
   const message = transactionToMessage(
     transaction as ZksyncTransactionSerializableEIP712,
   )


### PR DESCRIPTION
supersedes #2687

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a function `transactionToMessage` in `getEip712Domain.ts` and importing it in `abstractTestnet.ts` for EIP712 domain creation.

### Detailed summary
- Exported `transactionToMessage` function in `getEip712Domain.ts`
- Imported `transactionToMessage` in `abstractTestnet.ts` for EIP712 domain creation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->