### PR TITLE
feat: Add optional param UserOperationRequest to getStubSignature

### DIFF
--- a/.changeset/brave-starfishes-exercise.md
+++ b/.changeset/brave-starfishes-exercise.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**Account Abstraction:** Added optional param `UserOperationRequest` to `getStubSignature`

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -112,7 +112,7 @@ export type SmartAccountImplementation<
    * // '0x...'
    * ```
    */
-  getStubSignature: (parameters?: UserOperationRequest) => Promise<Hex>
+  getStubSignature: (parameters?: UserOperationRequest | undefined) => Promise<Hex>
   /** Custom nonce key manager. */
   nonceKeyManager?: NonceManager | undefined
   /**

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -112,7 +112,7 @@ export type SmartAccountImplementation<
    * // '0x...'
    * ```
    */
-  getStubSignature: () => Promise<Hex>
+  getStubSignature: (parameters?: UserOperationRequest) => Promise<Hex>
   /** Custom nonce key manager. */
   nonceKeyManager?: NonceManager | undefined
   /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `getStubSignature` function by adding an optional parameter `UserOperationRequest`. It modifies the handling of the `signature` property within the `prepareUserOperation` function, streamlining how signatures are processed.

### Detailed summary
- Added optional parameter `UserOperationRequest` to the `getStubSignature` function.
- Removed the retrieval of `signature` from the `Promise.all` call in `prepareUserOperation`.
- Updated the logic to conditionally set the `signature` property in the `request` object based on the presence of `parameters.signature`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->