### PR TITLE
docs: fix `getUserOperation` docs link

### DIFF
--- a/src/account-abstraction/actions/bundler/getUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/getUserOperation.ts
@@ -38,7 +38,7 @@ export type GetUserOperationErrorType =
 /**
  * Retrieves information about a User Operation given a hash.
  *
- * - Docs: https://viem.sh/docs/actions/bundler/getUserOperation
+ * - Docs: https://viem.sh/account-abstraction/actions/bundler/getUserOperation
  *
  * @param client - Client to use
  * @param parameters - {@link GetUserOperationParameters}


### PR DESCRIPTION
Fixes the documentation link for the `getUserOperation` function.








<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation link for the `getUserOperation` function in the `src/account-abstraction/actions/bundler/getUserOperation.ts` file to point to the correct URL.

### Detailed summary
- Changed the documentation link from `https://viem.sh/docs/actions/bundler/getUserOperation` to `https://viem.sh/account-abstraction/actions/bundler/getUserOperation`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->