### PR TITLE
Fix Celo maxFeePerGas calculation for fee currency transactions

### DIFF
--- a/.changeset/great-spies-march.md
+++ b/.changeset/great-spies-march.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Celo maxFeePerGas calculation for fee currency transactions.

--- a/src/celo/fees.test.ts
+++ b/src/celo/fees.test.ts
@@ -30,8 +30,8 @@ describe('celo/fees', () => {
     const requestMock = vi.spyOn(client, 'request')
     // @ts-ignore
     requestMock.mockImplementation((request) => {
-      if (request.method === 'eth_gasPrice') return '11619349802'
-      if (request.method === 'eth_maxPriorityFeePerGas') return '2323869960'
+      if (request.method === 'eth_gasPrice') return '15057755162'
+      if (request.method === 'eth_maxPriorityFeePerGas') return '602286'
       return
     })
 
@@ -39,6 +39,7 @@ describe('celo/fees', () => {
 
     const fees = await celoestimateFeesPerGasFn({
       client,
+      multiply: (value: bigint) => (value * 150n) / 100n,
       request: {
         feeCurrency: '0xfee',
       },
@@ -46,8 +47,8 @@ describe('celo/fees', () => {
 
     expect(fees).toMatchInlineSnapshot(`
         {
-          "maxFeePerGas": 11619349802n,
-          "maxPriorityFeePerGas": 2323869960n,
+          "maxFeePerGas": 22587235029n,
+          "maxPriorityFeePerGas": 602286n,
         }
       `)
     expect(requestMock).toHaveBeenCalledWith({

--- a/src/celo/fees.ts
+++ b/src/celo/fees.ts
@@ -30,8 +30,11 @@ export const fees: ChainFees<typeof formatters> = {
       ),
     ])
 
+    const suggestedMaxFeePerGas =
+      params.multiply(maxFeePerGas) + maxPriorityFeePerGas
+
     return {
-      maxFeePerGas,
+      maxFeePerGas: suggestedMaxFeePerGas,
       maxPriorityFeePerGas,
     }
   },

--- a/src/celo/sendTransaction.test.ts
+++ b/src/celo/sendTransaction.test.ts
@@ -29,14 +29,14 @@ describe('sendTransaction()', () => {
     }
 
     if (request.method === 'eth_maxPriorityFeePerGas') {
-      return 1n
+      return 602286n
     }
 
     if (
       request.method === 'eth_gasPrice' &&
       (request.params as string[])[0] === feeCurrencyAddress
     ) {
-      return 2n
+      return 15057755162n
     }
 
     if (request.method === 'eth_estimateGas') {
@@ -99,7 +99,7 @@ describe('sendTransaction()', () => {
     expect(transportRequestMock).toHaveBeenLastCalledWith({
       method: 'eth_sendRawTransaction',
       params: [
-        '0x7bf87782a4ec8001020194f39fd6e51aad88f6f4ce6ab8827279cfffb922660180c0940000000000000000000000000000000000000fee80a0a3163f9ff91200f4c8000f0217d85d16c329c2f38d48a7b4b70119989e475e57a0555fd5b2a6eac95426e33cd07ca5fec121ad46194611a013001f76bbc4b33136',
+        '0x7bf87f82a4ec80830930ae8504350cec000194f39fd6e51aad88f6f4ce6ab8827279cfffb922660180c0940000000000000000000000000000000000000fee80a0b61a83b7fe73e24f223f563447cdb69f6dedc7f7f7b2acc4e41f2e57143ccd57a03ce0bcc81c026ff0eb17274940748e23250fe988f71370eba1e59e43557835b3',
       ],
     })
   })


### PR DESCRIPTION
Previously the multiply function was not applied to the base fee returned from the node. This PR fixes that.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the calculation of `maxFeePerGas` for fee currency transactions in the Celo network, ensuring accurate gas fee estimations and adjustments in tests.

### Detailed summary
- Updated the calculation of `maxFeePerGas` in `src/celo/fees.ts` to use `suggestedMaxFeePerGas`.
- Adjusted mock return values for gas price and priority fee in `src/celo/fees.test.ts`.
- Changed expected values in the snapshot test for fees.
- Modified return values for gas price in `src/celo/sendTransaction.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->