### PR TITLE
Add `onRequestInit` method which can intercept request initialization with body to modify the payload/headers

### DIFF
--- a/.changeset/clean-toys-run.md
+++ b/.changeset/clean-toys-run.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ability for `onRequest` on the `http` transport to return request options.

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -19,7 +19,11 @@ export type HttpRpcClientOptions = {
   fetchOptions?: Omit<RequestInit, 'body'> | undefined
   /** A callback to handle the request. */
   onRequest?:
-    | ((request: Request) => MaybePromise<void | undefined | Request>)
+    | ((
+        request: Request,
+      ) => MaybePromise<
+        void | undefined | (RequestInit & { url?: string | undefined })
+      >)
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
@@ -36,7 +40,11 @@ export type HttpRequestParameters<
   fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
   /** A callback to handle the response. */
   onRequest?:
-    | ((request: Request) => MaybePromise<void | undefined | Request>)
+    | ((
+        request: Request,
+      ) => MaybePromise<
+        void | undefined | (RequestInit & { url?: string | undefined })
+      >)
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
@@ -105,9 +113,9 @@ export function getHttpRpcClient(
               method: method || 'POST',
               signal: signal_ || (timeout > 0 ? signal : null),
             }
-            let request = new Request(url, init)
-            request = (await onRequest?.(request)) ?? request
-            const response = await fetch(request)
+            const request = new Request(url, init)
+            const args = (await onRequest?.(request)) ?? { ...init, url }
+            const response = await fetch(args.url ?? url, args)
             return response
           },
           {

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -13,7 +13,7 @@ import {
 import { stringify } from '../stringify.js'
 import { idCache } from './id.js'
 
-export type OnRequestReturnType = void | undefined | Request
+type OnRequestReturnType = void | undefined | Request
 
 export type HttpRpcClientOptions = {
   /** Request configuration to pass to `fetch`. */

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -37,9 +37,7 @@ export type HttpRequestParameters<
   fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
   /** A callback to handle the response. */
   onRequest?:
-    | ((
-        request: Request,
-      ) => Promise<void | undefined | Request> | void | undefined | Request)
+    | ((request: Request) => Promise<OnRequestReturnType> | OnRequestReturnType)
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -13,14 +13,14 @@ import {
 import { stringify } from '../stringify.js'
 import { idCache } from './id.js'
 
+export type OnRequestReturnType = void | undefined | Request
+
 export type HttpRpcClientOptions = {
   /** Request configuration to pass to `fetch`. */
   fetchOptions?: Omit<RequestInit, 'body'> | undefined
   /** A callback to handle the request. */
   onRequest?:
-    | ((
-        request: Request,
-      ) => Promise<void | undefined | Request> | void | undefined | Request)
+    | ((request: Request) => Promise<OnRequestReturnType> | OnRequestReturnType)
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined


### PR DESCRIPTION
Proposed solution to fix #2630 - adds a new `onRequestInit` handler which receives the RequestInit object with body included. This allows for modification of the request payload while still supporting the use of dispatchers.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `http` transport's `onRequest` functionality, allowing it to return modified request options. This enables middleware-like behavior, such as adding headers dynamically before sending requests.

### Detailed summary
- Updated `onRequest` type to allow returning modified request options.
- Implemented logic in `getHttpRpcClient` to utilize modified request options.
- Added a test case to verify `onRequest` can return an override request with a hashed body header.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->