### PR TITLE
Reliable Default Sepolia RPC

### DIFF
--- a/.changeset/rare-parrots-lie.md
+++ b/.changeset/rare-parrots-lie.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Sepolia RPC URL.

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -6,7 +6,7 @@ export const sepolia = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://rpc.sepolia.org'],
+      http: ['https://rpc2.sepolia.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
This sepolia RPC used as the default is totally unreliable. We swap it for a more consistently available fallback.

cf https://chainlist.org/chain/11155111

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Sepolia RPC URL to `https://rpc2.sepolia.org`.

### Detailed summary
- Updated Sepolia RPC URL to `https://rpc2.sepolia.org` in `src/chains/definitions/sepolia.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->