### PR TITLE
Add multicall3 contract to Sonic Blaze Testnet

### DIFF
--- a/.changeset/something.md
+++ b/.changeset/something.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract to Sonic Blaze Testnet.

--- a/src/chains/definitions/sonicBlazeTestnet.ts
+++ b/src/chains/definitions/sonicBlazeTestnet.ts
@@ -17,5 +17,11 @@ export const sonicBlazeTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.sonicscan.org',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 1100,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Added the Multicall3 contract address to the viem configuration for use in Sonic Blaze Testnet.