### PR TITLE
fix: update unichain sepolia api url

### DIFF
--- a/.changeset/tiny-bananas-attend.md
+++ b/.changeset/tiny-bananas-attend.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Unichain block explorer API URL.

--- a/src/chains/definitions/unichainSepolia.ts
+++ b/src/chains/definitions/unichainSepolia.ts
@@ -21,7 +21,7 @@ export const unichainSepolia = /*#__PURE__*/ defineChain({
     default: {
       name: 'Uniscan',
       url: 'https://sepolia.uniscan.xyz',
-      apiUrl: 'https://api-sepolia.uniscan.xyz',
+      apiUrl: 'https://api-sepolia.uniscan.xyz/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Change `https://api-sepolia.uniscan.xyz` to `https://api-sepolia.uniscan.xyz/api`.

Closes #2975

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Unichain block explorer API URL to ensure it points to the correct endpoint.

### Detailed summary
- Updated the `apiUrl` in the `unichainSepolia.ts` file from `https://api-sepolia.uniscan.xyz` to `https://api-sepolia.uniscan.xyz/api`.
- Maintained the `name` and `url` fields for the `Uniscan` block explorer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->