### PR TITLE
fix: OP Stak L1 data fee broken link

### DIFF
--- a/site/pages/op-stack/actions/estimateContractL1Fee.md
+++ b/site/pages/op-stack/actions/estimateContractL1Fee.md
@@ -4,7 +4,7 @@ description: Estimates the L1 fee to execute an L2 contract write.
 
 # estimateContractL1Fee
 
-Estimates the [L1 data fee](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) to execute an L2 contract write.
+Estimates the [L1 data fee](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) to execute an L2 contract write.
 
 Invokes the `getL1Fee` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateContractL1Gas.md
+++ b/site/pages/op-stack/actions/estimateContractL1Gas.md
@@ -4,7 +4,7 @@ description: Estimates the L1 gas to execute an L2 contract write.
 
 # estimateContractL1Gas
 
-Estimates the [L1 data gas](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) to execute an L2 contract write.
+Estimates the [L1 data gas](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) to execute an L2 contract write.
 
 Invokes the `getL1GasUsed` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateContractTotalFee.md
+++ b/site/pages/op-stack/actions/estimateContractTotalFee.md
@@ -4,7 +4,7 @@ description: Estimates the total (L1 + L2) fee to execute an L2 contract write.
 
 # estimateContractTotalFee
 
-Estimates the total ([L1 data](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) + L2) fee to execute an L2 contract write.
+Estimates the total ([L1 data](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) + L2) fee to execute an L2 contract write.
 
 Invokes the `getL1Fee` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateContractTotalGas.md
+++ b/site/pages/op-stack/actions/estimateContractTotalGas.md
@@ -4,7 +4,7 @@ description: Estimates the total (L1 + L2) gas to execute an L2 contract write.
 
 # estimateContractTotalGas
 
-Estimates the total ([L1 data](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) + L2) gas to execute an L2 contract write.
+Estimates the total ([L1 data](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) + L2) gas to execute an L2 contract write.
 
 Invokes the `getL1GasUsed` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateL1Fee.md
+++ b/site/pages/op-stack/actions/estimateL1Fee.md
@@ -4,7 +4,7 @@ description: Estimates the L1 fee to execute an L2 transaction.
 
 # estimateL1Fee
 
-Estimates the [L1 data fee](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) to execute an L2 transaction.
+Estimates the [L1 data fee](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) to execute an L2 transaction.
 
 Invokes the `getL1Fee` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateL1Gas.md
+++ b/site/pages/op-stack/actions/estimateL1Gas.md
@@ -4,7 +4,7 @@ description: Estimates the amount of L1 gas required to execute an L2 transactio
 
 # estimateL1Gas
 
-Estimates the amount of [L1 data gas](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) required to execute an L2 transaction.
+Estimates the amount of [L1 data gas](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) required to execute an L2 transaction.
 
 Invokes the `getL1GasUsed` method on the [Gas Price Oracle](https://github.com/ethereum-optimism/optimism/blob/233ede59d16cb01bdd8e7ff662a153a4c3178bdd/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol) predeploy contract.
 

--- a/site/pages/op-stack/actions/estimateTotalFee.md
+++ b/site/pages/op-stack/actions/estimateTotalFee.md
@@ -4,7 +4,7 @@ description: Estimates the L1 + L2 fee to execute an L2 transaction.
 
 # estimateTotalFee
 
-Estimates the [L1 data fee](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) + L2 fee to execute an L2 transaction.
+Estimates the [L1 data fee](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) + L2 fee to execute an L2 transaction.
 
 It is the sum of [`estimateL1Fee`](/op-stack/actions/estimateL1Fee) (L1 Gas) and [`estimateGas`](/docs/actions/public/estimateGas.md) * [`getGasPrice`](/docs/actions/public/getGasPrice.md) (L2 Gas * L2 Gas Price).
 

--- a/site/pages/op-stack/actions/estimateTotalGas.md
+++ b/site/pages/op-stack/actions/estimateTotalGas.md
@@ -4,7 +4,7 @@ description: Estimates the amount of L1 + L2 gas required to execute an L2 trans
 
 # estimateTotalGas
 
-Estimates the amount of [L1 data gas](https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee) + L2 gas required to execute an L2 transaction.
+Estimates the amount of [L1 data gas](https://docs.optimism.io/stack/transactions/fees#l1-data-fee) + L2 gas required to execute an L2 transaction.
 
 It is the sum of [`estimateL1Gas`](/op-stack/actions/estimateL1Gas) (L1 Gas) and [`estimateGas`](/docs/actions/public/estimateGas.md) (L2 Gas).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation links for various estimation functions related to gas and fees in the Optimism ecosystem, changing them from a community URL to the official documentation URL.

### Detailed summary
- Updated links in `estimateTotalGas.md` to the official documentation.
- Updated links in `estimateL1Fee.md` to the official documentation.
- Updated links in `estimateTotalFee.md` to the official documentation.
- Updated links in `estimateContractL1Fee.md` to the official documentation.
- Updated links in `estimateContractL1Gas.md` to the official documentation.
- Updated links in `estimateL1Gas.md` to the official documentation.
- Updated links in `estimateContractTotalFee.md` to the official documentation.
- Updated links in `estimateContractTotalGas.md` to the official documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->