### PR TITLE
fix: getting fees with bundler client

### DIFF
--- a/src/account-abstraction/actions/bundler/prepareUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/prepareUserOperation.ts
@@ -424,7 +424,7 @@ export async function prepareUserOperation<
 
       // Otherwise, we will need to estimate the fees to fill the fee properties.
       try {
-        const client_ = 'client' in client ? (client.client as Client) : client
+        const client_ = bundlerClient.client ?? client
         const fees = await getAction(
           client_,
           estimateFeesPerGas,
@@ -567,7 +567,7 @@ export async function prepareUserOperation<
         typeof request.paymasterVerificationGasLimit === 'undefined')
     ) {
       const gas = await getAction(
-        client,
+        bundlerClient,
         estimateUserOperationGas,
         'estimateUserOperationGas',
       )({


### PR DESCRIPTION
I am using `createSmartAccountClient` from permissionless and missed that I either needed to pass in `client` or `userOperation` override.

At the time of getting fees, I was seeing `client_` come back as `undefined`, because the `client` is a bundler client with its own `client` key but the value is `undefined`. Then when attempting to use `getAction`, it was failing on the undefined client and the error was being swallowed by the ~empty `catch` statement.

I'm not sure if this is a good fix, especially since the bundler is unlikely to have this endpoint, so falling back to it seems like a bad idea?

Some alternatives:
- Fall back to the `bundlerClient.account.client`
- Adjust `catch` to warn something like "bundler client is missing `client` or `userOperation`"


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `prepareUserOperation` function to utilize `bundlerClient` instead of `client` for fee estimation and gas estimation, improving the handling of client references.

### Detailed summary
- Changed the assignment of `client_` to use `bundlerClient.client` with a nullish coalescing operator.
- Updated the argument for `getAction` in the gas estimation call to use `bundlerClient` instead of `client`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->