### PR TITLE
Update Telos RPCs

### DIFF
--- a/.changeset/slow-hornets-like.md
+++ b/.changeset/slow-hornets-like.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Update Telos RPCs
+Updated Telos RPC URLs.

--- a/.changeset/slow-hornets-like.md
+++ b/.changeset/slow-hornets-like.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Update Telos RPCs

--- a/src/chains/definitions/telos.ts
+++ b/src/chains/definitions/telos.ts
@@ -9,7 +9,7 @@ export const telos = /*#__PURE__*/ defineChain({
     symbol: 'TLOS',
   },
   rpcUrls: {
-    default: { http: ['https://mainnet.telos.net/evm'] },
+    default: { http: ['https://rpc.telos.net'] },
   },
   blockExplorers: {
     default: {

--- a/src/chains/definitions/telosTestnet.ts
+++ b/src/chains/definitions/telosTestnet.ts
@@ -9,7 +9,7 @@ export const telosTestnet = /*#__PURE__*/ defineChain({
     symbol: 'TLOS',
   },
   rpcUrls: {
-    default: { http: ['https://testnet.telos.net/evm'] },
+    default: { http: ['https://rpc.testnet.telos.net'] },
   },
   blockExplorers: {
     default: {


### PR DESCRIPTION
This PR is to update the RPCs for TelosEVM and TelosEVM Testnet to the new URLs that leverage the newer 2.0 reth based RPCs.

