### PR TITLE
update explorer to use evm specific endpoint

### DIFF
--- a/src/chains/definitions/flowMainnet.ts
+++ b/src/chains/definitions/flowMainnet.ts
@@ -16,7 +16,7 @@ export const flowMainnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Mainnet Explorer',
-      url: 'https://flowdiver.io',
+      url: 'https://evm.flowscan.io',
     },
   },
   contracts: {

--- a/src/chains/definitions/flowTestnet.ts
+++ b/src/chains/definitions/flowTestnet.ts
@@ -25,4 +25,5 @@ export const flowTestnet = /*#__PURE__*/ defineChain({
       blockCreated: 137518,
     },
   },
+  testnet: true,
 })

--- a/src/chains/definitions/flowTestnet.ts
+++ b/src/chains/definitions/flowTestnet.ts
@@ -16,7 +16,7 @@ export const flowTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Flow Diver',
-      url: 'https://testnet.flowdiver.io',
+      url: 'https://evm-testnet.flowscan.io',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Flow evm block explorer URL have changed for evm flow mainnet and evm flow testnet.
Add missing `testnet` flag on flow testnet configuration

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

