### PR TITLE
feat: add new Plume testnet

### DIFF
--- a/src/chains/definitions/plume.ts
+++ b/src/chains/definitions/plume.ts
@@ -4,7 +4,7 @@ const sourceId = 1 // ethereum
 
 export const plume = /*#__PURE__*/ defineChain({
   id: 98_865,
-  name: 'Plume',
+  name: 'Plume (Legacy)',
   nativeCurrency: {
     name: 'Plume Ether',
     symbol: 'ETH',

--- a/src/chains/definitions/plumeDevnet.ts
+++ b/src/chains/definitions/plumeDevnet.ts
@@ -4,7 +4,7 @@ const sourceId = 11_155_111 // sepolia
 
 export const plumeDevnet = /*#__PURE__*/ defineChain({
   id: 98_864,
-  name: 'Plume Devnet',
+  name: 'Plume Devnet (Legacy)',
   nativeCurrency: {
     name: 'Plume Sepolia Ether',
     symbol: 'ETH',

--- a/src/chains/definitions/plumeGasTestnet.ts
+++ b/src/chains/definitions/plumeGasTestnet.ts
@@ -2,18 +2,18 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 const sourceId = 11_155_111 // sepolia
 
-export const plumeTestnet = /*#__PURE__*/ defineChain({
-  id: 161_221_135,
-  name: 'Plume Testnet (Legacy)',
+export const plumeSepolia = /*#__PURE__*/ defineChain({
+  id: 98_867,
+  name: 'Plume Testnet',
   nativeCurrency: {
-    name: 'Plume Sepolia Ether',
-    symbol: 'ETH',
+    name: 'Plume',
+    symbol: 'PLUME',
     decimals: 18,
   },
   rpcUrls: {
     default: {
-      http: ['https://testnet-rpc.plumenetwork.xyz/http'],
-      webSocket: ['wss://testnet-rpc.plumenetwork.xyz/ws'],
+      http: ['https://testnet-rpc.plumenetwork.xyz'],
+      webSocket: ['wss://testnet-rpc.plumenetwork.xyz'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/plumeMainnet.ts
+++ b/src/chains/definitions/plumeMainnet.ts
@@ -4,7 +4,7 @@ const sourceId = 1 // ethereum
 
 export const plumeMainnet = /*#__PURE__*/ defineChain({
   id: 98_866,
-  name: 'Plume Mainnet',
+  name: 'Plume',
   nativeCurrency: {
     name: 'Plume',
     symbol: 'PLUME',

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -371,9 +371,11 @@ export { playfiAlbireo } from './definitions/playfiAlbireo.js'
 export { plinga } from './definitions/plinga.js'
 /** @deprecated Use `plumeMainnet` instead. */
 export { plume } from './definitions/plume.js'
+/** @deprecated Use `plumeSepolia` instead. */
 export { plumeDevnet } from './definitions/plumeDevnet.js'
 export { plumeMainnet } from './definitions/plumeMainnet.js'
-/** @deprecated Use `plumeDevnet` instead. */
+export { plumeSepolia } from './definitions/plumeSepolia.js'
+/** @deprecated Use `plumeSepolia` instead. */
 export { plumeTestnet } from './definitions/plumeTestnet.js'
 export { polterTestnet } from './definitions/polterTestnet.js'
 export { polygon } from './definitions/polygon.js'


### PR DESCRIPTION
Users on the existing Plume testnet with chain ID 98864 will be migrated over to the new Plume testnet over the next several weeks, before marking the existing Plume testnet as deprecated.