### PR TITLE
fix: correct logic for identifying repriced transactions

### DIFF
--- a/.changeset/sixty-mice-build.md
+++ b/.changeset/sixty-mice-build.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated waitForTransactionReceipt to only emit repriced when the contract call has not changed along with the recipient and value
+Fixed transaction reprice logic in `waitForTransactionReceipt` to account for `transaction.input` as well.

--- a/.changeset/sixty-mice-build.md
+++ b/.changeset/sixty-mice-build.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated waitForTransactionReceipt to only emit repriced when the contract call has not changed along with the recipient and value

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5434,6 +5434,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.22.3:
+    resolution: {integrity: sha512-lO8K4lL5vWfJ9dmeJo9BfwlJJ0vNDrgLXgwFJNzjLJ6eDfOGXr48yzNhqt96ybYS7SlM7ecT7yhJIVfhZLkOkw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -6690,7 +6698,7 @@ snapshots:
       pino-http: 8.6.1
       pino-pretty: 10.3.1
       prom-client: 14.2.0
-      viem: 2.22.2(typescript@5.6.2)(zod@3.23.8)
+      viem: 2.22.3(typescript@5.6.2)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -11278,6 +11286,24 @@ snapshots:
       vfile-message: 4.0.2
 
   viem@2.22.2(typescript@5.6.2)(zod@3.23.8):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/bip32': 1.6.0
+      '@scure/bip39': 1.5.0
+      abitype: 1.0.7(typescript@5.6.2)(zod@3.23.8)
+      isows: 1.0.6(ws@8.18.0)
+      ox: 0.6.0(typescript@5.6.2)(zod@3.23.8)
+      webauthn-p256: 0.0.10
+      ws: 8.18.0
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.22.3(typescript@5.6.2)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -308,7 +308,8 @@ export async function waitForTransactionReceipt<
                 let reason: ReplacementReason = 'replaced'
                 if (
                   replacementTransaction.to === replacedTransaction.to &&
-                  replacementTransaction.value === replacedTransaction.value
+                  replacementTransaction.value === replacedTransaction.value &&
+                  replacementTransaction.input === replacedTransaction.input
                 ) {
                   reason = 'repriced'
                 } else if (


### PR DESCRIPTION
This PR corrects the logic when identifying the reason associated with a replaced transaction.

Before, `repriced` was used to classify any replacement transaction with the same value and recipient as the original, but I believe it should also check the transaction `data` to ensure that if the transaction was a contract call, the function data has also not changed.

Therefore, I added a check to ensure the original and replacement transaction share the same contract call data before classifying a replacement as `repriced`

Added relevant tests, but had a bit of trouble running the test suite.