### PR TITLE
feat: update fantom sonic testnet details

### DIFF
--- a/src/chains/definitions/fantomSonicTestnet.ts
+++ b/src/chains/definitions/fantomSonicTestnet.ts
@@ -1,21 +1,21 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const fantomSonicTestnet = /*#__PURE__*/ defineChain({
-  id: 64_240,
-  name: 'Fantom Sonic Open Testnet',
+  id: 64_165,
+  name: 'Sonic Testnet',
   network: 'fantom-sonic-testnet',
   nativeCurrency: {
     decimals: 18,
-    name: 'Fantom',
-    symbol: 'FTM',
+    name: 'Sonic',
+    symbol: 'S',
   },
   rpcUrls: {
-    default: { http: ['https://rpcapi.sonic.fantom.network'] },
+    default: { http: ['https://rpc.testnet.soniclabs.com'] },
   },
   blockExplorers: {
     default: {
-      name: 'Fantom Sonic Open Testnet Explorer',
-      url: 'https://public-sonic.fantom.network',
+      name: 'Sonic Testnet Explorer',
+      url: 'https://testnet.soniclabs.com/',
     },
   },
   testnet: true,


### PR DESCRIPTION
<!-- UUpdating Sonic Testnet  details. Solving issue #3051  -->
<!----------------------------------------------------------------------
Updated 
id
name
nativeCurrency
   name
   currency
rppcUrls
  default
blockExplorers
  name
  url
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for the `fantomSonicTestnet` chain, changing its ID, name, native currency details, RPC URLs, and block explorer information to reflect a new testnet setup.

### Detailed summary
- Changed `id` from `64_240` to `64_165`
- Updated `name` from 'Fantom Sonic Open Testnet' to 'Sonic Testnet'
- Modified native currency `name` from 'Fantom' to 'Sonic' and `symbol` from 'FTM' to 'S'
- Updated `rpcUrls.default.http` from 'https://rpcapi.sonic.fantom.network' to 'https://rpc.testnet.soniclabs.com'
- Changed block explorer `name` from 'Fantom Sonic Open Testnet Explorer' to 'Sonic Testnet Explorer' and `url` from 'https://public-sonic.fantom.network' to 'https://testnet.soniclabs.com/'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->