### PR TITLE
Give access to credential's id

### DIFF
--- a/src/account-abstraction/accounts/toWebAuthnAccount.ts
+++ b/src/account-abstraction/accounts/toWebAuthnAccount.ts
@@ -41,6 +41,7 @@ export function toWebAuthnAccount(
   const { getFn, rpId } = parameters
   const { id, publicKey } = parameters.credential
   return {
+    id,
     publicKey,
     async sign({ hash }) {
       return sign({ credentialId: id, getFn, hash, rpId })

--- a/src/account-abstraction/accounts/types.ts
+++ b/src/account-abstraction/accounts/types.ts
@@ -220,6 +220,7 @@ export type SmartAccount<
 >
 
 export type WebAuthnAccount = {
+  id: string
   publicKey: Hex
   sign: ({ hash }: { hash: Hash }) => Promise<WebAuthnSignReturnType>
   signMessage: ({


### PR DESCRIPTION
Allow access to `credential.id` from `WebAuthnAccount`

