### PR TITLE
feat(zksync): add `ZKsync` local hyperchain networks

### DIFF
--- a/.changeset/eighty-wolves-tie.md
+++ b/.changeset/eighty-wolves-tie.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `ZKsync` local hyperchain networks

--- a/src/chains/definitions/zksyncLocalHyperchain.ts
+++ b/src/chains/definitions/zksyncLocalHyperchain.ts
@@ -1,0 +1,67 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
+
+// The local hyperchain setup: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml
+
+export const zksyncLocalHyperchain = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 270,
+  name: 'ZKsync CLI Local Hyperchain',
+  network: 'zksync-cli-local-hyperchain',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15100'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'ZKsync explorer',
+      url: 'http://localhost:15005/',
+      apiUrl: 'http://localhost:15005/api',
+    },
+  },
+  testnet: true,
+})
+
+export const zksyncLocalCustomHyperchain = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 272,
+  name: 'ZKsync CLI Local Hyperchain',
+  network: 'zksync-cli-local-custom-hyperchain',
+  nativeCurrency: { name: 'BAT', symbol: 'BAT', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15200'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'ZKsync explorer',
+      url: 'http://localhost:15005/',
+      apiUrl: 'http://localhost:15005/api',
+    },
+  },
+  testnet: true,
+})
+
+export const zksyncLocalHyperchainL1 = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 9,
+  name: 'ZKsync CLI Local Hyperchain L1',
+  network: 'zksync-cli-local-hyperchain-l1',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15045'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'http://localhost:15001/',
+      apiUrl: 'http://localhost:15001/api/v2',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -487,6 +487,11 @@ export {
   zksyncSepoliaTestnet as zkSyncSepoliaTestnet,
   zksyncSepoliaTestnet,
 } from './definitions/zksyncSepoliaTestnet.js'
+export {
+  zksyncLocalHyperchain,
+  zksyncLocalCustomHyperchain,
+  zksyncLocalHyperchainL1,
+} from './definitions/zksyncLocalHyperchain.js'
 export { zora } from './definitions/zora.js'
 export { zoraSepolia } from './definitions/zoraSepolia.js'
 export { zoraTestnet } from './definitions/zoraTestnet.js'


### PR DESCRIPTION
This PR adds ZKsync local hyperchain networks required for testing bridge functionalities. 

The setup is available here: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new local hyperchain networks for `ZKsync`, enhancing the blockchain's capabilities by defining multiple local environments for testing and development.

### Detailed summary
- Added `ZKsync` local hyperchain networks in `src/chains/definitions/zksyncLocalHyperchain.ts`.
- Defined three local hyperchains: 
  - `zksyncLocalHyperchain`
  - `zksyncLocalCustomHyperchain`
  - `zksyncLocalHyperchainL1`
- Each hyperchain includes configuration for `rpcUrls`, `blockExplorers`, and `nativeCurrency`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->