### PR TITLE
fix: resolve type error by explicitly typing headers as HeadersInit

### DIFF
--- a/.changeset/fast-timers-crash.md
+++ b/.changeset/fast-timers-crash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Resolved type error by explicitly typing `headers` as `HeadersInit` in CCIP.

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -136,7 +136,7 @@ export async function ccipRequest({
     const url = urls[i]
     const method = url.includes('{data}') ? 'GET' : 'POST'
     const body = method === 'POST' ? { data, sender } : undefined
-    const headers =
+    const headers: HeadersInit =
       method === 'POST' ? { 'Content-Type': 'application/json' } : {}
 
     try {


### PR DESCRIPTION
This PR fixes a type error in `src/utils/ccip.ts`, where the `headers` object was not assignable to `HeadersInit`. The type conflict occurred because the `'Content-Type'` property was optional, which is incompatible with `HeadersInit` requirements. Explicitly typing `headers` as `HeadersInit` resolves this, ensuring it works smoothly with the `fetch` API.

### Changes Made
- Explicitly typed `headers` as `HeadersInit`.
- Resolved the optional `'Content-Type'` property conflict.

### Why This Change Was Needed
Without this fix, TypeScript flagged an error for `headers`, breaking compatibility with `fetch` due to strict type requirements. Explicit typing improves type safety and resolves the incompatibility with `HeadersInit`.

### Additional Information for Reviewers
This PR does not introduce breaking changes and does not affect the public API. It’s a straightforward type fix that aligns the code with TypeScript’s strict type-checking.

**Checklist for Reviewers:**
- [x] Confirm all tests pass.
- [x] Confirm alignment with contribution guidelines.
- [x] Verify that no duplicate PRs exist for this issue.

Thank you for reviewing this fix!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on resolving a type error in the `CCIP` by explicitly typing the `headers` variable as `HeadersInit`, ensuring better type safety in the code.

### Detailed summary
- Updated `headers` declaration in `src/utils/ccip.ts` to explicitly type it as `HeadersInit`.
- Maintained the conditional logic for setting `headers` based on the `method`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->