### PR TITLE
Fix Zircuit Testnet explorer and RPC URLs

### DIFF
--- a/.changeset/sweet-crews-rhyme.md
+++ b/.changeset/sweet-crews-rhyme.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Zircuit Testnet explorer and RPC URLs.

--- a/src/chains/definitions/zircuitTestnet.ts
+++ b/src/chains/definitions/zircuitTestnet.ts
@@ -6,13 +6,16 @@ export const zircuitTestnet = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://zircuit1.p2pify.com'],
+      http: [
+        'https://zircuit1-testnet.p2pify.com',
+        'https://zircuit1-testnet.liquify.com',
+      ],
     },
   },
   blockExplorers: {
     default: {
-      name: 'Zircuit Explorer',
-      url: 'https://explorer.zircuit.com',
+      name: 'Zircuit Testnet Explorer',
+      url: 'https://explorer.testnet.zircuit.com',
     },
   },
   contracts: {
@@ -21,4 +24,5 @@ export const zircuitTestnet = /*#__PURE__*/ defineChain({
       blockCreated: 6040287,
     },
   },
+  testnet: true,
 })


### PR DESCRIPTION
Fixed block explorer and RPC URLs for Zircuit Testnet.

References:
- https://docs.zircuit.com/testnet/rpc-endpoints
- https://docs.zircuit.com/testnet/block-explorer



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `zircuitTestnet` configuration by fixing the RPC URLs and block explorer details to reflect the testnet environment.

### Detailed summary
- Updated `rpcUrls` to use:
  - `https://zircuit1-testnet.p2pify.com`
  - `https://zircuit1-testnet.liquify.com`
- Changed `blockExplorers` name to `Zircuit Testnet Explorer` and updated the URL to `https://explorer.testnet.zircuit.com`
- Added `testnet: true` property in the `zircuitTestnet` definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->