### PR TITLE
Add multicall3 for abstract testnet

### DIFF
--- a/.changeset/red-dryers-sniff.md
+++ b/.changeset/red-dryers-sniff.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract for Abstract Testnet.

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -22,6 +22,12 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  contracts: {
+    multicall3: {
+      address: "0xF9cda624FBC7e059355ce98a31693d299FACd963",
+      blockCreated: 358349
+    }
+  },
   custom: {
     getEip712Domain(transaction: ZksyncTransactionSerializableEIP712) {
       const message = transactionToMessage(transaction)


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Currently the abstract testnet chain definition does not include the multicall3 deployment.

Multicall3 is deployed at [0xF9cda624FBC7e059355ce98a31693d299FACd963](https://explorer.testnet.abs.xyz/address/0xF9cda624FBC7e059355ce98a31693d299FACd963#contract) as of block 358349.

This deployment matches the deployment address of other zk stack chains. 
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `multicall3` contract for Abstract Testnet, including its address and block creation information.

### Detailed summary
- Added `multicall3` contract for Abstract Testnet
- Included address and block creation details

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->