### PR TITLE
feat(zksync): add `ZKsync` local hyperchain networks

### DIFF
--- a/.changeset/eighty-wolves-tie.md
+++ b/.changeset/eighty-wolves-tie.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `ZKsync` local hyperchain networks

--- a/src/chains/definitions/zksyncLocalCustomHyperchain.ts
+++ b/src/chains/definitions/zksyncLocalCustomHyperchain.ts
@@ -1,0 +1,25 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
+
+// The local hyperchain setup: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml
+
+export const zksyncLocalCustomHyperchain = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 272,
+  name: 'ZKsync CLI Local Custom Hyperchain',
+  nativeCurrency: { name: 'BAT', symbol: 'BAT', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15200'],
+      webSocket: ['ws://localhost:15201'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'ZKsync explorer',
+      url: 'http://localhost:15005/',
+      apiUrl: 'http://localhost:15005/api',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/zksyncLocalHyperchain.ts
+++ b/src/chains/definitions/zksyncLocalHyperchain.ts
@@ -1,0 +1,25 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
+
+// The local hyperchain setup: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml
+
+export const zksyncLocalHyperchain = /*#__PURE__*/ defineChain({
+  ...chainConfig,
+  id: 270,
+  name: 'ZKsync CLI Local Hyperchain',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15100'],
+      webSocket: ['ws://localhost:15101'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'ZKsync explorer',
+      url: 'http://localhost:15005/',
+      apiUrl: 'http://localhost:15005/api',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/zksyncLocalHyperchainL1.ts
+++ b/src/chains/definitions/zksyncLocalHyperchainL1.ts
@@ -1,0 +1,22 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+// The local hyperchain setup: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml
+
+export const zksyncLocalHyperchainL1 = /*#__PURE__*/ defineChain({
+  id: 9,
+  name: 'ZKsync CLI Local Hyperchain L1',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['http://localhost:15045'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'http://localhost:15001/',
+      apiUrl: 'http://localhost:15001/api/v2',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -477,6 +477,9 @@ export {
   zksyncInMemoryNode as zkSyncInMemoryNode,
   zksyncInMemoryNode,
 } from './definitions/zksyncInMemoryNode.js'
+export { zksyncLocalCustomHyperchain } from './definitions/zksyncLocalCustomHyperchain.js'
+export { zksyncLocalHyperchain } from './definitions/zksyncLocalHyperchain.js'
+export { zksyncLocalHyperchainL1 } from './definitions/zksyncLocalHyperchainL1.js'
 export {
   /** @deprecated Use `zksync` instead */
   zksyncLocalNode as zkSyncLocalNode,

--- a/src/zksync/chains.ts
+++ b/src/zksync/chains.ts
@@ -1,5 +1,8 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export { zksync } from '../chains/definitions/zksync.js'
 export { zksyncInMemoryNode } from '../chains/definitions/zksyncInMemoryNode.js'
+export { zksyncLocalCustomHyperchain } from '../chains/definitions/zksyncLocalCustomHyperchain.js'
+export { zksyncLocalHyperchain } from '../chains/definitions/zksyncLocalHyperchain.js'
+export { zksyncLocalHyperchainL1 } from '../chains/definitions/zksyncLocalHyperchainL1.js'
 export { zksyncLocalNode } from '../chains/definitions/zksyncLocalNode.js'
 export { zksyncSepoliaTestnet } from '../chains/definitions/zksyncSepoliaTestnet.js'

--- a/src/zksync/index.ts
+++ b/src/zksync/index.ts
@@ -126,6 +126,9 @@ export {
   zksync,
   /** @deprecated Use `zksync` instead */
   zksyncInMemoryNode as zkSyncInMemoryNode,
+  zksyncLocalCustomHyperchain,
+  zksyncLocalHyperchain,
+  zksyncLocalHyperchainL1,
   zksyncInMemoryNode,
   /** @deprecated Use `zksync` instead */
   zksyncLocalNode as zkSyncLocalNode,


### PR DESCRIPTION
This PR adds ZKsync local hyperchain networks required for testing bridge functionalities.

The setup is available here: https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces local hyperchain networks for `ZKsync`, enhancing the functionality and structure of the codebase by adding new chain definitions and exports.

### Detailed summary
- Added `zksyncLocalCustomHyperchain`, `zksyncLocalHyperchain`, and `zksyncLocalHyperchainL1` definitions.
- Updated exports in `src/chains/index.ts` and `src/zksync/chains.ts`.
- Created new files for `zksyncLocalHyperchain`, `zksyncLocalCustomHyperchain`, and `zksyncLocalHyperchainL1` with respective configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->