### PR TITLE
fix Gnosis native currency

### DIFF
--- a/.changeset/clean-cooks-protect.md
+++ b/.changeset/clean-cooks-protect.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Gnosis native currency.

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -5,8 +5,8 @@ export const gnosis = /*#__PURE__*/ defineChain({
   name: 'Gnosis',
   nativeCurrency: {
     decimals: 18,
-    name: 'Gnosis',
-    symbol: 'xDAI',
+    name: 'xDAI',
+    symbol: 'XDAI',
   },
   rpcUrls: {
     default: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

Hi

Really small issue with Gnosis chain currency which should be xDai

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the native currency details for the `Gnosis` chain in the `viem` library, correcting the currency name and symbol.

### Detailed summary
- Updated `nativeCurrency` properties in `src/chains/definitions/gnosis.ts`:
  - Changed `name` from `'Gnosis'` to `'xDAI'`.
  - Changed `symbol` from `'xDAI'` to `'XDAI'`.  
- Added a patch note in `.changeset/clean-cooks-protect.md` indicating the fix for Gnosis native currency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->