### PR TITLE
Fix: Flare networks naming

### DIFF
--- a/.changeset/smooth-ladybugs-draw.md
+++ b/.changeset/smooth-ladybugs-draw.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated naming for Flare chains.

--- a/src/chains/definitions/flare.ts
+++ b/src/chains/definitions/flare.ts
@@ -5,7 +5,7 @@ export const flare = /*#__PURE__*/ defineChain({
   name: 'Flare Mainnet',
   nativeCurrency: {
     decimals: 18,
-    name: 'flare',
+    name: 'Flare',
     symbol: 'FLR',
   },
   rpcUrls: {

--- a/src/chains/definitions/flareTestnet.ts
+++ b/src/chains/definitions/flareTestnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const flareTestnet = /*#__PURE__*/ defineChain({
   id: 114,
-  name: 'Coston2',
+  name: 'Flare Testnet Coston2',
   nativeCurrency: {
     decimals: 18,
     name: 'coston2flare',

--- a/src/chains/definitions/flareTestnet.ts
+++ b/src/chains/definitions/flareTestnet.ts
@@ -5,7 +5,7 @@ export const flareTestnet = /*#__PURE__*/ defineChain({
   name: 'Flare Testnet Coston2',
   nativeCurrency: {
     decimals: 18,
-    name: 'coston2flare',
+    name: 'Coston2 Flare',
     symbol: 'C2FLR',
   },
   rpcUrls: {

--- a/src/chains/definitions/songbird.ts
+++ b/src/chains/definitions/songbird.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const songbird = /*#__PURE__*/ defineChain({
   id: 19,
-  name: 'Songbird Mainnet',
+  name: 'Songbird Canary-Network',
   nativeCurrency: {
     decimals: 18,
     name: 'songbird',

--- a/src/chains/definitions/songbird.ts
+++ b/src/chains/definitions/songbird.ts
@@ -5,7 +5,7 @@ export const songbird = /*#__PURE__*/ defineChain({
   name: 'Songbird Canary-Network',
   nativeCurrency: {
     decimals: 18,
-    name: 'songbird',
+    name: 'Songbird',
     symbol: 'SGB',
   },
   rpcUrls: {

--- a/src/chains/definitions/songbirdTestnet.ts
+++ b/src/chains/definitions/songbirdTestnet.ts
@@ -5,7 +5,7 @@ export const songbirdTestnet = /*#__PURE__*/ defineChain({
   name: 'Songbird Testnet Coston',
   nativeCurrency: {
     decimals: 18,
-    name: 'costonflare',
+    name: 'Coston Flare',
     symbol: 'CFLR',
   },
   rpcUrls: {

--- a/src/chains/definitions/songbirdTestnet.ts
+++ b/src/chains/definitions/songbirdTestnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const songbirdTestnet = /*#__PURE__*/ defineChain({
   id: 16,
-  name: 'Coston',
+  name: 'Songbird Testnet Coston',
   nativeCurrency: {
     decimals: 18,
     name: 'costonflare',


### PR DESCRIPTION
The network and native currency names for `Flare`, `Songbird` and their testnets does not correspond to ethereum-lists, utilized by MetaMask and others as a source of truth. This results in a warning. This PR adjusts the network and native currency names to the official ones defined in ethereum-lists:
* Songbird Canary-Network: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-19.json
* Songbird Testnet Coston: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-16.json
* Flare Testnet Coston2: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-114.json

**MetaMask screenshot with warning message**

<img src="https://github.com/user-attachments/assets/c7fc6550-2599-456a-9fe8-0eedfbd3c029" width="400">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update naming for Flare chains and Songbird networks for clarity and consistency.

### Detailed summary
- Updated naming for Flare chains
- Renamed Songbird Mainnet to Songbird Canary-Network
- Adjusted naming for Flare Testnet Coston2
- Renamed Songbird Testnet Coston to Songbird Testnet Coston

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->