### PR TITLE
Add missing apiUrl to xLayer

### DIFF
--- a/.changeset/three-parents-provide.md
+++ b/.changeset/three-parents-provide.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added missing API URL for `xLayer`.

--- a/src/chains/definitions/xLayer.ts
+++ b/src/chains/definitions/xLayer.ts
@@ -15,6 +15,7 @@ export const xLayer = /*#__PURE__*/ defineChain({
     default: {
       name: 'OKLink',
       url: 'https://www.oklink.com/xlayer',
+      apiUrl: 'https://www.oklink.com/api/v5/explorer/xlayer/api',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a missing API URL for the `xLayer` chain definition, ensuring that the API endpoint is correctly defined for accessing related data.

### Detailed summary
- Added `apiUrl` field to `xLayer` in `src/chains/definitions/xLayer.ts` with the value `https://www.oklink.com/api/v5/explorer/xlayer/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->