### PR TITLE
chore: remove accidentally committed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ vectors/**/*.json
 # docs
 site/dist
 .vercel
+vocs.config.tsx.timestamp*


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Seems the file [vocs.config.tsx.timestamp*](https://github.com/wevm/viem/blob/main/site/vocs.config.tsx.timestamp-1730655642417-e1ba3c2099142.mjs) was accidentally added and not gitignored in this commit:

[`46f8eb8` (#2961)](https://github.com/wevm/viem/pull/2961/commits/46f8eb89d38bda7211d992665bed33c3275ae777#diff-2e133a183de07f6bbb76c1b4ba6e5a725978e87284ca4cc208b4a145a15a024c)

this file gets generated by vite and is safe to ignore too. Example:

https://github.com/vitest-dev/vitest/blob/main/examples/sveltekit/.gitignore

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `.gitignore` file to manage ignored files and removing a specific timestamped configuration file.

### Detailed summary
- Added `vocs.config.tsx.timestamp*` to `.gitignore` to ignore timestamped configuration files.
- Deleted `site/vocs.config.tsx.timestamp-1730655642417-e1ba3c2099142.mjs` from the repository.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->