### PR TITLE
fix: Sonic block explorer url

### DIFF
--- a/src/chains/definitions/sonic.ts
+++ b/src/chains/definitions/sonic.ts
@@ -14,7 +14,7 @@ export const sonic = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Sonic Explorer',
-      url: 'https://sonicscan.org/',
+      url: 'https://sonicscan.org',
     },
   },
   contracts: {


### PR DESCRIPTION
Remove trailing slash from Sonic default block explorer url

