### PR TITLE
ZKsync: add `finalizeWithdrawal` action

### DIFF
--- a/.changeset/perfect-shoes-flow.md
+++ b/.changeset/perfect-shoes-flow.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `finalizeWithdrawal` action in the ZKsync extension

--- a/site/pages/zksync/actions/finalizeWithdrawal.md
+++ b/site/pages/zksync/actions/finalizeWithdrawal.md
@@ -1,0 +1,169 @@
+---
+description: Proves the inclusion of the `L2->L1` withdrawal message.
+---
+
+# finalizeWithdrawal
+
+Proves the inclusion of the `L2->L1` withdrawal message.
+
+## Usage
+
+:::code-group
+
+```ts [example.ts]
+import { account, walletClient, zksyncClient } from './config'
+
+const hash = await walletClient.finalizeWithdrawal({
+  account,
+  client: zksyncClient,
+  hash: '0x…',
+})
+```
+
+```ts [config.ts]
+import { createWalletClient, createPublicClient, custom } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { zksync, mainnet } from 'viem/chains'
+import { publicActionsL2, walletActionsL1 } from 'viem/zksync'
+
+export const zksyncClient = createPublicClient({
+  chain: zksync,
+  transport: custom(window.ethereum)
+}).extend(publicActionsL2())
+
+export const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum)
+}).extend(walletActionsL1())
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account
+export const account = privateKeyToAccount(...)
+```
+
+:::
+
+### Account Hoisting
+
+If you do not wish to pass an `account` to every `finalizeWithdrawal`, you can also hoist the Account on the Wallet Client (see `config.ts`).
+
+[Learn more](/docs/clients/wallet#account).
+
+:::code-group
+
+```ts [example.ts]
+import { walletClient, zksyncClient } from './config'
+ 
+const hash = await walletClient.finalizeWithdrawal({
+  client: zksyncClient,
+  hash: '0x…',
+})
+```
+
+```ts [config.ts (JSON-RPC Account)]
+import { createWalletClient, custom } from 'viem'
+import { zksync } from 'viem/chains'
+import { publicActionsL2, walletActionsL1 } from 'viem/zksync'
+
+export const zksyncClient = createPublicClient({
+  chain: zksync,
+  transport: custom(window.ethereum)
+}).extend(publicActionsL2())
+
+// Retrieve Account from an EIP-1193  Provider. // [!code focus]
+const [account] = await window.ethereum.request({  // [!code focus]
+  method: 'eth_requestAccounts' // [!code focus]
+}) // [!code focus]
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum) // [!code focus]
+}).extend(walletActionsL1())
+```
+
+```ts [config.ts (Local Account)]
+import { createWalletClient, custom } from 'viem'
+import { zksync } from 'viem/chains'
+import { privateKeyToAccount } from 'viem/accounts'
+import { publicActionsL2, walletActionsL1 } from 'viem/zksync'
+
+export const zksyncClient = createPublicClient({
+  chain: zksync,
+  transport: custom(window.ethereum)
+}).extend(publicActionsL2())
+
+export const walletClient = createWalletClient({
+  account: privateKeyToAccount('0x...'), // [!code focus]
+  transport: custom(window.ethereum)
+}).extend(walletActionsL1())
+```
+
+:::
+
+## Returns
+
+[`Hash`](/docs/glossary/types#hash)
+
+The [Transaction](/docs/glossary/terms#transaction) hash.
+
+## Parameters
+
+### client
+
+- **Type:** `Client`
+
+The L2 client for fetching data from L2 chain.
+
+```ts
+const hash = await walletClient.finalizeWithdrawal({
+  client: zksyncClient, // [!code focus]
+  hash: '0x…',
+})
+```
+
+### hash 
+
+- **Type:** `Hex`
+
+Hash of the L2 transaction where the withdrawal was initiated.
+
+```ts
+const hash = await walletClient.finalizeWithdrawal({
+  client: zksyncClient,
+  hash: '0x…',  // [!code focus]
+})
+```
+
+### index (optional)
+
+- **Type:** `number`
+- **Default:** `0`
+
+In case there were multiple withdrawals in one transaction, you may pass an index of the
+withdrawal you want to finalize.
+
+```ts
+const hash = await walletClient.finalizeWithdrawal({
+  client: zksyncClient,
+  hash: '0x…',
+  index: 0n, // [!code focus]
+})
+```
+
+### chain (optional)
+
+- **Type:** [`Chain`](/docs/glossary/types#chain)
+- **Default:** `walletClient.chain`
+
+The target chain. If there is a mismatch between the wallet's current chain & the target chain, an error will be thrown.
+
+```ts
+import { zksync } from 'viem/chains' // [!code focus]
+
+const hash = await walletClient.finalizeWithdrawal({
+  chain: zksync, // [!code focus]
+  client: zksyncClient,
+  hash: '0x…',
+})
+```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1804,6 +1804,10 @@ export const sidebar = {
             text: 'requestExecute',
             link: '/zksync/actions/requestExecute',
           },
+          {
+            text: 'finalizeWithdrawal',
+            link: '/zksync/actions/finalizeWithdrawal',
+          },
         ],
       },
       {

--- a/src/zksync/actions/finalizeWithdrawal.test.ts
+++ b/src/zksync/actions/finalizeWithdrawal.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest'
+
+import { anvilMainnet, anvilZksync } from '~test/src/anvil.js'
+import { accounts } from '~test/src/constants.js'
+import { mockRequestReturnData } from '~test/src/zksync.js'
+import { privateKeyToAccount } from '~viem/accounts/privateKeyToAccount.js'
+import { type EIP1193RequestFn, publicActions } from '~viem/index.js'
+import { publicActionsL2 } from '~viem/zksync/decorators/publicL2.js'
+import { finalizeWithdrawal } from './finalizeWithdrawal.js'
+
+const request = (async ({ method, params }) => {
+  if (method === 'eth_sendTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_sendRawTransaction')
+    return '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  if (method === 'eth_estimateGas') return 158774n
+  if (method === 'eth_call')
+    return '0x00000000000000000000000070a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+  if (method === 'eth_getTransactionCount') return 1n
+  if (method === 'eth_gasPrice') return 150_000_000n
+  if (method === 'eth_getBlockByNumber') return anvilMainnet.forkBlockNumber
+  if (method === 'eth_chainId') return anvilMainnet.chain.id
+  return anvilMainnet.getClient().request({ method, params } as any)
+}) as EIP1193RequestFn
+
+const baseClient = anvilMainnet.getClient({ batch: { multicall: false } })
+baseClient.request = request
+const client = baseClient.extend(publicActions)
+
+const baseClientWithAccount = anvilMainnet.getClient({
+  batch: { multicall: false },
+  account: true,
+})
+baseClientWithAccount.request = request
+const clientWithAccount = baseClientWithAccount.extend(publicActions)
+
+const baseClientL2 = anvilZksync.getClient()
+baseClientL2.request = (async ({ method, params }) => {
+  if (method === 'eth_call')
+    return '0x00000000000000000000000070a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
+  if (method === 'eth_estimateGas') return 158774n
+  return (
+    (await mockRequestReturnData(method)) ??
+    (await anvilZksync.getClient().request({ method, params } as any))
+  )
+}) as EIP1193RequestFn
+const clientL2 = baseClientL2.extend(publicActionsL2())
+
+test.skip('default', async () => {
+  expect(
+    await finalizeWithdrawal(client, {
+      account: privateKeyToAccount(accounts[0].privateKey),
+      client: clientL2,
+      hash: '0x08ac22b6d5d048ae8a486aa41a058bb01d82bdca6489760414aa15f61f27b943',
+    }),
+  ).toBeDefined()
+})
+
+test('default: account hoisting', async () => {
+  expect(
+    await finalizeWithdrawal(clientWithAccount, {
+      client: clientL2,
+      hash: '0x08ac22b6d5d048ae8a486aa41a058bb01d82bdca6489760414aa15f61f27b943',
+    }),
+  ).toBeDefined()
+})

--- a/src/zksync/actions/finalizeWithdrawal.ts
+++ b/src/zksync/actions/finalizeWithdrawal.ts
@@ -1,0 +1,248 @@
+import type { Address } from 'abitype'
+import type { Hex } from 'viem'
+import type { Account } from '../../accounts/types.js'
+import { readContract } from '../../actions/public/readContract.js'
+import {
+  type SendTransactionErrorType,
+  type SendTransactionParameters,
+  type SendTransactionRequest,
+  type SendTransactionReturnType,
+  sendTransaction,
+} from '../../actions/wallet/sendTransaction.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import { AccountNotFoundError } from '../../errors/account.js'
+import {
+  ChainNotFoundError,
+  type ChainNotFoundErrorType,
+} from '../../errors/chain.js'
+import type { Chain } from '../../types/chain.js'
+import {
+  decodeAbiParameters,
+  encodeFunctionData,
+  isAddressEqual,
+  parseAccount,
+  slice,
+} from '../../utils/index.js'
+import { l1SharedBridgeAbi, l2SharedBridgeAbi } from '../constants/abis.js'
+import { l2BaseTokenAddress } from '../constants/address.js'
+import {
+  WithdrawalLogNotFoundError,
+  type WithdrawalLogNotFoundErrorType,
+} from '../errors/bridge.js'
+import type { ChainEIP712 } from '../types/chain.js'
+import { getWithdrawalL2ToL1Log } from '../utils/bridge/getWithdrawalL2ToL1Log.js'
+import { getWithdrawalLog } from '../utils/bridge/getWithdrawalLog.js'
+import { getDefaultBridgeAddresses } from './getDefaultBridgeAddresses.js'
+import { getLogProof } from './getLogProof.js'
+
+export type FinalizeWithdrawalParameters<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends Chain | undefined = Chain | undefined,
+  chainL2 extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  accountL2 extends Account | undefined = Account | undefined,
+  request extends SendTransactionRequest<
+    chain,
+    chainOverride
+  > = SendTransactionRequest<chain, chainOverride>,
+> = Omit<
+  SendTransactionParameters<chain, account, chainOverride, request>,
+  'value' | 'data' | 'to'
+> & {
+  /** L2 client */
+  client: Client<Transport, chainL2, accountL2>
+  /** Hash of the L2 transaction where the withdrawal was initiated. */
+  hash: Hex
+  /** In case there were multiple withdrawals in one transaction, you may pass an index of the
+   withdrawal you want to finalize. */
+  index?: number | undefined
+}
+
+export type FinalizeWithdrawalReturnType = SendTransactionReturnType
+
+export type FinalizeWithdrawalErrorType =
+  | SendTransactionErrorType
+  | WithdrawalLogNotFoundErrorType
+  | ChainNotFoundErrorType
+
+/**
+ * Proves the inclusion of the `L2->L1` withdrawal message.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link FinalizeWithdrawalParameters}
+ * @returns hash - The [Transaction](https://viem.sh/docs/glossary/terms#transaction) hash. {@link FinalizeWithdrawalReturnType}
+ *
+ * @example
+ * import { createPublicClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { mainnet, zksync } from 'viem/chains'
+ * import { finalizeWithdrawal, publicActionsL2 } from 'viem/zksync'
+ *
+ * const client = createPublicClient({
+ *   chain: mainnet,
+ *   transport: http(),
+ * })
+ *
+ * const clientL2 = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * }).extend(publicActionsL2())
+ *
+ * const hash = await finalizeWithdrawal(client, {
+ *     account: privateKeyToAccount('0x…'),
+ *     client: clientL2,
+ *     hash: '0x...',
+ * })
+ *
+ * @example Account Hoisting
+ * import { createPublicClient, createWalletClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { mainnet, zksync } from 'viem/chains'
+ * import { finalizeWithdrawal, publicActionsL2 } from 'viem/zksync'
+ *
+ * const client = createWalletClient({
+ *   account: privateKeyToAccount('0x…'),
+ *   chain: mainnet,
+ *   transport: http(),
+ * })
+ *
+ * const clientL2 = createPublicClient({
+ *   chain: zksync,
+ *   transport: http(),
+ * }).extend(publicActionsL2())
+ *
+ * const hash = await finalizeWithdrawal(client, {
+ *     client: clientL2,
+ *     hash: '0x…',
+ * })
+ */
+export async function finalizeWithdrawal<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+  accountL2 extends Account | undefined,
+  const request extends SendTransactionRequest<chain, chainOverride>,
+  chainOverride extends Chain | undefined,
+  chainL2 extends ChainEIP712 | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: FinalizeWithdrawalParameters<
+    chain,
+    account,
+    chainOverride,
+    chainL2,
+    accountL2,
+    request
+  >,
+): Promise<FinalizeWithdrawalReturnType> {
+  const {
+    account: account_ = client.account,
+    client: l2Client,
+    hash,
+    index = 0,
+    ...rest
+  } = parameters
+  const account = account_ ? parseAccount(account_) : client.account
+  if (!account)
+    throw new AccountNotFoundError({
+      docsPath: '/docs/actions/wallet/sendTransaction',
+    })
+  if (!l2Client.chain) throw new ChainNotFoundError()
+
+  const {
+    l1BatchNumber,
+    l2MessageIndex,
+    l2TxNumberInBlock,
+    message,
+    sender,
+    proof,
+  } = await getFinalizeWithdrawalParams(l2Client, { hash, index })
+
+  let l1Bridge: Address
+
+  if (isAddressEqual(sender, l2BaseTokenAddress))
+    l1Bridge = (await getDefaultBridgeAddresses(l2Client)).sharedL1
+  else if (!(await isLegacyBridge(l2Client, { address: sender })))
+    l1Bridge = await readContract(l2Client, {
+      address: sender,
+      abi: l2SharedBridgeAbi,
+      functionName: 'l1SharedBridge',
+      args: [],
+    })
+  else
+    l1Bridge = await readContract(l2Client, {
+      address: sender,
+      abi: l2SharedBridgeAbi,
+      functionName: 'l1Bridge',
+      args: [],
+    })
+
+  const data = encodeFunctionData({
+    abi: l1SharedBridgeAbi,
+    functionName: 'finalizeWithdrawal',
+    args: [
+      BigInt(l2Client.chain.id),
+      l1BatchNumber!,
+      BigInt(l2MessageIndex),
+      Number(l2TxNumberInBlock),
+      message,
+      proof,
+    ],
+  })
+
+  return await sendTransaction(client, {
+    account,
+    to: l1Bridge,
+    data,
+    value: 0n,
+    ...rest,
+  } as SendTransactionParameters)
+}
+
+async function getFinalizeWithdrawalParams<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: { hash: Hex; index: number },
+) {
+  const { hash } = parameters
+  const { log, l1BatchTxId } = await getWithdrawalLog(client, parameters)
+  const { l2ToL1LogIndex } = await getWithdrawalL2ToL1Log(client, parameters)
+  const sender = slice(log.topics[1]!, 12) as Address
+  const proof = await getLogProof(client, {
+    txHash: hash,
+    index: l2ToL1LogIndex!,
+  })
+  if (!proof) {
+    throw new WithdrawalLogNotFoundError({ hash })
+  }
+
+  const [message] = decodeAbiParameters([{ type: 'bytes' }], log.data)
+
+  return {
+    l1BatchNumber: log.l1BatchNumber,
+    l2MessageIndex: proof.id,
+    l2TxNumberInBlock: l1BatchTxId,
+    message,
+    sender,
+    proof: proof.proof,
+  }
+}
+
+async function isLegacyBridge<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(client: Client<Transport, chain, account>, parameters: { address: Address }) {
+  try {
+    await readContract(client, {
+      address: parameters.address,
+      abi: l2SharedBridgeAbi,
+      functionName: 'l1SharedBridge',
+      args: [],
+    })
+    return false
+  } catch (_e) {
+    return true
+  }
+}

--- a/src/zksync/constants/abis.ts
+++ b/src/zksync/constants/abis.ts
@@ -647,6 +647,730 @@ export const l2SharedBridgeAbi = [
   },
 ] as const
 
+export const l1SharedBridgeAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'BridgehubDepositBaseTokenInitiated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'txDataHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'l2DepositTxHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'BridgehubDepositFinalized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'txDataHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'BridgehubDepositInitiated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'ClaimedFailedDepositSharedBridge',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'l2DepositTxHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'LegacyDepositInitiated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'WithdrawalFinalizedSharedBridge',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'BRIDGE_HUB',
+    outputs: [
+      {
+        internalType: 'contract IBridgehub',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'L1_WETH_TOKEN',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_txDataHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_txHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'bridgehubConfirmL2Transaction',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_prevMsgSender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2Value',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: '_data',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgehubDeposit',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'magicValue',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'address',
+            name: 'l2Contract',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes',
+            name: 'l2Calldata',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes[]',
+            name: 'factoryDeps',
+            type: 'bytes[]',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'txDataHash',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct L2TransactionRequestTwoBridgesInner',
+        name: 'request',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_prevMsgSender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'bridgehubDepositBaseToken',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_depositSender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_l2TxHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2BatchNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2MessageIndex',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint16',
+        name: '_l2TxNumberInBatch',
+        type: 'uint16',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: '_merkleProof',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'claimFailedDeposit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_depositSender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_l2TxHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2BatchNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2MessageIndex',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint16',
+        name: '_l2TxNumberInBatch',
+        type: 'uint16',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: '_merkleProof',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'claimFailedDepositLegacyErc20Bridge',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_l2TxHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'depositHappened',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_msgSender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l2Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2TxGasLimit',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2TxGasPerPubdataByte',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_refundRecipient',
+        type: 'address',
+      },
+    ],
+    name: 'depositLegacyErc20Bridge',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: 'txHash',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2BatchNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2MessageIndex',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint16',
+        name: '_l2TxNumberInBatch',
+        type: 'uint16',
+      },
+      {
+        internalType: 'bytes',
+        name: '_message',
+        type: 'bytes',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: '_merkleProof',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'finalizeWithdrawal',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_l2BatchNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2MessageIndex',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint16',
+        name: '_l2TxNumberInBatch',
+        type: 'uint16',
+      },
+      {
+        internalType: 'bytes',
+        name: '_message',
+        type: 'bytes',
+      },
+      {
+        internalType: 'bytes32[]',
+        name: '_merkleProof',
+        type: 'bytes32[]',
+      },
+    ],
+    name: 'finalizeWithdrawalLegacyErc20Bridge',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'l1Receiver',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'l1Token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2BatchNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l2MessageIndex',
+        type: 'uint256',
+      },
+    ],
+    name: 'isWithdrawalFinalized',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+    ],
+    name: 'l2BridgeAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'legacyBridge',
+    outputs: [
+      {
+        internalType: 'contract IL1ERC20Bridge',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+    ],
+    name: 'receiveEth',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_eraLegacyBridgeLastDepositBatch',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_eraLegacyBridgeLastDepositTxNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'setEraLegacyBridgeLastDepositTime',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_eraPostDiamondUpgradeFirstBatch',
+        type: 'uint256',
+      },
+    ],
+    name: 'setEraPostDiamondUpgradeFirstBatch',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_eraPostLegacyBridgeUpgradeFirstBatch',
+        type: 'uint256',
+      },
+    ],
+    name: 'setEraPostLegacyBridgeUpgradeFirstBatch',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
 export const ethTokenAbi = [
   {
     anonymous: false,

--- a/src/zksync/constants/address.ts
+++ b/src/zksync/constants/address.ts
@@ -14,3 +14,6 @@ export const ethAddressInContracts =
 /** The address of the base token. */
 export const l2BaseTokenAddress =
   '0x000000000000000000000000000000000000800a' as const
+
+export const l1MessengerAddress =
+  '0x0000000000000000000000000000000000008008' as const

--- a/src/zksync/decorators/walletL1.test.ts
+++ b/src/zksync/decorators/walletL1.test.ts
@@ -15,6 +15,7 @@ baseClient.request = (async ({ method, params }) => {
   if (method === 'eth_call')
     return '0x00000000000000000000000070a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55'
   if (method === 'eth_getTransactionCount') return 1n
+  if (method === 'eth_gasPrice') return 150_000_000n
   if (method === 'eth_getBlockByNumber') return anvilMainnet.forkBlockNumber
   if (method === 'eth_chainId') return anvilMainnet.chain.id
   return anvilMainnet.getClient().request({ method, params } as any)
@@ -43,6 +44,15 @@ test('requestExecute', async () => {
       l2GasLimit: 900_000n,
       gasPrice: 200_000_000_000n,
       gas: 500_000n,
+    }),
+  ).toBeDefined()
+})
+
+test('finalizeWithdrawal', async () => {
+  expect(
+    await client.finalizeWithdrawal({
+      client: zksyncClient,
+      hash: '0x08ac22b6d5d048ae8a486aa41a058bb01d82bdca6489760414aa15f61f27b943',
     }),
   ).toBeDefined()
 })

--- a/src/zksync/decorators/walletL1.ts
+++ b/src/zksync/decorators/walletL1.ts
@@ -3,6 +3,11 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { Account } from '../../types/account.js'
 import type { Chain } from '../../types/chain.js'
 import {
+  type FinalizeWithdrawalParameters,
+  type FinalizeWithdrawalReturnType,
+  finalizeWithdrawal,
+} from '../actions/finalizeWithdrawal.js'
+import {
   type RequestExecuteParameters,
   type RequestExecuteReturnType,
   requestExecute,
@@ -13,6 +18,48 @@ export type WalletActionsL1<
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
 > = {
+  /**
+   * Initiates the withdrawal process which withdraws ETH or any ERC20 token
+   * from the associated account on L2 network to the target account on L1 network.
+   *
+   * @param parameters - {@link FinalizeWithdrawalParameters}
+   * @returns hash - The [Transaction](https://viem.sh/docs/glossary/terms#transaction) hash. {@link FinalizeWithdrawalReturnType}
+   *
+   * @example
+   * import { createPublicClient, createWalletClient, http } from 'viem'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   * import { mainnet, zksync } from 'viem/chains'
+   * import { walletActionsL1, publicActionsL2 } from 'viem/zksync'
+   *
+   * const walletClient = createWalletClient({
+   *   account: privateKeyToAccount('0x…'),
+   *   chain: mainnet,
+   *   transport: http(),
+   * }).extend(walletActionsL1())
+   *
+   * const clientL2 = createPublicClient({
+   *   chain: zksync,
+   *   transport: http(),
+   * }).extend(publicActionsL2())
+   *
+   * const hash = await walletClient.finalizeWithdrawal({
+   *     client: clientL2,
+   *     hash: '0x…',
+   * })
+   */
+  finalizeWithdrawal: <
+    chainOverride extends Chain | undefined = undefined,
+    chainL2 extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+    accountL2 extends Account | undefined = Account | undefined,
+  >(
+    parameters: FinalizeWithdrawalParameters<
+      chain,
+      account,
+      chainOverride,
+      chainL2,
+      accountL2
+    >,
+  ) => Promise<FinalizeWithdrawalReturnType>
   /**
    * Requests execution of a L2 transaction from L1.
    *
@@ -66,6 +113,7 @@ export function walletActionsL1() {
   >(
     client: Client<transport, chain, account>,
   ): WalletActionsL1<chain, account> => ({
+    finalizeWithdrawal: (args) => finalizeWithdrawal(client, args),
     requestExecute: (args) => requestExecute(client, args),
   })
 }

--- a/src/zksync/errors/bridge.test.ts
+++ b/src/zksync/errors/bridge.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
   BaseFeeHigherThanValueError,
   TxHashNotFoundInLogsError,
+  WithdrawalLogNotFoundError,
 } from '~viem/zksync/errors/bridge.js'
 
 test('BaseFeeHigherThanValueError', () => {
@@ -19,6 +20,18 @@ test('TxHashNotFoundInLogsError', () => {
   expect(new TxHashNotFoundInLogsError()).toMatchInlineSnapshot(`
     [TxHashNotFoundInLogsError: The transaction hash not found in event logs.
 
+    Version: viem@x.y.z]
+  `)
+})
+
+test('WithdrawalLogNotFoundError', () => {
+  const hash =
+    '0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87'
+  expect(new WithdrawalLogNotFoundError({ hash })).toMatchInlineSnapshot(`
+    [WithdrawalLogNotFoundError: Withdrawal log with hash ${hash} not found.
+
+    Either the withdrawal transaction is still processing or it did not finish successfully.
+    
     Version: viem@x.y.z]
   `)
 })

--- a/src/zksync/errors/bridge.ts
+++ b/src/zksync/errors/bridge.ts
@@ -1,4 +1,5 @@
 import { BaseError } from '../../errors/base.js'
+import type { Hash } from '../../types/misc.js'
 
 export type BaseFeeHigherThanValueErrorType = BaseFeeHigherThanValueError & {
   name: 'BaseFeeHigherThanValueError'
@@ -25,5 +26,21 @@ export class TxHashNotFoundInLogsError extends BaseError {
     super('The transaction hash not found in event logs.', {
       name: 'TxHashNotFoundInLogsError',
     })
+  }
+}
+
+export type WithdrawalLogNotFoundErrorType = WithdrawalLogNotFoundError & {
+  name: 'WithdrawalLogNotFoundError'
+}
+export class WithdrawalLogNotFoundError extends BaseError {
+  constructor({ hash }: { hash: Hash }) {
+    super(
+      [
+        `Withdrawal log with hash ${hash} not found.`,
+        '',
+        'Either the withdrawal transaction is still processing or it did not finish successfully.',
+      ].join('\n'),
+      { name: 'WithdrawalLogNotFoundError' },
+    )
   }
 }

--- a/src/zksync/index.ts
+++ b/src/zksync/index.ts
@@ -141,6 +141,12 @@ export {
   type WithdrawReturnType,
   withdraw,
 } from './actions/withdraw.js'
+export {
+  type FinalizeWithdrawalErrorType,
+  type FinalizeWithdrawalParameters,
+  type FinalizeWithdrawalReturnType,
+  finalizeWithdrawal,
+} from './actions/finalizeWithdrawal.js'
 
 export {
   legacyEthAddress,

--- a/src/zksync/utils/bridge/getWithdrawalL2ToL1Log.test.ts
+++ b/src/zksync/utils/bridge/getWithdrawalL2ToL1Log.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { anvilZksync } from '~test/src/anvil.js'
+import { mockRequestReturnData } from '~test/src/zksync.js'
+import type { EIP1193RequestFn } from '~viem/types/eip1193.js'
+import { getWithdrawalL2ToL1Log } from './getWithdrawalL2ToL1Log.js'
+
+const client = anvilZksync.getClient({ batch: { multicall: false } })
+client.request = (async ({ method, params }) => {
+  return (
+    (await mockRequestReturnData(method)) ??
+    (await anvilZksync.getClient().request({ method, params } as any))
+  )
+}) as EIP1193RequestFn
+
+test('default', async () => {
+  expect(
+    await getWithdrawalL2ToL1Log(client, {
+      hash: '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+    }),
+  ).toBeDefined()
+})

--- a/src/zksync/utils/bridge/getWithdrawalL2ToL1Log.ts
+++ b/src/zksync/utils/bridge/getWithdrawalL2ToL1Log.ts
@@ -1,0 +1,47 @@
+import type { Address } from 'abitype'
+import type { Account } from '../../../accounts/index.js'
+import { getTransactionReceipt } from '../../../actions/index.js'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { Chain } from '../../../types/chain.js'
+import type { Hash } from '../../../types/misc.js'
+import { isAddressEqual } from '../../../utils/index.js'
+import { l1MessengerAddress } from '../../constants/address.js'
+import type { ZksyncL2ToL1Log } from '../../types/log.js'
+import type { ZksyncTransactionReceipt } from '../../types/transaction.js'
+
+export type GetWithdrawalL2ToL1LogParameters = {
+  /** Hash of the L2 transaction where the withdrawal was initiated. */
+  hash: Hash
+  /** In case there were multiple withdrawals in one transaction, you may pass an index of the
+   withdrawal you want to finalize. */
+  index?: number | undefined
+}
+
+export type GetWithdrawalL2ToL1LogReturnType = {
+  l2ToL1LogIndex: number | null
+  l2ToL1Log: ZksyncL2ToL1Log
+}
+
+/** @internal */
+export async function getWithdrawalL2ToL1Log<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: GetWithdrawalL2ToL1LogParameters,
+): Promise<GetWithdrawalL2ToL1LogReturnType> {
+  const { hash, index = 0 } = parameters
+  const receipt = (await getTransactionReceipt(client, {
+    hash,
+  })) as ZksyncTransactionReceipt
+  const messages = Array.from(receipt.l2ToL1Logs.entries()).filter(([, log]) =>
+    isAddressEqual(log.sender as Address, l1MessengerAddress),
+  )
+  const [l2ToL1LogIndex, l2ToL1Log] = messages[index]
+
+  return {
+    l2ToL1LogIndex,
+    l2ToL1Log,
+  }
+}

--- a/src/zksync/utils/bridge/getWithdrawalLog.test.ts
+++ b/src/zksync/utils/bridge/getWithdrawalLog.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { anvilZksync } from '~test/src/anvil.js'
+import { mockRequestReturnData } from '~test/src/zksync.js'
+import type { EIP1193RequestFn } from '~viem/types/eip1193.js'
+import { getWithdrawalLog } from './getWithdrawalLog.js'
+
+const client = anvilZksync.getClient({ batch: { multicall: false } })
+client.request = (async ({ method, params }) => {
+  return (
+    (await mockRequestReturnData(method)) ??
+    (await anvilZksync.getClient().request({ method, params } as any))
+  )
+}) as EIP1193RequestFn
+
+test('default', async () => {
+  expect(
+    await getWithdrawalLog(client, {
+      hash: '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+    }),
+  ).toBeDefined()
+})

--- a/src/zksync/utils/bridge/getWithdrawalLog.ts
+++ b/src/zksync/utils/bridge/getWithdrawalLog.ts
@@ -1,0 +1,47 @@
+import type { Account } from '../../../accounts/types.js'
+import { getTransactionReceipt } from '../../../actions/index.js'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { Chain } from '../../../types/chain.js'
+import type { Hash } from '../../../types/misc.js'
+import { isAddressEqual, toFunctionHash } from '../../../utils/index.js'
+import { l1MessengerAddress } from '../../constants/address.js'
+import type { ZksyncLog } from '../../types/log.js'
+import type { ZksyncTransactionReceipt } from '../../types/transaction.js'
+
+export type GetWithdrawalLogParameters = {
+  /** Hash of the L2 transaction where the withdrawal was initiated. */
+  hash: Hash
+  /** In case there were multiple withdrawals in one transaction, you may pass an index of the
+     withdrawal you want to finalize. */
+  index?: number | undefined
+}
+
+export type GetWithdrawalLogReturnType = {
+  log: ZksyncLog
+  l1BatchTxId: bigint | null
+}
+
+/** @internal */
+export async function getWithdrawalLog<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: GetWithdrawalLogParameters,
+): Promise<GetWithdrawalLogReturnType> {
+  const { hash, index = 0 } = parameters
+  const receipt = (await getTransactionReceipt(client, {
+    hash,
+  })) as ZksyncTransactionReceipt
+  const log = receipt.logs.filter(
+    (log) =>
+      isAddressEqual(log.address, l1MessengerAddress) &&
+      log.topics[0] === toFunctionHash('L1MessageSent(address,bytes32,bytes)'),
+  )[index]
+
+  return {
+    log,
+    l1BatchTxId: receipt.l1BatchTxIndex,
+  }
+}

--- a/test/src/zksync.ts
+++ b/test/src/zksync.ts
@@ -1,6 +1,7 @@
 import { zksyncLocalNode } from '~viem/chains/index.js'
 import { createClient } from '~viem/clients/createClient.js'
 import { http } from '~viem/index.js'
+import type { ZksyncTransactionReceipt } from '~viem/zksync/index.js'
 import { accounts as acc } from './constants.js'
 
 export const zksyncClientLocalNode = createClient({
@@ -184,6 +185,186 @@ export const mockTransactionDetails = {
 
 export const mockedGasEstimation = 123456789n
 
+const mockedReceipt: ZksyncTransactionReceipt = {
+  transactionHash:
+    '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+  transactionIndex: 0,
+  blockHash:
+    '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+  blockNumber: 45n,
+  l1BatchTxIndex: 0n,
+  l1BatchNumber: 22n,
+  from: '0x36615cf349d7f6344891b1e7ca7c72883f5dc049',
+  to: '0x000000000000000000000000000000000000800a',
+  cumulativeGasUsed: 0n,
+  gasUsed: 221700n,
+  contractAddress: null,
+  logs: [
+    {
+      address: '0x000000000000000000000000000000000000800a',
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+        '0x0000000000000000000000000000000000000000000000000000000000008001',
+      ],
+      data: '0x00000000000000000000000000000000000000000000000000001cd79e564400',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 0,
+      transactionLogIndex: 0,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x000000000000000000000000000000000000800a',
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x0000000000000000000000000000000000000000000000000000000000008001',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+      ],
+      data: '0x000000000000000000000000000000000000000000000000000004ce9a63b600',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 1,
+      transactionLogIndex: 1,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x000000000000000000000000000000000000800a',
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+        '0x000000000000000000000000000000000000000000000000000000000000800a',
+      ],
+      data: '0x00000000000000000000000000000000000000000000000000000001a13b8600',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 2,
+      transactionLogIndex: 2,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x0000000000000000000000000000000000008008',
+      topics: [
+        '0x27fe8c0b49f49507b9d4fe5968c9f49edfe5c9df277d433a07a0717ede97638d',
+      ],
+      data: '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008008000000000000000000000000000000000000000000000000000000000000800a0bc337b42226405c56d0c4db2bd874946831bd2b0b00e51e72d0cf430165fe7f',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 3,
+      transactionLogIndex: 3,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x0000000000000000000000000000000000008008',
+      topics: [
+        '0x3a36e47291f4201faf137fab081d92295bce2d53be2c6ca68ba82c7faa9ce241',
+        '0x000000000000000000000000000000000000000000000000000000000000800a',
+        '0x0bc337b42226405c56d0c4db2bd874946831bd2b0b00e51e72d0cf430165fe7f',
+      ],
+      data: '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000386c0960f936615cf349d7f6344891b1e7ca7c72883f5dc04900000000000000000000000000000000000000000000000000000001a13b86000000000000000000',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 4,
+      transactionLogIndex: 4,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x000000000000000000000000000000000000800a',
+      topics: [
+        '0x2717ead6b9200dd235aad468c9809ea400fe33ac69b5bfaa6d3e90fc922b6398',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+      ],
+      data: '0x00000000000000000000000000000000000000000000000000000001a13b8600',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 5,
+      transactionLogIndex: 5,
+      logType: null,
+      removed: false,
+    },
+    {
+      address: '0x000000000000000000000000000000000000800a',
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x0000000000000000000000000000000000000000000000000000000000008001',
+        '0x00000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
+      ],
+      data: '0x000000000000000000000000000000000000000000000000000003df28f90a00',
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      blockNumber: 45n,
+      l1BatchNumber: 22n,
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      transactionIndex: 0,
+      logIndex: 6,
+      transactionLogIndex: 6,
+      logType: null,
+      removed: false,
+    },
+  ],
+  l2ToL1Logs: [
+    {
+      blockNumber: 40n,
+      blockHash:
+        '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+      l1BatchNumber: 22n,
+      transactionIndex: 0n,
+      shardId: 0n,
+      isService: true,
+      sender: '0x0000000000000000000000000000000000008008',
+      key: '0x000000000000000000000000000000000000000000000000000000000000800a',
+      value:
+        '0x0bc337b42226405c56d0c4db2bd874946831bd2b0b00e51e72d0cf430165fe7f',
+      transactionHash:
+        '0x15c295874fe9ad8f6708def4208119c68999f7a76ac6447c111e658ba6bfaa1e',
+      logIndex: 0n,
+    },
+  ],
+  status: 'success',
+  root: '0x395fdbf0faa12cb49438dcbcf96ddb130b8c0730dd0a0dd6999e247e2c2bca85',
+  logsBloom:
+    '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+  type: 'eip1559',
+  effectiveGasPrice: 100000000n,
+}
+
 export const mockRequestReturnData = async (method: string) => {
   if (method === 'zks_L1ChainId') return mockChainId
   if (method === 'zks_estimateFee') return mockFeeValues
@@ -201,6 +382,7 @@ export const mockRequestReturnData = async (method: string) => {
   if (method === 'zks_getTransactionDetails') return mockTransactionDetails
   if (method === 'zks_L1BatchNumber') return mockedL1BatchNumber
   if (method === 'zks_estimateGasL1ToL2') return mockedGasEstimation
+  if (method === 'eth_getTransactionReceipt') return mockedReceipt
   return undefined
 }
 


### PR DESCRIPTION
Introduce the  `finalizeWithdrawal` action, enabling finalization of withdrawal transaction on L1.