### PR TITLE
cache address in toCoinbaseSmartWallet

### DIFF
--- a/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
+++ b/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
@@ -70,7 +70,8 @@ export type CoinbaseSmartAccountImplementation = Assign<
 export async function toCoinbaseSmartAccount(
   parameters: ToCoinbaseSmartAccountParameters,
 ): Promise<ToCoinbaseSmartAccountReturnType> {
-  const { address, client, owners, nonce = 0n } = parameters
+  const { client, owners, nonce = 0n } = parameters
+  let address = parameters.address
 
   const entryPoint = {
     abi: entryPoint06Abi,
@@ -115,12 +116,12 @@ export async function toCoinbaseSmartAccount(
     },
 
     async getAddress() {
-      if (address) return address
-      return await readContract(client, {
+      address ??= await readContract(client, {
         ...factory,
         functionName: 'getAddress',
         args: [owners_bytes, nonce],
       })
+      return address
     },
 
     async getFactoryArgs() {

--- a/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
+++ b/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
@@ -116,12 +116,12 @@ export async function toCoinbaseSmartAccount(
     },
 
     async getAddress() {
-      address ??= await readContract(client, {
+      if (address) return address
+      return await readContract(client, {
         ...factory,
         functionName: 'getAddress',
         args: [owners_bytes, nonce],
       })
-      return address
     },
 
     async getFactoryArgs() {

--- a/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
+++ b/src/account-abstraction/accounts/implementations/toCoinbaseSmartAccount.ts
@@ -71,6 +71,7 @@ export async function toCoinbaseSmartAccount(
   parameters: ToCoinbaseSmartAccountParameters,
 ): Promise<ToCoinbaseSmartAccountReturnType> {
   const { client, owners, nonce = 0n } = parameters
+  
   let address = parameters.address
 
   const entryPoint = {


### PR DESCRIPTION
The address in `toCoinbaseSmartAccount` is derived from args that can't be changed later, so we may as well cache this value rather than fetching it repeatedly.

Alternatively, we could overwrite `getAddress` in `toSmartAccount` with a function that returns the address since its fetched immediately. But unclear if the intent of this is to be always deterministic. Also unclear if `this.getAddress()` would be scoped to the object from `toCoinbaseSmartWallet` or `toSmartAccount`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the handling of the `address` property within the `ToCoinbaseSmartAccountParameters` in the `toCoinbaseSmartAccount.ts` file. It changes how `address` is destructured from `parameters`, shifting from destructuring to a separate assignment.

### Detailed summary
- Removed `address` from destructuring in the parameters.
- Introduced a separate assignment for `address` from `parameters`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->