### PR TITLE
Add ens to berachain

### DIFF
--- a/.changeset/lovely-dodos-sit.md
+++ b/.changeset/lovely-dodos-sit.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ENS contracts to Berachain L1.

--- a/src/chains/definitions/berachain.ts
+++ b/src/chains/definitions/berachain.ts
@@ -12,6 +12,14 @@ export const berachain = /*#__PURE__*/ defineChain({
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 0,
     },
+    ensRegistry: {
+      address: '0x5b22280886a2f5e09a49bea7e320eab0e5320e28',
+      blockCreated: 877007,
+    },
+    ensUniversalResolver: {
+      address: '0xddfb18888a9466688235887dec2a10c4f5effee9',
+      blockCreated: 877008,
+    },
   },
   rpcUrls: {
     default: { http: ['https://rpc.berachain.com'] },


### PR DESCRIPTION
Add ensRegistry and ensUniversalResolver to Berachain Bartio using Beranames => https://beranames.com

Contracts have been verified as requested by contributing guidelines.

Registry => https://berascan.com/address/0x5b22280886a2f5e09a49bea7e320eab0e5320e28
Universal Resolver => https://berascan.com/address/0xddfb18888a9466688235887dec2a10c4f5effee9

Documentation => https://docs.beranames.com/

Reference to testnet PR => https://github.com/wevm/viem/pull/3101