### PR TITLE
chore: `abitype` 1.0.7 and test using `bigint` for `chainId` in `hashTypedData`

### DIFF
--- a/.changeset/tidy-mice-switch.md
+++ b/.changeset/tidy-mice-switch.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Using abitype 1.0.7

--- a/.changeset/tidy-mice-switch.md
+++ b/.changeset/tidy-mice-switch.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Using abitype 1.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 20.16.12
       '@vitest/coverage-v8':
         specifier: ^1.0.4
-        version: 1.0.4(vitest@1.0.4)
+        version: 1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.36.0))
       '@vitest/ui':
         specifier: ^1.0.4
         version: 1.0.4(vitest@1.0.4)
@@ -550,8 +550,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
       abitype:
-        specifier: 1.0.6
-        version: 1.0.6(typescript@5.7.2)(zod@3.23.8)
+        specifier: 1.0.7
+        version: 1.0.7(typescript@5.7.2)(zod@3.23.8)
       isows:
         specifier: 1.0.6
         version: 1.0.6(ws@8.18.0)
@@ -2419,6 +2419,17 @@ packages:
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.0.7:
+    resolution: {integrity: sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -7627,7 +7638,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.0.4(vitest@1.0.4)':
+  '@vitest/coverage-v8@1.0.4(vitest@1.0.4(@types/node@20.16.12)(@vitest/ui@1.0.4)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -7776,7 +7787,12 @@ snapshots:
       typescript: 5.6.2
       zod: 3.23.8
 
-  abitype@1.0.6(typescript@5.7.2)(zod@3.23.8):
+  abitype@1.0.7(typescript@5.6.2)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.6.2
+      zod: 3.23.8
+
+  abitype@1.0.7(typescript@5.7.2)(zod@3.23.8):
     optionalDependencies:
       typescript: 5.7.2
       zod: 3.23.8
@@ -10029,7 +10045,7 @@ snapshots:
       '@noble/hashes': 1.6.1
       '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
-      abitype: 1.0.6(typescript@5.6.2)(zod@3.23.8)
+      abitype: 1.0.7(typescript@5.6.2)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.6.2
@@ -10043,7 +10059,7 @@ snapshots:
       '@noble/hashes': 1.6.1
       '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
-      abitype: 1.0.6(typescript@5.7.2)(zod@3.23.8)
+      abitype: 1.0.7(typescript@5.7.2)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.7.2
@@ -11386,7 +11402,7 @@ snapshots:
       '@noble/hashes': 1.6.1
       '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
-      abitype: 1.0.6(typescript@5.6.2)(zod@3.23.8)
+      abitype: 1.0.7(typescript@5.6.2)(zod@3.23.8)
       isows: 1.0.6(ws@8.18.0)
       ox: 0.1.2(typescript@5.6.2)(zod@3.23.8)
       webauthn-p256: 0.0.10

--- a/src/package.json
+++ b/src/package.json
@@ -143,7 +143,7 @@
     "@noble/hashes": "1.6.1",
     "@scure/bip32": "1.6.0",
     "@scure/bip39": "1.5.0",
-    "abitype": "1.0.6",
+    "abitype": "1.0.7",
     "isows": "1.0.6",
     "ox": "0.1.2",
     "webauthn-p256": "0.0.10",

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -61,6 +61,18 @@ test('domain: empty name', () => {
   )
 })
 
+test('domain: bigint value for chainId', () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { chainId: 14018334920824264832118464179726739019961432051877733167310318607178n },
+      primaryType: 'Mail',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x14ed1dbbfecbe5de3919f7ea47daafdf3a29dfbb60dd88d85509f79773d503a5"',
+  )
+})
+
 test('minimal valid typed message', () => {
   const hash = hashTypedData({
     types: {

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -65,7 +65,10 @@ test('domain: bigint value for chainId', () => {
   expect(
     hashTypedData({
       ...typedData.complex,
-      domain: { chainId: 14018334920824264832118464179726739019961432051877733167310318607178n },
+      domain: {
+        chainId:
+          14018334920824264832118464179726739019961432051877733167310318607178n,
+      },
       primaryType: 'Mail',
     }),
   ).toMatchInlineSnapshot(


### PR DESCRIPTION
This PR updates the `abitype` version and adds a test to validate the new type for `chainId` in the context of EIP712.

