### PR TITLE
Adds multicall to berachain mainnet

### DIFF
--- a/.changeset/dry-ducks-love.md
+++ b/.changeset/dry-ducks-love.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Berachain multicall.

--- a/src/chains/definitions/berachain.ts
+++ b/src/chains/definitions/berachain.ts
@@ -6,6 +6,12 @@ export const berachain = /*#__PURE__*/ defineChain({
     decimals: 18,
     name: 'BERA Token',
     symbol: 'BERA',
+  },  
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 0,
+    },
   },
   rpcUrls: {
     default: { http: ['https://rpc.berachain.com'] },


### PR DESCRIPTION
This PR adds the multicall3 address to the brand new Berachain Mainnet. It was included in the genesis file so it's available from block 0. 

Thank you Bears! 🐻 