### PR TITLE
Proper Content-Type header on CCIP POST requests

### DIFF
--- a/.changeset/dirty-hounds-lay.md
+++ b/.changeset/dirty-hounds-lay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `Content-Type` header to CCIP `POST` requests.

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -136,15 +136,15 @@ export async function ccipRequest({
     const url = urls[i]
     const method = url.includes('{data}') ? 'GET' : 'POST'
     const body = method === 'POST' ? { data, sender } : undefined
-    const headers = method === 'POST' ? { 'Content-Type':'application/json' } : {}
+    const headers = method === 'POST' ? { 'Content-Type' : 'application/json' } : {}
 
     try {
       const response = await fetch(
         url.replace('{sender}', sender).replace('{data}', data),
         {
-          method,
-          headers,
           body: JSON.stringify(body),
+          headers,
+          method,
         },
       )
 

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -136,13 +136,15 @@ export async function ccipRequest({
     const url = urls[i]
     const method = url.includes('{data}') ? 'GET' : 'POST'
     const body = method === 'POST' ? { data, sender } : undefined
+    const headers = method === 'POST' ? { 'Content-Type':'application/json' } : {}
 
     try {
       const response = await fetch(
         url.replace('{sender}', sender).replace('{data}', data),
         {
-          body: JSON.stringify(body),
           method,
+          headers,
+          body: JSON.stringify(body),
         },
       )
 


### PR DESCRIPTION
Currently, CCIP POST requests are sent without `Content-Type` headers, which makes requests fail for servers that reject the body if the header isn't present.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the CCIP functionality by ensuring that `POST` requests include the appropriate `Content-Type` header, which is essential for correctly indicating the format of the data being sent.

### Detailed summary
- In the `ccip.ts` file, a `headers` object is created for `POST` requests, setting `Content-Type` to `application/json`.
- The `fetch` call is updated to include the newly created `headers` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->