### PR TITLE
ZKsync: provide public actions for fetching token addresses on L1 and L2 chains

### DIFF
--- a/.changeset/honest-apricots-jump.md
+++ b/.changeset/honest-apricots-jump.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `getL1TokenAddress` and `getL2TokenAddress` public actions in ZKsync extension

--- a/site/pages/zksync/actions/getL1TokenAddress.md
+++ b/site/pages/zksync/actions/getL1TokenAddress.md
@@ -1,0 +1,58 @@
+---
+description: Returns the L1 token address equivalent for a L2 token address as they are not equal.
+---
+
+# getL1TokenAddress
+
+Returns the L1 token address equivalent for a L2 token address as they are not equal.
+
+:::info
+
+Only works for tokens bridged on default ZKsync Era bridges.
+
+:::
+
+## Usage
+
+:::code-group
+
+```ts [example.ts]
+import { client } from './config'
+
+const address = await client.getL1TokenAddress({
+  token: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b'
+})
+```
+
+```ts [config.ts]
+import { createPublicClient, http } from 'viem'
+import { zksync } from 'viem/chains'
+import { publicActionsL2 } from 'viem/zksync'
+
+export const client = createPublicClient({
+    chain: zksync,
+    transport: http(),
+}).extend(publicActionsL2())
+```
+
+:::
+
+## Returns
+
+`Address`
+
+Returns the L1 token address equivalent for a L2 token address.
+
+## Parameters
+
+### token
+
+- **Type:** `Address`
+
+The address of the token on L2.
+
+```ts
+const address = await client.getL1TokenAddress({
+    token: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b'
+})
+```

--- a/site/pages/zksync/actions/getL2TokenAddress.md
+++ b/site/pages/zksync/actions/getL2TokenAddress.md
@@ -1,0 +1,70 @@
+---
+description: Returns the L2 token address equivalent for a L1 token address as they are not equal.
+---
+
+# getL2TokenAddress
+
+Returns the L2 token address equivalent for a L1 token address as they are not equal.
+
+:::info
+Only works for tokens bridged on default ZKsync Era bridges.
+:::
+
+## Usage
+
+:::code-group
+
+```ts [example.ts]
+import { client } from './config'
+
+const address = await client.getL2TokenAddress({
+    token: '0x5C221E77624690fff6dd741493D735a17716c26B'
+})
+```
+
+```ts [config.ts]
+import { createPublicClient, http } from 'viem'
+import { zksync } from 'viem/chains'
+import { publicActionsL2 } from 'viem/zksync'
+
+export const client = createPublicClient({
+    chain: zksync,
+    transport: http(),
+}).extend(publicActionsL2())
+```
+
+:::
+
+## Returns
+
+`Address`
+
+Returns the L2 token address equivalent for a L1 token address.
+
+## Parameters
+
+### token
+
+- **Type:** `Address`
+
+The address of the token on L1.
+
+```ts
+const address = await client.getL2TokenAddress({
+    token: '0x5C221E77624690fff6dd741493D735a17716c26B'
+})
+```
+
+### bridgeAddress (optional)
+
+- **Type:** `Address`
+
+The address of custom bridge, which will be used to get l2 token address.
+
+```ts
+const address = await client.getL2TokenAddress({
+    token: '0x5C221E77624690fff6dd741493D735a17716c26B',
+    bridgeAddress: '0xf8c919286126ccf2e8abc362a15158a461429c82' // [!code focus]
+})
+```
+

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1707,6 +1707,14 @@ export const sidebar = {
             link: '/zksync/actions/getL1ChainId',
           },
           {
+            text: 'getL1TokenAddress',
+            link: '/zksync/actions/getL1TokenAddress',
+          },
+          {
+            text: 'getL2TokenAddress',
+            link: '/zksync/actions/getL2TokenAddress',
+          },
+          {
             text: 'getLogProof',
             link: '/zksync/actions/getLogProof',
           },

--- a/src/zksync/actions/getL1TokenAddress.test.ts
+++ b/src/zksync/actions/getL1TokenAddress.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import { anvilZksync } from '~test/src/anvil.js'
+import { mockAddresses } from '~test/src/zksync.js'
+import { publicActionsL2 } from '~viem/zksync/decorators/publicL2.js'
+import { type EIP1193RequestFn, padHex } from '../../index.js'
+import { legacyEthAddress } from '../constants/address.js'
+import { getL1TokenAddress } from './getL1TokenAddress.js'
+
+const daiL1 = '0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+const daiL2 = '0xFC073319977e314F251EAE6ae6bE76B0B3BAeeCF'
+
+const client = anvilZksync.getClient().extend(publicActionsL2())
+
+client.request = (async ({ method, params }) => {
+  if (method === 'eth_call') return padHex(daiL1)
+  if (method === 'eth_estimateGas') return 158774n
+  if (method === 'zks_getBridgeContracts') return mockAddresses
+  return anvilZksync.getClient().request({ method, params } as any)
+}) as EIP1193RequestFn
+
+test('default', async () => {
+  expect(await getL1TokenAddress(client, { token: daiL2 })).toBe(daiL1)
+})
+
+test('args: legacyEthAddress', async () => {
+  expect(
+    await getL1TokenAddress(client, { token: legacyEthAddress }),
+  ).toBeDefined()
+})

--- a/src/zksync/actions/getL1TokenAddress.ts
+++ b/src/zksync/actions/getL1TokenAddress.ts
@@ -1,0 +1,59 @@
+import type { Address } from '../../accounts/index.js'
+import { readContract } from '../../actions/public/readContract.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { Account } from '../../types/account.js'
+import type { Chain } from '../../types/chain.js'
+import { isAddressEqual } from '../../utils/index.js'
+import { l2SharedBridgeAbi } from '../constants/abis.js'
+import { legacyEthAddress } from '../constants/address.js'
+import { getDefaultBridgeAddresses } from './getDefaultBridgeAddresses.js'
+
+export type GetL1TokenAddressParameters = {
+  /** The address of the token on L2. */
+  token: Address
+}
+
+export type GetL1TokenAddressReturnType = Address
+
+/**
+ * Returns the L1 token address equivalent for a L2 token address as they are not equal.
+ * ETH address is set to zero address.
+ *
+ * @remarks Only works for tokens bridged on default ZKsync Era bridges.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link GetL1TokenAddressParameters}
+ * @returns The L1 token address equivalent for a L2 token address.
+ *
+ *
+ * @example
+ * import { createPublicClient, http } from 'viem'
+ * import { zksync } from 'viem/chains'
+ *
+ * const client = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * })
+ *
+ * const address = await getL1TokenAddress(client, {token: '0x...'});
+ */
+export async function getL1TokenAddress<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: GetL1TokenAddressParameters,
+): Promise<Address> {
+  const { token } = parameters
+  if (isAddressEqual(token, legacyEthAddress)) return legacyEthAddress
+
+  const bridgeAddress = (await getDefaultBridgeAddresses(client)).sharedL2
+
+  return await readContract(client, {
+    address: bridgeAddress,
+    abi: l2SharedBridgeAbi,
+    functionName: 'l1TokenAddress',
+    args: [token],
+  })
+}

--- a/src/zksync/actions/getL2TokenAddress.test.ts
+++ b/src/zksync/actions/getL2TokenAddress.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest'
+import { anvilZksync } from '~test/src/anvil.js'
+import { mockAddresses, mockBaseTokenL1Address } from '~test/src/zksync.js'
+import { publicActionsL2 } from '~viem/zksync/decorators/publicL2.js'
+import { type EIP1193RequestFn, padHex } from '../../index.js'
+import { legacyEthAddress } from '../constants/address.js'
+import { getL2TokenAddress } from './getL2TokenAddress.js'
+
+const daiL1 = '0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+const daiL2 = '0xFC073319977e314F251EAE6ae6bE76B0B3BAeeCF'
+
+const client = anvilZksync.getClient().extend(publicActionsL2())
+
+client.request = (async ({ method, params }) => {
+  if (method === 'eth_call') return padHex(daiL2)
+  if (method === 'eth_estimateGas') return 158774n
+  if (method === 'zks_getBridgeContracts') return mockAddresses
+  if (method === 'zks_getBaseTokenL1Address') return mockBaseTokenL1Address
+  return anvilZksync.getClient().request({ method, params } as any)
+}) as EIP1193RequestFn
+
+test('default', async () => {
+  expect(await getL2TokenAddress(client, { token: daiL1 })).toBe(daiL2)
+})
+
+test('args: legacyEthAddress', async () => {
+  expect(
+    await getL2TokenAddress(client, { token: legacyEthAddress }),
+  ).toBeDefined()
+})

--- a/src/zksync/actions/getL2TokenAddress.ts
+++ b/src/zksync/actions/getL2TokenAddress.ts
@@ -1,0 +1,70 @@
+import type { Address } from '../../accounts/index.js'
+import { readContract } from '../../actions/public/readContract.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { Account } from '../../types/account.js'
+import type { Chain } from '../../types/chain.js'
+import { isAddressEqual } from '../../utils/index.js'
+import { l2SharedBridgeAbi } from '../constants/abis.js'
+import {
+  ethAddressInContracts,
+  l2BaseTokenAddress,
+  legacyEthAddress,
+} from '../constants/address.js'
+import { getBaseTokenL1Address } from './getBaseTokenL1Address.js'
+import { getDefaultBridgeAddresses } from './getDefaultBridgeAddresses.js'
+
+export type GetL2TokenAddressParameters = {
+  /** The address of the token on L1. */
+  token: Address
+  /** The address of custom bridge, which will be used to get l2 token address. */
+  bridgeAddress?: Address | undefined
+}
+
+export type GetL2TokenAddressReturnType = Address
+
+/**
+ * Returns the L2 token address equivalent for a L1 token address as they are not equal.
+ * ETH address is set to zero address.
+ *
+ * @remarks Only works for tokens bridged on default ZKsync Era bridges.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link GetL2TokenAddressParameters}
+ * @returns The L2 token address equivalent for a L1 token address.
+ *
+ *
+ * @example
+ * import { createPublicClient, http } from 'viem'
+ * import { zksync } from 'viem/chains'
+ * import { publicActionsL2 } from 'viem/zksync'
+ *
+ * const client = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * }).extend(publicActionsL2())
+ *
+ * const address = await getL2TokenAddress(client, {token: '0x...'});
+ */
+export async function getL2TokenAddress<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: GetL2TokenAddressParameters,
+): Promise<Address> {
+  let { token, bridgeAddress } = parameters
+  if (isAddressEqual(token, legacyEthAddress)) token = ethAddressInContracts
+
+  const baseToken = await getBaseTokenL1Address(client)
+  if (isAddressEqual(token, baseToken)) return l2BaseTokenAddress
+
+  bridgeAddress ??= (await getDefaultBridgeAddresses(client)).sharedL2
+
+  return await readContract(client, {
+    address: bridgeAddress,
+    abi: l2SharedBridgeAbi,
+    functionName: 'l2TokenAddress',
+    args: [token],
+  })
+}

--- a/src/zksync/constants/abis.ts
+++ b/src/zksync/constants/abis.ts
@@ -461,3 +461,434 @@ export const paymasterAbi = [
     type: 'function',
   },
 ]
+
+export const l2SharedBridgeAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Receiver',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'FinalizeDeposit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Receiver',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l2Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'WithdrawalInitiated',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Sender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l2Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_data',
+        type: 'bytes',
+      },
+    ],
+    name: 'finalizeDeposit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l1Bridge',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l1SharedBridge',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l2Token',
+        type: 'address',
+      },
+    ],
+    name: 'l1TokenAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+    ],
+    name: 'l2TokenAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l2Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+export const ethTokenAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Mint',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l2Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdrawal',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l2Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: '_additionalData',
+        type: 'bytes',
+      },
+    ],
+    name: 'WithdrawalWithMessage',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFromTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: '_additionalData',
+        type: 'bytes',
+      },
+    ],
+    name: 'withdrawWithMessage',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+] as const

--- a/src/zksync/decorators/publicL2.ts
+++ b/src/zksync/decorators/publicL2.ts
@@ -53,6 +53,16 @@ import {
   getL1ChainId,
 } from '../actions/getL1ChainId.js'
 import {
+  type GetL1TokenAddressParameters,
+  type GetL1TokenAddressReturnType,
+  getL1TokenAddress,
+} from '../actions/getL1TokenAddress.js'
+import {
+  type GetL2TokenAddressParameters,
+  type GetL2TokenAddressReturnType,
+  getL2TokenAddress,
+} from '../actions/getL2TokenAddress.js'
+import {
   type GetLogProofParameters,
   type GetLogProofReturnType,
   getLogProof,
@@ -411,6 +421,56 @@ export type PublicActionsL2<
    * const address = await client.getBaseTokenL1Address();
    */
   getBaseTokenL1Address: () => Promise<GetBaseTokenL1AddressReturnType>
+
+  /**
+   * Returns the L2 token address equivalent for a L1 token address as they are not equal.
+   * ETH address is set to zero address.
+   *
+   * @remarks Only works for tokens bridged on default ZKsync Era bridges.
+   *
+   * @param args - {@link GetL2TokenAddressParameters}
+   * @returns The L2 token address equivalent for a L1 token address.
+   *
+   * @example
+   * import { createPublicClient, http } from 'viem'
+   * import { zksync } from 'viem/chains'
+   * import { publicActionsL2 } from 'viem/zksync'
+   *
+   * const client = createPublicClient({
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const address = await client.getL2TokenAddress({token: '0x...'});
+   */
+  getL2TokenAddress: (
+    args: GetL2TokenAddressParameters,
+  ) => Promise<GetL2TokenAddressReturnType>
+
+  /**
+   * Returns the L1 token address equivalent for a L2 token address as they are not equal.
+   * ETH address is set to zero address.
+   *
+   * @remarks Only works for tokens bridged on default ZKsync Era bridges.
+   *
+   * @param args - {@link GetL1TokenAddressParameters}
+   * @returns The L1 token address equivalent for a L2 token address.
+   *
+   * @example
+   * import { createPublicClient, http } from 'viem'
+   * import { zksync } from 'viem/chains'
+   * import { publicActionsL2 } from 'viem/zksync'
+   *
+   * const client = createPublicClient({
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const address = await client.getL1TokenAddress({token: '0x...'});
+   */
+  getL1TokenAddress: (
+    args: GetL1TokenAddressParameters,
+  ) => Promise<GetL1TokenAddressReturnType>
 }
 
 export function publicActionsL2() {
@@ -438,6 +498,8 @@ export function publicActionsL2() {
       estimateFee: (args) => estimateFee(client, args),
       getBridgehubContractAddress: () => getBridgehubContractAddress(client),
       getBaseTokenL1Address: () => getBaseTokenL1Address(client),
+      getL2TokenAddress: (args) => getL2TokenAddress(client, args),
+      getL1TokenAddress: (args) => getL1TokenAddress(client, args),
     }
   }
 }

--- a/src/zksync/index.ts
+++ b/src/zksync/index.ts
@@ -119,6 +119,16 @@ export {
   type SignTransactionReturnType,
   signTransaction,
 } from './actions/signTransaction.js'
+export {
+  type GetL2TokenAddressReturnType,
+  type GetL2TokenAddressParameters,
+  getL2TokenAddress,
+} from './actions/getL2TokenAddress.js'
+export {
+  type GetL1TokenAddressReturnType,
+  type GetL1TokenAddressParameters,
+  getL1TokenAddress,
+} from './actions/getL1TokenAddress.js'
 
 export {
   /** @deprecated Use `zksync` instead */


### PR DESCRIPTION
To enable seamless bridging of assets across chains, it is necessary to retrieve the corresponding token address on the other chain for a given asset. This involves implementing two public actions to facilitate the mapping between L1 and L2 token addresses.

Implementend the following public actions:

`getL1TokensAddress()` - returns the L1 token address equivalent for a L2 token address.
`getL2TokensAddress()` - returns the L2 token address equivalent for a L1 token address.