### PR TITLE
feat: make `from` an optional parameter on `TransactionRequest`

### DIFF
--- a/.changeset/small-maps-drive.md
+++ b/.changeset/small-maps-drive.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Converted `from` to an optional parameter on `TransactionRequest`.

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -216,7 +216,7 @@ export type TransactionRequestBase<
   /** Contract code or a hashed method call with encoded args */
   data?: Hex | undefined
   /** Transaction sender */
-  from: Address
+  from?: Address | undefined
   /** Gas provided for transaction execution */
   gas?: quantity | undefined
   /** Unique number identifying this transaction */

--- a/src/utils/transaction/getTransactionType.test-d.ts
+++ b/src/utils/transaction/getTransactionType.test-d.ts
@@ -124,7 +124,7 @@ test('const: 4844 attributes', () => {
   ).toEqualTypeOf<'eip4844'>()
   expectTypeOf(getTransactionType({ sidecars: [] })).toEqualTypeOf<'eip4844'>()
   expectTypeOf(
-    getTransactionType({ blobVersionedHashes: [] }),
+    getTransactionType({ accessList: [], blobVersionedHashes: [] }),
   ).toEqualTypeOf<'eip4844'>()
 })
 
@@ -148,6 +148,10 @@ test('const: 7702 attributes', () => {
     }),
   ).toEqualTypeOf<'eip7702'>()
   expectTypeOf(
-    getTransactionType({ authorizationList: [], maxPriorityFeePerGas: 1n }),
+    getTransactionType({
+      accessList: [],
+      authorizationList: [],
+      maxPriorityFeePerGas: 1n,
+    }),
   ).toEqualTypeOf<'eip7702'>()
 })

--- a/src/utils/transaction/getTransactionType.ts
+++ b/src/utils/transaction/getTransactionType.ts
@@ -9,62 +9,24 @@ import type {
   FeeValuesLegacy,
 } from '../../index.js'
 import type {
-  TransactionRequestEIP1559,
-  TransactionRequestEIP2930,
-  TransactionRequestEIP4844,
-  TransactionRequestEIP7702,
   TransactionRequestGeneric,
-  TransactionRequestLegacy,
-  TransactionSerializableEIP1559,
   TransactionSerializableEIP2930,
   TransactionSerializableEIP4844,
   TransactionSerializableEIP7702,
   TransactionSerializableGeneric,
-  TransactionSerializableLegacy,
 } from '../../types/transaction.js'
-import type {
-  Assign,
-  ExactPartial,
-  IsNever,
-  OneOf,
-  ValueOf,
-} from '../../types/utils.js'
+import type { Assign, ExactPartial, IsNever, OneOf } from '../../types/utils.js'
 
 export type GetTransactionType<
   transaction extends OneOf<
     TransactionSerializableGeneric | TransactionRequestGeneric
   > = TransactionSerializableGeneric,
   result =
-    | (transaction extends
-        | MatchKeys<TransactionSerializableLegacy, transaction>
-        | MatchKeys<TransactionRequestLegacy, transaction>
-        | LegacyProperties
-        ? 'legacy'
-        : never)
-    | (transaction extends
-        | MatchKeys<TransactionSerializableEIP1559, transaction>
-        | MatchKeys<TransactionRequestEIP1559, transaction>
-        | EIP1559Properties
-        ? 'eip1559'
-        : never)
-    | (transaction extends
-        | MatchKeys<TransactionSerializableEIP2930, transaction>
-        | MatchKeys<TransactionRequestEIP2930, transaction>
-        | EIP2930Properties
-        ? 'eip2930'
-        : never)
-    | (transaction extends
-        | MatchKeys<TransactionSerializableEIP4844, transaction>
-        | MatchKeys<TransactionRequestEIP4844, transaction>
-        | EIP4844Properties
-        ? 'eip4844'
-        : never)
-    | (transaction extends
-        | MatchKeys<TransactionSerializableEIP7702, transaction>
-        | MatchKeys<TransactionRequestEIP7702, transaction>
-        | EIP7702Properties
-        ? 'eip7702'
-        : never)
+    | (transaction extends LegacyProperties ? 'legacy' : never)
+    | (transaction extends EIP1559Properties ? 'eip1559' : never)
+    | (transaction extends EIP2930Properties ? 'eip2930' : never)
+    | (transaction extends EIP4844Properties ? 'eip4844' : never)
+    | (transaction extends EIP7702Properties ? 'eip7702' : never)
     | (transaction['type'] extends TransactionSerializableGeneric['type']
         ? Extract<transaction['type'], string>
         : never),
@@ -115,14 +77,6 @@ export function getTransactionType<
 ////////////////////////////////////////////////////////////////////////////////////////////
 // Types
 
-type MatchKeys<T extends object, U extends object> = ValueOf<
-  Required<{
-    [K in keyof U]: K extends keyof T ? K : undefined
-  }>
-> extends string
-  ? T
-  : never
-
 type BaseProperties = {
   accessList?: undefined
   authorizationList?: undefined
@@ -151,13 +105,13 @@ type EIP1559Properties = Assign<
   }
 >
 type EIP2930Properties = Assign<
-  BaseProperties,
-  ExactPartial<FeeValuesLegacy> & {
+  ExactPartial<LegacyProperties>,
+  {
     accessList: TransactionSerializableEIP2930['accessList']
   }
 >
 type EIP4844Properties = Assign<
-  BaseProperties,
+  ExactPartial<EIP1559Properties>,
   ExactPartial<FeeValuesEIP4844> &
     OneOf<
       | {
@@ -173,8 +127,8 @@ type EIP4844Properties = Assign<
     >
 >
 type EIP7702Properties = Assign<
-  BaseProperties,
-  ExactPartial<FeeValuesEIP1559> & {
+  ExactPartial<EIP1559Properties>,
+  {
     authorizationList: TransactionSerializableEIP7702['authorizationList']
   }
 >


### PR DESCRIPTION
- Made `from` an optional parameter on `TransactionRequeset`. Justification: it is not required in the [Execution Spec](https://github.com/ethereum/execution-apis/blob/main/src/schemas/transaction.yaml#L358-L423).
- Simplified `getTransactionType` types.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `TransactionRequest` type by making the `from` property optional and refining the `getTransactionType` utility to accommodate new transaction types and properties.

### Detailed summary
- Made `from` an optional parameter in `TransactionRequest`.
- Updated test cases for `getTransactionType` to include `accessList`.
- Refactored type definitions in `getTransactionType.ts`, removing legacy types and improving type assignments for EIP properties.
- Adjusted `EIP2930Properties`, `EIP4844Properties`, and `EIP7702Properties` to use `ExactPartial` with the correct base properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->