### PR TITLE
fix: update `setTimeout` return type in `socket.ts`

### DIFF
--- a/.changeset/small-pianos-agree.md
+++ b/.changeset/small-pianos-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated internal `keepAliveTimer` type.

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -128,7 +128,7 @@ export async function getSocketRpcClient<socket extends {}>(
 
       let error: Error | Event | undefined
       let socket: Socket<{}>
-      let keepAliveTimer: Timer | undefined
+      let keepAliveTimer: ReturnType<typeof setInterval> | undefined
 
       // Set up socket implementation.
       async function setup() {


### PR DESCRIPTION
When we install Viem we get a Typescript issue because `Timer` is not defined in some environments. Instead, we can look at the return type for `setTimeout` so that this works well across Node and web environments.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the type of the `keepAliveTimer` variable in the `src/utils/rpc/socket.ts` file to improve type safety and clarity.

### Detailed summary
- Updated the type of `keepAliveTimer` from `Timer | undefined` to `ReturnType<typeof setInterval> | undefined`.
- Added a note in the `.changeset/small-pianos-agree.md` file indicating the patch for `viem` and the update to the internal `keepAliveTimer` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->