### PR TITLE
fix: Donatuz rpc url

### DIFF
--- a/.changeset/short-tools-complain.md
+++ b/.changeset/short-tools-complain.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixes Donatuz network RPC URL
+Fixed Donatuz network RPC URL

--- a/.changeset/short-tools-complain.md
+++ b/.changeset/short-tools-complain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixes Donatuz network RPC URL

--- a/src/chains/definitions/donatuz.ts
+++ b/src/chains/definitions/donatuz.ts
@@ -9,7 +9,7 @@ export const donatuz = /*#__PURE__*/ defineChain({
     symbol: 'ETH',
   },
   rpcUrls: {
-    default: { http: ['ttps://rpc.donatuz.com'] },
+    default: { http: ['https://rpc.donatuz.com'] },
   },
   blockExplorers: {
     default: {


### PR DESCRIPTION
## Summary
- Fixes Donatuz network RPC URL which was missing an `h`

