### PR TITLE
feat: Improve return type for toSignature

### DIFF
--- a/.changeset/silly-geckos-agree.md
+++ b/.changeset/silly-geckos-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Improved return type for toSignature

--- a/src/utils/hash/normalizeSignature.test-d.ts
+++ b/src/utils/hash/normalizeSignature.test-d.ts
@@ -1,0 +1,139 @@
+import { expectTypeOf, test } from 'vitest'
+import { normalizeSignature } from './normalizeSignature.js'
+
+/**
+ * Cases where we should be able to get proper types for this, but where the feature just isn't implemented in Viem
+ */
+type TodoType = string
+
+test('foo()', () => {
+  expectTypeOf(normalizeSignature('event foo()')).toMatchTypeOf<'foo()'>()
+})
+
+test('bar(uint foo)', () => {
+  expectTypeOf(normalizeSignature('bar(uint foo)')).toMatchTypeOf<TodoType>()
+})
+
+test('processAccount(uint256 , address )', () => {
+  expectTypeOf(
+    normalizeSignature('processAccount(uint256 , address )'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('function bar()', () => {
+  expectTypeOf(normalizeSignature('function bar()')).toMatchTypeOf<'bar()'>()
+})
+
+test('function bar()', () => {
+  expectTypeOf(normalizeSignature('function  bar( )')).toMatchTypeOf<TodoType>()
+})
+
+test('event Bar()', () => {
+  expectTypeOf(normalizeSignature('event Bar()')).toMatchTypeOf<'Bar()'>()
+})
+
+test('function bar(uint foo)', () => {
+  expectTypeOf(
+    normalizeSignature('function bar(uint foo)'),
+  ).toMatchTypeOf<'bar(uint256)'>()
+})
+
+test('function bar(uint foo, address baz)', () => {
+  expectTypeOf(
+    normalizeSignature('function bar(uint foo, address baz)'),
+  ).toMatchTypeOf<'bar(uint256,address)'>()
+})
+
+test('event Barry(uint foo)', () => {
+  expectTypeOf(
+    normalizeSignature('event Barry(uint foo)'),
+  ).toMatchTypeOf<'Barry(uint256)'>()
+})
+
+test('Barry(uint indexed foo)', () => {
+  expectTypeOf(
+    normalizeSignature('Barry(uint indexed foo)'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('event Barry(uint indexed foo)', () => {
+  expectTypeOf(
+    normalizeSignature('event Barry(uint indexed foo)'),
+  ).toMatchTypeOf<'Barry(uint256)'>()
+})
+
+test('function _compound(uint256 a, uint256 b, uint256 c)', () => {
+  expectTypeOf(
+    normalizeSignature('function _compound(uint256 a, uint256 b, uint256 c)'),
+  ).toMatchTypeOf<'_compound(uint256,uint256,uint256)'>()
+})
+
+test('bar(uint foo, (uint baz))', () => {
+  expectTypeOf(
+    normalizeSignature('bar(uint foo, (uint baz))'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('bar(uint foo, (uint baz, bool x))', () => {
+  expectTypeOf(
+    normalizeSignature('bar(uint foo, (uint baz, bool x))'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('bar(uint foo, (uint baz, bool x) foo)', () => {
+  expectTypeOf(
+    normalizeSignature('bar(uint foo, (uint baz, bool x) foo)'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('bar(uint[] foo, (uint baz, bool x))', () => {
+  expectTypeOf(
+    normalizeSignature('bar(uint[] foo, (uint baz, bool x))'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('bar(uint[] foo, (uint baz, bool x)[])', () => {
+  expectTypeOf(
+    normalizeSignature('bar(uint[] foo, (uint baz, bool x)[])'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('foo(uint bar)', () => {
+  expectTypeOf(
+    normalizeSignature('foo(uint bar) payable returns (uint)'),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('function submitBlocksWithCallbacks(bool isDataCompressed, bytes calldata data, ((uint16,(uint16,uint16,uint16,bytes)[])[], address[])  calldata config)', () => {
+  expectTypeOf(
+    normalizeSignature(
+      'function submitBlocksWithCallbacks(bool isDataCompressed, bytes calldata data, ((uint16,(uint16,uint16,uint16,bytes)[])[], address[])  calldata config)',
+    ),
+  ).toMatchTypeOf<'submitBlocksWithCallbacks(bool,bytes,((uint16,(uint16,uint16,uint16,bytes)[])[],address[]))'>(
+    'submitBlocksWithCallbacks(bool,bytes,((uint16,(uint16,uint16,uint16,bytes)[])[],address[]))',
+  )
+})
+
+test('function createEdition(string name, string symbol, uint64 editionSize, uint16 royaltyBPS, address fundsRecipient, address defaultAdmin, (uint104 publicSalePrice, uint32 maxSalePurchasePerAddress, uint64 publicSaleStart, uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig, string description, string animationURI, string imageURI) returns (address)', () => {
+  expectTypeOf(
+    normalizeSignature(
+      'function createEdition(string name, string symbol, uint64 editionSize, uint16 royaltyBPS, address fundsRecipient, address defaultAdmin, (uint104 publicSalePrice, uint32 maxSalePurchasePerAddress, uint64 publicSaleStart, uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig, string description, string animationURI, string imageURI) returns (address)',
+    ),
+  ).toMatchTypeOf<'createEdition(string,string,uint64,uint16,address,address,(uint104,uint32,uint64,uint64,uint64,uint64,bytes32),string,string,string)'>()
+})
+
+test('trim spaces', () => {
+  expectTypeOf(
+    normalizeSignature(
+      'function  createEdition(string  name,string symbol,   uint64 editionSize  , uint16   royaltyBPS,     address     fundsRecipient,   address    defaultAdmin, ( uint104   publicSalePrice  ,   uint32 maxSalePurchasePerAddress, uint64 publicSaleStart,   uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig , string description, string animationURI, string imageURI ) returns (address)',
+    ),
+  ).toMatchTypeOf<TodoType>()
+})
+
+test('error: invalid signatures', () => {
+  // TODO: these should be errors, but they aren't yet
+  // assertType<never>(normalizeSignature('bar'))
+  // assertType<never>(normalizeSignature('bar(uint foo'))
+  // assertType<never>(normalizeSignature('baruint foo)'))
+  // assertType<never>(normalizeSignature('bar(uint foo, (uint baz)'))
+})

--- a/src/utils/hash/toSignature.ts
+++ b/src/utils/hash/toSignature.ts
@@ -1,8 +1,14 @@
-import { type AbiEvent, type AbiFunction, formatAbiItem } from 'abitype'
+import {
+  type AbiEvent,
+  type AbiFunction,
+  type SignatureAbiItem,
+  formatAbiItem,
+} from 'abitype'
 
 import type { ErrorType } from '../../errors/utils.js'
 import {
   type NormalizeSignatureErrorType,
+  type ToSignature,
   normalizeSignature,
 } from './normalizeSignature.js'
 
@@ -25,10 +31,16 @@ export type ToSignatureErrorType = NormalizeSignatureErrorType | ErrorType
  * })
  * // 'ownerOf(uint256)'
  */
-export const toSignature = (def: string | AbiFunction | AbiEvent) => {
+export const toSignature = <const Def extends string | AbiFunction | AbiEvent>(
+  def: Def,
+): Def extends AbiFunction | AbiEvent
+  ? SignatureAbiItem<Def>
+  : Def extends string
+    ? ToSignature<Def>
+    : never => {
   const def_ = (() => {
     if (typeof def === 'string') return def
     return formatAbiItem(def)
   })()
-  return normalizeSignature(def_)
+  return normalizeSignature(def_) as ToSignature<typeof def_>
 }


### PR DESCRIPTION
Integrates https://github.com/wevm/abitype/pull/255 into Viem to improve the return type of `toSignature`

This helps resolve these two discussions: https://github.com/wevm/viem/discussions/260 and https://github.com/wevm/viem/discussions/2706

A follow-up PR to this will have to be adding the option to pass the full signature to functions like `getContractEvents` and `getAbiItem`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the type safety and return types of the `toSignature` and `normalizeSignature` functions in the codebase, enhancing the handling of ABI signatures.

### Detailed summary
- Updated `toSignature` to use generics for better return types.
- Enhanced `normalizeSignature` with stricter type definitions.
- Added detailed comments addressing limitations and expected behavior of signature normalization.
- Introduced new tests to validate the changes in type handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->