### PR TITLE
fix(docs): Update waitForUserOperationReceipt page title to correctly reflect page content

### DIFF
--- a/site/pages/account-abstraction/actions/bundler/waitForUserOperationReceipt.md
+++ b/site/pages/account-abstraction/actions/bundler/waitForUserOperationReceipt.md
@@ -2,7 +2,7 @@
 description: Waits for the User Operation to be included on a Block, and then returns the User Operation receipt.
 ---
 
-# getUserOperationReceipt
+# waitForUserOperationReceipt
 
 Waits for the User Operation to be included on a [Block](https://viem.sh/docs/glossary/terms#block) (one confirmation), and then returns the User Operation receipt.
 


### PR DESCRIPTION
https://viem.sh/account-abstraction/actions/bundler/waitForUserOperationReceipt#getuseroperationreceipt

The title on this page should be `waitForUserOperationReceipt`

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

