### PR TITLE
Add Multicall address to Superposition

### DIFF
--- a/.changeset/old-bags-run.md
+++ b/.changeset/old-bags-run.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Multicall address to Superposition.

--- a/src/chains/definitions/superposition.ts
+++ b/src/chains/definitions/superposition.ts
@@ -13,5 +13,11 @@ export const superposition = /*#__PURE__*/ defineChain({
       url: 'https://explorer.superposition.so',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 39,
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the Multicall address to the `Superposition` chain definition.

### Detailed summary
- Updated the `superposition.ts` file to include a new `multicall3` contract.
- Added the `address` for `multicall3`: `0xcA11bde05977b3631167028862bE2a173976CA11`.
- Specified `blockCreated` as `39`.
- Set `testnet` to `false`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->