### PR TITLE
Update Redbelly Testnet Block Explorer and Add Redbelly Mainnet

### DIFF
--- a/.changeset/tough-cameras-pay.md
+++ b/.changeset/tough-cameras-pay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Redbelly Testnet's Block Explorer and Add Redbelly Mainnet chain.

--- a/src/chains/definitions/redbellyMainnet.ts
+++ b/src/chains/definitions/redbellyMainnet.ts
@@ -1,0 +1,24 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const redbellyMainnet = /*#__PURE__*/ defineChain({
+  id: 151,
+  name: 'Redbelly Network Mainnet',
+  nativeCurrency: {
+    name: 'Redbelly Native Coin',
+    symbol: 'RBNT',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://governor.mainnet.redbelly.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Routescan',
+      url: 'https://redbelly.routescan.io/',
+      apiUrl: 'https://api.routescan.io/v2/network/mainnet/evm/151/etherscan/api',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/redbellyTestnet.ts
+++ b/src/chains/definitions/redbellyTestnet.ts
@@ -15,9 +15,9 @@ export const redbellyTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Ethernal',
-      url: 'https://explorer.testnet.redbelly.network',
-      apiUrl: 'https://ethernal.fly.dev/api',
+      name: 'Routescan',
+      url: 'https://redbelly.testnet.routescan.io/',
+      apiUrl:'https://api.routescan.io/v2/network/testnet/evm/153_2/etherscan/api',
     },
   },
   testnet: true,


### PR DESCRIPTION
**PR overview**
This PR introduces a new chain definition i.e. redbellyMainnet for chain Redbelly Network Mainnet and updates the Redbelly Network Testnet's block explorer information.

Detailed summary

- Added a new chain definition redbellyMainnet for Redbelly Network Mainnet
- Defined chain properties such as ID, name, native currency, RPC URLs, block explorers
- Updated redbellyTestnet chain properties for block explorer


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the block explorer for the `Redbelly Testnet` and introduces the `Redbelly Mainnet` with its configurations, including native currency details and RPC URLs.

### Detailed summary
- Updated `blockExplorers` for `Redbelly Testnet`:
  - Changed `name` from `Ethernal` to `Routescan`
  - Updated `url` and `apiUrl` to new endpoints
- Added `Redbelly Mainnet` definition:
  - Defined `id`, `name`, `nativeCurrency`, `rpcUrls`, and `blockExplorers` for the mainnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->