### PR TITLE
docs: fix wrong viem installation code group

### DIFF
--- a/site/pages/docs/installation.mdx
+++ b/site/pages/docs/installation.mdx
@@ -20,7 +20,7 @@ yarn add viem
 ```
 
 ```bash [bun]
-bun add wagmi viem@{{viemVersion}} @tanstack/react-query
+bun add viem
 ```
 :::
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Fixes a typo

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the installation command for adding dependencies by removing the `wagmi` package and the version placeholder for `viem`. 

### Detailed summary
- Changed the command from `bun add wagmi viem@{{viemVersion}} @tanstack/react-query` to `bun add viem`
- Removed `wagmi` and `@tanstack/react-query` from the installation command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->