### PR TITLE
bug: EIP-3668 `sender` must be lowercase

### DIFF
--- a/.changeset/chilled-radios-clap.md
+++ b/.changeset/chilled-radios-clap.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Lowercased `sender` in CCIP-read.

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -141,7 +141,7 @@ export async function ccipRequest({
 
     try {
       const response = await fetch(
-        url.replace('{sender}', sender).replace('{data}', data),
+        url.replace('{sender}', sender.toLowerCase()).replace('{data}', data),
         {
           body: JSON.stringify(body),
           headers,


### PR DESCRIPTION
- add `toLowerCase()` to `"sender"` (I left `"data"` as-is)

Reference: https://eips.ethereum.org/EIPS/eip-3668

> Each URL may include two substitution parameters, {sender} and {data}. Before a call is made to the URL, sender is replaced with the lowercase 0x-prefixed hexadecimal formatted sender parameter, and data is replaced by the 0x-prefixed hexadecimal formatted callData parameter.