### PR TITLE
feat: add mekong chain

### DIFF
--- a/.changeset/small-cheetahs-applaud.md
+++ b/.changeset/small-cheetahs-applaud.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Mekong chain.

--- a/src/chains/definitions/mekong.ts
+++ b/src/chains/definitions/mekong.ts
@@ -12,7 +12,7 @@ export const mekong = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Block Explorer',
-      url: '	https://explorer.mekong.ethpandaops.io',
+      url: 'https://explorer.mekong.ethpandaops.io',
     },
   },
   testnet: true,

--- a/src/chains/definitions/mekong.ts
+++ b/src/chains/definitions/mekong.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const coinex = /*#__PURE__*/ defineChain({
+  id: 7078815900,
+  name: 'Mekong Pectra Devnet',
+  nativeCurrency: { name: 'eth', symbol: 'eth', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.mekong.ethpandaops.io'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Block Explorer',
+      url: 'https://www.coinex.net',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/mekong.ts
+++ b/src/chains/definitions/mekong.ts
@@ -12,7 +12,7 @@ export const mekong = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Block Explorer',
-      url: 'https://www.coinex.net',
+      url: '	https://explorer.mekong.ethpandaops.io',
     },
   },
   testnet: true,

--- a/src/chains/definitions/mekong.ts
+++ b/src/chains/definitions/mekong.ts
@@ -1,6 +1,6 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
-export const coinex = /*#__PURE__*/ defineChain({
+export const mekong = /*#__PURE__*/ defineChain({
   id: 7078815900,
   name: 'Mekong Pectra Devnet',
   nativeCurrency: { name: 'eth', symbol: 'eth', decimals: 18 },

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -237,6 +237,7 @@ export { mantleTestnet } from './definitions/mantleTestnet.js'
 export { mapProtocol } from './definitions/mapProtocol.js'
 export { matchain } from './definitions/matchain.js'
 export { matchainTestnet } from './definitions/matchainTestnet.js'
+export { mekong } from './definitions/mekong.js';
 export { meld } from './definitions/meld.js'
 export { merlin } from './definitions/merlin.js'
 export { metachain } from './definitions/metachain.js'


### PR DESCRIPTION
# PR overview
This PR introduces support for the [`Mekong`](https://mekong.ethpandaops.io/) devnet by adding a new chain definition and exporting it from the main chains index.

Detailed summary
- Added `Mekong` to the project.
- Created a new file src/chains/definitions/mekong.ts with the mekong chain definition.
- Defined properties such as id, name, nativeCurrency, rpcUrls, and blockExplorers.
- Exported `mekong` from src/chains/index.ts.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `Mekong` chain to the project, enhancing the available blockchain options.

### Detailed summary
- Added `Mekong` chain definition in `src/chains/definitions/mekong.ts`.
- Exported `mekong` from `src/chains/index.ts`.
- Defined `Mekong` with ID `7078815900`, name `Mekong Pectra Devnet`, and specified its native currency and RPC URLs.
- Set `Mekong` as a testnet with a dedicated block explorer URL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->