### PR TITLE
Fix null pointer exception in getNodeError check for ExecutionRevertedError

### DIFF
--- a/.changeset/khaki-onions-teach.md
+++ b/.changeset/khaki-onions-teach.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix null pointer exception in getNodeError check for ExecutionRevertedError

--- a/.changeset/khaki-onions-teach.md
+++ b/.changeset/khaki-onions-teach.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fix null pointer exception in getNodeError check for ExecutionRevertedError
+Fixed undefined reference in `getNodeError`.

--- a/src/utils/errors/getNodeError.test.ts
+++ b/src/utils/errors/getNodeError.test.ts
@@ -297,6 +297,23 @@ test('ExecutionRevertedError', () => {
   `)
 })
 
+test('UnknownNodeError check with null cause in error chain', () => {
+  const error = new TransactionRejectedRpcError(
+    new Error('null cause', { cause: null }),
+  )
+  const result = getNodeError(error, {
+    account: address.vitalik,
+    maxFeePerGas: parseGwei('10'),
+    maxPriorityFeePerGas: parseGwei('11'),
+  })
+  expect(result).toMatchInlineSnapshot(`
+    [UnknownNodeError: An error occurred while executing: Transaction creation failed.
+
+    Details: null cause
+    Version: viem@x.y.z]
+  `)
+})
+
 test('Unknown node error', () => {
   const error = new TransactionRejectedRpcError(
     new RpcRequestError({

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -68,7 +68,7 @@ export function getNodeError(
   const executionRevertedError =
     err instanceof BaseError
       ? err.walk(
-          (e) => (e as { code: number }).code === ExecutionRevertedError.code,
+          (e) => (e as { code: number } | null | undefined)?.code === ExecutionRevertedError.code,
         )
       : err
   if (executionRevertedError instanceof BaseError)


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
# Overview
This PR fix null pointer exception in getNodeError check for ExecutionRevertedError

# Detailed summary
When using viem client with custom provider, i faced null pointer exception because the error walk check for ExecutionRevertedError in getNodeError didn't check for null cause in error returned from provider.
This PR added null check in ExecutionRevertedError walk check and test case for it.

![Screenshot_2024-09-24_at_14 34 50](https://github.com/user-attachments/assets/0534b8bd-07f5-4938-bf8a-4b9e78c929b7)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an undefined reference issue in the `getNodeError` function and adding a new test case for handling errors with a null cause.

### Detailed summary
- Fixed undefined reference in `getNodeError` by updating the type check to handle `null` and `undefined` values.
- Added a new test case for `UnknownNodeError` to check error handling when the cause is `null`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->