### PR TITLE
Fix getUserOperationError for `UserOp execution reverted 0x`

### DIFF
--- a/.changeset/rare-fishes-bow.md
+++ b/.changeset/rare-fishes-bow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getUserOperationError` runtime error.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 20.16.12
       '@vitest/coverage-v8':
         specifier: ^1.0.4
-        version: 1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.31.0))
+        version: 1.0.4(vitest@1.0.4)
       '@vitest/ui':
         specifier: ^1.0.4
         version: 1.0.4(vitest@1.0.4)
@@ -7844,7 +7844,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.31.0))':
+  '@vitest/coverage-v8@1.0.4(vitest@1.0.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3

--- a/src/account-abstraction/utils/errors/getUserOperationError.test.ts
+++ b/src/account-abstraction/utils/errors/getUserOperationError.test.ts
@@ -563,3 +563,50 @@ test('bundler error', () => {
     Version: viem@x.y.z]
   `)
 })
+
+test('bundler error (execution reverted without calls)', () => {
+  const error = new RpcRequestError({
+    body: {},
+    error: {
+      code: -32521,
+      message: 'UserOperation reverted during simulation with reason: 0x',
+    },
+    url: '',
+  })
+  const result = getUserOperationError(error, {
+    callData: '0xdeadbeef',
+    callGasLimit: 1n,
+    nonce: 1n,
+    preVerificationGas: 1n,
+    verificationGasLimit: 1n,
+    signature: '0xdeadbeef',
+    sender: '0xdeadbeef',
+    factory: '0x0000000000000000000000000000000000000000',
+    factoryData: '0xdeadbeef',
+    maxFeePerGas: 1n,
+    maxPriorityFeePerGas: 2n,
+    paymasterData: '0xdeadbeef',
+    paymaster: '0xffff',
+  })
+  expect(result).toMatchInlineSnapshot(`
+    [UserOperationExecutionError: Execution reverted with reason: UserOperation reverted during simulation with reason: 0x.
+
+    Request Arguments:
+      callData:              0xdeadbeef
+      callGasLimit:          1
+      factory:               0x0000000000000000000000000000000000000000
+      factoryData:           0xdeadbeef
+      maxFeePerGas:          0.000000001 gwei
+      maxPriorityFeePerGas:  0.000000002 gwei
+      nonce:                 1
+      paymaster:             0xffff
+      paymasterData:         0xdeadbeef
+      preVerificationGas:    1
+      sender:                0xdeadbeef
+      signature:             0xdeadbeef
+      verificationGasLimit:  1
+
+    Details: UserOperation reverted during simulation with reason: 0x
+    Version: viem@x.y.z]
+  `)
+})

--- a/src/account-abstraction/utils/errors/getUserOperationError.ts
+++ b/src/account-abstraction/utils/errors/getUserOperationError.ts
@@ -55,7 +55,7 @@ export function getUserOperationError<err extends ErrorType<string>>(
       err as {} as BaseError,
       args as GetBundlerErrorParameters,
     )
-    if (cause instanceof ExecutionRevertedError) {
+    if (calls && cause instanceof ExecutionRevertedError) {
       const revertData = getRevertData(cause)
       const contractCalls = calls?.filter(
         (call: any) => call.abi || call.data,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
The function, `getUserOperationError` has run time error when processing UserOperationError: `UserOperation reverted during simulation with reason: 0x`.  Please refer to the following capture.

#### Error
![Screenshot 2024-10-17 at 21 58 53](https://github.com/user-attachments/assets/139f5ebb-b3e2-4c37-989b-145bc634fd18)

Even though this is unknown contract execution reverted error, it should be displaying the original error instead of this runtime issue, which leads to some confusion for debugging. 

This PR includes a very small fix in `getUserOperationError` function which validates the `calls` values from function input before proceeding to determine the contract call data.

### To reproduce the error

#### Test input
```
const error = new RpcRequestError({
  body: {},
  error: {
    code: -32521,
    message: 'UserOperation reverted during simulation with reason: 0x',
  },
  url: '',
})
```

### Expected
It should return the original error message (`UserOperation reverted during simulation with reason: 0x`) with the `UserOperation` object provided to the RPC call.
```
[UserOperationExecutionError: Execution reverted with reason: UserOperation reverted during simulation with reason: 0x.

Request Arguments:
  callData:              0xdeadbeef
  callGasLimit:          1
  factory:               0x0000000000000000000000000000000000000000
  factoryData:           0xdeadbeef
  maxFeePerGas:          0.000000001 gwei
  maxPriorityFeePerGas:  0.000000002 gwei
  nonce:                 1
  paymaster:             0xffff
  paymasterData:         0xdeadbeef
  preVerificationGas:    1
  sender:                0xdeadbeef
  signature:             0xdeadbeef
  verificationGasLimit:  1

Details: UserOperation reverted during simulation with reason: 0x
Version: viem@x.y.z]
```


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a runtime error in the `getUserOperationError` function by adding a condition to check for `calls` and enhancing the test coverage for scenarios where execution is reverted without calls.

### Detailed summary
- Fixed a runtime error in `getUserOperationError` by adding a check for `calls`.
- Updated the test for `getUserOperationError` to handle the case of execution reverted without calls.
- Added a new test case that checks the output when a specific `RpcRequestError` occurs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->