### PR TITLE
fix: typos in documentation files

### DIFF
--- a/site/pages/zksync.mdx
+++ b/site/pages/zksync.mdx
@@ -1,5 +1,5 @@
 ---
-description:  Getting tarted with the ZKsync in Viem
+description:  Getting started with the ZKsync in Viem
 ---
 
 # Getting Started with ZKsync


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "tarted" to "started".

Please review the changes and let me know if any additional changes are needed.




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typographical error in the `description` field of the `zksync.mdx` file.

### Detailed summary
- Updated the `description` from "Getting tarted with the ZKsync in Viem" to "Getting started with the ZKsync in Viem".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->