### PR TITLE
chore: update AstarZkEVM rpc url

### DIFF
--- a/.changeset/breezy-bugs-occur.md
+++ b/.changeset/breezy-bugs-occur.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated AstarZkEVM RPC URL.

--- a/src/chains/definitions/astarZkEVM.ts
+++ b/src/chains/definitions/astarZkEVM.ts
@@ -7,7 +7,7 @@ export const astarZkEVM = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://rpc.startale.com/astar-zkevm'],
+      http: ['https://rpc-zkevm.astar.network'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Current default RPC was having connectivity issues.
Switched to a different one as default.

Didn't leave the old one, as we're not certain when the issues will be resolved.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the RPC URL for the `astarZkEVM` chain definition.

### Detailed summary
- Updated the `rpcUrls` for `astarZkEVM` from `https://rpc.startale.com/astar-zkevm` to `https://rpc-zkevm.astar.network`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->