### PR TITLE
chore: add Multicall address to Fluence

### DIFF
--- a/.changeset/young-badgers-warn.md
+++ b/.changeset/young-badgers-warn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Multicall address to Fluence.

--- a/src/chains/definitions/fluence.ts
+++ b/src/chains/definitions/fluence.ts
@@ -17,4 +17,10 @@ export const fluence = /*#__PURE__*/ defineChain({
       apiUrl: 'https://blockscout.mainnet.fluence.dev/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 207583,
+    },
+  },
 })

--- a/src/chains/definitions/fluenceStage.ts
+++ b/src/chains/definitions/fluenceStage.ts
@@ -17,5 +17,11 @@ export const fluenceStage = /*#__PURE__*/ defineChain({
       apiUrl: 'https://blockscout.stage.fluence.dev/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 83227,
+    },
+  },
   testnet: true,
 })

--- a/src/chains/definitions/fluenceTestnet.ts
+++ b/src/chains/definitions/fluenceTestnet.ts
@@ -17,5 +17,11 @@ export const fluenceTestnet = /*#__PURE__*/ defineChain({
       apiUrl: 'https://blockscout.testnet.fluence.dev/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 96424,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `multicall3` contract address to the `Fluence` blockchain definitions across multiple files.

### Detailed summary
- Added `multicall3` contract to:
  - `src/chains/definitions/fluence.ts` with `address: '0xcA11bde05977b3631167028862bE2a173976CA11'` and `blockCreated: 207583`.
  - `src/chains/definitions/fluenceStage.ts` with `address: '0xcA11bde05977b3631167028862bE2a173976CA11'` and `blockCreated: 83227`.
  - `src/chains/definitions/fluenceTestnet.ts` with `address: '0xcA11bde05977b3631167028862bE2a173976CA11'` and `blockCreated: 96424`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->