### PR TITLE
Add multicall3 for ultron chain

### DIFF
--- a/src/chains/definitions/ultron.ts
+++ b/src/chains/definitions/ultron.ts
@@ -15,9 +15,11 @@ export const ultron = /*#__PURE__*/ defineChain({
       url: 'https://ulxscan.com',
     },
   },
-  multicall3: {
-    address: '0xd4293a20D46211657F13C186Da6cb3125516141f',
-    blockCreated: 10892598,
+  contracts: {
+    multicall3: {
+      address: '0xd4293a20D46211657F13C186Da6cb3125516141f',
+      blockCreated: 10892598,
+    },
   },
   testnet: false,
 })

--- a/src/chains/definitions/ultronTestnet.ts
+++ b/src/chains/definitions/ultronTestnet.ts
@@ -15,9 +15,11 @@ export const ultronTestnet = /*#__PURE__*/ defineChain({
       url: 'https://explorer.ultron-dev.io',
     },
   },
-  multicall3: {
-    address: '0x1926Ada2bee7214730066841E487D82c68AC91D3',
-    blockCreated: 2559331,
+  contracts: {
+    multicall3: {
+      address: '0x1926Ada2bee7214730066841E487D82c68AC91D3',
+      blockCreated: 2559331,
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
This PR adds the Ultron chain multicall address in the ultron.ts file and Ultron testnet chain multicall address in the ultronTestnet.ts file

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces `multicall3` contract configurations for both the mainnet and testnet versions of the `ultron` chain definitions.

### Detailed summary
- In `src/chains/definitions/ultron.ts`:
  - Added `contracts` object with `multicall3`:
    - `address`: '0xd4293a20D46211657F13C186Da6cb3125516141f'
    - `blockCreated`: 10892598
- In `src/chains/definitions/ultronTestnet.ts`:
  - Added `contracts` object with `multicall3`:
    - `address`: '0x1926Ada2bee7214730066841E487D82c68AC91D3'
    - `blockCreated`: 2559331

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->