### PR TITLE
feat: add bttc donau testnet chain

### DIFF
--- a/src/chains/definitions/bitTorrentDonau.ts
+++ b/src/chains/definitions/bitTorrentDonau.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const bitTorrentTestnet = /*#__PURE__*/ defineChain({
-  id: 1028,
+  id: 1029,
   name: 'BitTorrent Chain Donau',
   network: 'bittorrent-chain-donau',
   nativeCurrency: { name: 'BitTorrent', symbol: 'BTT', decimals: 18 },

--- a/src/chains/definitions/bitTorrentDonau.ts
+++ b/src/chains/definitions/bitTorrentDonau.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const bitTorrentTestnet = /*#__PURE__*/ defineChain({
+  id: 1028,
+  name: 'BitTorrent Chain Donau',
+  network: 'bittorrent-chain-donau',
+  nativeCurrency: { name: 'BitTorrent', symbol: 'BTT', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://pre-rpc.bt.io'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Bttcscan',
+      url: 'https://testnet.bttcscan.com',
+      apiUrl: 'https://api-testnet.bttcscan.com/api',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -43,6 +43,8 @@ export { bevmMainnet } from './definitions/bevmMainnet.js'
 export { bitkub } from './definitions/bitkub.js'
 export { bitkubTestnet } from './definitions/bitkubTestnet.js'
 export { bitTorrent } from './definitions/bitTorrent.js'
+export { bitTorrentDonau } from './definitions/bitTorrentDonau.js'
+/** @deprecated Use `bitTorrentDonau` instead. */
 export { bitTorrentTestnet } from './definitions/bitTorrentTestnet.js'
 export { blast } from './definitions/blast.js'
 export { blastSepolia } from './definitions/blastSepolia.js'


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
The BTTC Testnet in viem is deprecated 
[here is reference from bt.io official website]
(https://doc.bt.io/docs/networks/network#:~:text=BTTC%20Donau%20Testnet%E2%80%8B,ChainID%3A%201029)

I have added the latest details and bttc donau as well

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new chain definition for `bitTorrentDonau` and updates the exports in `src/chains/index.ts`, marking `bitTorrentTestnet` as deprecated in favor of the new chain.

### Detailed summary
- Added export for `bitTorrentDonau` from `./definitions/bitTorrentDonau.js`.
- Deprecated `bitTorrentTestnet` with a note to use `bitTorrentDonau` instead.
- Introduced `bitTorrentDonau` chain definition with specific properties including `id`, `name`, `network`, `nativeCurrency`, `rpcUrls`, and `blockExplorers`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->