### PR TITLE
fix: `TransactionReceipt` Returns `null`  for `l1tol2logs` in abs chain 

### DIFF
--- a/.changeset/angry-cars-poke.md
+++ b/.changeset/angry-cars-poke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**ZKsync:** Fixed `TransactionReceipt` formatter & type.

--- a/src/zksync/formatters.ts
+++ b/src/zksync/formatters.ts
@@ -81,7 +81,7 @@ export const formatters = {
           return {
             blockNumber: hexToBigInt(l2ToL1Log.blockHash),
             blockHash: l2ToL1Log.blockHash,
-            l1BatchNumber: hexToBigInt(l2ToL1Log.l1BatchNumber),
+            l1BatchNumber: l2ToL1Log.l1BatchNumber ? hexToBigInt(l2ToL1Log.l1BatchNumber) : null,
             transactionIndex: hexToBigInt(l2ToL1Log.transactionIndex),
             shardId: hexToBigInt(l2ToL1Log.shardId),
             isService: l2ToL1Log.isService,

--- a/src/zksync/types/log.ts
+++ b/src/zksync/types/log.ts
@@ -45,7 +45,7 @@ export type ZksyncL2ToL1Log = {
 export type ZksyncRpcL2ToL1Log = {
   blockNumber: Hex
   blockHash: Hex
-  l1BatchNumber: Hex
+  l1BatchNumber: Hex | null
   transactionIndex: Hex
   shardId: Hex
   isService: boolean


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

On the Abstract Testnet chain, in most recent transactions, `l2ToL1Logs` may return `null`.

![image](https://github.com/user-attachments/assets/5d4eefb4-4e59-45db-bb9b-b40638972b9f)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `TransactionReceipt` formatter and type for ZKsync by updating the handling of the `l1BatchNumber` property to allow for null values.

### Detailed summary
- Updated `l1BatchNumber` type in `src/zksync/types/log.ts` to `Hex | null`.
- Modified `l1BatchNumber` handling in `src/zksync/formatters.ts` to return `null` if `l2ToL1Log.l1BatchNumber` is not present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->