### PR TITLE
Changes for 5ireChain mainnet and thunder testnet

### DIFF
--- a/src/chains/definitions/5ireChain.ts
+++ b/src/chains/definitions/5ireChain.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const fireChain = /*#__PURE__*/ defineChain({
+  id: 995,
+  name: '5ireChain',
+  nativeCurrency: { name: '5ire Token', symbol: '5IRE', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.5ire.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: '5ireChain Mainnet Explorer',
+      url: 'https://5irescan.io/',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/thunderTestnet.ts
+++ b/src/chains/definitions/thunderTestnet.ts
@@ -6,13 +6,13 @@ export const thunderTestnet = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: '5ire Token', symbol: '5IRE', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://rpc-testnet.5ire.network'],
+      http: ['https://rpc.testnet.5ire.network'],
     },
   },
   blockExplorers: {
     default: {
-      name: '5ireChain Explorer',
-      url: 'https://explorer.5ire.network',
+      name: '5ireChain Thunder Explorer',
+      url: 'https://testnet.5irescan.io/',
     },
   },
   testnet: true,

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -139,6 +139,7 @@ export { fibo } from './definitions/fibo.js'
 export { filecoin } from './definitions/filecoin.js'
 export { filecoinCalibration } from './definitions/filecoinCalibration.js'
 export { filecoinHyperspace } from './definitions/filecoinHyperspace.js'
+export { fireChain } from './definitions/5ireChain.js'
 export { flare } from './definitions/flare.js'
 export { flareTestnet } from './definitions/flareTestnet.js'
 /** @deprecated */


### PR DESCRIPTION
- Update RPC for thunder testnet.
- Add 5ireChain mainnet file



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `fireChain` definition for the `5ireChain`, updates the `thunderTestnet` configuration, and modifies the exported modules in `index.ts`.

### Detailed summary
- Added export for `fireChain` from `./definitions/5ireChain.js`.
- Updated `rpcUrls` in `thunderTestnet` from `https://rpc-testnet.5ire.network` to `https://rpc.testnet.5ire.network`.
- Modified `blockExplorers` in `thunderTestnet` to change the name to `5ireChain Thunder Explorer` and the URL to `https://testnet.5irescan.io/`.
- Defined `fireChain` in `5ireChain.ts` with properties like `id`, `name`, `nativeCurrency`, `rpcUrls`, and `blockExplorers`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->