### PR TITLE
feat: add PremiumBlock Testnet

### DIFF
--- a/.changeset/unlucky-pears-cry.md
+++ b/.changeset/unlucky-pears-cry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added PremiumBlock Testnet.

--- a/src/chains/definitions/premiumBlock.ts
+++ b/src/chains/definitions/premiumBlock.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const premiumBlockTestnet = /*#__PURE__*/ defineChain({
+  id: 23_023,
+  name: 'PremiumBlock Testnet',
+  nativeCurrency: { name: 'Premium Block', symbol: 'PBLK', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.premiumblock.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'PremiumBlocks Explorer',
+      url: 'https://scan.premiumblock.org',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -351,6 +351,7 @@ export { polygonZkEvm } from './definitions/polygonZkEvm.js'
 export { polygonZkEvmCardona } from './definitions/polygonZkEvmCardona.js'
 /** @deprecated Use `polygonZkEvmCardona` instead. */
 export { polygonZkEvmTestnet } from './definitions/polygonZkEvmTestnet.js'
+export { premiumBlockTestnet } from './definitions/PremiumBlock.js'
 export { pulsechain } from './definitions/pulsechain.js'
 export { pulsechainV4 } from './definitions/pulsechainV4.js'
 export { ql1 } from './definitions/ql1.js'


### PR DESCRIPTION
Add PremiumBlock Chain

This PR adds support for PremiumBlock Chain with the following specifications:

Chain Name: PremiumBlock (PBLK)
Chain ID: 23023
RPC Endpoint: https://rpc.premiumblock.org/
Block Explorer: https://scan.premiumblock.org/ (EIP3091 compliant)
Native Currency: PBLK (18 decimals)
Features: EIP1559 support
The chain information has been formatted according to the repository standards and includes all required fields.