### PR TITLE
fix(EIP712): `domain`'s `chainId` was not getting the types correctly when `bigint`

### DIFF
--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -72,7 +72,7 @@ test('domain: bigint value for chainId', () => {
       primaryType: 'Mail',
     }),
   ).toMatchInlineSnapshot(
-    '"0x14ed1dbbfecbe5de3919f7ea47daafdf3a29dfbb60dd88d85509f79773d503a5"',
+    '"0xb7cb45cf19c056d355e5d807ba0eac8cd5b4a7193f7ed978f4f9339f76cdf4d9"',
   )
 })
 

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -142,7 +142,7 @@ export function getTypesForEIP712Domain({
   return [
     typeof domain?.name === 'string' && { name: 'name', type: 'string' },
     domain?.version && { name: 'version', type: 'string' },
-    typeof domain?.chainId === 'number' && {
+    typeof domain?.chainId === 'number' || typeof domain?.chainId === 'bigint' && {
       name: 'chainId',
       type: 'uint256',
     },


### PR DESCRIPTION
This modification was missing after `bigint` was added here https://github.com/wevm/abitype/commit/ee60e674458824fccfd22874a8815075cc5b269a so the hash was not calculated correctly in this case.

