### PR TITLE
Update GuruNetwork RPC URL

### DIFF
--- a/.changeset/early-penguins-beg.md
+++ b/.changeset/early-penguins-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated GuruNetwork RPC URLs.

--- a/src/chains/definitions/guruNetwork.ts
+++ b/src/chains/definitions/guruNetwork.ts
@@ -10,7 +10,7 @@ export const guruNetwork = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.gurunetwork.ai/archive/260'],
+      http: ['https://rpc-main.gurunetwork.ai', 'https://rpc.gurunetwork.ai/archive/260'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/guruTestnet.ts
+++ b/src/chains/definitions/guruTestnet.ts
@@ -10,7 +10,7 @@ export const guruTestnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.gurunetwork.ai/archive/261'],
+      http: ['https://rpc-test.gurunetwork.ai', 'https://rpc.gurunetwork.ai/archive/261'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
This PR updates the RPC URLs for GuruNetwork Testnet and Mainnet. The new RPCs are more reliable and stable