### PR TITLE
Revert Abstract EIP712 domain changes

### DIFF
--- a/.changeset/cyan-owls-compete.md
+++ b/.changeset/cyan-owls-compete.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Reverted custom Abstract EIP712 domain changes.

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -1,7 +1,5 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../../zksync/chainConfig.js'
-import type { ZksyncTransactionSerializableEIP712 } from '../../zksync/types/transaction.js'
-import { transactionToMessage } from '../../zksync/utils/getEip712Domain.js'
 
 export const abstractTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
@@ -22,42 +20,4 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
-  contracts: {
-    multicall3: {
-      address: '0xF9cda624FBC7e059355ce98a31693d299FACd963',
-      blockCreated: 358349,
-    },
-  },
-  custom: {
-    getEip712Domain(transaction: ZksyncTransactionSerializableEIP712) {
-      const message = transactionToMessage(transaction)
-
-      return {
-        domain: {
-          name: 'Abstract', // Use 'Abstract' rather than 'zkSync'
-          version: '2',
-          chainId: transaction.chainId,
-        },
-        types: {
-          Transaction: [
-            { name: 'txType', type: 'uint256' },
-            { name: 'from', type: 'uint256' },
-            { name: 'to', type: 'uint256' },
-            { name: 'gasLimit', type: 'uint256' },
-            { name: 'gasPerPubdataByteLimit', type: 'uint256' },
-            { name: 'maxFeePerGas', type: 'uint256' },
-            { name: 'maxPriorityFeePerGas', type: 'uint256' },
-            { name: 'paymaster', type: 'uint256' },
-            { name: 'nonce', type: 'uint256' },
-            { name: 'value', type: 'uint256' },
-            { name: 'data', type: 'bytes' },
-            { name: 'factoryDeps', type: 'bytes32[]' },
-            { name: 'paymasterInput', type: 'bytes' },
-          ],
-        },
-        primaryType: 'Transaction',
-        message: message,
-      }
-    },
-  },
 })

--- a/src/chains/definitions/abstractTestnet.ts
+++ b/src/chains/definitions/abstractTestnet.ts
@@ -20,4 +20,10 @@ export const abstractTestnet = /*#__PURE__*/ defineChain({
     },
   },
   testnet: true,
+  contracts: {
+    multicall3: {
+      address: '0xF9cda624FBC7e059355ce98a31693d299FACd963',
+      blockCreated: 358349,
+    },
+  },
 })

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -50,7 +50,7 @@ export const getEip712Domain: EIP712DomainFn<
 //////////////////////////////////////////////////////////////////////////////
 // Utilities
 
-export function transactionToMessage(
+function transactionToMessage(
   transaction: ZksyncTransactionSerializableEIP712,
 ): ZksyncEIP712TransactionSignable {
   const {


### PR DESCRIPTION
It turns out, the `zkSync` domain name is hardcoded into the bootloader, meaning we can't change this domain in our code without modifying the node directly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR reverts custom EIP712 domain changes in `viem` and removes related functions from `abstractTestnet`.

### Detailed summary
- Reverted custom EIP712 domain changes in `viem`.
- Removed `getEip712Domain` function from `abstractTestnet`.
- Updated `transactionToMessage` to be an exported function in `getEip712Domain.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->