### PR TITLE
feat: add alienx chain

### DIFF
--- a/.changeset/heavy-crabs-relax.md
+++ b/.changeset/heavy-crabs-relax.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Add AlienX chain.
+Added AlienX chain.

--- a/.changeset/heavy-crabs-relax.md
+++ b/.changeset/heavy-crabs-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add AlienX chain.

--- a/src/chains/definitions/alienX.ts
+++ b/src/chains/definitions/alienX.ts
@@ -1,0 +1,17 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const alienx = /*#__PURE__*/ defineChain({
+  id: 10241024,
+  name: 'AlienX Mainnet',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://rpc.alienxchain.io/http'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'AlienX Explorer',
+      url: 'https://explorer.alienxchain.io',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/alienXHalTestnet.ts
+++ b/src/chains/definitions/alienXHalTestnet.ts
@@ -1,0 +1,17 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const alienxHalTestnet = /*#__PURE__*/ defineChain({
+  id: 10241025,
+  name: 'ALIENX Hal Testnet',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://hal-rpc.alienxchain.io/http'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'AlienX Explorer',
+      url: 'https://hal-explorer.alienxchain.io',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/alienXHalTestnet.ts
+++ b/src/chains/definitions/alienXHalTestnet.ts
@@ -13,5 +13,5 @@ export const alienxHalTestnet = /*#__PURE__*/ defineChain({
       url: 'https://hal-explorer.alienxchain.io',
     },
   },
-  testnet: false,
+  testnet: true,
 })

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -3,6 +3,8 @@ export type { Chain } from '../types/chain.js'
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export { abstractTestnet } from './definitions/abstractTestnet.js'
 export { acala } from './definitions/acala.js'
+export { alienx } from './definitions/alienX.js'
+export { alienxHalTestnet } from './definitions/alienXHalTestnet.js'
 export { ancient8 } from './definitions/ancient8.js'
 export { ancient8Sepolia } from './definitions/ancient8Sepolia.js'
 export { anvil } from './definitions/anvil.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces support for the `AlienX` blockchain by adding both the mainnet and a testnet configuration. It includes new exports and definitions for the `alienx` and `alienxHalTestnet` chains.

### Detailed summary
- Added `alienx` mainnet definition in `src/chains/definitions/alienX.ts`.
- Added `alienxHalTestnet` definition in `src/chains/definitions/alienXHalTestnet.ts`.
- Updated `src/chains/index.ts` to export `alienx` and `alienxHalTestnet`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `AlienX` blockchain and its testnet, `ALIENX Hal Testnet`, into the project, allowing for integration with these new chains.

### Detailed summary
- Added `AlienX` chain to `src/chains/index.ts`.
- Created `alienX.ts` defining `AlienX Mainnet` with its properties.
- Created `alienXHalTestnet.ts` defining `ALIENX Hal Testnet` with its properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`