### PR TITLE
feat(transport): Add shouldThrow as an option to fallback transport

### DIFF
--- a/.changeset/two-bears-warn.md
+++ b/.changeset/two-bears-warn.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `shouldThrow` option to fallback transport

--- a/.changeset/two-bears-warn.md
+++ b/.changeset/two-bears-warn.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
-Added `shouldThrow` option to fallback transport
+Added `shouldThrow` option to `fallback` transport.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "trustedDependencies": ["c-kzg"],
   "packageManager": "pnpm@9.1.0",
   "engines": {
-    "node": "22.x"
+    "node": "23.x"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"

--- a/site/pages/docs/clients/transports/fallback.md
+++ b/site/pages/docs/clients/transports/fallback.md
@@ -263,7 +263,7 @@ const transport = fallback([alchemy, infura], {
 
 - **Type:** `function`
 
-A boolean check on an `Error` object on whether a given error in a transport should throw, or should cause the `fallback` to continue to the next one.
+Whether the `fallback` Transport should immediately throw an error, or continue and try the next Transport.
 
 ```ts twoslash
 import { createPublicClient, fallback, http } from 'viem'
@@ -272,17 +272,8 @@ const alchemy = http('')
 const infura = http('') 
 // ---cut---
 const transport = fallback([alchemy, infura], {
-  shouldThrow: (err: Error) => { // [!code focus:12]
-    if ('code' in error && typeof error.code === 'number') {
-      if (
-        error.code === TransactionRejectedRpcError.code ||
-        error.code === UserRejectedRequestError.code ||
-        ExecutionRevertedError.nodeMessage.test(error.message) ||
-        error.code === 5000 // CAIP UserRejectedRequestError
-      )
-        return true
-    }
-    return false
-  },
+  shouldThrow: (err: Error) => { // [!code focus]
+    return err.message.includes('sad times') // [!code focus]
+  }, // [!code focus]
 })
 ```

--- a/site/pages/docs/clients/transports/fallback.md
+++ b/site/pages/docs/clients/transports/fallback.md
@@ -259,3 +259,30 @@ const transport = fallback([alchemy, infura], {
 })
 ```
 
+### shouldThrow (optional)
+
+- **Type:** `function`
+
+A boolean check on an `Error` object on whether a given error in a transport should throw, or should cause the `fallback` to continue to the next one.
+
+```ts twoslash
+import { createPublicClient, fallback, http } from 'viem'
+import { mainnet } from 'viem/chains'
+const alchemy = http('') 
+const infura = http('') 
+// ---cut---
+const transport = fallback([alchemy, infura], {
+  shouldThrow: (err: Error) => { // [!code focus:12]
+    if ('code' in error && typeof error.code === 'number') {
+      if (
+        error.code === TransactionRejectedRpcError.code ||
+        error.code === UserRejectedRequestError.code ||
+        ExecutionRevertedError.nodeMessage.test(error.message) ||
+        error.code === 5000 // CAIP UserRejectedRequestError
+      )
+        return true
+    }
+    return false
+  },
+})
+```

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -448,6 +448,58 @@ describe('request', () => {
     expect(count).toBe(2)
   })
 
+  test('error (rpc - custom shouldThrow)', async () => {
+    let count = 0
+    const server1 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+      })
+      res.end(
+        JSON.stringify({
+          error: {
+            code: 9999,
+            message: 'sad times',
+          },
+        }),
+      )
+    })
+    const server2 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+      })
+      res.end(
+        JSON.stringify({
+          error: {
+            code: MethodNotSupportedRpcError.code,
+            message: 'sad times',
+          },
+        }),
+      )
+    })
+    const server3 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+      })
+      res.end(JSON.stringify({ result: '0x1' }))
+    })
+
+    const transport = fallback([
+      http(server1.url),
+      http(server2.url),
+      http(server3.url),
+    ], { shouldThrow: (error: Error) => ('code' in error && error.code === 9999 )})({
+      chain: localhost,
+    })
+    await expect(
+      transport.request({ method: 'eth_blockNumber' }),
+    ).rejects.toThrowError()
+
+    expect(count).toBe(1)
+  })
+
   test('all error', async () => {
     let count = 0
     const server1 = await createHttpServer((_req, res) => {

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -486,11 +486,10 @@ describe('request', () => {
       res.end(JSON.stringify({ result: '0x1' }))
     })
 
-    const transport = fallback([
-      http(server1.url),
-      http(server2.url),
-      http(server3.url),
-    ], { shouldThrow: (error: Error) => ('code' in error && error.code === 9999 )})({
+    const transport = fallback(
+      [http(server1.url), http(server2.url), http(server3.url)],
+      { shouldThrow: (error: Error) => 'code' in error && error.code === 9999 },
+    )({
       chain: localhost,
     })
     await expect(

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -111,7 +111,7 @@ export function fallback<const transports extends readonly Transport[]>(
     key = 'fallback',
     name = 'Fallback',
     rank = false,
-    shouldThrow: shouldThrowFn = shouldThrow,
+    shouldThrow: shouldThrow_ = shouldThrow,
     retryCount,
     retryDelay,
   } = config
@@ -158,7 +158,7 @@ export function fallback<const transports extends readonly Transport[]>(
                 status: 'error',
               })
 
-              if (shouldThrowFn(err as Error)) throw err
+              if (shouldThrow_(err as Error)) throw err
 
               // If we've reached the end of the fallbacks, throw the error.
               if (i === transports.length - 1) throw err

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -85,6 +85,8 @@ export type FallbackTransportConfig = {
   retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
   retryDelay?: TransportConfig['retryDelay'] | undefined
+  /** Callback on whether an error should throw or try the next transport in the fallback. */
+  shouldThrow?: (error: Error) => boolean | undefined
 }
 
 export type FallbackTransport<
@@ -109,6 +111,7 @@ export function fallback<const transports extends readonly Transport[]>(
     key = 'fallback',
     name = 'Fallback',
     rank = false,
+    shouldThrow = defaultShouldThrow,
     retryCount,
     retryDelay,
   } = config
@@ -203,7 +206,7 @@ export function fallback<const transports extends readonly Transport[]>(
   }) as FallbackTransport<transports>
 }
 
-function shouldThrow(error: Error) {
+function defaultShouldThrow(error: Error) {
   if ('code' in error && typeof error.code === 'number') {
     if (
       error.code === TransactionRejectedRpcError.code ||

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -111,7 +111,7 @@ export function fallback<const transports extends readonly Transport[]>(
     key = 'fallback',
     name = 'Fallback',
     rank = false,
-    shouldThrow = defaultShouldThrow,
+    shouldThrow: shouldThrowFn = shouldThrow,
     retryCount,
     retryDelay,
   } = config
@@ -158,7 +158,7 @@ export function fallback<const transports extends readonly Transport[]>(
                 status: 'error',
               })
 
-              if (shouldThrow(err as Error)) throw err
+              if (shouldThrowFn(err as Error)) throw err
 
               // If we've reached the end of the fallbacks, throw the error.
               if (i === transports.length - 1) throw err
@@ -206,7 +206,7 @@ export function fallback<const transports extends readonly Transport[]>(
   }) as FallbackTransport<transports>
 }
 
-function defaultShouldThrow(error: Error) {
+export function shouldThrow(error: Error) {
   if ('code' in error && typeof error.code === 'number') {
     if (
       error.code === TransactionRejectedRpcError.code ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,6 +507,7 @@ export {
   type FallbackTransportConfig,
   type FallbackTransportErrorType,
   fallback,
+  shouldThrow,
 } from './clients/transports/fallback.js'
 export {
   type HttpTransport,


### PR DESCRIPTION
Adds a `shouldThrow` option to the fallback transport, to customize which errors trigger a fallback vs a throw. We are using this so a contract error (eg a failed `require` in contract code) does not trigger the fallback and fails immediately.

Happy to add some tests if this contribution makes sense.