### PR TITLE
Correct etherlink testnet block explorer url

### DIFF
--- a/src/chains/definitions/etherlinkTestnet.ts
+++ b/src/chains/definitions/etherlinkTestnet.ts
@@ -14,7 +14,7 @@ export const etherlinkTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Etherlink Testnet',
-      url: 'https://testnet-explorer.etherlink.com',
+      url: 'https://testnet.explorer.etherlink.com',
     },
   },
   testnet: true,


### PR DESCRIPTION
Correct of the Etherlink testnet block explorer url.
