### PR TITLE
Add parent beacon block root type to Block.ts

### DIFF
--- a/.changeset/plenty-shoes-roll.md
+++ b/.changeset/plenty-shoes-roll.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `parentBeaconBlockRoot` to `Block` type.

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -40,6 +40,8 @@ export type Block<
   nonce: blockTag extends 'pending' ? null : Hex
   /** Block number or `null` if pending */
   number: blockTag extends 'pending' ? null : quantity
+  /** Root of the parent beacon chain block */
+  parentBeaconBlockRoot?: Hex | undefined
   /** Parent block hash */
   parentHash: Hash
   /** Root of the this block’s receipts trie */
@@ -65,8 +67,6 @@ export type Block<
   withdrawals?: Withdrawal[] | undefined
   /** Root of the this block’s withdrawals trie */
   withdrawalsRoot?: Hex | undefined
-  /** Root of the parent beacon chain block */
-  parentBeaconBlockRoot?: Hex | undefined
 }
 
 export type BlockIdentifier<quantity = bigint> = {

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -65,6 +65,8 @@ export type Block<
   withdrawals?: Withdrawal[] | undefined
   /** Root of the this block’s withdrawals trie */
   withdrawalsRoot?: Hex | undefined
+  /** Root of the parent beacon chain block */
+  parentBeaconBlockRoot?: Hex | undefined
 }
 
 export type BlockIdentifier<quantity = bigint> = {


### PR DESCRIPTION
Adds the `parentBeaconBlockRoot` optional property to the Block type

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new field `parentBeaconBlockRoot` to the `Block` type in `block.ts`.

### Detailed summary
- Added `parentBeaconBlockRoot` field to `Block` type in `block.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->