### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/src/experimental/eip5792/actions/writeContracts.ts
+++ b/src/experimental/eip5792/actions/writeContracts.ts
@@ -143,7 +143,7 @@ export type WriteContractFunctionParameters<
   ///
   allFunctionNames = ContractFunctionName<abi, mutability>,
   allArgs = ContractFunctionArgs<abi, mutability, functionName>,
-  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferrable), allow `args` to be optional.
+  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferable), allow `args` to be optional.
   // important that both branches return same structural type
 > = {
   address: Address

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -201,7 +201,7 @@ export type ContractFunctionParameters<
   ///
   allFunctionNames = ContractFunctionName<abi, mutability>,
   allArgs = ContractFunctionArgs<abi, mutability, functionName>,
-  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferrable), allow `args` to be optional.
+  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferable), allow `args` to be optional.
   // important that both branches return same structural type
 > = {
   abi: abi

--- a/src/utils/abi/getAbiItem.test.ts
+++ b/src/utils/abi/getAbiItem.test.ts
@@ -504,7 +504,7 @@ test('overloads: tuple', () => {
   `)
 })
 
-test('overloads: ambiguious types', () => {
+test('overloads: ambiguous types', () => {
   expect(() =>
     getAbiItem({
       abi: parseAbi(['function foo(address)', 'function foo(bytes20)']),


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->


 fix some typos in comment


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos and clarifying comments in the TypeScript files related to ABI handling and contract functions.

### Detailed summary
- Fixed a typo in the test description from `ambiguious` to `ambiguous` in `src/utils/abi/getAbiItem.test.ts`.
- Updated comments for clarity regarding `args` inference in `src/types/contract.ts` and `src/experimental/eip5792/actions/writeContracts.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->