### PR TITLE
Clarify that Kernel is ZeroDev

### DIFF
--- a/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount.md
@@ -1,10 +1,10 @@
-# Kernel Smart Account
+# Kernel (ZeroDev) Smart Account
 
 :::warning
 **Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
 :::
 
-To implement the [Kernel Smart Account](https://github.com/zerodevapp/kernel), you can use the [`toEcdsaKernelSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+To implement the [Kernel (ZeroDev) Smart Account](https://github.com/zerodevapp/kernel), you can use the [`toEcdsaKernelSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toEcdsaKernelSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
 
 ## Install
 

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1125,7 +1125,7 @@ export const sidebar = {
                 link: '/account-abstraction/accounts/smart/toLightSmartAccount',
               },
               {
-                text: 'Kernel',
+                text: 'Kernel (ZeroDev)',
                 link: '/account-abstraction/accounts/smart/toEcdsaKernelSmartAccount',
               },
               {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the text and documentation related to the `Kernel` Smart Account to clarify its association with `ZeroDev`. It enhances user awareness about the implementation and its maintenance.

### Detailed summary
- Updated the sidebar entry text from `Kernel` to `Kernel (ZeroDev)`.
- Modified the `toEcdsaKernelSmartAccount.md` file to reflect `Kernel (ZeroDev)` in the title and description.
- Added a warning note about maintenance by `permissionless.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->