### PR TITLE
fix: Updated the disputeGameFactory contract and the explorer URL for Soneium Minato

### DIFF
--- a/.changeset/wise-drinks-hunt.md
+++ b/.changeset/wise-drinks-hunt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated the disputeGameFactory contract and the explorer URL for Soneium Minato

--- a/src/chains/definitions/soneiumMinato.ts
+++ b/src/chains/definitions/soneiumMinato.ts
@@ -16,15 +16,15 @@ export const soneiumMinato = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://explorer-testnet.soneium.org',
-      apiUrl: 'https://explorer-testnet.soneium.org/api',
+      url: 'https://soneium-minato.blockscout.com',
+      apiUrl: 'https://soneium-minato.blockscout.com/api',
     },
   },
   contracts: {
     ...chainConfig.contracts,
     disputeGameFactory: {
       [sourceId]: {
-        address: '0xF69dB6cA559C52d9A4BB6e2B2901f490Ca35Fbf6',
+        address: '0xB3Ad2c38E6e0640d7ce6aA952AB3A60E81bf7a01',
       },
     },
     l2OutputOracle: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

* Updated the `disputeGameFactory` due to the Fault Proof upgrade
* Updated the explorer URL as the previous one will be deprecated  

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `disputeGameFactory` contract address and modifies the explorer URL for the `Soneium Minato` chain.

### Detailed summary
- Changed the `url` from `https://explorer-testnet.soneium.org` to `https://soneium-minato.blockscout.com`.
- Updated the `apiUrl` from `https://explorer-testnet.soneium.org/api` to `https://soneium-minato.blockscout.com/api`.
- Modified the `disputeGameFactory` `address` from `0xF69dB6cA559C52d9A4BB6e2B2901f490Ca35Fbf6` to `0xB3Ad2c38E6e0640d7ce6aA952AB3A60E81bf7a01`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->