### PR TITLE
feat: upgrade from MATIC to POL on polygon amoy testnet (fixes #2966)

### DIFF
--- a/.changeset/pink-pumpkins-bake.md
+++ b/.changeset/pink-pumpkins-bake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update from MATIC to POL on Polygon Amoy.

--- a/src/chains/definitions/polygonAmoy.ts
+++ b/src/chains/definitions/polygonAmoy.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const polygonAmoy = /*#__PURE__*/ defineChain({
   id: 80_002,
   name: 'Polygon Amoy',
-  nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
+  nativeCurrency: { name: 'POL', symbol: 'POL', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://rpc-amoy.polygon.technology'],


### PR DESCRIPTION
polygon has upgraded from the MATIC token to the POL token (see details here: https://polygon.technology/blog/matic-to-pol-migration-is-now-live-everything-you-need-to-know). 

A previous pull request (https://github.com/wevm/viem/pull/2698) made this change in the polygon mainnet, but the amoy testnet still refers to the deprecating MATIC token. This code change upgrades the amoy testnet in the same way.

See discussion here: https://github.com/wevm/viem/discussions/2966
fixes #2966

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the native currency for the `Polygon Amoy` chain from `MATIC` to `POL`.

### Detailed summary
- Updated the `nativeCurrency` from:
  - `{ name: 'MATIC', symbol: 'MATIC', decimals: 18 }`
  - to `{ name: 'POL', symbol: 'POL', decimals: 18 }` in `src/chains/definitions/polygonAmoy.ts`.
- Added a note in `.changeset/pink-pumpkins-bake.md` indicating the change.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->