### PR TITLE
Add Multicall address to Velas EVM Mainnet

### DIFF
--- a/.changeset/wild-coats-jumper.md
+++ b/.changeset/wild-coats-jumper.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Multicall address to Velas EVM Mainnet.

--- a/src/chains/definitions/velas.ts
+++ b/src/chains/definitions/velas.ts
@@ -15,5 +15,11 @@ export const velas = /*#__PURE__*/ defineChain({
       url: 'https://evmexplorer.velas.com',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 55883577,
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the Multicall address for the `Velas EVM Mainnet` in the project.

### Detailed summary
- Updated the `.changeset/wild-coats-jumper.md` file to note the addition of the Multicall address.
- Added a new `multicall3` contract entry in `src/chains/definitions/velas.ts` with:
  - `address`: `'0xcA11bde05977b3631167028862bE2a173976CA11'`
  - `blockCreated`: `55883577`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->