### PR TITLE
Fix incorrect JSDoc comments for sendUnsignedTransaction

### DIFF
--- a/src/clients/decorators/test.ts
+++ b/src/clients/decorators/test.ts
@@ -356,9 +356,9 @@ export type TestActions = {
    */
   revert: (args: RevertParameters) => Promise<void>
   /**
-   * Returns the details of all transactions currently pending for inclusion in the next block(s), as well as the ones that are being scheduled for future execution only.
+   * Executes a transaction regardless of the signature.
    *
-   * - Docs: https://viem.sh/docs/actions/test/getTxpoolContent
+   * - Docs: https://viem.sh/docs/actions/test/sendUnsignedTransaction
    *
    * @param args – {@link SendUnsignedTransactionParameters}
    * @returns The transaction hash. {@link SendUnsignedTransactionReturnType}


### PR DESCRIPTION
The JSDocs for the test client's `sendUnsignedTransaction` are currently incorrect, seeminly having some values (description & link to dopcumentation website) mistakenly copied from the docs for `getTxpoolContent`. I noticed this while trying to call `sendUnsignedTransaction` and seeing confusing messaging in my IDE.

This PR fixes the JSDoc comments, linking to the correct page and fixing the description. I had a look around and could not find any other instances of such errors, so it seems to be an isolated incident.