### PR TITLE
Add DOSChain and DOSChain Testnet

### DIFF
--- a/.changeset/thirty-carrots-repair.md
+++ b/.changeset/thirty-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added DOSChain and DOSChain Testnet chain.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3106,7 +3106,6 @@ packages:
 
   bun@1.1.12:
     resolution: {integrity: sha512-NZzeZuZk7VwCs8VAXnXUHCPOlTS/IyHCscChtT1M1FLSwhBcVMsGVStYlXaaoqsinBKgp0CGJdhnJw2gR3NkDw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -6646,6 +6645,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.21.22:
+    resolution: {integrity: sha512-jU+WniqIhwDXfgWWkNX7YqlGqenzTa5roLDNs2cbcUGQXxG8aQt1vlTqeezM8W1kepkaU/jvR2QSq/lGirpzrQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -8233,7 +8240,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.21.21(typescript@5.6.2)(zod@3.22.4)
+      viem: 2.21.22(typescript@5.6.2)(zod@3.22.4)
       yargs: 17.7.2
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
@@ -14142,7 +14149,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.21.21(typescript@5.6.2)(zod@3.22.4):
+  viem@2.21.22(typescript@5.6.2)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.6.0

--- a/src/chains/definitions/dosChain.ts
+++ b/src/chains/definitions/dosChain.ts
@@ -1,0 +1,27 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const dosChain = /*#__PURE__*/ defineChain({
+  id: 7979,
+  name: 'DOS Chain',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'DOS Chain',
+    symbol: 'DOS',
+  },
+  rpcUrls: {
+    default: { http: ['https://main.doschain.com'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'DOS Chain Explorer',
+      url: 'https://doscan.io',
+      apiUrl: 'https://api.doscan.io',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 161908,
+    },
+  },
+})

--- a/src/chains/definitions/dosChainTestnet.ts
+++ b/src/chains/definitions/dosChainTestnet.ts
@@ -1,0 +1,28 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const dosChainTestnet = /*#__PURE__*/ defineChain({
+  id: 3939,
+  name: 'DOS Chain Testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'DOS Chain Testnet',
+    symbol: 'DOS',
+  },
+  rpcUrls: {
+    default: { http: ['https://test.doschain.com'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'DOS Chain Testnet Explorer',
+      url: 'https://test.doscan.io',
+      apiUrl: 'https://api-test.doscan.io',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 69623,
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -412,6 +412,8 @@ export { zoraSepolia } from './definitions/zoraSepolia.js'
 export { zoraTestnet } from './definitions/zoraTestnet.js'
 export { zircuit } from './definitions/zircuit.js'
 export { zircuitTestnet } from './definitions/zircuitTestnet.js'
+export { dosChain } from './definitions/dosChain.js'
+export { dosChainTestnet } from './definitions/dosChainTestnet.js'
 
 //////////////////////////////////////////////////////////////////////////////////////
 // Required type exports to prevent TypeScript error "TS2742".


### PR DESCRIPTION
We partner up with openfort which uses viem to abstract web3 operations. They ask us to submit a PR to add our chain (DOS Chain) into viem to procceed.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `DOSChain` and `DOSChain Testnet` by adding their definitions and updating the relevant exports in the codebase. It also updates the `viem` package version in the lock file.

### Detailed summary
- Added `DOSChain` and `DOSChain Testnet` definitions in `src/chains/definitions`.
- Exported `dosChain` and `dosChainTestnet` from `src/chains/index.ts`.
- Updated `pnpm-lock.yaml` to include `viem` version `2.21.22`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->