### PR TITLE
Fix op-stack docs

### DIFF
--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -120,7 +120,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -150,7 +150,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -207,7 +207,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -238,7 +238,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -302,7 +302,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -332,7 +332,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -411,7 +411,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -441,7 +441,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -549,7 +549,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,
@@ -579,7 +579,7 @@ export const walletClientL1 = createWalletClient({
 export const publicClientL2 = createPublicClient({
   chain: optimism,
   transport: http()
-})
+}).extend(publicActionsL2())
 
 export const walletClientL2 = createWalletClient({
   account,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixed omitted extending `publicActionsL2()` on `publicClientL2`, op-stack withdraw example codes.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on extending the functionality of the `publicClientL2` instances in the `withdrawals.md` file by adding `publicActionsL2()` to the client configuration.

### Detailed summary
- Added `.extend(publicActionsL2())` to multiple instances of `publicClientL2`.
- This change was applied consistently across several sections of the `withdrawals.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->