### PR TITLE
Add kinto chain

### DIFF
--- a/.changeset/rude-bikes-smash.md
+++ b/.changeset/rude-bikes-smash.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added kinto chain
+Added Kinto chain.

--- a/.changeset/rude-bikes-smash.md
+++ b/.changeset/rude-bikes-smash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added kinto chain

--- a/src/chains/definitions/kinto.ts
+++ b/src/chains/definitions/kinto.ts
@@ -1,0 +1,18 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const kinto = /*#__PURE__*/ defineChain({
+  id: 7887,
+  name: 'Kinto Mainnet',
+  network: 'Kinto Mainnet',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://rpc.kinto.xyz/http'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Kava EVM Explorer',
+      url: 'https://explorer.kinto.xyz',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/kinto.ts
+++ b/src/chains/definitions/kinto.ts
@@ -10,7 +10,7 @@ export const kinto = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Kava EVM Explorer',
+      name: 'Kinto Explorer',
       url: 'https://explorer.kinto.xyz',
     },
   },

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -155,6 +155,7 @@ export { kakarotSepolia } from './definitions/kakarotSepolia.js'
 export { kava } from './definitions/kava.js'
 export { kavaTestnet } from './definitions/kavaTestnet.js'
 export { kcc } from './definitions/kcc.js'
+export { kinto } from './definitions/kinto.js'
 /** @deprecated Use `kaia` instead. */
 export { klaytn } from './definitions/klaytn.js'
 /** @deprecated Use `kairos` instead. */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the Kinto chain by introducing a new chain definition. 

### Detailed summary
- Added `kinto` chain definition in `chains/definitions/kinto.ts`
- `kinto` chain has ID 7887 and is named "Kinto Mainnet"
- Provides RPC URLs and block explorer information
- Testnet flag set to false

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the `kinto` chain by including its definition in the `chains` module.

### Detailed summary
- Added `kinto` chain definition to support Kinto Mainnet
- Definition includes ID, name, network, native currency, RPC URLs, block explorer details
- Testnet flag set to false

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`