### PR TITLE
feat: add Plume Mainnet

### DIFF
--- a/.changeset/orange-seahorses-shout.md
+++ b/.changeset/orange-seahorses-shout.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Plume Mainnet.

--- a/src/chains/definitions/plume.ts
+++ b/src/chains/definitions/plume.ts
@@ -4,7 +4,7 @@ const sourceId = 1 // ethereum
 
 export const plume = /*#__PURE__*/ defineChain({
   id: 98_865,
-  name: 'Plume Mainnet',
+  name: 'Plume',
   nativeCurrency: {
     name: 'Plume Ether',
     symbol: 'ETH',

--- a/src/chains/definitions/plumeMainnet.ts
+++ b/src/chains/definitions/plumeMainnet.ts
@@ -1,0 +1,27 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+const sourceId = 1 // ethereum
+
+export const plumeMainnet = /*#__PURE__*/ defineChain({
+  id: 98_866,
+  name: 'Plume Mainnet',
+  nativeCurrency: {
+    name: 'Plume',
+    symbol: 'PLUME',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://phoenix-rpc.plumenetwork.xyz'],
+      webSocket: ['wss://phoenix-rpc.plumenetwork.xyz'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Blockscout',
+      url: 'https://phoenix-explorer.plumenetwork.xyz',
+      apiUrl: 'https://phoenix-explorer.plumenetwork.xyz/api',
+    },
+  },
+  sourceId,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -369,6 +369,7 @@ export { playfiAlbireo } from './definitions/playfiAlbireo.js'
 export { plinga } from './definitions/plinga.js'
 export { plume } from './definitions/plume.js'
 export { plumeDevnet } from './definitions/plumeDevnet.js'
+export { plumeMainnet } from './definitions/plumeMainnet.js'
 /** @deprecated Use `plumeDevnet` instead. */
 export { plumeTestnet } from './definitions/plumeTestnet.js'
 export { polterTestnet } from './definitions/polterTestnet.js'

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -367,6 +367,7 @@ export { phoenix } from './definitions/phoenix.js'
 export { planq } from './definitions/planq.js'
 export { playfiAlbireo } from './definitions/playfiAlbireo.js'
 export { plinga } from './definitions/plinga.js'
+/** @deprecated Use `plumeMainnet` instead. */
 export { plume } from './definitions/plume.js'
 export { plumeDevnet } from './definitions/plumeDevnet.js'
 export { plumeMainnet } from './definitions/plumeMainnet.js'


### PR DESCRIPTION
Users on the existing Plume private mainnet with chain ID 98865 will be migrated over to the new Plume private mainnet over the next several weeks, before mark the existing Plume private mainnet as deprecated.