### PR TITLE
fix: waitForTransactionReceipt race condition when polling many blocks

### DIFF
--- a/.changeset/serious-cougars-serve.md
+++ b/.changeset/serious-cougars-serve.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `waitForTransactionReceipt` race condition when polling many blocks

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -43,6 +43,7 @@ export function observe<callbacks extends Callbacks>(
   }
 
   const unwatch = () => {
+    if (!getListeners().find((cb: any) => cb.id === callbackId)) return
     const cleanup = cleanupCache.get(observerId)
     if (getListeners().length === 1 && cleanup) cleanup()
     unsubscribe()


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

[Observe](https://github.com/wevm/viem/blob/main/src/utils/observe.ts) prematurely cleans up when there is still listeners subscribed if one listener call his unwatch many times as [this test shows](https://github.com/nfmelendez/viem/blob/main/src/utils/observe.test.ts#L178-L206). This problem triggers a race condition in `waitForTransactionReceipt`, there will be a premature cancel to the polling when one `waitForTransactionReceipt` get many blocks, therefore will find the same receipt many times and triggers the unwatch many times while other are waiting for their receipt,[ as is shown in this test:  ](https://github.com/nfmelendez/viem/blob/d18645327fd29a0334ba7b21c77a50c22d6c46fe/src/actions/public/waitForTransactionReceipt.test.ts#L112-L185)

This Fixes https://github.com/wevm/viem/issues/2650

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses a race condition in the `waitForTransactionReceipt` function when polling multiple blocks. It includes tests to ensure proper cleanup of listeners and verifies that transactions do not interfere with each other's receipt polling.

### Detailed summary
- Fixed race condition in `waitForTransactionReceipt` during block polling.
- Added a test to ensure cleanup of emit function when the last listener unwatches.
- Enhanced tests for `waitForTransactionReceipt` to handle multiple transactions without triggering race conditions.
- Mocked transaction behaviors to simulate real-world scenarios in tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->