### PR TITLE
Rethrow the original `eth_sendTransaction` error if `wallet_sendTransaction` isn't supported

### DIFF
--- a/.changeset/moody-melons-jump.md
+++ b/.changeset/moody-melons-jump.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `sendTransaction` error bubbling for fallback.

--- a/.changeset/sweet-berries-peel.md
+++ b/.changeset/sweet-berries-peel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Rethrow the original `eth_sendTransaction` error if `wallet_sendTransaction` isn't supported

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -639,7 +639,7 @@ describe('args: chain', async () => {
     const originalError = new InvalidInputRpcError(new Error())
 
     const request = client.request
-    client.request = (parameters: any) => {
+    client.request = async (parameters: any) => {
       if (parameters.method === 'eth_sendTransaction') throw originalError
       if (parameters.method === 'wallet_sendTransaction')
         throw new MethodNotSupportedRpcError(new Error())
@@ -652,7 +652,17 @@ describe('args: chain', async () => {
         to: targetAccount.address,
         value: 0n,
       }),
-    ).rejects.toThrowError(originalError)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [TransactionExecutionError: Missing or invalid parameters.
+      Double check you have provided the correct parameters.
+
+      Request Arguments:
+        from:   0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+        to:     0x70997970c51812dc3a010c7d01b50e0d17dc79c8
+        value:  0 ETH
+
+      Version: viem@x.y.z]
+    `)
   })
 
   test('behavior: nullish account', async () => {

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -13,7 +13,10 @@ import { deploy } from '../../../test/src/utils.js'
 import { generatePrivateKey } from '../../accounts/generatePrivateKey.js'
 import { createWalletClient } from '../../clients/createWalletClient.js'
 import { http } from '../../clients/transports/http.js'
-import { InvalidInputRpcError } from '../../errors/rpc.js'
+import {
+  InvalidInputRpcError,
+  MethodNotSupportedRpcError,
+} from '../../errors/rpc.js'
 import { signAuthorization } from '../../experimental/index.js'
 import type { Hex } from '../../types/misc.js'
 import type { TransactionSerializable } from '../../types/transaction.js'
@@ -625,6 +628,31 @@ describe('args: chain', async () => {
         value: 0n,
       }),
     ).toBeDefined()
+  })
+
+  test("behavior: transport doesn't support `wallet_sendTransaction` so the original error is rethrown", async () => {
+    // Using a new client to reset the cached info about wallet_sendTransaction
+    // being supported.
+    const client = anvilMainnet.getClient()
+    await setup()
+
+    const originalError = new InvalidInputRpcError(new Error())
+
+    const request = client.request
+    client.request = (parameters: any) => {
+      if (parameters.method === 'eth_sendTransaction') throw originalError
+      if (parameters.method === 'wallet_sendTransaction')
+        throw new MethodNotSupportedRpcError(new Error())
+      return request(parameters)
+    }
+
+    await expect(() =>
+      sendTransaction(client, {
+        account: sourceAccount.address,
+        to: targetAccount.address,
+        value: 0n,
+      }),
+    ).rejects.toThrowError(originalError)
   })
 
   test('behavior: nullish account', async () => {

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -247,14 +247,14 @@ export async function sendTransaction<
       } catch (e) {
         if (isWalletNamespaceSupported === false) throw e
 
-        const originalError = e as BaseError
+        const error = e as BaseError
         // If the transport does not support the method or input, attempt to use the
         // `wallet_sendTransaction` method.
         if (
-          originalError.name === 'InvalidInputRpcError' ||
-          originalError.name === 'InvalidParamsRpcError' ||
-          originalError.name === 'MethodNotFoundRpcError' ||
-          originalError.name === 'MethodNotSupportedRpcError'
+          error.name === 'InvalidInputRpcError' ||
+          error.name === 'InvalidParamsRpcError' ||
+          error.name === 'MethodNotFoundRpcError' ||
+          error.name === 'MethodNotSupportedRpcError'
         ) {
           return await client
             .request(
@@ -268,21 +268,21 @@ export async function sendTransaction<
               supportsWalletNamespace.set(client.uid, true)
               return hash
             })
-            .catch((err) => {
-              const walletNamespaceError = err as BaseError
+            .catch((e) => {
+              const walletNamespaceError = e as BaseError
               if (
                 walletNamespaceError.name === 'MethodNotFoundRpcError' ||
                 walletNamespaceError.name === 'MethodNotSupportedRpcError'
               ) {
                 supportsWalletNamespace.set(client.uid, false)
-                throw originalError
+                throw error
               }
 
               throw walletNamespaceError
             })
         }
 
-        throw originalError
+        throw error
       }
     }
 


### PR DESCRIPTION
This is an initial stub at rethrowing the original `eth_sendTransaction` error if `wallet_sendTransaction` error isn't supported.

I also modified the code a bit, so that `wallet_sendTransaction` is only tried once per client if not supported.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `sendTransaction` function by ensuring that original errors are rethrown when the `wallet_sendTransaction` method is not supported. It enhances the logic for determining method support and improves test coverage.

### Detailed summary
- Fixed error bubbling for `sendTransaction` when `wallet_sendTransaction` isn't supported.
- Introduced a check to determine if the wallet namespace is supported.
- Updated error handling to rethrow original errors for unsupported methods.
- Added a test to verify behavior when `wallet_sendTransaction` is unsupported.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->