### PR TITLE
chore: add changeset for Metis Sepolia

### DIFF
--- a/.changeset/beige-chicken-approve.md
+++ b/.changeset/beige-chicken-approve.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Metis Sepolia testnet chain and deprecated metisGoerli

--- a/src/chains/definitions/metis.ts
+++ b/src/chains/definitions/metis.ts
@@ -9,8 +9,21 @@ export const metis = /*#__PURE__*/ defineChain({
     symbol: 'METIS',
   },
   rpcUrls: {
-    default: { http: ['https://andromeda.metis.io/?owner=1088'] },
+    default: {
+      http: [
+          'https://metis.rpc.hypersync.xyz',
+          'https://metis-pokt.nodies.app',
+          'https://api.blockeden.xyz/metis/67nCBdZQSH9z3YqDDjdm',
+          'https://metis-andromeda.rpc.thirdweb.com',
+          'https://metis-andromeda.gateway.tenderly.co',
+          'https://metis.api.onfinality.io/public',
+          'wss://metis-rpc.publicnode.com',
+          'https://andromeda.metis.io/?owner=1088',
+          'wss://metis.drpc.org',
+          'https://metis-mainnet.public.blastapi.io',
+      ],
   },
+},
   blockExplorers: {
     default: {
       name: 'Metis Explorer',

--- a/src/chains/definitions/metisSepolia.ts
+++ b/src/chains/definitions/metisSepolia.ts
@@ -1,0 +1,34 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const metisSepolia = /*#__PURE__*/ defineChain({
+  id: 59902, 
+  name: 'Metis Sepolia',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Test Metis',
+    symbol: 'tMETIS',
+  },
+  rpcUrls: {
+    default: {
+      http: [
+        'wss://metis-sepolia-rpc.publicnode.com',
+        'https://sepolia.metisdevops.link',
+        'https://metis-sepolia-rpc.publicnode.com',
+        'https://metis-sepolia.gateway.tenderly.co'
+      ],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Metis Sepolia Explorer',
+      url: 'https://sepolia-explorer.metisdevops.link/', 
+      apiUrl: 'https://sepolia-explorer.metisdevops.link/api-docs',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 224185,
+    },
+  },
+})

--- a/src/chains/definitions/metisSepolia.ts
+++ b/src/chains/definitions/metisSepolia.ts
@@ -21,7 +21,7 @@ export const metisSepolia = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Metis Sepolia Explorer',
-      url: 'https://sepolia-explorer.metisdevops.link/', 
+      url: 'https://sepolia-explorer.metisdevops.link', 
       apiUrl: 'https://sepolia-explorer.metisdevops.link/api-docs',
     },
   },

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -298,6 +298,8 @@ export { metalL2 } from './definitions/metalL2.js'
 export { meter } from './definitions/meter.js'
 export { meterTestnet } from './definitions/meterTestnet.js'
 export { metis } from './definitions/metis.js'
+export { metisSepolia } from './definitions/metisSepolia.js'
+/** @deprecated Use `metisSepolia` instead. */
 export { metisGoerli } from './definitions/metisGoerli.js'
 export { mev } from './definitions/mev.js'
 export { mevTestnet } from './definitions/mevTestnet.js'


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

# What does this PR do?
- Adds Metis Sepolia testnet chain configuration
- Deprecates Metis Goerli chain in favor of Metis Sepolia
- Updates chain exports in index.ts

# Changes
- Added src/chains/definitions/metisSepolia.ts
- Added deprecation notice for metisGoerli
- Updated exports in index.ts to include metisSepolia

# Related Info
- Chain ID: 59902
- RPC Endpoint: https://sepolia.metis.io/?owner=1088
- Block Explorer: https://sepolia.explorer.metisdevops.link

# Checklist
- [x] Added new chain definition
- [x] Updated exports
- [x] Added changeset
- [x] Chain is live and accessible
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

