### PR TITLE
Added WMC Testnet chain configuration

### DIFF
--- a/.changeset/empty-kangaroos-join.md
+++ b/.changeset/empty-kangaroos-join.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added WMC Testnet chain configuration

--- a/.changeset/empty-kangaroos-join.md
+++ b/.changeset/empty-kangaroos-join.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added WMC Testnet chain configuration
+Added WMC Testnet chain.

--- a/src/chains/definitions/wmcTestnet.ts
+++ b/src/chains/definitions/wmcTestnet.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const wmcTestnet = /*#__PURE__*/ defineChain({
+  id: 42070,
+  name: 'WMC Testnet',
+  nativeCurrency: { name: 'WMTx', symbol: 'WMTx', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc-testnet-base.worldmobile.net'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'WMC Explorer',
+      url: 'https://explorer2-base-testnet.worldmobile.net/',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/wmcTestnet.ts
+++ b/src/chains/definitions/wmcTestnet.ts
@@ -12,7 +12,7 @@ export const wmcTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'WMC Explorer',
-      url: 'https://explorer2-base-testnet.worldmobile.net/',
+      url: 'https://explorer2-base-testnet.worldmobile.net',
     },
   },
   testnet: true,

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -490,6 +490,7 @@ export { wanchainTestnet } from './definitions/wanchainTestnet.js'
 export { weaveVMAlphanet } from './definitions/weavevmAlphanet.js'
 export { wemix } from './definitions/wemix.js'
 export { wemixTestnet } from './definitions/wemixTestnet.js'
+export { wmcTestnet } from './definitions/wmcTestnet.js';
 export { worldchain } from './definitions/worldchain.js'
 export { worldchainSepolia } from './definitions/worldchainSepolia.js'
 export { worldLand } from './definitions/worldLand.js'


### PR DESCRIPTION
**Description:**

This PR adds the configuration for the **WMC Testnet** chain to the Viem project. The configuration includes:

- Chain ID: **42070**
- RPC URL: https://rpc-testnet-base.worldmobile.net
- Native Currency:
   - Name: **WMTx**
   - Symbol: **WMTx**
   - Decimals: **18**
- Block Explorer:
   - Name: **WMC Explorer**
   - URL: https://explorer2-base-testnet.worldmobile.net

This chain is a testnet and has been configured as such in the testnet flag.

**Changes Made:**

- Added a new file wmcTestnet.ts to src/chains/definitions/.
- Exported the chain in src/chains/index.ts.

**Why this PR is important:**

Adding the **WMC Testnet** to Viem enables developers to integrate their applications with the chain using the Viem library.



