### PR TITLE
fix: export `hashStruct`

### DIFF
--- a/.changeset/cool-tips-lick.md
+++ b/.changeset/cool-tips-lick.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `hashStruct`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -293,6 +293,7 @@ test('exports', () => {
       "getSerializedTransactionType",
       "getTransactionType",
       "hashDomain",
+      "hashStruct",
       "hashTypedData",
       "compactSignatureToSignature",
       "hexToCompactSignature",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1272,10 +1272,12 @@ export {
 } from './utils/transaction/getTransactionType.js'
 export {
   type HashDomainErrorType,
+  type HashStructErrorType,
   type HashTypedDataErrorType,
   type HashTypedDataParameters,
   type HashTypedDataReturnType,
   hashDomain,
+  hashStruct,
   hashTypedData,
 } from './utils/signature/hashTypedData.js'
 export {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -406,8 +406,10 @@ export { type Sha256ErrorType, sha256 } from './hash/sha256.js'
 export { type Ripemd160ErrorType, ripemd160 } from './hash/ripemd160.js'
 export {
   type HashDomainErrorType,
+  type HashStructErrorType,
   type HashTypedDataParameters,
   type HashTypedDataReturnType,
+  hashStruct,
   hashTypedData,
 } from './signature/hashTypedData.js'
 export {

--- a/src/utils/signature/hashTypedData.ts
+++ b/src/utils/signature/hashTypedData.ts
@@ -100,7 +100,7 @@ export function hashDomain({
   })
 }
 
-type HashStructErrorType = EncodeDataErrorType | Keccak256ErrorType | ErrorType
+export type HashStructErrorType = EncodeDataErrorType | Keccak256ErrorType | ErrorType
 
 export function hashStruct({
   data,


### PR DESCRIPTION
## Summary

It is not possible to import `hashStruct`. This method is useful should a contract not follow EIP-712.

This exports `hashStruct` and the associated `HashStructErrorType`.

Note: there is also an [open discussion requesting this change](https://github.com/wevm/viem/discussions/761).

## Changes

- Export `HashStructErrorType`
- Import `hashStruct` and `HashStructErrorType` in both index and `/utils`