### PR TITLE
Fix ApeScan API URL

### DIFF
--- a/.changeset/violet-mugs-brake.md
+++ b/.changeset/violet-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated ApeScan API URL.

--- a/src/chains/definitions/apeChain.ts
+++ b/src/chains/definitions/apeChain.ts
@@ -20,7 +20,7 @@ export const apeChain = /*#__PURE__*/ defineChain({
     default: {
       name: 'Apescan',
       url: 'https://apescan.io',
-      apiUrl: 'https://api.apescan.io',
+      apiUrl: 'https://api.apescan.io/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Fix ApeScan API URL

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the API URL for the `ApeScan` service in the `apeChain.ts` file to ensure it points to the correct endpoint.

### Detailed summary
- Updated the `apiUrl` for `ApeScan` from `https://api.apescan.io` to `https://api.apescan.io/api`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->