### PR TITLE
Handle Non-JSON Error Responses from Providers

### DIFF
--- a/.changeset/calm-socks-remain.md
+++ b/.changeset/calm-socks-remain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed handling of malformed JSON on WebSocket RPC.

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -40,7 +40,7 @@ export async function getWebSocketRpcClient(
           const _data = JSON.parse(data);
           onResponse(_data);
         } catch (error) {
-          onResponse(data);
+          onError(error);
         }
       }
 

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -36,7 +36,12 @@ export async function getWebSocketRpcClient(
         onClose()
       }
       function onMessage({ data }: MessageEvent) {
-        onResponse(JSON.parse(data))
+        try {
+          const _data = JSON.parse(data);
+          onResponse(_data);
+        } catch (error) {
+          onResponse(data);
+        }
       }
 
       // Setup event listeners for RPC & subscription responses.


### PR DESCRIPTION
Some providers, return error responses as strings instead of JSON objects. For example, getBlock.io returns "rate limit reached" as a plain string, causing a SyntaxError when attempting to parse it as JSON.
