### PR TITLE
Update Metis Mainnet RPCs in Viem

### DIFF
--- a/src/chains/definitions/metis.ts
+++ b/src/chains/definitions/metis.ts
@@ -9,10 +9,27 @@ export const metis = /*#__PURE__*/ defineChain({
     symbol: 'METIS',
   },
   rpcUrls: {
-    default: { http: ['https://andromeda.metis.io/?owner=1088'] },
+      default: {
+          http: [
+              'https://metis.rpc.hypersync.xyz',
+              'https://metis.pokt.nodes.app',
+              'https://api.blockeden.xyz/metis/67nCbZDQS9Hgz3YgQDjdm',
+              'https://metis-andromeda.rpc.thirdweb.com',
+              'https://metis-andromeda.gateway.tenderly.co',
+          ],
+      },
+      public: {
+          http: [
+              'https://metis.rpc.hypersync.xyz',
+              'https://metis.pokt.nodes.app',
+              'https://api.blockeden.xyz/metis/67nCbZDQS9Hgz3YgQDjdm',
+              'https://metis-andromeda.rpc.thirdweb.com',
+              'https://metis-andromeda.gateway.tenderly.co',
+          ],
+      },
   },
   blockExplorers: {
-    default: {
+    default: {c
       name: 'Metis Explorer',
       url: 'https://explorer.metis.io',
       apiUrl:


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR updates the RPC URLs for the Metis network in the viem repository to include multiple reliable and redundant RPC providers. These updates ensure better performance, redundancy, and accessibility for developers interacting with the Metis network.

Issues this solves
This PR enhances the existing configuration for the Metis network by:
	•	Adding additional RPC endpoints for reliability and fault tolerance.
	  •	Ensuring decentralized and fast access to the Metis blockchain.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

