### PR TITLE
Reserve Bitfi - chainId 891891

### DIFF
--- a/.changeset/bitfi.md
+++ b/.changeset/bitfi.md
@@ -1,0 +1,24 @@
+{
+  "name": "BitFi Testnet",
+  "chain": "BitFi",
+  "rpc": ["https://rpc1-testnet.bitfi.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://testnet.bitfi.xyz",
+  "shortName": "bitfi",
+  "chainId": 891891,
+  "networkId": 891891,
+  "icon": "bitfi",
+  "explorers": [
+    {
+      "name": "bitfiscan-testnet",
+      "icon": "bitfi",
+      "url": "https://testnet.bitfi.xyz",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This is to reserve chainId 891891. The chain is not yet active.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding configuration details for the BitFi Testnet chain.

### Detailed summary
- Added configuration for BitFi Testnet chain
- Defined RPC endpoint, native currency, chain ID, network ID, and explorers
- Included information URL and icon for the chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->