### PR TITLE
fix: update happychain testnet deprecated urls

### DIFF
--- a/.changeset/quiet-chicken-joke.md
+++ b/.changeset/quiet-chicken-joke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Happychain Testnet URLs.

--- a/src/chains/definitions/happychainTestnet.ts
+++ b/src/chains/definitions/happychainTestnet.ts
@@ -17,7 +17,7 @@ export const happychainTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Happy Chain Testnet Explorer',
-      url: 'https://explorer.testnet.happy.tech/',
+      url: 'https://explorer.testnet.happy.tech',
     },
   },
   contracts: {

--- a/src/chains/definitions/happychainTestnet.ts
+++ b/src/chains/definitions/happychainTestnet.ts
@@ -10,14 +10,14 @@ export const happychainTestnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://happy-testnet-sepolia.rpc.caldera.xyz/http'],
-      webSocket: ['wss://happy-testnet-sepolia.rpc.caldera.xyz/ws'],
+      http: ['https://rpc.testnet.happy.tech/http'],
+      webSocket: ['wss://rpc.testnet.happy.tech/ws'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Happy Chain Testnet Explorer',
-      url: 'https://happy-testnet-sepolia.explorer.caldera.xyz/',
+      url: 'https://explorer.testnet.happy.tech/',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Updates deprecated Happychain Testnet URLS for RPC endpoint and explorer

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

