### PR TITLE
feat: update xdc-testnet

### DIFF
--- a/.changeset/bright-birds-know.md
+++ b/.changeset/bright-birds-know.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated XDC Testnet Block Explorer URL.

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -20,7 +20,7 @@ export const xdc = /*#__PURE__*/ defineChain({
     blocksscan: {
       name: 'Blocksscan',
       url: 'https://xdcscan.io',
-    }
+    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -17,10 +17,6 @@ export const xdc = /*#__PURE__*/ defineChain({
       name: 'XDCScan',
       url: 'https://xdcscan.com',
     },
-    blocksscan: {
-      name: 'Blocksscan',
-      url: 'https://xdcscan.io',
-    },
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -10,12 +10,17 @@ export const xdc = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: { http: ['https://rpc.xdcrpc.com'] },
+    xinfin: { http: ['https://erpc.xinfin.network'] },
   },
   blockExplorers: {
     default: {
       name: 'XDCScan',
       url: 'https://xdcscan.com',
     },
+    blocksscan: {
+      name: 'Blocksscan',
+      url: 'https://xdcscan.io',
+    }
   },
   contracts: {
     multicall3: {

--- a/src/chains/definitions/xdc.ts
+++ b/src/chains/definitions/xdc.ts
@@ -10,7 +10,6 @@ export const xdc = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: { http: ['https://rpc.xdcrpc.com'] },
-    xinfin: { http: ['https://erpc.xinfin.network'] },
   },
   blockExplorers: {
     default: {

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -19,12 +19,12 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
     blocksscan: {
       name: 'Blocksscan',
       url: 'https://apothem.blocksscan.io',
-    }
+    },
   },
   contracts: {
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 59765389,
-    }
+    },
   },
 })

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -13,14 +13,18 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
+      name: 'XDCScan',
+      url: 'https://testnet.xdcscan.com',
+    },
+    blocksscan: {
       name: 'Blocksscan',
       url: 'https://apothem.blocksscan.io',
-    },
+    }
   },
   contracts: {
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 59765389,
-    },
+    }
   },
 })

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -16,10 +16,6 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
       name: 'XDCScan',
       url: 'https://testnet.xdcscan.com',
     },
-    blocksscan: {
-      name: 'Blocksscan',
-      url: 'https://apothem.blocksscan.io',
-    },
   },
   contracts: {
     multicall3: {


### PR DESCRIPTION
1. Alternative xinfin mainnet rpc
2. Update blockscan for testnet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the block explorer URL for the `XDC Testnet` in the codebase.

### Detailed summary
- Changed the `name` of the block explorer from `Blocksscan` to `XDCScan`.
- Updated the `url` of the block explorer from `https://apothem.blocksscan.io` to `https://testnet.xdcscan.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->