### PR TITLE
Add contract multicall3 for Flare Mainnet

### DIFF
--- a/.changeset/three-horses-drum.md
+++ b/.changeset/three-horses-drum.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract for Flare Mainnet.

--- a/src/chains/definitions/flare.ts
+++ b/src/chains/definitions/flare.ts
@@ -18,4 +18,10 @@ export const flare = /*#__PURE__*/ defineChain({
       apiUrl: 'https://flare-explorer.flare.network/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 3002461,
+    },
+  },
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `multicall3` contract for the `Flare Mainnet`, enhancing the functionality related to multicall operations.

### Detailed summary
- Added a new `multicall3` contract definition in the `src/chains/definitions/flare.ts` file.
- Included the contract's `address` as `0xcA11bde05977b3631167028862bE2a173976CA11`.
- Specified the `blockCreated` value as `3002461`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->