### PR TITLE
Add docs for multiple smart accounts via permissionless

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
     "typescript": "5.6.2",
     "vitest": "^1.0.4"
   },
-  "trustedDependencies": [
-    "c-kzg"
-  ],
+  "trustedDependencies": ["c-kzg"],
   "packageManager": "pnpm@9.1.0",
   "engines": {
     "node": "22.x"
@@ -83,32 +81,13 @@
     "pre-commit": "pnpm check"
   },
   "knip": {
-    "ignore": [
-      ".github/**",
-      "environments/**",
-      "vectors/**"
-    ],
-    "ignoreBinaries": [
-      "dev",
-      "forge",
-      "only-allow",
-      "printf"
-    ],
-    "ignoreDependencies": [
-      "bun",
-      "@size-limit/preset-big-lib"
-    ],
-    "ignoreWorkspaces": [
-      "examples/**",
-      "test"
-    ],
+    "ignore": [".github/**", "environments/**", "vectors/**"],
+    "ignoreBinaries": ["dev", "forge", "only-allow", "printf"],
+    "ignoreDependencies": ["bun", "@size-limit/preset-big-lib"],
+    "ignoreWorkspaces": ["examples/**", "test"],
     "vitest": {
-      "config": [
-        "test/vitest.config.ts"
-      ],
-      "entry": [
-        "**/*.{bench,bench-d,test,test-d,spec}.?(c|m)[jt]s?(x)"
-      ]
+      "config": ["test/vitest.config.ts"],
+      "entry": ["**/*.{bench,bench-d,test,test-d,spec}.?(c|m)[jt]s?(x)"]
     },
     "workspaces": {
       ".": {
@@ -120,15 +99,10 @@
           "{account-abstraction,accounts,actions,celo,chains,ens,experimental,experimental/erc7739,linea,node,nonce,op-stack,siwe,utils,window,zksync}/index.ts!",
           "chains/utils.ts!"
         ],
-        "ignore": [
-          "node/trustedSetups_cjs.ts"
-        ]
+        "ignore": ["node/trustedSetups_cjs.ts"]
       },
       "site": {
-        "project": [
-          "**/*.ts",
-          "**/*.tsx"
-        ]
+        "project": ["**/*.ts", "**/*.tsx"]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ethers": "^6.13.4",
     "glob": "^10.4.5",
     "knip": "^5.33.3",
+    "permissionless": "^0.2.14",
     "prool": "^0.0.16",
     "publint": "^0.2.11",
     "sherif": "^0.8.4",
@@ -71,7 +72,9 @@
     "typescript": "5.6.2",
     "vitest": "^1.0.4"
   },
-  "trustedDependencies": ["c-kzg"],
+  "trustedDependencies": [
+    "c-kzg"
+  ],
   "packageManager": "pnpm@9.1.0",
   "engines": {
     "node": "22.x"
@@ -80,13 +83,32 @@
     "pre-commit": "pnpm check"
   },
   "knip": {
-    "ignore": [".github/**", "environments/**", "vectors/**"],
-    "ignoreBinaries": ["dev", "forge", "only-allow", "printf"],
-    "ignoreDependencies": ["bun", "@size-limit/preset-big-lib"],
-    "ignoreWorkspaces": ["examples/**", "test"],
+    "ignore": [
+      ".github/**",
+      "environments/**",
+      "vectors/**"
+    ],
+    "ignoreBinaries": [
+      "dev",
+      "forge",
+      "only-allow",
+      "printf"
+    ],
+    "ignoreDependencies": [
+      "bun",
+      "@size-limit/preset-big-lib"
+    ],
+    "ignoreWorkspaces": [
+      "examples/**",
+      "test"
+    ],
     "vitest": {
-      "config": ["test/vitest.config.ts"],
-      "entry": ["**/*.{bench,bench-d,test,test-d,spec}.?(c|m)[jt]s?(x)"]
+      "config": [
+        "test/vitest.config.ts"
+      ],
+      "entry": [
+        "**/*.{bench,bench-d,test,test-d,spec}.?(c|m)[jt]s?(x)"
+      ]
     },
     "workspaces": {
       ".": {
@@ -98,10 +120,15 @@
           "{account-abstraction,accounts,actions,celo,chains,ens,experimental,experimental/erc7739,linea,node,nonce,op-stack,siwe,utils,window,zksync}/index.ts!",
           "chains/utils.ts!"
         ],
-        "ignore": ["node/trustedSetups_cjs.ts"]
+        "ignore": [
+          "node/trustedSetups_cjs.ts"
+        ]
       },
       "site": {
-        "project": ["**/*.ts", "**/*.tsx"]
+        "project": [
+          "**/*.ts",
+          "**/*.tsx"
+        ]
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 20.16.12
       '@vitest/coverage-v8':
         specifier: ^1.0.4
-        version: 1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.36.0))
+        version: 1.0.4(vitest@1.0.4)
       '@vitest/ui':
         specifier: ^1.0.4
         version: 1.0.4(vitest@1.0.4)
@@ -71,6 +71,9 @@ importers:
       knip:
         specifier: ^5.33.3
         version: 5.33.3(@types/node@20.16.12)(typescript@5.6.2)
+      permissionless:
+        specifier: ^0.2.14
+        version: 0.2.14(viem@2.21.40(typescript@5.6.2)(zod@3.23.8))
       prool:
         specifier: ^0.0.16
         version: 0.0.16(@pimlico/alto@0.0.4(typescript@5.6.2))
@@ -168,7 +171,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -181,7 +184,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -194,7 +197,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -207,7 +210,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -220,7 +223,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -239,7 +242,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -267,7 +270,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -289,7 +292,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -302,7 +305,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -321,7 +324,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -343,7 +346,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -356,7 +359,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -369,7 +372,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -382,7 +385,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -429,7 +432,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -457,7 +460,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -479,7 +482,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -498,7 +501,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: latest
-        version: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+        version: 2.21.40(typescript@5.6.2)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: ^18.0.27
@@ -2626,7 +2629,6 @@ packages:
 
   bun@1.1.30:
     resolution: {integrity: sha512-ysRL1pq10Xba0jqVLPrKU3YIv0ohfp3cTajCPtpjCyppbn3lfiAVNpGoHfyaxS17OlPmWmR67UZRPw/EueQuug==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -4368,6 +4370,11 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  permissionless@0.2.14:
+    resolution: {integrity: sha512-4/r4gf6uGE7WfFaE4tVBxNd+QSLh0cVMkhC6yHzPUBBBLgrPf+gcUZjLsTamSLFm81K+m13jq3IQ3J0ooenWhg==}
+    peerDependencies:
+      viem: ^2.21.22
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5410,8 +5417,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.21.39:
-    resolution: {integrity: sha512-8zPdwVE66BBqnu7JgYWFLzt1mrHS48+GHug2sGqDtdALZ7/LDht/WuUodVT5xOouyLsxsOKJBnqgErtUVes6ZA==}
+  viem@2.21.40:
+    resolution: {integrity: sha512-no/mE3l7B0mdUTtvO7z/cTLENttQ/M7+ombqFGXJqsQrxv9wrYsTIGpS3za+FA5a447hY+x9D8Wxny84q1zAaA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -6677,7 +6684,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.21.39(typescript@5.6.2)(zod@3.23.8)
+      viem: 2.21.40(typescript@5.6.2)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -7560,7 +7567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.36.0))':
+  '@vitest/coverage-v8@1.0.4(vitest@1.0.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -10055,6 +10062,10 @@ snapshots:
 
   pend@1.2.0: {}
 
+  permissionless@0.2.14(viem@2.21.40(typescript@5.6.2)(zod@3.23.8)):
+    dependencies:
+      viem: 2.21.40(typescript@5.6.2)(zod@3.23.8)
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -11247,7 +11258,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  viem@2.21.39(typescript@5.6.2)(zod@3.23.8):
+  viem@2.21.40(typescript@5.6.2)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.6.0

--- a/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
@@ -1,0 +1,44 @@
+# Kernel
+
+To implement the [Kernel Smart Wallet](https://github.com/zerodevapp/kernel), you can use [`toEcdsaKernelSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toEcdsaKernelSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toEcdsaKernelSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owners: [owner], // [!code focus]
+  version: "0.3.1", // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<EcdsaKernelSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toEcdsaKernelSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
@@ -1,20 +1,44 @@
 # Kernel
 
-To implement the [Kernel Smart Wallet](https://github.com/zerodevapp/kernel), you can use [`toEcdsaKernelSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement the [Kernel Smart Wallet](https://github.com/zerodevapp/kernel), you can use the [`toEcdsaKernelSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toEcdsaKernelSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toEcdsaKernelSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
 const account = await toEcdsaKernelSmartAccount({ // [!code focus]
   client, // [!code focus]
   owners: [owner], // [!code focus]
-  version: "0.3.1", // [!code focus]
+  version: '0.3.1', // [!code focus]
 }) // [!code focus]
 ```
 
@@ -41,4 +65,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toEcdsaKernelSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toLightSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toLightSmartAccount.md
@@ -1,20 +1,44 @@
 # Light
 
-To implement the Alchemy's [Light Smart Wallet](https://github.com/alchemyplatform/light-account), you can use [`toLightSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement Alchemy's [Light Smart Wallet](https://github.com/alchemyplatform/light-account), you can use the [`toLightSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toLightSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toLightSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
 const account = await toLightSmartAccount({ // [!code focus]
   client, // [!code focus]
   owner: owner, // [!code focus]
-  version: "2.0.0" // [!code focus]
+  version: '2.0.0', // [!code focus]
 }) // [!code focus]
 ```
 
@@ -41,4 +65,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toLightSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toLightSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toLightSmartAccount.md
@@ -1,0 +1,44 @@
+# Light
+
+To implement the Alchemy's [Light Smart Wallet](https://github.com/alchemyplatform/light-account), you can use [`toLightSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toLightSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toLightSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owner: owner, // [!code focus]
+  version: "2.0.0" // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<LightSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toLightSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toLightSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toNexusSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toNexusSmartAccount.md
@@ -1,20 +1,44 @@
 # Nexus
 
-To implement the Biconomy's [Nexus Smart Wallet](https://github.com/bcnmy/nexus), you can use [`toNexusSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement Biconomy's [Nexus Smart Wallet](https://github.com/bcnmy/nexus), you can use the [`toNexusSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toNexusSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toNexusSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
 const account = await toNexusSmartAccount({ // [!code focus]
   client, // [!code focus]
   owners: [owner], // [!code focus]
-  version: "1.0.0" // [!code focus]
+  version: '1.0.0' // [!code focus]
 }) // [!code focus]
 ```
 
@@ -41,4 +65,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toNexusSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toNexusSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toNexusSmartAccount.md
@@ -1,0 +1,44 @@
+# Nexus
+
+To implement the Biconomy's [Nexus Smart Wallet](https://github.com/bcnmy/nexus), you can use [`toNexusSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toNexusSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toNexusSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owners: [owner], // [!code focus]
+  version: "1.0.0" // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<NexusSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toNexusSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toNexusSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
@@ -1,20 +1,44 @@
 # Safe
 
-To implement the [Safe Smart Wallet](https://github.com/safe-global/safe-smart-account), you can use [`toSafeSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement [Safe Smart Wallet](https://github.com/safe-global/safe-smart-account), you can use the [`toSafeSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toSafeSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toSafeSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
 const account = await toSafeSmartAccount({ // [!code focus]
   client, // [!code focus]
   owners: [owner], // [!code focus]
-  version: "1.4.1", // [!code focus]
+  version: '1.4.1', // [!code focus]
 }) // [!code focus]
 ```
 
@@ -41,4 +65,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toSafeSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toSafeSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toSafeSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
@@ -1,0 +1,44 @@
+# Safe
+
+To implement the [Safe Smart Wallet](https://github.com/safe-global/safe-smart-account), you can use [`toSafeSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toSafeSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toSafeSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owners: [owner], // [!code focus]
+  version: "1.4.1", // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<SafeSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toSafeSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toSafeSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toSimpleSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toSimpleSmartAccount.md
@@ -1,13 +1,37 @@
 # Simple
 
-To implement the [Simple Smart Wallet](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccount.sol), you can use [`toSimpleSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement the [Simple Smart Wallet](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccount.sol), you can use the [`toSimpleSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toSimpleSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toSimpleSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
@@ -40,4 +64,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toSimpleSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toSimpleSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toSimpleSmartAccount.md
@@ -1,0 +1,43 @@
+# Simple
+
+To implement the [Simple Smart Wallet](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccount.sol), you can use [`toSimpleSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toSimpleSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toSimpleSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owners: [owner], // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<SimpleSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toSimpleSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toTrustSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toTrustSmartAccount.md
@@ -1,0 +1,43 @@
+# Trust
+
+To implement the [Trust Smart Wallet](https://developer.trustwallet.com/developer/barz-smart-wallet/build-with-trust-wallet-and-barz-aa-sdk), you can use [`toTrustSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { toTrustSmartAccount } from "permissionless/accounts" // [!code focus]
+import { client } from './client.js'
+import { owner } from './owner.js'
+
+const account = await toTrustSmartAccount({ // [!code focus]
+  client, // [!code focus]
+  owner: owner, // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [client.ts] filename="config.ts"
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+ 
+export const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+```
+
+```ts twoslash [owner.ts (Private Key)] filename="owner.ts"
+import { privateKeyToAccount } from 'viem/accounts'
+ 
+export const owner = privateKeyToAccount('0x...')
+```
+:::
+
+## Returns
+
+`SmartAccount<TrustSmartAccountImplementation>`
+
+## Parameters
+
+Checkout detailed parameters for `toTrustSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount#parameters)

--- a/site/pages/account-abstraction/accounts/smart/toTrustSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toTrustSmartAccount.md
@@ -1,13 +1,37 @@
 # Trust
 
-To implement the [Trust Smart Wallet](https://developer.trustwallet.com/developer/barz-smart-wallet/build-with-trust-wallet-and-barz-aa-sdk), you can use [`toTrustSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount) from [permissionless.js](https://docs.pimlico.io/permissionless/)
+:::warning
+**Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
+:::
+
+To implement the [Trust Smart Wallet](https://developer.trustwallet.com/developer/barz-smart-wallet/build-with-trust-wallet-and-barz-aa-sdk), you can use the [`toTrustSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+
+## Install
+
+:::code-group
+```bash [pnpm]
+pnpm add permissionless
+```
+
+```bash [npm]
+npm install permissionless
+```
+
+```bash [yarn]
+yarn add permissionless
+```
+
+```bash [bun]
+bun add permissionless
+```
+:::
 
 ## Usage
 
 :::code-group
 
 ```ts twoslash [example.ts]
-import { toTrustSmartAccount } from "permissionless/accounts" // [!code focus]
+import { toTrustSmartAccount } from 'permissionless/accounts' // [!code focus]
 import { client } from './client.js'
 import { owner } from './owner.js'
 
@@ -40,4 +64,4 @@ export const owner = privateKeyToAccount('0x...')
 
 ## Parameters
 
-Checkout detailed parameters for `toTrustSmartAccount` at permissionless.js [documentation](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount#parameters)
+[See Parameters](https://docs.pimlico.io/permissionless/reference/accounts/toTrustSmartAccount#parameters)

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1113,18 +1113,6 @@ export const sidebar = {
                 link: '/account-abstraction/accounts/smart/toCoinbaseSmartAccount',
               },
               {
-                text: 'Safe',
-                link: '/account-abstraction/accounts/smart/toSafeSmartAccount',
-              },
-              {
-                text: 'Kernel',
-                link: '/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount',
-              },
-              {
-                text: 'Simple',
-                link: '/account-abstraction/accounts/smart/toSimpleSmartAccount',
-              },
-              {
                 text: 'Biconomy',
                 link: '/account-abstraction/accounts/smart/toNexusSmartAccount',
               },
@@ -1133,12 +1121,24 @@ export const sidebar = {
                 link: '/account-abstraction/accounts/smart/toLightSmartAccount',
               },
               {
-                text: 'Trust',
-                link: '/account-abstraction/accounts/smart/toTrustSmartAccount',
+                text: 'Kernel',
+                link: '/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount',
+              },
+              {
+                text: 'Safe',
+                link: '/account-abstraction/accounts/smart/toSafeSmartAccount',
+              },
+              {
+                text: 'Simple',
+                link: '/account-abstraction/accounts/smart/toSimpleSmartAccount',
               },
               {
                 text: 'Solady',
                 link: '/account-abstraction/accounts/smart/toSoladySmartAccount',
+              },
+              {
+                text: 'Trust',
+                link: '/account-abstraction/accounts/smart/toTrustSmartAccount',
               },
               {
                 text: 'Custom',

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1113,6 +1113,30 @@ export const sidebar = {
                 link: '/account-abstraction/accounts/smart/toCoinbaseSmartAccount',
               },
               {
+                text: 'Safe',
+                link: '/account-abstraction/accounts/smart/toSafeSmartAccount',
+              },
+              {
+                text: 'Kernel',
+                link: '/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount',
+              },
+              {
+                text: 'Simple',
+                link: '/account-abstraction/accounts/smart/toSimpleSmartAccount',
+              },
+              {
+                text: 'Biconomy',
+                link: '/account-abstraction/accounts/smart/toNexusSmartAccount',
+              },
+              {
+                text: 'Alchemy',
+                link: '/account-abstraction/accounts/smart/toLightSmartAccount',
+              },
+              {
+                text: 'Trust',
+                link: '/account-abstraction/accounts/smart/toTrustSmartAccount',
+              },
+              {
                 text: 'Solady',
                 link: '/account-abstraction/accounts/smart/toSoladySmartAccount',
               },


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `permissionless` library and adds new smart account options in the sidebar, along with their respective documentation pages.

### Detailed summary
- Added `"permissionless": "^0.2.14"` to `package.json`.
- Updated `site/sidebar.ts` with new smart account links:
  - `Biconomy`
  - `Alchemy`
  - `Kernel`
  - `Safe`
  - `Simple`
  - `Trust`
- Created documentation for new smart accounts:
  - `toNexusSmartAccount`
  - `toSafeSmartAccount`
  - `toLightSmartAccount`
  - `toTrustSmartAccount`
  - `toEcdsaKernelSmartAccount`
  - `toSimpleSmartAccount`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->