### PR TITLE
Makes types tsconfig use nodenext like everything else.

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,7 @@
     "src/node/trustedSetups_esm.ts"
   ],
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "sourceMap": true,
     "rootDir": "./src"
   }


### PR DESCRIPTION
Currently, the `_types` is built using `node` module resolution, which results in this project generating invalid types.  Details about the TypeScript bug can be found at https://github.com/microsoft/TypeScript/issues/60930#issue-2773343774 and there are no plans to fix it since `node` (which is equivalent to `node10`) is being deprecated in TypeScript soon.

The rest of this project uses `nodenext`, so this changes the types `tsconfig` file to also use `nodenext`, and fix the bug that currently prevents the library from being used correctly in native ESM projects.