### PR TITLE
Create swell_l2.ts

### DIFF
--- a/src/chains/definitions/swell_l2.ts
+++ b/src/chains/definitions/swell_l2.ts
@@ -1,0 +1,24 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const swellL2 = /*#__PURE__*/ defineChain({
+  id: 1923,
+  name: 'Swell L2',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: [''], 
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: '',
+      apiUrl: '', 
+    },
+  },
+  testnet: false,
+})


### PR DESCRIPTION
Adding Swell L2 Chain ID

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new chain definition for `Swell L2`, including its properties such as `id`, `name`, `nativeCurrency`, `rpcUrls`, `blockExplorers`, and `testnet` status.

### Detailed summary
- Added a new chain definition for `Swell L2`.
- Set `id` to `1923`.
- Defined `name` as `Swell L2`.
- Specified `nativeCurrency` with `name`, `symbol`, and `decimals`.
- Established `rpcUrls` with a default HTTP array.
- Included `blockExplorers` with default name and URLs.
- Marked `testnet` as `false`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->