### PR TITLE
feat: add WeaveVM Alphanet chain

### DIFF
--- a/.changeset/wild-guests-do.md
+++ b/.changeset/wild-guests-do.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added WeaveVM Alphanet chain.

--- a/src/chains/definitions/weavevmAlphanet.ts
+++ b/src/chains/definitions/weavevmAlphanet.ts
@@ -3,7 +3,6 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const weaveVMAlphanet = /*#__PURE__*/ defineChain({
   id: 9496,
   name: 'WeaveVM Alphanet',
-  network: 'weavevm-alphanet',
   nativeCurrency: { name: 'Testnet WeaveVM', symbol: 'tWVM', decimals: 18 },
   rpcUrls: {
     default: { http: ['https://testnet-rpc.wvm.dev'] },
@@ -12,12 +11,6 @@ export const weaveVMAlphanet = /*#__PURE__*/ defineChain({
     default: {
       name: 'WeaveVM Alphanet Explorer',
       url: 'https://explorer.wvm.dev',
-    },
-  },
-  contracts: {
-    multicall3: {
-      address: '0x7c6db9c77dCE482dFCb315cD5B9B505702651d26',
-      blockCreated: 1820864,
     },
   },
   testnet: true,

--- a/src/chains/definitions/weavevmAlphanet.ts
+++ b/src/chains/definitions/weavevmAlphanet.ts
@@ -1,0 +1,24 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const weaveVMAlphanet = /*#__PURE__*/ defineChain({
+  id: 9496,
+  name: 'WeaveVM Alphanet',
+  network: 'weavevm-alphanet',
+  nativeCurrency: { name: 'Testnet WeaveVM', symbol: 'tWVM', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://testnet-rpc.wvm.dev'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'WeaveVM Alphanet Explorer',
+      url: 'https://explorer.wvm.dev',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x7c6db9c77dCE482dFCb315cD5B9B505702651d26',
+      blockCreated: 1820864,
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -342,6 +342,7 @@ export { wemix } from './definitions/wemix.js'
 export { wemixTestnet } from './definitions/wemixTestnet.js'
 export { worldchain } from './definitions/worldchain.js'
 export { worldchainSepolia } from './definitions/worldchainSepolia.js'
+export { weaveVMAlphanet } from './definitions/weavevmAlphanet.js'
 export {
   xLayerTestnet,
   /** @deprecated Use `xLayerTestnet` */

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -338,11 +338,11 @@ export { unreal } from './definitions/unreal.js'
 export { vechain } from './definitions/vechain.js'
 export { wanchain } from './definitions/wanchain.js'
 export { wanchainTestnet } from './definitions/wanchainTestnet.js'
+export { weaveVMAlphanet } from './definitions/weavevmAlphanet.js'
 export { wemix } from './definitions/wemix.js'
 export { wemixTestnet } from './definitions/wemixTestnet.js'
 export { worldchain } from './definitions/worldchain.js'
 export { worldchainSepolia } from './definitions/worldchainSepolia.js'
-export { weaveVMAlphanet } from './definitions/weavevmAlphanet.js'
 export {
   xLayerTestnet,
   /** @deprecated Use `xLayerTestnet` */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new blockchain definition for the `WeaveVM Alphanet` chain, including its configuration and export in the project.

### Detailed summary
- Added a new entry for `WeaveVM Alphanet` in `.changeset/wild-guests-do.md`.
- Exported `weaveVMAlphanet` from `src/chains/index.ts`.
- Created `weavevmAlphanet.ts` with chain details:
  - ID: 9496
  - Name: 'WeaveVM Alphanet'
  - Native currency: 'Testnet WeaveVM' (symbol: `tWVM`, decimals: 18)
  - RPC URL: `https://testnet-rpc.wvm.dev`
  - Block explorer: `https://explorer.wvm.dev`
  - Marked as a testnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->