### PR TITLE
Remove unnecessary double quote in creditcoin3 testnet rpcUrls

### DIFF
--- a/.changeset/quiet-carpets-raise.md
+++ b/.changeset/quiet-carpets-raise.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Remove unnecessary double quote in creditcoin3 testnet rpcUrls

--- a/.changeset/quiet-carpets-raise.md
+++ b/.changeset/quiet-carpets-raise.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Remove unnecessary double quote in creditcoin3 testnet rpcUrls
+Updated creditcoin3 testnet rpcUrls

--- a/src/chains/definitions/creditCoin3Testnet.ts
+++ b/src/chains/definitions/creditCoin3Testnet.ts
@@ -7,7 +7,7 @@ export const creditCoin3Testnet = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://rpc.cc3-testnet.creditcoin.network'],
-      webSocket: ['wss://rpc.cc3-testnet.creditcoin.network"'],
+      webSocket: ['wss://rpc.cc3-testnet.creditcoin.network'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Sorry there was a typo in this [PR](https://github.com/wevm/viem/pull/3254).