### PR TITLE
Add multicall3 contract  and update block explorer

### DIFF
--- a/src/chains/definitions/thunderCore.ts
+++ b/src/chains/definitions/thunderCore.ts
@@ -12,7 +12,13 @@ export const thunderCore = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'ThunderCore Explorer',
-      url: 'https://viewblock.io/thundercore',
+      url: 'https://explorer-mainnet.thundercore.com',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 137684666,
     },
   },
   testnet: false,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ThunderCore Explorer` configuration by changing the URL and adding details about the `multicall3` contract.

### Detailed summary
- Updated the `url` for `ThunderCore Explorer` from `https://viewblock.io/thundercore` to `https://explorer-mainnet.thundercore.com`.
- Added a new `contracts` section with details for `multicall3`:
  - `address`: '0xcA11bde05977b3631167028862bE2a173976CA11'
  - `blockCreated`: 137684666
- Set `testnet` to false.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->