### PR TITLE
Fixes pre fp withdrawal error status to return ready-to-prove

### DIFF
--- a/.changeset/slow-monkeys-notice.md
+++ b/.changeset/slow-monkeys-notice.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixes bug in getWithdrawalStatus for pre fault proof withdrawals

--- a/.changeset/slow-monkeys-notice.md
+++ b/.changeset/slow-monkeys-notice.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixes bug in getWithdrawalStatus for pre fault proof withdrawals
+**OP Stack**: Fixed bug in getWithdrawalStatus for pre fault proof withdrawals

--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -248,7 +248,9 @@ export async function getWithdrawalStatus<
         errorMessage === 'OptimismPortal: invalid game type' ||
         errorMessage === 'OptimismPortal: withdrawal has not been proven yet' ||
         errorMessage ===
-          'OptimismPortal: withdrawal has not been proven by proof submitter address yet'
+          'OptimismPortal: withdrawal has not been proven by proof submitter address yet' ||
+        errorMessage ===
+          'OptimismPortal: dispute game created before respected game type was updated'
       )
         return 'ready-to-prove'
       if (


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixes bug in `getWithdrawalStatus` for pre fault proof withdrawals.

The status function wasn't handling this [error](https://github.com/ethereum-optimism/optimism/blob/7105bad6736fcb9f45ac83d9ef45605adbf8fdfe/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L676-L679) and when we encounter this error we want to return `ready-to-prove` 

Tested against this hash `0xd45b140c2240ec54153cce72e2176cd0d263a9fbf81620b09dcc9a19faa92c15`
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `getWithdrawalStatus` function in the `OP Stack` related to pre fault-proof withdrawals.

### Detailed summary
- Fixed bug in `getWithdrawalStatus` for pre fault-proof withdrawals
- Updated error message conditions in `getWithdrawalStatus.ts` file
- Added handling for new error message condition in `getWithdrawalStatus.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->