### PR TITLE
Fix klaytn deprecated comment

### DIFF
--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -225,9 +225,9 @@ export { kcc } from './definitions/kcc.js'
 export { kinto } from './definitions/kinto.js'
 /** @deprecated Use `kaia` instead. */
 export { klaytn } from './definitions/klaytn.js'
-/** @deprecated Use `kairos` instead. */
 export { kaia } from './definitions/kaia.js'
 export { kairos } from './definitions/kairos.js'
+/** @deprecated Use `kairos` instead. */
 export { klaytnBaobab } from './definitions/klaytnBaobab.js'
 export { koi } from './definitions/koi.js'
 export { kroma } from './definitions/kroma.js'


### PR DESCRIPTION
Fix incorrect deprecated comment location (https://github.com/wevm/viem/pull/2897/files#diff-bcdf494bd48667265e1dcbf43c7054c780c64d2c940330be7c5fdaed5597e1a7R196)
