### PR TITLE
Adds missing re-exports.

### DIFF
--- a/.changeset/plenty-mayflies-leave.md
+++ b/.changeset/plenty-mayflies-leave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added missing re-exports.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ wagmi
 src/node/trustedSetups_esm.ts
 **/trusted-setups/**/*.txt
 .idea
+.pnpm-store
 
 # local env files
 .env

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,11 @@ export {
   type CallReturnType,
 } from './actions/public/call.js'
 export type {
+  CreateAccessListParameters,
+  CreateAccessListReturnType,
+  CreateAccessListErrorType,
+} from './actions/public/createAccessList.js'
+export type {
   CreateBlockFilterErrorType,
   CreateBlockFilterReturnType,
 } from './actions/public/createBlockFilter.js'
@@ -268,6 +273,22 @@ export type {
 } from './actions/public/multicall.js'
 export type { SnapshotErrorType } from './actions/test/snapshot.js'
 export type {
+  SimulateBlocksParameters,
+  SimulateBlocksReturnType,
+  SimulateBlocksErrorType,
+} from './actions/public/simulateBlocks.js'
+export type {
+  SimulateCallsParameters,
+  SimulateCallsReturnType,
+  SimulateCallsErrorType,
+} from './actions/public/simulateCalls.js'
+export type {
+  GetMutabilityAwareValue,
+  SimulateContractParameters,
+  SimulateContractReturnType,
+  SimulateContractErrorType,
+} from './actions/public/simulateContract.js'
+export type {
   OnBlock,
   OnBlockParameter,
   WatchBlocksErrorType,
@@ -419,11 +440,6 @@ export type {
   SignTypedDataParameters,
   SignTypedDataReturnType,
 } from './actions/wallet/signTypedData.js'
-export type {
-  SimulateContractErrorType,
-  SimulateContractParameters,
-  SimulateContractReturnType,
-} from './actions/public/simulateContract.js'
 export type {
   StopImpersonatingAccountErrorType,
   StopImpersonatingAccountParameters,


### PR DESCRIPTION
Without these, something as simple as the following results in a compiler error in projects that depend on viem:
```ts export const createReadClient = () => {
	return createWalletClient({ chain: mainnet, transport: custom(ethereum), cacheTime }).extend(publicActions)
}
```

This is because `publicActions`'s return type depends on `CreateAccessList` and `Simulate*`.

Note: The current mechanism of manually adding these things to `index.ts` seems ripe for this class of failure.  It feels like either an alternative re-export system should be used (e.g., `export * from '...'`) or some automation should be built to ensure that everything is properly re-exported.

I also added `.pnpm-store` to `.gitignore` because with out it this commit was going to be a bajillion files large as `pnpn install` drops a ton of stuff in that folder as a cache.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

