### PR TITLE
Add Dispute Game Factory address for Base Mainnet

### DIFF
--- a/.changeset/chilled-boats-stare.md
+++ b/.changeset/chilled-boats-stare.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Dispute Game Factory contract for Base.

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -22,6 +22,11 @@ export const base = /*#__PURE__*/ defineChain({
   },
   contracts: {
     ...chainConfig.contracts,
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e',
+      },
+    },
     l2OutputOracle: {
       [sourceId]: {
         address: '0x56315b90c40730925ec5485cf004d835058518A0',


### PR DESCRIPTION
To support Fault Proofs w/ Base Mainnet.

I can confirm this is the correct address at the time of writing (I've been doing the testing) ~~though we should hold off merging this PR until the Superchain Ops PR has been reviewed, and merged~~. EDIT: We have now verified the simulated state. 

See https://github.com/ethereum-optimism/superchain-ops/pull/352

Related to https://docs.base.org/docs/preparing-for-fault-proofs-on-base/

Sepolia https://github.com/wevm/viem/pull/2519

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `Dispute Game Factory` contract for the `Base` chain and updates the `base.ts` configuration to include this new contract.

### Detailed summary
- Added `disputeGameFactory` entry to the `contracts` object in `src/chains/definitions/base.ts`.
- Specified a source ID and address for the `disputeGameFactory`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->