### PR TITLE
Add Unichain Sepolia Testnet

### DIFF
--- a/.changeset/lemon-kids-complain.md
+++ b/.changeset/lemon-kids-complain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add Unichain Sepolia Testnet

--- a/src/chains/definitions/unichainSepolia.ts
+++ b/src/chains/definitions/unichainSepolia.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 const sourceId = 11_155_111 // sepolia
 
 export const unichainSepolia = /*#__PURE__*/ defineChain({
-  id: 168_587_773,
+  id: 1301,
   name: 'Unichain Sepolia',
   nativeCurrency: {
     name: 'Ether',

--- a/src/chains/definitions/unichainSepolia.ts
+++ b/src/chains/definitions/unichainSepolia.ts
@@ -1,0 +1,33 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+const sourceId = 11_155_111 // sepolia
+
+export const unichainSepolia = /*#__PURE__*/ defineChain({
+  id: 168_587_773,
+  name: 'Unichain Sepolia',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://sepolia.unichain.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Uniscan',
+      url: 'https://sepolia.uniscan.xyz',
+      apiUrl: 'https://api-sepolia.uniscan.xyz',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 0,
+    },
+  },
+  testnet: true,
+  sourceId,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -347,6 +347,7 @@ export { tenet } from './definitions/tenet.js'
 export { thaiChain } from './definitions/thaiChain.js'
 export { thunderTestnet } from './definitions/thunderTestnet.js'
 export { tron } from './definitions/tron.js'
+export { unichainSepolia } from './definitions/unichainSepolia.js';
 export { unique } from './definitions/unique.js'
 export { uniqueQuartz } from './definitions/uniqueQuartz.js'
 export { uniqueOpal } from './definitions/uniqueOpal.js'


### PR DESCRIPTION
Adds Unichain Sepolia Testnet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `Unichain Sepolia` testnet by adding its definition and exporting it from the relevant files.

### Detailed summary
- Added a new entry for `unichainSepolia` in `src/chains/index.ts`.
- Created `unichainSepolia` definition in `src/chains/definitions/unichainSepolia.ts` with:
  - ID: 1301
  - Name: 'Unichain Sepolia'
  - Native currency: Ether (ETH)
  - RPC URL: `https://sepolia.unichain.org`
  - Block explorer: `Uniscan`
  - Multicall3 contract address
  - Marked as a testnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->