### PR TITLE
feat: replace invalid blockExplorers and add the multicall3 contract

### DIFF
--- a/.changeset/red-trains-teach.md
+++ b/.changeset/red-trains-teach.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Replaced invalid blockExplorers and added the multicall3 contract.
+Added multicall3 contract to ThunderCore.

--- a/.changeset/red-trains-teach.md
+++ b/.changeset/red-trains-teach.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaced invalid blockExplorers and added the multicall3 contract.

--- a/src/chains/definitions/thunderCore.ts
+++ b/src/chains/definitions/thunderCore.ts
@@ -12,7 +12,13 @@ export const thunderCore = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'ThunderCore Explorer',
-      url: 'https://viewblock.io/thundercore',
+      url: 'https://explorer-mainnet.thundercore.com',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 0,
     },
   },
   testnet: false,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `multicall3` contract to the `ThunderCore` chain definition, along with updating the explorer URL for `ThunderCore`.

### Detailed summary
- Updated the `url` for `ThunderCore Explorer` to `https://explorer-mainnet.thundercore.com`.
- Added `multicall3` contract with:
  - `address`: `0xcA11bde05977b3631167028862bE2a173976CA11`
  - `blockCreated`: `0`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->