### PR TITLE
Added the missing parseAbi function import

### DIFF
--- a/site/pages/docs/actions/public/simulate.md
+++ b/site/pages/docs/actions/public/simulate.md
@@ -58,7 +58,7 @@ The `calls` property also accepts **Contract Calls**, and can be used via the `a
 :::code-group
 
 ```ts twoslash [example.ts]
-import { parseEther } from 'viem'
+import { parseAbi, parseEther } from 'viem'
 import { client } from './config'
 
 const abi = parseAbi([


### PR DESCRIPTION
https://viem.sh/docs/actions/public/simulate#contract-calls 

Fixed the issue where hovering over parseAbi showed any type, ensuring the correct type is displayed.