### PR TITLE
Add ENS (BNS) to berachain bartio

### DIFF
--- a/.changeset/five-timers-decide.md
+++ b/.changeset/five-timers-decide.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ENS contract addresses to Berachain bArtio.

--- a/src/chains/definitions/berachainTestnetbArtio.ts
+++ b/src/chains/definitions/berachainTestnetbArtio.ts
@@ -13,6 +13,14 @@ export const berachainTestnetbArtio = /*#__PURE__*/ defineChain({
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 109269,
     },
+    ensRegistry: {
+      address: '0xB0eef18971290b333450586D33dcA6cE122651D2',
+      blockCreated: 7736794,
+    },
+    ensUniversalResolver: {
+      address: '0x41692Ef1EA0C79E6b73077E4A67572D2BDbD7057',
+      blockCreated: 7736795,
+    },
   },
   rpcUrls: {
     default: { http: ['https://bartio.rpc.berachain.com'] },


### PR DESCRIPTION
Add ensRegistry and ensUniversalResolver to Berachain Bartio using Beranames => https://x.com/beranames

Contracts have been verified as requested by contributing guidelines. 

Registry => https://bartio.beratrail.io/address/0xB0eef18971290b333450586D33dcA6cE122651D2
Universal Resolver => https://bartio.beratrail.io/address/0x41692Ef1EA0C79E6b73077E4A67572D2BDbD7057

Documentation => https://docs.beranames.com