### PR TITLE
docs: add missing `recoverMessageAddress` import

### DIFF
--- a/site/pages/docs/utilities/recoverMessageAddress.md
+++ b/site/pages/docs/utilities/recoverMessageAddress.md
@@ -13,6 +13,7 @@ Useful for obtaining the address of a message that was signed with [`signMessage
 :::code-group
 
 ```ts [example.ts]
+import { recoverMessageAddress } from 'viem';
 import { account, walletClient } from './config'
  
 const signature = await walletClient.signMessage({


### PR DESCRIPTION
One of the examples in the docs for [`recoverMessageAddress`](https://viem.sh/docs/utilities/recoverMessageAddress) is missing the `recoverMessageAddress` import — see the first line:

<img width="500" alt="Screenshot 2024-10-03 at 11 12 03" src="https://github.com/user-attachments/assets/4ba80ee6-2916-4fca-bc4e-fe94b5ddbdc3">

(the example in the docs for [`verifyMessage`](https://viem.sh/docs/utilities/verifyMessage), on the other hand, has the `viem` import — see the first line)

<img width="500" alt="Screenshot 2024-10-03 at 11 12 39" src="https://github.com/user-attachments/assets/c2e59196-60f1-42a1-97ee-45e48af94d15">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `recoverMessageAddress` function, providing a clearer example of its usage with a specific signature.

### Detailed summary
- Added an example of using the `recoverMessageAddress` function in the `example.ts` file.
- The example includes a message and a signature for better clarity.
- Ensured the code block is properly closed with a newline at the end of the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->