### PR TITLE
Update Block Explorer Information to the New Official Explorer: KaiaScan

### DIFF
--- a/.changeset/spotty-papayas-yell.md
+++ b/.changeset/spotty-papayas-yell.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Kaia Chain explorer.

--- a/src/chains/definitions/kaia.ts
+++ b/src/chains/definitions/kaia.ts
@@ -13,8 +13,8 @@ export const kaia = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'KaiaScope',
-      url: 'https://kaiascope.com',
+      name: 'KaiaScan',
+      url: 'https://kaiascan.com/',
       apiUrl: 'https://api-cypress.klaytnscope.com/api',
     },
   },

--- a/src/chains/definitions/kaia.ts
+++ b/src/chains/definitions/kaia.ts
@@ -14,7 +14,7 @@ export const kaia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'KaiaScan',
-      url: 'https://kaiascan.com/',
+      url: 'https://kaiascan.com',
       apiUrl: 'https://api-cypress.klaytnscope.com/api',
     },
   },

--- a/src/chains/definitions/kaia.ts
+++ b/src/chains/definitions/kaia.ts
@@ -14,7 +14,7 @@ export const kaia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'KaiaScan',
-      url: 'https://kaiascan.com',
+      url: 'https://kaiascan.io',
       apiUrl: 'https://api-cypress.klaytnscope.com/api',
     },
   },

--- a/src/chains/definitions/kairos.ts
+++ b/src/chains/definitions/kairos.ts
@@ -15,7 +15,7 @@ export const kairos = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'KaiaScan',
-      url: 'https://kairos.kaiascan.io/',
+      url: 'https://kairos.kaiascan.io',
     },
   },
   contracts: {

--- a/src/chains/definitions/kairos.ts
+++ b/src/chains/definitions/kairos.ts
@@ -14,8 +14,8 @@ export const kairos = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'KaiaScope',
-      url: 'https://kairos.kaiascope.com',
+      name: 'KaiaScan',
+      url: 'https://kairos.kaiascan.io/',
     },
   },
   contracts: {


### PR DESCRIPTION
This PR updates the project to use the new official blockchain explorer, **KaiaScan**, replacing the previous KaiaScope explorer. The change has been made because KaiaScan offers faster performance and provides more accurate blockchain data compared to KaiaScope.

**Changes:**
- Updated block explorer name to "KaiaScan."
- Updated block explorer URL to https://kaiascan.com/.

With these updates, users will have access to enhanced data accuracy and improved performance.

For more details regarding the new KaiaScan explorer, please refer to the [KaiaScan Announcement](https://x.com/KaiaChain/status/1831567505565086208).

Please review and approve the changes.


https://x.com/KaiaChain/status/1831567505565086208

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the block explorer names and URLs for the `KaiaChain` in two files, enhancing the clarity and accuracy of the information provided.

### Detailed summary
- In `src/chains/definitions/kairos.ts`:
  - Changed `name` from `KaiaScope` to `KaiaScan`
  - Updated `url` from `https://kairos.kaiascope.com` to `https://kairos.kaiascan.io`
  
- In `src/chains/definitions/kaia.ts`:
  - Changed `name` from `KaiaScope` to `KaiaScan`
  - Updated `url` from `https://kaiascope.com` to `https://kaiascan.io`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->