### PR TITLE
fix: narrow sign transaction return type based on the transaction type

### DIFF
--- a/.changeset/early-rice-wink.md
+++ b/.changeset/early-rice-wink.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Narrow the return type of signTransaction

--- a/.changeset/early-rice-wink.md
+++ b/.changeset/early-rice-wink.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Narrow the return type of signTransaction
+Narrow the return type of signTransaction.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3106,7 +3106,6 @@ packages:
 
   bun@1.1.12:
     resolution: {integrity: sha512-NZzeZuZk7VwCs8VAXnXUHCPOlTS/IyHCscChtT1M1FLSwhBcVMsGVStYlXaaoqsinBKgp0CGJdhnJw2gR3NkDw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -6646,6 +6645,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.21.24:
+    resolution: {integrity: sha512-e9wEcQoHH2uuLJ885mWVI7IGx8QUiMWwr3vpeRyCm9H4Cu8u2rwSG8SzAwq12aKENx+0gAs36WHPj7KChJWeSA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -8233,7 +8240,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.21.23(typescript@5.6.2)(zod@3.22.4)
+      viem: 2.21.24(typescript@5.6.2)(zod@3.22.4)
       yargs: 17.7.2
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
@@ -14142,7 +14149,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.21.23(typescript@5.6.2)(zod@3.22.4):
+  viem@2.21.24(typescript@5.6.2)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.6.0

--- a/src/actions/wallet/signTransaction.test-d.ts
+++ b/src/actions/wallet/signTransaction.test-d.ts
@@ -8,12 +8,14 @@ import { createWalletClient } from '../../clients/createWalletClient.js'
 import { http } from '../../clients/transports/http.js'
 import type { Chain } from '../../types/chain.js'
 
-import { signTransaction } from './signTransaction.js'
 import type {
-  TransactionSerializedLegacy,
   TransactionSerializedEIP1559,
   TransactionSerializedEIP2930,
+  TransactionSerializedEIP4844,
+  TransactionSerializedEIP7702,
+  TransactionSerializedLegacy,
 } from '~viem/index.js'
+import { signTransaction } from './signTransaction.js'
 
 const walletClient = createWalletClient({
   account: '0x',
@@ -82,6 +84,44 @@ test('legacy', () => {
     maxPriorityFeePerGas: 0n,
     type: 'legacy',
   })
+})
+
+test('eip7702', () => {
+  const signature1 = signTransaction(walletClient, {
+    authorizationList: [],
+  })
+  const signature2 = signTransaction(walletClient, {
+    authorizationList: [],
+    type: 'eip7702',
+  })
+
+  expectTypeOf(signature1).toEqualTypeOf<
+    Promise<TransactionSerializedEIP7702>
+  >()
+  expectTypeOf(signature2).toEqualTypeOf<
+    Promise<TransactionSerializedEIP7702>
+  >()
+})
+
+test('eip4844', () => {
+  const signature1 = signTransaction(walletClient, {
+    blobs: [],
+    maxFeePerBlobGas: 0n,
+    to: '0x0000000000000000000000000000000000000000',
+  })
+  const signature2 = signTransaction(walletClient, {
+    blobs: [],
+    maxFeePerBlobGas: 0n,
+    to: '0x0000000000000000000000000000000000000000',
+    type: 'eip4844',
+  })
+
+  expectTypeOf(signature1).toEqualTypeOf<
+    Promise<TransactionSerializedEIP4844>
+  >()
+  expectTypeOf(signature2).toEqualTypeOf<
+    Promise<TransactionSerializedEIP4844>
+  >()
 })
 
 test('eip1559', () => {

--- a/src/actions/wallet/signTransaction.test-d.ts
+++ b/src/actions/wallet/signTransaction.test-d.ts
@@ -1,3 +1,164 @@
-import { test } from 'vitest'
+import type { Address } from 'abitype'
 
-test.todo('default')
+import { expectTypeOf, test } from 'vitest'
+
+import { anvilMainnet } from '../../../test/src/anvil.js'
+import type { Account } from '../../accounts/types.js'
+import { createWalletClient } from '../../clients/createWalletClient.js'
+import { http } from '../../clients/transports/http.js'
+import type { Chain } from '../../types/chain.js'
+
+import { signTransaction } from './signTransaction.js'
+import type {
+  TransactionSerializedLegacy,
+  TransactionSerializedEIP1559,
+  TransactionSerializedEIP2930,
+} from '~viem/index.js'
+
+const walletClient = createWalletClient({
+  account: '0x',
+  chain: anvilMainnet.chain,
+  transport: http(anvilMainnet.rpcUrl.http),
+})
+const walletClientWithoutAccount = createWalletClient({
+  chain: anvilMainnet.chain,
+  transport: http(anvilMainnet.rpcUrl.http),
+})
+const walletClientWithoutChain = createWalletClient({
+  account: '0x',
+  transport: http(anvilMainnet.rpcUrl.http),
+})
+
+test('with and without `account`', () => {
+  signTransaction(walletClient, {
+    account: '0x' as Account | Address | undefined,
+    // ^?
+  })
+  signTransaction(walletClientWithoutAccount, {
+    account: '0x' as Account | Address,
+    // ^?
+  })
+})
+
+test('with and without `chain`', () => {
+  signTransaction(walletClient, {
+    chain: anvilMainnet.chain as Chain | undefined,
+    // ^?
+  })
+  signTransaction(walletClientWithoutChain, {
+    chain: anvilMainnet.chain as Chain,
+    // ^?
+  })
+})
+
+test('legacy', () => {
+  const signature1 = signTransaction(walletClient, {
+    gasPrice: 0n,
+  })
+  const signature2 = signTransaction(walletClient, {
+    type: 'legacy',
+  })
+
+  expectTypeOf(signature1).toEqualTypeOf<Promise<TransactionSerializedLegacy>>()
+  expectTypeOf(signature2).toEqualTypeOf<Promise<TransactionSerializedLegacy>>()
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+})
+
+test('eip1559', () => {
+  const signature1 = signTransaction(walletClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+  const signature2 = signTransaction(walletClient, {
+    type: 'eip1559',
+  })
+
+  expectTypeOf(signature1).toEqualTypeOf<
+    Promise<TransactionSerializedEIP1559>
+  >()
+  expectTypeOf(signature2).toEqualTypeOf<
+    Promise<TransactionSerializedEIP1559>
+  >()
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip1559',
+  })
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    gasPrice: 0n,
+    type: 'eip1559',
+  })
+})
+
+test('eip2930', () => {
+  const signature1 = signTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+  })
+
+  const signature2 = signTransaction(walletClient, {
+    type: 'eip2930',
+  })
+
+  expectTypeOf(signature1).toEqualTypeOf<
+    Promise<TransactionSerializedEIP2930>
+  >()
+  expectTypeOf(signature2).toEqualTypeOf<
+    Promise<TransactionSerializedEIP2930>
+  >()
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+  // @ts-expect-error
+  signTransaction(walletClient, {
+    accessList: [],
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+})

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -20,7 +20,6 @@ import type {
   TransactionRequest,
   TransactionSerializable,
   TransactionSerialized,
-  TransactionType,
 } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
@@ -42,7 +41,7 @@ import {
 import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 
-type SignTransactionRequest<
+export type SignTransactionRequest<
   chain extends Chain | undefined = Chain | undefined,
   chainOverride extends Chain | undefined = Chain | undefined,
   ///
@@ -62,8 +61,9 @@ export type SignTransactionParameters<
   GetChainParameter<chain, chainOverride> &
   GetTransactionRequestKzgParameter<request>
 
-export type SignTransactionReturnType<transactionType extends TransactionType> =
-  TransactionSerialized<transactionType>
+export type SignTransactionReturnType<
+  request extends SignTransactionRequest = SignTransactionRequest,
+> = TransactionSerialized<GetTransactionType<request>>
 
 export type SignTransactionErrorType =
   | ParseAccountErrorType
@@ -126,11 +126,10 @@ export async function signTransaction<
     chain,
     chainOverride
   > = SignTransactionRequest<chain, chainOverride>,
-  transactionType extends TransactionType = GetTransactionType<request>,
 >(
   client: Client<Transport, chain, account>,
   parameters: SignTransactionParameters<chain, account, chainOverride, request>,
-): Promise<SignTransactionReturnType<transactionType>> {
+): Promise<SignTransactionReturnType<request>> {
   const {
     account: account_ = client.account,
     chain = client.chain,
@@ -166,7 +165,7 @@ export async function signTransaction<
         chainId,
       } as TransactionSerializable,
       { serializer: client.chain?.serializers?.transaction },
-    ) as Promise<SignTransactionReturnType<transactionType>>
+    ) as Promise<SignTransactionReturnType<request>>
 
   return await client.request(
     {

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -23,6 +23,7 @@ import type {
   TransactionType,
 } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
+import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
 import {
   type AssertCurrentChainErrorType,
@@ -61,11 +62,8 @@ export type SignTransactionParameters<
   GetChainParameter<chain, chainOverride> &
   GetTransactionRequestKzgParameter<request>
 
-export type SignTransactionReturnType<
-  transactionType extends TransactionType | undefined,
-> = TransactionSerialized<
-  transactionType extends TransactionType ? transactionType : TransactionType
->
+export type SignTransactionReturnType<transactionType extends TransactionType> =
+  TransactionSerialized<transactionType>
 
 export type SignTransactionErrorType =
   | ParseAccountErrorType
@@ -128,10 +126,11 @@ export async function signTransaction<
     chain,
     chainOverride
   > = SignTransactionRequest<chain, chainOverride>,
+  transactionType extends TransactionType = GetTransactionType<request>,
 >(
   client: Client<Transport, chain, account>,
   parameters: SignTransactionParameters<chain, account, chainOverride, request>,
-): Promise<SignTransactionReturnType<request['type']>> {
+): Promise<SignTransactionReturnType<transactionType>> {
   const {
     account: account_ = client.account,
     chain = client.chain,
@@ -167,7 +166,7 @@ export async function signTransaction<
         chainId,
       } as TransactionSerializable,
       { serializer: client.chain?.serializers?.transaction },
-    ) as Promise<SignTransactionReturnType<request['type']>>
+    ) as Promise<SignTransactionReturnType<transactionType>>
 
   return await client.request(
     {

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -20,6 +20,7 @@ import type {
   TransactionRequest,
   TransactionSerializable,
   TransactionSerialized,
+  TransactionType,
 } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
@@ -60,7 +61,11 @@ export type SignTransactionParameters<
   GetChainParameter<chain, chainOverride> &
   GetTransactionRequestKzgParameter<request>
 
-export type SignTransactionReturnType = TransactionSerialized
+export type SignTransactionReturnType<
+  transactionType extends TransactionType | undefined,
+> = TransactionSerialized<
+  transactionType extends TransactionType ? transactionType : TransactionType
+>
 
 export type SignTransactionErrorType =
   | ParseAccountErrorType
@@ -126,7 +131,7 @@ export async function signTransaction<
 >(
   client: Client<Transport, chain, account>,
   parameters: SignTransactionParameters<chain, account, chainOverride, request>,
-): Promise<SignTransactionReturnType> {
+): Promise<SignTransactionReturnType<request['type']>> {
   const {
     account: account_ = client.account,
     chain = client.chain,
@@ -162,7 +167,7 @@ export async function signTransaction<
         chainId,
       } as TransactionSerializable,
       { serializer: client.chain?.serializers?.transaction },
-    ) as Promise<SignTransactionReturnType>
+    ) as Promise<SignTransactionReturnType<request['type']>>
 
   return await client.request(
     {

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -23,7 +23,6 @@ import type {
   TransactionType,
 } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
-import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
 import {
   type AssertCurrentChainErrorType,
@@ -40,6 +39,7 @@ import {
   type AssertRequestErrorType,
   assertRequest,
 } from '../../utils/transaction/assertRequest.js'
+import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 
 type SignTransactionRequest<

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -55,6 +55,7 @@ import {
 } from '../../actions/wallet/signMessage.js'
 import {
   type SignTransactionParameters,
+  type SignTransactionRequest,
   type SignTransactionReturnType,
   signTransaction,
 } from '../../actions/wallet/signTransaction.js'
@@ -469,9 +470,15 @@ export type WalletActions<
    * })
    * const signature = await client.signTransaction(request)
    */
-  signTransaction: <chainOverride extends Chain | undefined>(
-    args: SignTransactionParameters<chain, account, chainOverride>,
-  ) => Promise<SignTransactionReturnType>
+  signTransaction: <
+    chainOverride extends Chain | undefined,
+    const request extends SignTransactionRequest<
+      chain,
+      chainOverride
+    > = SignTransactionRequest<chain, chainOverride>,
+  >(
+    args: SignTransactionParameters<chain, account, chainOverride, request>,
+  ) => Promise<SignTransactionReturnType<request>>
   /**
    * Signs typed data and calculates an Ethereum-specific signature in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`.
    *


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on narrowing the return type of the `signTransaction` function in the wallet client, enhancing type safety and ensuring more precise types for transaction requests.

### Detailed summary
- Updated the return type of `signTransaction` to be more specific based on the request type.
- Modified `signTransaction` parameters to include a default request type.
- Added tests for various transaction types (`legacy`, `eip1559`, `eip2930`, `eip4844`, `eip7702`) to validate type expectations. 
- Updated `pnpm-lock.yaml` to reflect the new version of `viem`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->