### PR TITLE
fix: use correct link for `toSafeSmartAccount`

### DIFF
--- a/.changeset/witty-feet-flow.md
+++ b/.changeset/witty-feet-flow.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Update Safe AA docs

--- a/.changeset/witty-feet-flow.md
+++ b/.changeset/witty-feet-flow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Safe AA docs

--- a/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
+++ b/site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md
@@ -4,7 +4,7 @@
 **Note:** This implementation is maintained & distributed by [permissionless.js](https://docs.pimlico.io/permissionless).
 :::
 
-To implement [Safe Smart Account](https://github.com/safe-global/safe-smart-account), you can use the [`toSafeSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
+To implement [Safe Smart Account](https://github.com/safe-global/safe-smart-account), you can use the [`toSafeSmartAccount`](https://docs.pimlico.io/permissionless/reference/accounts/toSafeSmartAccount) module from [permissionless.js](https://docs.pimlico.io/permissionless/)
 
 ## Install
 


### PR DESCRIPTION
## Summary

The current documentation embeds the wrong link for the `toSafeSmartAccount` module from permissionless.js. This corrects it.

## Changes

- Change `https://docs.pimlico.io/permissionless/reference/accounts/toSimpleSmartAccount` to `https://docs.pimlico.io/permissionless/reference/accounts/toSafeSmartAccount`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a documentation file by correcting a link to the `toSafeSmartAccount` module in the `site/pages/account-abstraction/accounts/smart/toSafeSmartAccount.md` file.

### Detailed summary
- Changed the link reference for the `toSafeSmartAccount` module from `toSimpleSmartAccount` to `toSafeSmartAccount`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->