### PR TITLE
fix: `disputaGameFactory` contract address in World Chain

### DIFF
--- a/.changeset/selfish-pandas-smoke.md
+++ b/.changeset/selfish-pandas-smoke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `disputeGameFactory` contract address in World Chain

--- a/src/chains/definitions/worldchain.ts
+++ b/src/chains/definitions/worldchain.ts
@@ -32,7 +32,7 @@ export const worldchain = /*#__PURE__*/ defineChain({
     },
     disputeGameFactory: {
       [sourceId]: {
-        address: '0x0E90dCAFBC242D2C861A20Bb20EC8E7182965a52',
+        address: '0x069c4c579671f8c120b1327a73217D01Ea2EC5ea',
       },
     },
     l2OutputOracle: {


### PR DESCRIPTION
Official addresses: https://docs.world.org/world-chain/developers/world-chain-contracts#ethereum-mainnet
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

