### PR TITLE
Fixes prepareUserOperation

### DIFF
--- a/.changeset/cuddly-rats-think.md
+++ b/.changeset/cuddly-rats-think.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixes prepareUserOperation issue of chainId being null when Chain is not passed

--- a/src/account-abstraction/actions/bundler/prepareUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/prepareUserOperation.ts
@@ -496,7 +496,7 @@ export async function prepareUserOperation<
 
   // If no chain is passed, we get the chainId using bundlerClient.
   let chainId!: number
-  if(typeof client.chain === 'undefined') {
+  if (typeof client.chain === 'undefined') {
     chainId = await bundlerClient.getChainId()
   } else {
     chainId = client.chain.id

--- a/src/account-abstraction/actions/bundler/prepareUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/prepareUserOperation.ts
@@ -494,6 +494,14 @@ export async function prepareUserOperation<
 
   // console.log('wat')
 
+  // If no chain is passed, we get the chainId using bundlerClient.
+  let chainId!: number
+  if(typeof client.chain === 'undefined') {
+    chainId = await bundlerClient.getChainId()
+  } else {
+    chainId = client.chain.id
+  }
+
   // If the User Operation is intended to be sponsored, we will need to fill the paymaster-related
   // User Operation properties required to estimate the User Operation gas.
   let isPaymasterPopulated = false
@@ -508,7 +516,7 @@ export async function prepareUserOperation<
       sponsor,
       ...paymasterArgs
     } = await getPaymasterStubData({
-      chainId: client.chain!.id!,
+      chainId: chainId,
       entryPointAddress: account.entryPoint.address,
       context: paymasterContext,
       ...(request as UserOperation),
@@ -606,7 +614,7 @@ export async function prepareUserOperation<
   ) {
     // Retrieve paymaster-related User Operation properties to be used for **sending** the User Operation.
     const paymaster = await getPaymasterData({
-      chainId: client.chain!.id!,
+      chainId: chainId,
       entryPointAddress: account.entryPoint.address,
       context: paymasterContext,
       ...(request as UserOperation),


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Fixes: #2796

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses the `prepareUserOperation` function by fixing an issue where `chainId` could be null if the `Chain` was not provided. It ensures that the `chainId` is correctly retrieved from `bundlerClient` when necessary.

### Detailed summary
- Introduced a check for `client.chain` to set `chainId`.
- If `client.chain` is undefined, `chainId` is fetched using `bundlerClient.getChainId()`.
- Updated references to `chainId` in the `getPaymasterStubData` and `getPaymasterData` calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->