### PR TITLE
fix: Updated Cronos zkEVM chain configs

### DIFF
--- a/.changeset/change-cronoszkevm-chainid.md
+++ b/.changeset/change-cronoszkevm-chainid.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated CronoszkEVM chainId to 240.
+Updated CronoszkEVM chain configs.

--- a/.changeset/change-cronoszkevm-chainid.md
+++ b/.changeset/change-cronoszkevm-chainid.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated CronoszkEVM chainId to 240.

--- a/src/chains/definitions/cronoszkEVM.ts
+++ b/src/chains/definitions/cronoszkEVM.ts
@@ -1,6 +1,8 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
 
 export const cronoszkEVM = /*#__PURE__*/ defineChain({
+  ...chainConfig,
   id: 388,
   name: 'Cronos zkEVM Mainnet',
   nativeCurrency: {

--- a/src/chains/definitions/cronoszkEVMTestnet.ts
+++ b/src/chains/definitions/cronoszkEVMTestnet.ts
@@ -1,6 +1,8 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
+import { chainConfig } from '../../zksync/chainConfig.js'
 
 export const cronoszkEVMTestnet = /*#__PURE__*/ defineChain({
+  ...chainConfig,
   id: 240,
   name: 'Cronos zkEVM Testnet',
   nativeCurrency: {

--- a/src/chains/definitions/cronoszkEVMTestnet.ts
+++ b/src/chains/definitions/cronoszkEVMTestnet.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const cronoszkEVMTestnet = /*#__PURE__*/ defineChain({
-  id: 282,
+  id: 240,
   name: 'Cronos zkEVM Testnet',
   nativeCurrency: {
     decimals: 18,


### PR DESCRIPTION
- Add missing default chain configs (Cronos zkEVM is a zkSync fork, so it can resuse these chain configs)
- Update testnet chain id, the chainid of Cronos zkEVM is 240, doc: https://docs-zkevm.cronos.org/for-developers/develop-smart-contracts-and-dapps#cronos-zkevm-sepolia-testnet