### PR TITLE
feat(op-stack): Support multiple Withdrawal logs in the same transaction in `getWithdrawalStatus`

### DIFF
--- a/.changeset/sour-pets-fail.md
+++ b/.changeset/sour-pets-fail.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**OP Stack:** Added `logIndex` as a parameter to `getWithdrawalStatus`.

--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -116,6 +116,7 @@ export async function getWithdrawalStatus<
 >(
   client: Client<Transport, chain, account>,
   parameters: GetWithdrawalStatusParameters<chain, chainOverride>,
+  logIndex = 0
 ): Promise<GetWithdrawalStatusReturnType> {
   const {
     chain = client.chain,
@@ -132,7 +133,7 @@ export async function getWithdrawalStatus<
     return Object.values(targetChain.contracts.portal)[0].address
   })()
 
-  const [withdrawal] = getWithdrawals(receipt)
+  const withdrawal = getWithdrawals(receipt)[logIndex]
 
   if (!withdrawal)
     throw new ReceiptContainsNoWithdrawalsError({

--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -62,6 +62,11 @@ export type GetWithdrawalStatusParameters<
      * @default 100
      */
     gameLimit?: number
+    /**
+     * The relative index of the withdrawal in the transaction receipt logs.
+     * @default 0
+     */
+    logIndex?: number
     receipt: TransactionReceipt
   }
 export type GetWithdrawalStatusReturnType =
@@ -115,14 +120,14 @@ export async function getWithdrawalStatus<
   chainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: GetWithdrawalStatusParameters<chain, chainOverride>,
-  logIndex = 0
+  parameters: GetWithdrawalStatusParameters<chain, chainOverride>
 ): Promise<GetWithdrawalStatusReturnType> {
   const {
     chain = client.chain,
     gameLimit = 100,
     receipt,
     targetChain: targetChain_,
+    logIndex = 0,
   } = parameters
 
   const targetChain = targetChain_ as unknown as TargetChain


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

`getWithdrawalStatus` should support multiple `MessagePassed` logs emitted in the same transaction receipt. I'm sure this isn't the most correct implementation but I just wanted to highlight this feature request.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new parameter, `logIndex`, to the `getWithdrawalStatus` function, allowing users to specify the relative index of the withdrawal in the transaction receipt logs.

### Detailed summary
- Added `logIndex` parameter to `GetWithdrawalStatusParameters` in `getWithdrawalStatus.ts`.
- Updated the function to default `logIndex` to `0`.
- Changed withdrawal retrieval to use `logIndex` for accessing the specific withdrawal from logs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->