### PR TITLE
chore: add `cacheTime` test and fix example link in `getBlockNumber`

### DIFF
--- a/src/actions/public/getBlockNumber.test.ts
+++ b/src/actions/public/getBlockNumber.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, expect, test, vi } from 'vitest'
 
 import { anvilMainnet } from '../../../test/src/anvil.js'
-import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
 import { getBlockNumber, getBlockNumberCache } from './getBlockNumber.js'
 

--- a/src/actions/public/getBlockNumber.test.ts
+++ b/src/actions/public/getBlockNumber.test.ts
@@ -34,13 +34,13 @@ test('behavior: caches blockNumber within cacheTime', async () => {
 
   // Advance time by half of cacheTime
   await wait(cacheTime / 2)
-  const b = await getBlockNumber(client, { cacheTime })
+  const b = await getBlockNumber(client)
   // Within cacheTime, the block number should be the same
   expect(a).toBe(b)
 
   // Advance time by the remaining half plus 1ms to exceed cacheTime
-  await wait(cacheTime / 2 + 1)
-  const c = await getBlockNumber(client, { cacheTime })
+  await wait(cacheTime / 2)
+  const c = await getBlockNumber(client)
   // After cacheTime has passed, the block number should be different
   expect(a).not.toBe(c)
 })

--- a/src/actions/public/getBlockNumber.test.ts
+++ b/src/actions/public/getBlockNumber.test.ts
@@ -38,7 +38,7 @@ test('behavior: caches blockNumber within cacheTime', async () => {
   // Within cacheTime, the block number should be the same
   expect(a).toBe(b)
 
-  // Advance time by the remaining half plus 1ms to exceed cacheTime
+  // Advance time by the remaining half to exceed cacheTime
   await wait(cacheTime / 2)
   const c = await getBlockNumber(client)
   // After cacheTime has passed, the block number should be different

--- a/src/actions/public/getBlockNumber.test.ts
+++ b/src/actions/public/getBlockNumber.test.ts
@@ -29,18 +29,21 @@ test('behavior: caches', async () => {
 
 test('behavior: caches blockNumber within cacheTime', async () => {
   const cacheTime = 100
-  const a = await getBlockNumber(client, { cacheTime })
-  await mine(client, { blocks: 1 })
+  vi.useFakeTimers()
 
-  // Advance time by half of cacheTime
-  await wait(cacheTime / 2)
+  const a = await getBlockNumber(client, { cacheTime })
+  mine(client, { blocks: 1 })
+
+  vi.advanceTimersByTime(cacheTime / 2)
   const b = await getBlockNumber(client)
   // Within cacheTime, the block number should be the same
   expect(a).toBe(b)
 
-  // Advance time by the remaining half to exceed cacheTime
-  await wait(cacheTime / 2)
+  // Advance time by the remaining half plus 1ms to ensure the cache is invalidated
+  vi.advanceTimersByTime(1 + cacheTime / 2)
   const c = await getBlockNumber(client)
   // After cacheTime has passed, the block number should be different
   expect(a).not.toBe(c)
+
+  vi.useRealTimers()
 })

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -32,7 +32,7 @@ export function getBlockNumberCache(id: string) {
  * Returns the number of the most recent block seen.
  *
  * - Docs: https://viem.sh/docs/actions/public/getBlockNumber
- * - Examples: https://stackblitz.com/github/wevm/viem/tree/main/examples/blocks/fetching-blocks
+ * - Examples: https://stackblitz.com/github/wevm/viem/tree/main/examples/blocks_fetching-blocks
  * - JSON-RPC Methods: [`eth_blockNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber)
  *
  * @param client - Client to use


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the documentation for the `getBlockNumber` function and adding a new test case to verify the caching behavior of the function.

### Detailed summary
- Updated example link in the documentation for `getBlockNumber`.
- Added a new test case to `getBlockNumber.test.ts` to check caching behavior within a specified `cacheTime`.
- Utilized `vi.useFakeTimers()` to simulate timer behavior in tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->