### PR TITLE
fix: estimateGas infinite loop for linea

### DIFF
--- a/.changeset/plenty-pets-kneel.md
+++ b/.changeset/plenty-pets-kneel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**Linea Extension:** Fixed `estimateGas` infinite loop.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5559,6 +5559,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.21.33:
+    resolution: {integrity: sha512-1SKGePp+DS3FO3IwnLU5oo0Ugrjeaige+Z3i8Eijxv3u9VwnMuM59j3La8rVU/vucwO+SO0rvhRi4w/1uvD7ug==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -6961,7 +6969,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.21.32(typescript@5.6.2)(zod@3.22.4)
+      viem: 2.21.33(typescript@5.6.2)(zod@3.22.4)
       yargs: 17.7.2
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
@@ -11572,7 +11580,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.21.32(typescript@5.6.2)(zod@3.22.4):
+  viem@2.21.33(typescript@5.6.2)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.6.0

--- a/src/linea/actions/estimateGas.ts
+++ b/src/linea/actions/estimateGas.ts
@@ -1,10 +1,6 @@
 import type { Account } from '../../accounts/types.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import type { EstimateGasParameters as EstimateGasParameters_base } from '../../actions/public/estimateGas.js'
-import {
-  type PrepareTransactionRequestParameters,
-  prepareTransactionRequest,
-} from '../../actions/wallet/prepareTransactionRequest.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
@@ -82,13 +78,7 @@ export async function estimateGas<
       to,
       value,
       ...rest
-    } =
-      account?.type === 'local'
-        ? ((await prepareTransactionRequest(
-            client,
-            args as PrepareTransactionRequestParameters,
-          )) as EstimateGasParameters)
-        : args
+    } = args
 
     const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
     const block = blockNumberHex || blockTag


### PR DESCRIPTION
Fixes #2849

When the `account.type` is `local`, the custom `estimateGas` function for Linea calls the `prepareTransactionResult` that internally calls back the `estimateGas` causing an infinite loop. Removing that logic fixed the issue

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an infinite loop issue in the `estimateGas` function and updating the `viem` package version.

### Detailed summary
- Fixed infinite loop in the `estimateGas` function located in `src/linea/actions/estimateGas.ts`.
- Updated `viem` package version from `2.21.32` to `2.21.33` in `pnpm-lock.yaml`.
- Adjusted peer dependency for `typescript` to be optional in `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->