### PR TITLE
docs: update a dead link

### DIFF
--- a/site/pages/docs/abi/encodeAbiParameters.md
+++ b/site/pages/docs/abi/encodeAbiParameters.md
@@ -4,7 +4,7 @@ description: Generates ABI encoded data.
 
 # encodeAbiParameters
 
-Generates ABI encoded data using the [ABI specification](https://docs.soliditylang.org/en/latest/abi-spec.html#types), given a set of ABI parameters (`inputs`/`outputs`) and their corresponding values.
+Generates ABI encoded data using the [ABI specification](https://docs.soliditylang.org/en/latest/abi-spec.html), given a set of ABI parameters (`inputs`/`outputs`) and their corresponding values.
 
 The `encodeAbiParameters` function is used by the other contract encoding utilities (ie. `encodeFunctionData`, `encodeEventTopics`, etc).
 

--- a/site/pages/docs/abi/encodeAbiParameters.md
+++ b/site/pages/docs/abi/encodeAbiParameters.md
@@ -4,7 +4,7 @@ description: Generates ABI encoded data.
 
 # encodeAbiParameters
 
-Generates ABI encoded data using the [ABI specification](https://solidity.readthedocs.io/en/latest/abi-spec), given a set of ABI parameters (`inputs`/`outputs`) and their corresponding values.
+Generates ABI encoded data using the [ABI specification](https://docs.soliditylang.org/en/latest/abi-spec.html#types), given a set of ABI parameters (`inputs`/`outputs`) and their corresponding values.
 
 The `encodeAbiParameters` function is used by the other contract encoding utilities (ie. `encodeFunctionData`, `encodeEventTopics`, etc).
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a link in the documentation for the `encodeAbiParameters` function to point to the correct Solidity ABI specification page.

### Detailed summary
- Changed the URL in the documentation from `https://solidity.readthedocs.io/en/latest/abi-spec` to `https://docs.soliditylang.org/en/latest/abi-spec.html`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->