### PR TITLE
Update watchEvent.md

### DIFF
--- a/site/pages/docs/actions/public/watchEvent.md
+++ b/site/pages/docs/actions/public/watchEvent.md
@@ -339,7 +339,7 @@ Error thrown from listening for new Event Logs.
 // ---cut---
 const unwatch = publicClient.watchEvent(
   { 
-    onError: error => console.log(error) // [!code focus:1]
+    onError: error => console.log(error), // [!code focus:1]
     onLogs: logs => console.log(logs),
   }
 )


### PR DESCRIPTION
Missing `,` in documentation caused error:

<img width="755" alt="Captura de pantalla 2025-01-08 a las 0 10 45" src="https://github.com/user-attachments/assets/498391e5-9031-4fb4-9884-8ff952b8e169" />
