### PR TITLE
Upgrade alfajores to op

### DIFF
--- a/.changeset/nasty-doors-wash.md
+++ b/.changeset/nasty-doors-wash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+update celo alfajores chain to include op contract addresses

--- a/.changeset/nasty-doors-wash.md
+++ b/.changeset/nasty-doors-wash.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-update celo alfajores chain to include op contract addresses and celoscan
+update celo alfajores chain to include op contract addresses

--- a/.changeset/nasty-doors-wash.md
+++ b/.changeset/nasty-doors-wash.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-update celo alfajores chain to include op contract addresses
+update celo alfajores chain to include op contract addresses and celoscan

--- a/src/celo/chainConfig.ts
+++ b/src/celo/chainConfig.ts
@@ -1,7 +1,7 @@
+import { contracts } from '../op-stack/contracts.js'
 import { fees } from './fees.js'
 import { formatters } from './formatters.js'
 import { serializers } from './serializers.js'
-import { contracts } from '../op-stack/contracts.js'
 
 export const chainConfig = {
   contracts,

--- a/src/celo/chainConfig.ts
+++ b/src/celo/chainConfig.ts
@@ -1,8 +1,10 @@
 import { fees } from './fees.js'
 import { formatters } from './formatters.js'
 import { serializers } from './serializers.js'
+import { contracts } from '../op-stack/contracts.js'
 
 export const chainConfig = {
+  contracts,
   formatters,
   serializers,
   fees,

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -1,7 +1,7 @@
 import { chainConfig } from '../../celo/chainConfig.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 
-const sourceId = 11_155_111 // sepolia 
+const sourceId = 11_155_111 // sepolia
 
 export const celoAlfajores = /*#__PURE__*/ defineChain({
   ...chainConfig,

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -23,11 +23,6 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
       url: 'https://explorer.celo.org/alfajores',
       apiUrl: 'https://explorer.celo.org/api',
     },
-    celoscan: {
-      name: 'CeloScan',
-      url: 'https://alfajores.celoscan.io/',
-      apiUrl: 'https://api-alfajores.celoscan.io/api',
-    },
   },
   contracts: {
     ...chainConfig.contracts,

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -27,7 +27,7 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
       name: 'CeloScan',
       url: 'https://alfajores.celoscan.io/',
       apiUrl: 'https://api-alfajores.celoscan.io/api',
-    }
+    },
   },
   contracts: {
     ...chainConfig.contracts,
@@ -37,7 +37,7 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
     },
     portal: {
       [sourceId]: {
-        address: "0x969d247cB586C0bF02212B9ae6e690e8b0d762bA"
+        address: '0x969d247cB586C0bF02212B9ae6e690e8b0d762bA',
       },
     },
     disputeGameFactory: {
@@ -59,7 +59,7 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
       [sourceId]: {
         address: '0x4200000000000000000000000000000000000010',
       },
-    }
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -1,6 +1,8 @@
 import { chainConfig } from '../../celo/chainConfig.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+const sourceId = 11_155_111 // sepolia 
+
 export const celoAlfajores = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 44_787,
@@ -23,9 +25,30 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 14569001,
+    },
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0x831f39053688f05698ad0fB5f4DE7e56B2949c55',
+      },
+    },
+    l2OutputOracle: {
+      [sourceId]: {
+        address: '0x419577592C884868C3ed85B97169b93362581855',
+      },
+    },
+    portal: {
+      [sourceId]: {
+        address: '0xB29597c6866c6C2870348f1035335B75eEf79d07',
+      },
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0x9FEBd0F16b97e0AEF9151AF07106d733E87B1be4',
+      },
     },
   },
   testnet: true,

--- a/src/chains/definitions/celoAlfajores.ts
+++ b/src/chains/definitions/celoAlfajores.ts
@@ -23,6 +23,11 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
       url: 'https://explorer.celo.org/alfajores',
       apiUrl: 'https://explorer.celo.org/api',
     },
+    celoscan: {
+      name: 'CeloScan',
+      url: 'https://alfajores.celoscan.io/',
+      apiUrl: 'https://api-alfajores.celoscan.io/api',
+    }
   },
   contracts: {
     ...chainConfig.contracts,
@@ -30,26 +35,31 @@ export const celoAlfajores = /*#__PURE__*/ defineChain({
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 14569001,
     },
+    portal: {
+      [sourceId]: {
+        address: "0x969d247cB586C0bF02212B9ae6e690e8b0d762bA"
+      },
+    },
     disputeGameFactory: {
       [sourceId]: {
-        address: '0x831f39053688f05698ad0fB5f4DE7e56B2949c55',
+        address: '0xB0C46509E24a0745d201114016fD666D6D1E3f8e',
       },
     },
     l2OutputOracle: {
       [sourceId]: {
-        address: '0x419577592C884868C3ed85B97169b93362581855',
-      },
-    },
-    portal: {
-      [sourceId]: {
-        address: '0xB29597c6866c6C2870348f1035335B75eEf79d07',
+        address: '0x58eeeEC56C6e92b1898367fa7372ab3f6483F054',
       },
     },
     l1StandardBridge: {
       [sourceId]: {
-        address: '0x9FEBd0F16b97e0AEF9151AF07106d733E87B1be4',
+        address: '0x65E8f629B13535f902020668Fe73aEc24e52F5D8',
       },
     },
+    l2StandardBridge: {
+      [sourceId]: {
+        address: '0x4200000000000000000000000000000000000010',
+      },
+    }
   },
   testnet: true,
 })


### PR DESCRIPTION
Alfajores will be upgraded from an L1 to an OP L2 at end of the month

This PR adds the relevant contract addresses to the chain definition 

(pending review by team)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Celo Alfajores chain configuration to include new contract addresses.

### Detailed summary
- Updated Celo Alfajores chain with new contract addresses
- Added contracts: portal, disputeGameFactory, l2OutputOracle, l1StandardBridge, l2StandardBridge

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->