### PR TITLE
ZKsync: add `withdraw` action

### DIFF
--- a/.changeset/fuzzy-scissors-carry.md
+++ b/.changeset/fuzzy-scissors-carry.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `withdraw` action in ZKsync extension

--- a/site/pages/zksync/actions/withdraw.md
+++ b/site/pages/zksync/actions/withdraw.md
@@ -1,0 +1,300 @@
+---
+description: Initiates the withdrawal process which withdraws ETH or any ERC20 token from the associated account on L2 network to the target account on L1 network.
+---
+
+# withdraw
+
+Initiates the withdrawal process which withdraws ETH or any ERC20 token
+from the associated account on L2 network to the target account on L1 network.
+
+## Usage
+
+:::code-group
+
+```ts [example.ts]
+import { account, walletClient } from './config'
+import { legacyEthAddress } from 'viem/zksync'
+
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+})
+```
+
+```ts [config.ts]
+import { createWalletClient, custom } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { zksync } from 'viem/chains'
+import { eip712Actions } from 'viem/zksync'
+
+export const walletClient = createWalletClient({
+  chain: zksync,
+  transport: custom(window.ethereum)
+}).extend(publicActionsL2())
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account
+export const account = privateKeyToAccount(...)
+```
+
+:::
+
+### Account Hoisting
+
+If you do not wish to pass an `account` to every `withdraw`, you can also hoist the Account on the Wallet Client (see `config.ts`).
+
+[Learn more](/docs/clients/wallet#account).
+
+:::code-group
+
+```ts [example.ts]
+import { walletClient } from './config'
+import { legacyEthAddress } from 'viem/zksync'
+ 
+const hash = await walletClient.withdraw({ // [!code focus:99]
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,  
+})
+// '0x...'
+```
+
+```ts [config.ts (JSON-RPC Account)]
+import { createWalletClient, custom } from 'viem'
+import { publicActionsL2 } from 'viem/zksync'
+
+// Retrieve Account from an EIP-712 Provider. // [!code focus]
+const [account] = await window.ethereum.request({  // [!code focus]
+  method: 'eth_requestAccounts' // [!code focus]
+}) // [!code focus]
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum) // [!code focus]
+}).extend(publicActionsL2())
+```
+
+```ts [config.ts (Local Account)]
+import { createWalletClient, custom } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { publicActionsL2 } from 'viem/zksync'
+
+export const walletClient = createWalletClient({
+  account: privateKeyToAccount('0x...'), // [!code focus]
+  transport: custom(window.ethereum)
+}).extend(publicActionsL2())
+```
+
+:::
+
+## Returns
+
+[`Hash`](/docs/glossary/types#hash)
+
+The [Transaction](/docs/glossary/terms#transaction) hash.
+
+## Parameters
+
+### account
+
+- **Type:** `Account | Address`
+
+The Account to send the transaction from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-private-key-mnemonic-etc).
+
+```ts
+const hash = await walletClient.withdraw({
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus]
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+})
+```
+
+### amount
+
+- **Type:** `bigint`
+
+The amount of the token to withdraw.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n, // [!code focus]
+  token: legacyEthAddress,
+})
+```
+
+### token
+
+- **Type:** `Address`
+
+The address of the token on L2.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress, // [!code focus]
+})
+```
+
+### bridgeAddress (optional)
+
+- **Type:** `Address`
+
+The address of the bridge contract to be used. By default, uses shared bridge.
+
+```ts
+const address = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  bridgeAddress: '0xf8c919286126ccf2e8abc362a15158a461429c82' // [!code focus]
+})
+```
+
+### chain (optional)
+
+- **Type:** [`Chain`](/docs/glossary/types#chain)
+- **Default:** `walletClient.chain`
+
+The target chain. If there is a mismatch between the wallet's current chain & the target chain, an error will be thrown.
+
+The chain is also used to infer its request type.
+
+```ts
+import { zksync } from 'viem/chains' // [!code focus]
+
+const hash = await walletClient.withdraw({
+  chain: zksync, // [!code focus]
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+})
+```
+
+### gasPerPubdata (optional)
+
+- **Type:** `bigint`
+
+The amount of gas for publishing one byte of data on Ethereum.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  gasPerPubdata: 50000, // [!code focus]
+})
+```
+
+### gasPrice (optional)
+
+- **Type:** `bigint`
+
+The price (in wei) to pay per gas. Only applies to [Legacy Transactions](/docs/glossary/terms#legacy-transaction).
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  gasPrice: parseGwei('20'), // [!code focus]
+})
+```
+
+### maxFeePerGas (optional)
+
+- **Type:** `bigint`
+
+Total fee per gas (in wei), inclusive of `maxPriorityFeePerGas`. Only applies to [EIP-1559 Transactions](/docs/glossary/terms#eip-1559-transaction)
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  maxFeePerGas: parseGwei('20'),  // [!code focus]
+})
+```
+
+### maxPriorityFeePerGas (optional)
+
+- **Type:** `bigint`
+
+Max priority fee per gas (in wei). Only applies to [EIP-1559 Transactions](/docs/glossary/terms#eip-1559-transaction)
+
+```ts
+const hash = await walletClient.withdraw({
+  account, 
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  maxFeePerGas: parseGwei('20'),
+  maxPriorityFeePerGas: parseGwei('2'), // [!code focus]
+})
+```
+
+### nonce (optional)
+
+- **Type:** `number`
+
+Unique number identifying this transaction.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  nonce: 69 // [!code focus]
+})
+```
+
+
+### paymaster (optional)
+
+- **Type:** `Account | Address`
+
+Address of the paymaster account that will pay the fees. The `paymasterInput` field is required with this one.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021', // [!code focus]
+  paymasterInput: '0x8c5a...' // [!code focus]
+})
+```
+
+### paymasterInput (optional)
+
+- **Type:** `0x${string}`
+
+Input data to the paymaster. The `paymaster` field is required with this one.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  paymaster: '0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021', // [!code focus]
+  paymasterInput: '0x8c5a...' // [!code focus]
+})
+```
+
+### to (optional)
+
+- **Type:** `Address`
+
+The address of the recipient on L1. Defaults to the sender address.
+
+```ts
+const hash = await walletClient.withdraw({
+  account,
+  amount: 1_000_000_000_000_000_000n,
+  token: legacyEthAddress,
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
+})
+```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1789,6 +1789,15 @@ export const sidebar = {
         ],
       },
       {
+        text: 'L2 Wallet Actions',
+        items: [
+          {
+            text: 'withdraw',
+            link: '/zksync/actions/withdraw',
+          },
+        ],
+      },
+      {
         text: 'L1 Wallet Actions',
         items: [
           {

--- a/src/zksync/actions/withdraw.test.ts
+++ b/src/zksync/actions/withdraw.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'vitest'
+
+import { anvilZksync } from '~test/src/anvil.js'
+import { accounts } from '~test/src/constants.js'
+import { mockRequestReturnData } from '~test/src/zksync.js'
+import { privateKeyToAccount } from '~viem/accounts/privateKeyToAccount.js'
+import type { EIP1193RequestFn } from '~viem/index.js'
+import { legacyEthAddress, publicActionsL2 } from '~viem/zksync/index.js'
+import { withdraw } from './withdraw.js'
+
+const request = (async ({ method, params }) => {
+  if (method === 'eth_sendRawTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_sendTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_call')
+    return '0x00000000000000000000000070a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+  if (method === 'eth_estimateGas') return 158774n
+  if (method === 'eth_getTransactionCount') return 1n
+  if (method === 'eth_getBlockByNumber') return anvilZksync.forkBlockNumber
+  if (method === 'eth_gasPrice') return 200_000_000_000n
+  if (method === 'eth_chainId') return anvilZksync.chain.id
+  return (
+    (await mockRequestReturnData(method)) ??
+    (await anvilZksync.getClient().request({ method, params } as any))
+  )
+}) as EIP1193RequestFn
+
+const baseClient = anvilZksync.getClient({ batch: { multicall: false } })
+baseClient.request = request
+const client = baseClient.extend(publicActionsL2())
+
+const baseClientWithAccount = anvilZksync.getClient({
+  account: true,
+  batch: { multicall: false },
+})
+baseClientWithAccount.request = request
+const clientWithAccount = baseClientWithAccount.extend(publicActionsL2())
+
+test.skip('default', async () => {
+  expect(
+    await withdraw(client, {
+      account: privateKeyToAccount(accounts[0].privateKey),
+      amount: 7_000_000_000n,
+      token: legacyEthAddress,
+    }),
+  ).toBeDefined()
+})
+
+test('default: account hoisting', async () => {
+  expect(
+    await withdraw(clientWithAccount, {
+      amount: 7_000_000_000n,
+      token: legacyEthAddress,
+    }),
+  ).toBeDefined()
+})
+
+test('errors: no account provided', async () => {
+  await expect(() =>
+    withdraw(client, {
+      amount: 7_000_000_000n,
+      token: legacyEthAddress,
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [AccountNotFoundError: Could not find an Account to execute with this Action.
+      Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the Client.
+
+      Docs: https://viem.sh/docs/actions/wallet/sendTransaction
+      Version: viem@x.y.z]
+  `)
+})

--- a/src/zksync/actions/withdraw.ts
+++ b/src/zksync/actions/withdraw.ts
@@ -1,0 +1,185 @@
+import type { Address } from 'abitype'
+import type { Account } from '../../accounts/types.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import { AccountNotFoundError } from '../../errors/account.js'
+import type { GetAccountParameter } from '../../types/account.js'
+import type { GetChainParameter } from '../../types/chain.js'
+import type { UnionOmit } from '../../types/utils.js'
+import type { EncodeFunctionDataReturnType } from '../../utils/abi/encodeFunctionData.js'
+import {
+  encodeFunctionData,
+  isAddressEqual,
+  parseAccount,
+} from '../../utils/index.js'
+import { ethTokenAbi, l2SharedBridgeAbi } from '../constants/abis.js'
+import {
+  ethAddressInContracts,
+  l2BaseTokenAddress,
+  legacyEthAddress,
+} from '../constants/address.js'
+import type { ChainEIP712 } from '../types/chain.js'
+import type { ZksyncTransactionRequest } from '../types/transaction.js'
+import { getDefaultBridgeAddresses } from './getDefaultBridgeAddresses.js'
+import { getL2TokenAddress } from './getL2TokenAddress.js'
+import {
+  type SendTransactionErrorType,
+  type SendTransactionParameters,
+  type SendTransactionReturnType,
+  sendTransaction,
+} from './sendTransaction.js'
+
+export type WithdrawParameters<
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+> = UnionOmit<
+  ZksyncTransactionRequest,
+  'from' | 'type' | 'value' | 'data' | 'to' | 'factoryDeps' | 'maxFeePerBlobGas'
+> &
+  Partial<GetAccountParameter<account>> &
+  Partial<GetChainParameter<chain, chainOverride>> & {
+    /** The address of the recipient on L1. Defaults to the sender address. */
+    to?: Address
+    /** The address of the token. */
+    token: Address
+    /** The amount of the token to withdraw. */
+    amount: bigint
+    /** The address of the bridge contract to be used. */
+    bridgeAddress?: Address
+  }
+
+export type WithdrawReturnType = SendTransactionReturnType
+
+export type WithdrawErrorType = SendTransactionErrorType
+
+/**
+ * Initiates the withdrawal process which withdraws ETH or any ERC20 token
+ * from the associated account on L2 network to the target account on L1 network.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link WithdrawParameters}
+ * @returns hash - The [Transaction](https://viem.sh/docs/glossary/terms#transaction) hash. {@link WithdrawReturnType}
+ *
+ *
+ * @example
+ * import { createPublicClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { zksync } from 'viem/chains'
+ * import { withdraw, legacyEthAddress } from 'viem/zksync'
+ *
+ * const client = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * })
+ *
+ * const hash = await withdraw(client, {
+ *     account: privateKeyToAccount('0x…'),
+ *     amount: 1_000_000_000_000_000_000n,
+ *     token: legacyEthAddress,
+ * })
+ *
+ * @example Account Hoisting
+ * import { createPublicClient, createWalletClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { zksync } from 'viem/chains'
+ * import { withdraw, legacyEthAddress } from 'viem/zksync'
+ *
+ * const client = createWalletClient({
+ *   account: privateKeyToAccount('0x…'),
+ *   chain: zksync,
+ *   transport: http(),
+ * })
+ *
+ * const hash = await withdraw(client, {
+ *     amount: 1_000_000_000_000_000_000n,
+ *     token: legacyEthAddress,
+ * })
+ *
+ * @example Paymaster
+ * import { createPublicClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { zksync } from 'viem/chains'
+ * import {
+ *   withdraw,
+ *   legacyEthAddress,
+ *   getApprovalBasedPaymasterInput
+ * } from 'viem/zksync'
+ *
+ * const client = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * })
+ *
+ * const hash = await withdraw(client, {
+ *     account: privateKeyToAccount('0x…'),
+ *     amount: 1_000_000_000_000_000_000n,
+ *     token: legacyEthAddress,
+ *     paymaster: '0x0EEc6f45108B4b806e27B81d9002e162BD910670',
+ *     paymasterInput: getApprovalBasedPaymasterInput({
+ *       minAllowance: 1n,
+ *       token: '0x2dc3685cA34163952CF4A5395b0039c00DFa851D',
+ *       innerInput: new Uint8Array(),
+ *     }),
+ * })
+ */
+export async function withdraw<
+  chain extends ChainEIP712 | undefined,
+  account extends Account | undefined,
+  chainOverride extends ChainEIP712 | undefined = undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: WithdrawParameters<chain, account, chainOverride>,
+): Promise<WithdrawReturnType> {
+  let {
+    account: account_ = client.account,
+    token = l2BaseTokenAddress,
+    to,
+    amount,
+    bridgeAddress,
+    ...rest
+  } = parameters
+  const account = account_ ? parseAccount(account_) : client.account
+  if (!account)
+    throw new AccountNotFoundError({
+      docsPath: '/docs/actions/wallet/sendTransaction',
+    })
+
+  if (!to) to = account.address
+  let data: EncodeFunctionDataReturnType
+  let contract: Address
+  let value = 0n
+
+  if (
+    isAddressEqual(token, legacyEthAddress) ||
+    isAddressEqual(token, ethAddressInContracts)
+  )
+    token = await getL2TokenAddress(client, { token: ethAddressInContracts })
+
+  if (isAddressEqual(token, l2BaseTokenAddress)) {
+    data = encodeFunctionData({
+      abi: ethTokenAbi,
+      functionName: 'withdraw',
+      args: [to],
+    })
+    value = amount
+    contract = l2BaseTokenAddress
+  } else {
+    data = encodeFunctionData({
+      abi: l2SharedBridgeAbi,
+      functionName: 'withdraw',
+      args: [to, token, amount],
+    })
+    contract = bridgeAddress
+      ? bridgeAddress
+      : (await getDefaultBridgeAddresses(client)).sharedL2
+  }
+
+  return await sendTransaction(client, {
+    account,
+    to: contract,
+    data,
+    value,
+    ...rest,
+  } as SendTransactionParameters)
+}

--- a/src/zksync/constants/abis.ts
+++ b/src/zksync/constants/abis.ts
@@ -647,6 +647,252 @@ export const l2SharedBridgeAbi = [
   },
 ] as const
 
+export const ethTokenAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Mint',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l2Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdrawal',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l2Sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: '_additionalData',
+        type: 'bytes',
+      },
+    ],
+    name: 'WithdrawalWithMessage',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFromTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_l1Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: '_additionalData',
+        type: 'bytes',
+      },
+    ],
+    name: 'withdrawWithMessage',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+] as const
+
 export const bridgehubAbi = [
   {
     anonymous: false,

--- a/src/zksync/constants/address.ts
+++ b/src/zksync/constants/address.ts
@@ -4,11 +4,13 @@ export const contractDeployerAddress =
 export const contract2FactoryAddress =
   '0x0000000000000000000000000000000000010000' as const
 
+/** The address of the L1 `ETH` token. */
 export const legacyEthAddress =
   '0x0000000000000000000000000000000000000000' as const
 
 export const ethAddressInContracts =
   '0x0000000000000000000000000000000000000001' as const
 
+/** The address of the base token. */
 export const l2BaseTokenAddress =
   '0x000000000000000000000000000000000000800a' as const

--- a/src/zksync/decorators/walletL2.test.ts
+++ b/src/zksync/decorators/walletL2.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { anvilZksync } from '~test/src/anvil.js'
+import { mockRequestReturnData } from '~test/src/zksync.js'
+import type { EIP1193RequestFn } from '~viem/index.js'
+import { legacyEthAddress } from '~viem/zksync/index.js'
+import { walletActionsL2 } from './walletL2.js'
+
+const baseClient = anvilZksync.getClient({
+  account: true,
+  batch: { multicall: false },
+})
+baseClient.request = (async ({ method, params }) => {
+  if (method === 'eth_sendRawTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_sendTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_call')
+    return '0x00000000000000000000000070a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+  if (method === 'eth_estimateGas') return 158774n
+  if (method === 'eth_getTransactionCount') return 1n
+  if (method === 'eth_getBlockByNumber') return anvilZksync.forkBlockNumber
+  if (method === 'eth_gasPrice') return 200_000_000_000n
+  if (method === 'eth_chainId') return anvilZksync.chain.id
+  return (
+    (await mockRequestReturnData(method)) ??
+    (await anvilZksync.getClient().request({ method, params } as any))
+  )
+}) as EIP1193RequestFn
+const client = baseClient.extend(walletActionsL2())
+
+test('withdraw', async () => {
+  expect(
+    await client.withdraw({
+      amount: 7_000_000_000n,
+      token: legacyEthAddress,
+    }),
+  ).toBeDefined()
+})

--- a/src/zksync/decorators/walletL2.ts
+++ b/src/zksync/decorators/walletL2.ts
@@ -1,0 +1,95 @@
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { Account } from '../../types/account.js'
+import {
+  type WithdrawParameters,
+  type WithdrawReturnType,
+  withdraw,
+} from '../actions/withdraw.js'
+import type { ChainEIP712 } from '../types/chain.js'
+
+export type WalletActionsL2<
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+> = {
+  /**
+   * Initiates the withdrawal process which withdraws ETH or any ERC20 token
+   * from the associated account on L2 network to the target account on L1 network.
+   *
+   * @param args - {@link WithdrawParameters}
+   * @returns hash - The [Transaction](https://viem.sh/docs/glossary/terms#transaction) hash. {@link WithdrawReturnType}
+   *
+   *
+   * @example
+   * import { createPublicClient, http } from 'viem'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   * import { zksync } from 'viem/chains'
+   * import { publicActionsL2, legacyEthAddress } from 'viem/zksync'
+   *
+   * const client = createPublicClient({
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const hash = await client.withdraw({
+   *     account: privateKeyToAccount('0x…'),
+   *     amount: 1_000_000_000_000_000_000n,
+   *     token: legacyEthAddress,
+   * })
+   *
+   * @example Account Hoisting
+   * import { createWalletClient, http } from 'viem'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   * import { zksync } from 'viem/chains'
+   * import { publicActionsL2, legacyEthAddress } from 'viem/zksync'
+   *
+   * const client = createWalletClient({
+   *   account: privateKeyToAccount('0x…'),
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const hash = await client.withdraw({
+   *     amount: 1_000_000_000_000_000_000n,
+   *     token: legacyEthAddress,
+   * })
+   *
+   * @example Paymaster
+   * import { createPublicClient, http } from 'viem'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   * import { zksync } from 'viem/chains'
+   * import { publicActionsL2, legacyEthAddress } from 'viem/zksync'
+   *
+   * const client = createPublicClient({
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const hash = await client.withdraw({
+   *     account: privateKeyToAccount('0x…'),
+   *     amount: 1_000_000_000_000_000_000n,
+   *     token: legacyEthAddress,
+   *     paymaster: '0x0EEc6f45108B4b806e27B81d9002e162BD910670',
+   *     paymasterInput: getApprovalBasedPaymasterInput({
+   *       minAllowance: 1n,
+   *       token: '0x2dc3685cA34163952CF4A5395b0039c00DFa851D',
+   *       innerInput: new Uint8Array(),
+   *     }),
+   * })
+   */
+  withdraw: <chainOverride extends ChainEIP712 | undefined = undefined>(
+    args: WithdrawParameters<chain, account, chainOverride>,
+  ) => Promise<WithdrawReturnType>
+}
+
+export function walletActionsL2() {
+  return <
+    transport extends Transport,
+    chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+    account extends Account | undefined = Account | undefined,
+  >(
+    client: Client<transport, chain, account>,
+  ): WalletActionsL2<chain, account> => ({
+    withdraw: (args) => withdraw(client, args),
+  })
+}

--- a/src/zksync/index.ts
+++ b/src/zksync/index.ts
@@ -135,6 +135,17 @@ export {
   type GetL1TokenAddressParameters,
   getL1TokenAddress,
 } from './actions/getL1TokenAddress.js'
+export {
+  type WithdrawErrorType,
+  type WithdrawParameters,
+  type WithdrawReturnType,
+  withdraw,
+} from './actions/withdraw.js'
+
+export {
+  legacyEthAddress,
+  l2BaseTokenAddress,
+} from './constants/address.js'
 
 export {
   /** @deprecated Use `zksync` instead */
@@ -175,6 +186,11 @@ export {
   walletActionsL1,
   type WalletActionsL1,
 } from './decorators/walletL1.js'
+
+export {
+  walletActionsL2,
+  type WalletActionsL2,
+} from './decorators/walletL2.js'
 
 export { serializeTransaction } from './serializers.js'
 


### PR DESCRIPTION
Introduce the `withdraw` action, enabling  withdrawing assets from L2 to L1.
