### PR TITLE
Minor typo fix in CHANGELOG.md

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1641,7 +1641,7 @@
 
 - [#2153](https://github.com/wevm/viem/pull/2153) [`71a17c0a2abcd81963e23cb76a3e8a792abbd7b6`](https://github.com/wevm/viem/commit/71a17c0a2abcd81963e23cb76a3e8a792abbd7b6) Thanks [@billalxcode](https://github.com/billalxcode)! - Added DreyerX Mainnet chain.
 
-- [#2155](https://github.com/wevm/viem/pull/2155) [`803fa0de429942b800172f87c93c41fa69f9c030`](https://github.com/wevm/viem/commit/803fa0de429942b800172f87c93c41fa69f9c030) Thanks [@jxom](https://github.com/jxom)! - Added experimental 3074 utilties:
+- [#2155](https://github.com/wevm/viem/pull/2155) [`803fa0de429942b800172f87c93c41fa69f9c030`](https://github.com/wevm/viem/commit/803fa0de429942b800172f87c93c41fa69f9c030) Thanks [@jxom](https://github.com/jxom)! - Added experimental 3074 utilities:
 
   - `signAuthMessage`
   - `recoverAuthMessageAddress`


### PR DESCRIPTION
# Pull Request Title
Fix Minor Typo in `CHANGELOG.md`

## Description
This pull request addresses a typo in the `CHANGELOG.md` file to improve accuracy and clarity.

### Original Text
> Added experimental 3074 **utilties**:

### Corrected Text
> Added experimental 3074 **utilities**:

## Changes Made
- Fixed the typo: `utilties` → `utilities`.


