### PR TITLE
Check if parameters have gas fees first

### DIFF
--- a/.changeset/nice-rules-fix.md
+++ b/.changeset/nice-rules-fix.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**Account Abstraction:** Updated precedence of user-defined fee parameters in `prepareUserOperation`.

--- a/src/account-abstraction/actions/bundler/prepareUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/prepareUserOperation.ts
@@ -406,6 +406,13 @@ export async function prepareUserOperation<
     (async () => {
       if (!properties.includes('fees')) return undefined
 
+      // If we have sufficient properties for fees, return them.
+      if (
+        typeof parameters.maxFeePerGas === 'bigint' &&
+        typeof parameters.maxPriorityFeePerGas === 'bigint'
+      )
+        return request
+
       // If the Bundler Client has a `estimateFeesPerGas` hook, run it.
       if (bundlerClient?.userOperation?.estimateFeesPerGas) {
         const fees = await bundlerClient.userOperation.estimateFeesPerGas({
@@ -418,13 +425,6 @@ export async function prepareUserOperation<
           ...fees,
         }
       }
-
-      // If we have sufficient properties for fees, return them.
-      if (
-        typeof parameters.maxFeePerGas === 'bigint' &&
-        typeof parameters.maxPriorityFeePerGas === 'bigint'
-      )
-        return request
 
       // Otherwise, we will need to estimate the fees to fill the fee properties.
       try {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
This PR fixes the issue where `prepareUserOperation` overrides the gas field that are already present in the user operation.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the handling of user-defined fee parameters in the `prepareUserOperation` function to improve the precedence of these parameters.

### Detailed summary
- Updated the precedence of user-defined fee parameters in `prepareUserOperation`.
- Removed redundant check for sufficient fee properties before returning the request.
- Retained the logic to estimate fees if user-defined properties are not sufficient.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->