### PR TITLE
Add multicall3 contract to Berachain Artio

### DIFF
--- a/.changeset/real-eels-shop.md
+++ b/.changeset/real-eels-shop.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract to Berachain Artio.

--- a/src/chains/definitions/berachainTestnet.ts
+++ b/src/chains/definitions/berachainTestnet.ts
@@ -17,5 +17,11 @@ export const berachainTestnet = /*#__PURE__*/ defineChain({
       url: 'https://artio.beratrail.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 866924,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Added the Multicall3 contract address to the viem configuration for use in `Berachain Artio`. This ensures support for batch contract calls with improved efficiency.