### PR TITLE
Make `BaseError#walk` tolerant to an `undefined` cause

### DIFF
--- a/.changeset/khaki-queens-explain.md
+++ b/.changeset/khaki-queens-explain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Make `BaseError#walk` tolerant to an `undefined` cause.

--- a/src/errors/base.test.ts
+++ b/src/errors/base.test.ts
@@ -179,6 +179,15 @@ test('walk: predicate fn (no match)', () => {
   expect(err.walk((err) => err instanceof FooError)).toBeNull()
 })
 
+test('walk: undefined cause', () => {
+  const withCauseUndefined = new Error('Cuase undefined', { cause: undefined })
+
+  const err = new BaseError('test1', {
+    cause: withCauseUndefined,
+  })
+  expect(err.walk()).toBe(withCauseUndefined)
+})
+
 test('setErrorConfig', () => {
   class FooError extends BaseError {
     constructor() {

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -87,7 +87,7 @@ function walk(
   fn?: ((err: unknown) => boolean) | undefined,
 ): unknown {
   if (fn?.(err)) return err
-  if (err && typeof err === 'object' && 'cause' in err)
+  if (err && typeof err === 'object' && 'cause' in err && err.cause !== undefined)
     return walk(err.cause, fn)
   return fn ? null : err
 }


### PR DESCRIPTION
I had an issue where I was setting `Error.cause` to `undefined`, and `viem` was giving me some errors because it was trying to access an `undefined`. This PR fixes it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `BaseError#walk` method to handle cases where the `cause` property is `undefined`, ensuring it doesn't throw errors in such scenarios.

### Detailed summary
- Modified the logic in `BaseError#walk` to check if `err.cause` is not `undefined` before recursively calling `walk`.
- Added a test case to verify that `walk` correctly handles an error with an `undefined` cause.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->