### PR TITLE
feat: add support for `wallet_sendTransaction` fallback

### DIFF
--- a/.changeset/smooth-kiwis-run.md
+++ b/.changeset/smooth-kiwis-run.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for `wallet_sendTransaction`.

--- a/site/pages/docs/actions/wallet/sendTransaction.md
+++ b/site/pages/docs/actions/wallet/sendTransaction.md
@@ -87,11 +87,11 @@ The [Transaction](/docs/glossary/terms#transaction) hash.
 
 ### account
 
-- **Type:** `Account | Address`
+- **Type:** `Account | Address | null`
 
 The Account to send the transaction from.
 
-Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-private-key-mnemonic-etc).
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-private-key-mnemonic-etc). If set to `null`, it is assumed that the transport will handle filling the sender of the transaction.
 
 ```ts twoslash
 // [!include ~/snippets/walletClient.ts]

--- a/site/pages/docs/contract/writeContract.md
+++ b/site/pages/docs/contract/writeContract.md
@@ -248,11 +248,11 @@ await walletClient.writeContract({
 
 ### account
 
-- **Type:** `Account | Address`
+- **Type:** `Account | Address | null`
 
 The Account to write to the contract from.
 
-Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-private-key-mnemonic-etc).
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-private-key-mnemonic-etc). If set to `null`, it is assumed that the transport will handle the filling the sender of the transaction.
 
 ```ts
 await walletClient.writeContract({

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -328,12 +328,12 @@ test('with and without wallet client `account`', () => {
 
   expectTypeOf(contractWithAccount.write.approve)
     .parameter(1)
-    .extract<{ account?: Account | Address | undefined }>()
+    .extract<{ account?: Account | Address | null | undefined }>()
     // @ts-expect-error
     .toBeNever()
   expectTypeOf(contractWithoutAccount.write.approve)
     .parameter(1)
-    .extract<{ account: Account | Address }>()
+    .extract<{ account: Account | Address | null }>()
     // @ts-expect-error
     .toBeNever()
 })

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -122,7 +122,7 @@ export type PrepareTransactionRequestParameters<
     chainOverride
   > = PrepareTransactionRequestRequest<chain, chainOverride>,
 > = request &
-  GetAccountParameter<account, accountOverride, false> &
+  GetAccountParameter<account, accountOverride, false, true> &
   GetChainParameter<chain, chainOverride> &
   GetTransactionRequestKzgParameter<request> & { chainId?: number | undefined }
 

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -13,6 +13,7 @@ import { deploy } from '../../../test/src/utils.js'
 import { generatePrivateKey } from '../../accounts/generatePrivateKey.js'
 import { createWalletClient } from '../../clients/createWalletClient.js'
 import { http } from '../../clients/transports/http.js'
+import { InvalidInputRpcError } from '../../errors/rpc.js'
 import { signAuthorization } from '../../experimental/index.js'
 import type { Hex } from '../../types/misc.js'
 import type { TransactionSerializable } from '../../types/transaction.js'
@@ -40,7 +41,6 @@ import { reset } from '../test/reset.js'
 import { setBalance } from '../test/setBalance.js'
 import { setNextBlockBaseFeePerGas } from '../test/setNextBlockBaseFeePerGas.js'
 import { sendTransaction } from './sendTransaction.js'
-import { InvalidInputRpcError } from '../../errors/rpc.js'
 
 const client = anvilMainnet.getClient()
 const clientWithAccount = anvilMainnet.getClient({

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -40,6 +40,7 @@ import { reset } from '../test/reset.js'
 import { setBalance } from '../test/setBalance.js'
 import { setNextBlockBaseFeePerGas } from '../test/setNextBlockBaseFeePerGas.js'
 import { sendTransaction } from './sendTransaction.js'
+import { InvalidInputRpcError } from '../../errors/rpc.js'
 
 const client = anvilMainnet.getClient()
 const clientWithAccount = anvilMainnet.getClient({
@@ -604,6 +605,25 @@ describe('args: chain', async () => {
 
       Version: viem@x.y.z]
     `)
+  })
+
+  test('behavior: nullish account, transport supports `wallet_sendTransaction`', async () => {
+    await setup()
+
+    const request = client.request
+    client.request = (parameters: any) => {
+      if (parameters.method === 'eth_sendTransaction')
+        throw new InvalidInputRpcError(new Error())
+      return request(parameters)
+    }
+
+    expect(
+      await sendTransaction(client, {
+        account: null,
+        to: targetAccount.address,
+        value: 0n,
+      }),
+    ).toBeDefined()
   })
 })
 

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -607,7 +607,7 @@ describe('args: chain', async () => {
     `)
   })
 
-  test('behavior: nullish account, transport supports `wallet_sendTransaction`', async () => {
+  test('behavior: transport supports `wallet_sendTransaction`', async () => {
     await setup()
 
     const request = client.request
@@ -616,6 +616,18 @@ describe('args: chain', async () => {
         throw new InvalidInputRpcError(new Error())
       return request(parameters)
     }
+
+    expect(
+      await sendTransaction(client, {
+        account: sourceAccount.address,
+        to: targetAccount.address,
+        value: 0n,
+      }),
+    ).toBeDefined()
+  })
+
+  test('behavior: nullish account', async () => {
+    await setup()
 
     expect(
       await sendTransaction(client, {

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -237,7 +237,10 @@ export async function sendTransaction<
         const error = e as BaseError
         // If the transport does not support the input, attempt to use the
         // `wallet_sendTransaction` method.
-        if (error.name === 'InvalidInputRpcError')
+        if (
+          error.name === 'InvalidInputRpcError' ||
+          error.name === 'InvalidParamsRpcError'
+        )
           return await client.request({
             method: 'wallet_sendTransaction',
             params: [params],

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -14,6 +14,7 @@ import { optimism } from '../../chains/index.js'
 import { createWalletClient } from '../../clients/createWalletClient.js'
 import { walletActions } from '../../clients/decorators/wallet.js'
 import { http } from '../../clients/transports/http.js'
+import { InvalidInputRpcError } from '../../errors/rpc.js'
 import { signAuthorization } from '../../experimental/index.js'
 import { decodeEventLog, getAddress, parseEther } from '../../utils/index.js'
 import { getBalance } from '../public/getBalance.js'
@@ -22,7 +23,6 @@ import { getTransactionReceipt } from '../public/getTransactionReceipt.js'
 import { simulateContract } from '../public/simulateContract.js'
 import { mine } from '../test/mine.js'
 import { writeContract } from './writeContract.js'
-import { InvalidInputRpcError } from '../../errors/rpc.js'
 
 const client = anvilMainnet.getClient().extend(walletActions)
 const clientWithAccount = anvilMainnet.getClient({

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -1,4 +1,4 @@
-import type { Abi } from 'abitype'
+import type { Abi, Address } from 'abitype'
 
 import type { Account } from '../../accounts/types.js'
 import {
@@ -71,7 +71,7 @@ export type WriteContractParameters<
 > &
   GetChainParameter<chain, chainOverride> &
   Prettify<
-    GetAccountParameter<account> &
+    GetAccountParameter<account, Account | Address, true, true> &
       GetMutabilityAwareValue<
         abi,
         'nonpayable' | 'payable',

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -181,11 +181,11 @@ export async function writeContract<
     ...request
   } = parameters as WriteContractParameters
 
-  if (!account_)
+  if (typeof account_ === 'undefined')
     throw new AccountNotFoundError({
       docsPath: '/docs/contract/writeContract',
     })
-  const account = parseAccount(account_)
+  const account = account_ ? parseAccount(account_) : null
 
   const data = encodeFunctionData({
     abi,
@@ -211,7 +211,7 @@ export async function writeContract<
       args,
       docsPath: '/docs/contract/writeContract',
       functionName,
-      sender: account.address,
+      sender: account?.address,
     })
   }
 }

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -88,7 +88,7 @@ describe('extend', () => {
 
     client.extend(() => ({
       async sendTransaction(args) {
-        expectTypeOf(args.account).toEqualTypeOf<Address | Account>()
+        expectTypeOf(args.account).toEqualTypeOf<Address | Account | null>()
         expectTypeOf(args.to).toEqualTypeOf<Address | null | undefined>()
         expectTypeOf(args.value).toEqualTypeOf<bigint | undefined>()
         return '0x'

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -160,7 +160,7 @@ export class TransactionExecutionError extends BaseError {
       to,
       value,
     }: Omit<SendTransactionParameters, 'account' | 'chain'> & {
-      account: Account
+      account: Account | null
       chain?: Chain | undefined
       docsPath?: string | undefined
     },

--- a/src/experimental/eip5792/actions/getCapabilities.ts
+++ b/src/experimental/eip5792/actions/getCapabilities.ts
@@ -1,9 +1,11 @@
+import type { Address } from 'abitype'
+
 import { parseAccount } from '../../../accounts/utils/parseAccount.js'
 import type { Client } from '../../../clients/createClient.js'
 import type { Transport } from '../../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../../errors/account.js'
 import type { ErrorType } from '../../../errors/utils.js'
-import type { Account, GetAccountParameter } from '../../../types/account.js'
+import type { Account } from '../../../types/account.js'
 import type { Chain } from '../../../types/chain.js'
 import type {
   WalletCapabilities,
@@ -12,9 +14,9 @@ import type {
 import type { Prettify } from '../../../types/utils.js'
 import type { RequestErrorType } from '../../../utils/buildRequest.js'
 
-export type GetCapabilitiesParameters<
-  account extends Account | undefined = Account | undefined,
-> = GetAccountParameter<account>
+export type GetCapabilitiesParameters = {
+  account?: Account | Address | undefined
+}
 
 export type GetCapabilitiesReturnType = Prettify<
   WalletCapabilitiesRecord<WalletCapabilities, number>
@@ -42,24 +44,11 @@ export type GetCapabilitiesErrorType = RequestErrorType | ErrorType
  * })
  * const capabilities = await getCapabilities(client)
  */
-export async function getCapabilities<
-  chain extends Chain | undefined,
-  account extends Account | undefined = undefined,
->(
-  ...parameters: account extends Account
-    ?
-        | [client: Client<Transport, chain, account>]
-        | [
-            client: Client<Transport, chain, account>,
-            parameters: GetCapabilitiesParameters<account>,
-          ]
-    : [
-        client: Client<Transport, chain, account>,
-        parameters: GetCapabilitiesParameters<account>,
-      ]
+export async function getCapabilities<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  parameters: GetCapabilitiesParameters = {},
 ): Promise<GetCapabilitiesReturnType> {
-  const [client, args] = parameters
-  const account_raw = args?.account ?? client.account
+  const account_raw = parameters?.account ?? client.account
 
   if (!account_raw) throw new AccountNotFoundError()
   const account = parseAccount(account_raw)

--- a/src/experimental/eip5792/decorators/eip5792.ts
+++ b/src/experimental/eip5792/decorators/eip5792.ts
@@ -80,9 +80,7 @@ export type Eip5792Actions<
    * })
    */
   getCapabilities: (
-    ...parameters: account extends Account
-      ? [] | [parameters: GetCapabilitiesParameters<account>]
-      : [parameters: GetCapabilitiesParameters<undefined>]
+    parameters?: GetCapabilitiesParameters,
   ) => Promise<GetCapabilitiesReturnType>
   /**
    * Requests the connected wallet to send a batch of calls.

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'abitype'
 
 import type { Account, JsonRpcAccount } from '../accounts/types.js'
-import type { IsUndefined, Prettify } from './utils.js'
+import type { IsUndefined, MaybeRequired, Prettify } from './utils.js'
 
 export type DeriveAccount<
   account extends Account | undefined,
@@ -12,11 +12,22 @@ export type GetAccountParameter<
   account extends Account | undefined = Account | undefined,
   accountOverride extends Account | Address | undefined = Account | Address,
   required extends boolean = true,
-> = IsUndefined<account> extends true
-  ? required extends true
-    ? { account: accountOverride | Account | Address }
-    : { account?: accountOverride | Account | Address | undefined }
-  : { account?: accountOverride | Account | Address | undefined }
+  nullish extends boolean = false,
+> = MaybeRequired<
+  {
+    account?:
+      | accountOverride
+      | Account
+      | Address
+      | (nullish extends true ? null : never)
+      | undefined
+  },
+  IsUndefined<account> extends true
+    ? required extends true
+      ? true
+      : false
+    : false
+>
 
 export type ParseAccount<
   accountOrAddress extends Account | Address | undefined =

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -19,7 +19,7 @@ export type GetTransactionErrorParameters = Omit<
   SendTransactionParameters,
   'account' | 'chain'
 > & {
-  account: Account
+  account: Account | null
   chain?: Chain | undefined
   docsPath?: string | undefined
 }

--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -213,6 +213,9 @@ function defineAnvil<const chain extends Chain>(
                 ],
               },
             ]
+          if (method === 'wallet_sendTransaction') {
+            method = 'eth_sendTransaction'
+          }
 
           return request({ method, params }, opts)
         },


### PR DESCRIPTION
Adds support for falling back to `wallet_sendTransaction` if `eth_sendTransaction` fails.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `wallet_sendTransaction` method, allowing transactions to be sent through wallets. It also updates type definitions to accommodate `null` accounts and adjusts related tests to ensure compatibility.

### Detailed summary
- Added support for `wallet_sendTransaction` in various functions.
- Updated type definitions to allow `account` to be `null`.
- Modified transaction methods to handle `null` accounts.
- Enhanced tests for sending transactions with `null` accounts.
- Adjusted error handling for unsupported methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->