### PR TITLE
Planq Network: Add additional RPCs, add multicall3 address

### DIFF
--- a/.changeset/gorgeous-eggs-count.md
+++ b/.changeset/gorgeous-eggs-count.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Planq Network: Add additional RPCs, add multicall3 address

--- a/src/chains/definitions/planq.ts
+++ b/src/chains/definitions/planq.ts
@@ -9,12 +9,24 @@ export const planq = /*#__PURE__*/ defineChain({
     symbol: 'PLQ',
   },
   rpcUrls: {
-    default: { http: ['https://evm-rpc.planq.network'] },
+    default: { 
+      http: [
+        'https://planq-rpc.nodies.app', 
+        'https://evm-rpc.planq.network', 
+        'https://jsonrpc.planq.nodestake.top'
+      ] 
+    },
   },
   blockExplorers: {
     default: {
       name: 'Planq Explorer',
       url: 'https://evm.planq.network',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 8470015,
     },
   },
   testnet: false,


### PR DESCRIPTION
This PR adds additional RPCs to Planq Mainnet and as well adds the deployed multicall3 address to the config.

