### PR TITLE
Add raw option to http transport

### DIFF
--- a/.changeset/nine-mails-lie.md
+++ b/.changeset/nine-mails-lie.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `raw` option to `http` transport.

--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -141,6 +141,32 @@ describe('config', () => {
       }
     `)
   })
+
+  test('raw', () => {
+    const transport = http('https://mockapi.com/rpc', {
+      raw: true,
+    })({})
+
+    expect(transport).toMatchInlineSnapshot(`
+      {
+        "config": {
+          "key": "http",
+          "methods": undefined,
+          "name": "HTTP JSON-RPC",
+          "request": [Function],
+          "retryCount": 3,
+          "retryDelay": 150,
+          "timeout": 10000,
+          "type": "http",
+        },
+        "request": [Function],
+        "value": {
+          "fetchOptions": undefined,
+          "url": "https://mockapi.com/rpc",
+        },
+      }
+    `)
+  })
 })
 
 describe('request', () => {
@@ -311,22 +337,22 @@ describe('request', () => {
         .map((arg) => JSON.stringify(arg)),
     ).toMatchInlineSnapshot(`
       [
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber","params":[1]}",
-        "{"jsonrpc":"2.0","id":24,"method":"eth_chainId"}",
-        "{"jsonrpc":"2.0","id":25,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":24,"method":"eth_blockNumber","params":[1]}",
+        "{"jsonrpc":"2.0","id":25,"method":"eth_chainId"}",
+        "{"jsonrpc":"2.0","id":26,"method":"eth_blockNumber"}",
       ]
     `)
     expect(results).toMatchInlineSnapshot(`
       [
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber","params":[1]}",
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":24,"method":"eth_chainId"}",
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":25,"method":"eth_blockNumber"}",
-        "{"jsonrpc":"2.0","id":22,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":24,"method":"eth_blockNumber","params":[1]}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":25,"method":"eth_chainId"}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":26,"method":"eth_blockNumber"}",
+        "{"jsonrpc":"2.0","id":23,"method":"eth_blockNumber"}",
       ]
     `)
   })
@@ -530,6 +556,27 @@ describe('request', () => {
 
       Details: The request timed out.
       Version: viem@x.y.z]
+    `)
+  })
+
+  test('behavior: raw', async () => {
+    const transport = http(anvilMainnet.rpcUrl.http, {
+      key: 'jsonRpc',
+      name: 'JSON RPC',
+      raw: true,
+    })({
+      chain: localhost,
+    })
+
+    const response = await transport.request({ method: '' })
+    expect(response).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": -32601,
+          "message": "Method not found",
+        },
+        "result": undefined,
+      }
     `)
   })
 

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -19,7 +19,10 @@ import {
   createTransport,
 } from './createTransport.js'
 
-export type HttpTransportConfig<raw extends boolean | undefined = undefined> = {
+export type HttpTransportConfig<
+  rpcSchema extends RpcSchema | undefined = undefined,
+  raw extends boolean = false,
+> = {
   /**
    * Whether to enable Batch JSON-RPC.
    * @link https://www.jsonrpc.org/specification#batch
@@ -48,14 +51,16 @@ export type HttpTransportConfig<raw extends boolean | undefined = undefined> = {
   methods?: TransportConfig['methods'] | undefined
   /** The name of the HTTP transport. */
   name?: TransportConfig['name'] | undefined
+  /** Whether to return JSON RPC errors as responses instead of throwing. */
+  raw?: raw | boolean | undefined
   /** The max number of times to retry. */
   retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
   retryDelay?: TransportConfig['retryDelay'] | undefined
+  /** Typed JSON-RPC schema for the transport. */
+  rpcSchema?: rpcSchema | RpcSchema | undefined
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
   timeout?: TransportConfig['timeout'] | undefined
-  /** Whether to return JSON RPC errors as responses instead of throwing. */
-  raw?: raw | undefined
 }
 
 export type HttpTransport<
@@ -84,7 +89,7 @@ export function http<
 >(
   /** URL of the JSON-RPC API. Defaults to the chain's public RPC URL. */
   url?: string | undefined,
-  config: HttpTransportConfig<raw> = {},
+  config: HttpTransportConfig<rpcSchema, raw> = {},
 ): HttpTransport<rpcSchema, raw> {
   const {
     batch,
@@ -144,10 +149,7 @@ export function http<
 
           const [{ error, result }] = await fn(body)
 
-          if (raw) {
-            return { error, result }
-          }
-
+          if (raw) return { error, result }
           if (error)
             throw new RpcRequestError({
               body,

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1950,16 +1950,25 @@ type DerivedRpcSchema<
 
 export type EIP1193RequestFn<
   rpcSchema extends RpcSchema | undefined = undefined,
+  raw extends boolean = false,
 > = <
   rpcSchemaOverride extends RpcSchemaOverride | undefined = undefined,
   _parameters extends EIP1193Parameters<
     DerivedRpcSchema<rpcSchema, rpcSchemaOverride>
   > = EIP1193Parameters<DerivedRpcSchema<rpcSchema, rpcSchemaOverride>>,
   _returnType = DerivedRpcSchema<rpcSchema, rpcSchemaOverride> extends RpcSchema
-    ? Extract<
-        DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
-        { Method: _parameters['method'] }
-      >['ReturnType']
+    ? raw extends true
+      ? {
+          result?: Extract<
+            DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
+            { Method: _parameters['method'] }
+          >['ReturnType']
+          error?: any
+        }
+      : Extract<
+          DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
+          { Method: _parameters['method'] }
+        >['ReturnType']
     : unknown,
 >(
   args: _parameters,

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'abitype'
 
 import type * as BlockOverrides from 'ox/BlockOverrides'
+import type * as Rpc from 'ox/RpcResponse'
 import type {
   RpcEstimateUserOperationGasReturnType,
   RpcGetUserOperationByHashReturnType,
@@ -1958,18 +1959,29 @@ export type EIP1193RequestFn<
   > = EIP1193Parameters<DerivedRpcSchema<rpcSchema, rpcSchemaOverride>>,
   _returnType = DerivedRpcSchema<rpcSchema, rpcSchemaOverride> extends RpcSchema
     ? raw extends true
-      ? {
-          result?: Extract<
-            DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
-            { Method: _parameters['method'] }
-          >['ReturnType']
-          error?: any
-        }
+      ? OneOf<
+          | {
+              result: Extract<
+                DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
+                { Method: _parameters['method'] }
+              >['ReturnType']
+            }
+          | { error: Rpc.ErrorObject }
+        >
       : Extract<
           DerivedRpcSchema<rpcSchema, rpcSchemaOverride>[number],
           { Method: _parameters['method'] }
         >['ReturnType']
-    : unknown,
+    : raw extends true
+      ? OneOf<
+          | {
+              result: unknown
+            }
+          | {
+              error: Rpc.ErrorObject
+            }
+        >
+      : unknown,
 >(
   args: _parameters,
   options?: EIP1193RequestOptions | undefined,

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -40,7 +40,7 @@ export async function getWebSocketRpcClient(
           const _data = JSON.parse(data)
           onResponse(_data)
         } catch (error) {
-          onError(error)
+          onError(error as Error)
         }
       }
 


### PR DESCRIPTION
This allows the transport to be used in a lower level mode suitable for situations like a proxy.

The main alternative I explored was catching errors and reconstructing raw errors from `RpcRequestError`. This is not ideal in a high throughput production environment since creating stack traces incurs an unneeded performance cost.

If supportive of direction will round with docs.
