### PR TITLE
fix: avoid nonce gap in nonceManager (#3142)

### DIFF
--- a/.changeset/brave-cooks-carry.md
+++ b/.changeset/brave-cooks-carry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue that caused the nonce to increment prematurely in prepareTransactionRequest, resulting in possible nonce gaps. Now the nonce manager logic is arranged so that gas estimation is performed first, ensuring no wasted nonce if gas estimation fails

--- a/.changeset/brave-cooks-carry.md
+++ b/.changeset/brave-cooks-carry.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed an issue that caused the nonce to increment prematurely in prepareTransactionRequest, resulting in possible nonce gaps. Now the nonce manager logic is arranged so that gas estimation is performed first, ensuring no wasted nonce if gas estimation fails
+Fixed premature nonce increment by rearranging gas estimation logic.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -383,7 +383,7 @@ export async function prepareTransactionRequest<
     }
   }
 
-  if (parameters.includes('gas') && typeof gas === 'undefined') {
+  if (parameters.includes('gas') && typeof gas === 'undefined')
     request.gas = await getAction(
       client,
       estimateGas,
@@ -394,7 +394,6 @@ export async function prepareTransactionRequest<
         ? { address: account.address, type: 'json-rpc' }
         : account,
     } as EstimateGasParameters)
-  }
 
   if (parameters.includes('nonce') && typeof nonce === 'undefined' && account) {
     if (nonceManager) {

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -316,26 +316,6 @@ export async function prepareTransactionRequest<
 
   if (parameters.includes('chainId')) request.chainId = await getChainId()
 
-  if (parameters.includes('nonce') && typeof nonce === 'undefined' && account) {
-    if (nonceManager) {
-      const chainId = await getChainId()
-      request.nonce = await nonceManager.consume({
-        address: account.address,
-        chainId,
-        client,
-      })
-    } else {
-      request.nonce = await getAction(
-        client,
-        getTransactionCount,
-        'getTransactionCount',
-      )({
-        address: account.address,
-        blockTag: 'pending',
-      })
-    }
-  }
-
   if (
     (parameters.includes('fees') || parameters.includes('type')) &&
     typeof type === 'undefined'
@@ -403,7 +383,7 @@ export async function prepareTransactionRequest<
     }
   }
 
-  if (parameters.includes('gas') && typeof gas === 'undefined')
+  if (parameters.includes('gas') && typeof gas === 'undefined') {
     request.gas = await getAction(
       client,
       estimateGas,
@@ -414,6 +394,27 @@ export async function prepareTransactionRequest<
         ? { address: account.address, type: 'json-rpc' }
         : account,
     } as EstimateGasParameters)
+  }
+
+  if (parameters.includes('nonce') && typeof nonce === 'undefined' && account) {
+    if (nonceManager) {
+      const chainId = await getChainId()
+      request.nonce = await nonceManager.consume({
+        address: account.address,
+        chainId,
+        client,
+      })
+    } else {
+      request.nonce = await getAction(
+        client,
+        getTransactionCount,
+        'getTransactionCount',
+      )({
+        address: account.address,
+        blockTag: 'pending',
+      })
+    }
+  }
 
   assertRequest(request as AssertRequestParameters)
 


### PR DESCRIPTION
Fixes [#3142](https://github.com/wevm/viem/issues/3142) by deferring the nonce consumption in `prepareTransactionRequest` until after gas estimation succeeds, avoiding a nonce gap when gas estimation fails.

## Changes
- Reordered logic so `nonceManager.consume(...)` is called after gas estimation
- Added a changeset for a patch release

## Details
- Old behavior: We called `nonceManager.consume(...)` before gas estimation, so if gas estimation failed, we never broadcast a transaction but had already incremented the nonce.
- New behavior: We’ve reordered the logic in `prepareTransactionRequest` so that all fees and gas estimation happen first. Only if those steps succeed do we call `consume(...)` from the nonce manager. This way, no extra nonce is burned on failure.
- Alternative considered: Rolling back the nonce in a try/catch: We tested that approach but decided to defer `consume` entirely until the end, which is simpler and avoids the need for a rollback