### PR TITLE
Use official opBNB explorer URLs

### DIFF
--- a/.changeset/neat-files-fold.md
+++ b/.changeset/neat-files-fold.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated opBNB Explorer URLs.

--- a/src/chains/definitions/opBNB.ts
+++ b/src/chains/definitions/opBNB.ts
@@ -17,7 +17,7 @@ export const opBNB = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'opBNB (BSCScan)',
-      url: 'https://opbnb.bscscan.com/',
+      url: 'https://opbnb.bscscan.com',
       apiUrl: 'https://api-opbnb.bscscan.com/api'
     },
   },

--- a/src/chains/definitions/opBNB.ts
+++ b/src/chains/definitions/opBNB.ts
@@ -16,8 +16,9 @@ export const opBNB = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'opbnbscan',
-      url: 'https://mainnet.opbnbscan.com',
+      name: 'opBNB (BSCScan)',
+      url: 'https://opbnb.bscscan.com/',
+      apiUrl: 'https://api-opbnb.bscscan.com/api'
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `opBNB` chain's block explorer information, specifically changing the name and URLs related to the opBNB Explorer.

### Detailed summary
- Updated the block explorer name from `opbnbscan` to `opBNB (BSCScan)`.
- Changed the block explorer URL from `https://mainnet.opbnbscan.com` to `https://opbnb.bscscan.com`.
- Added an `apiUrl` for the block explorer: `https://api-opbnb.bscscan.com/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->