### PR TITLE
Added elysiumTestnet chain

### DIFF
--- a/.changeset/many-bananas-bathe.md
+++ b/.changeset/many-bananas-bathe.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `elysiumTestnet` chain.

--- a/src/chains/definitions/elysiumTestnet.ts
+++ b/src/chains/definitions/elysiumTestnet.ts
@@ -1,0 +1,27 @@
+import { chainConfig } from '../../op-stack/chainConfig.js'
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+
+export const elysiumTestnet = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 1338,
+  name: 'Elysium Testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'LAVA',
+    symbol: 'LAVA',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.atlantischain.network/','https://elysium-test-rpc.vulcanforged.com'],
+      webSocket: ['wss://atlantischain.network/'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Elysium testnet explorer',
+      url: 'https://blockscout.atlantischain.network/'
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/elysiumTestnet.ts
+++ b/src/chains/definitions/elysiumTestnet.ts
@@ -13,14 +13,13 @@ export const elysiumTestnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.atlantischain.network/','https://elysium-test-rpc.vulcanforged.com'],
-      webSocket: ['wss://atlantischain.network/'],
+      http: ['https://elysium-test-rpc.vulcanforged.com'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Elysium testnet explorer',
-      url: 'https://blockscout.atlantischain.network/'
+      url: 'https://elysium-explorer.vulcanforged.com'
     },
   },
   testnet: true,

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -93,6 +93,7 @@ export { edgeless } from './definitions/edgeless.js'
 export { edgelessTestnet } from './definitions/edgelessTestnet.js'
 export { edgeware } from './definitions/edgeware.js'
 export { edgewareTestnet } from './definitions/edgewareTestnet.js'
+export { elysiumTestnet} from './definitions/elysiumTestnet.js';
 export { eon } from './definitions/eon.js'
 export { eos } from './definitions/eos.js'
 export { eosTestnet } from './definitions/eosTestnet.js'


### PR DESCRIPTION
### PR-Codex overview
This PR adds support for the `elysiumTestnet` chain with its definitions and configurations.

### Detailed summary
Added `elysiumTestnet` chain definition in `chains/index.ts`
Created `elysiumTestnet` chain configurations in `chains/definitions/elysiumTestnet.ts`
Utilised `defineChain` function to define the chain with ID, name, currency, RPC URLs, block explorers, and testnet flag

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `elysiumTestnet` chain to the project, enhancing the chain definitions and providing necessary configurations for its integration.

### Detailed summary
- Added `elysiumTestnet` chain to `src/chains/index.ts`.
- Created `elysiumTestnet` definition in `src/chains/definitions/elysiumTestnet.ts` with:
  - `id`: 1338
  - `name`: 'Elysium Testnet'
  - `nativeCurrency`: 'LAVA' with 18 decimals
  - `rpcUrls` and `blockExplorers` configurations
  - Marked as a testnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->