### PR TITLE
fix: change title in `getUserOperation` page

### DIFF
--- a/site/pages/account-abstraction/actions/bundler/getUserOperation.md
+++ b/site/pages/account-abstraction/actions/bundler/getUserOperation.md
@@ -2,7 +2,7 @@
 description: Retrieves information about a User Operation given a hash.
 ---
 
-# getUserOperationReceipt
+# getUserOperation
 
 Retrieves information about a User Operation given a hash.
 


### PR DESCRIPTION
Fixes the title in the `getUserOperation` page (`getUserOperationReceipt` -> `getUserOperation`).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the function name from `getUserOperationReceipt` to `getUserOperation` in the `bundler` module.

### Detailed summary
- Renamed function from `getUserOperationReceipt` to `getUserOperation` in `bundler` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->