### PR TITLE
add XRPLEVM Testnet

### DIFF
--- a/.changeset/stale-cheetahs-travel.md
+++ b/.changeset/stale-cheetahs-travel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added XRPL EVM Testnet.

--- a/src/chains/definitions/xrplevmTestnet.ts
+++ b/src/chains/definitions/xrplevmTestnet.ts
@@ -1,0 +1,28 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xrplevmTestnet = /*#__PURE__*/ defineChain({
+  id: 1449000,
+  name: 'XRPL EVM Testnet',
+  nativeCurrency: {
+    name: 'XRP',
+    symbol: 'XRP',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.testnet.xrplevm.org'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'blockscout',
+      url: 'https://explorer.testnet.xrplevm.org',
+      apiUrl: 'https://explorer.testnet.xrplevm.org/api/v2',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x82Cc144D7d0AD4B1c27cb41420e82b82Ad6e9B31',
+      blockCreated: 492302,
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -552,6 +552,7 @@ export {
   xLayerTestnet,
 } from './definitions/xLayerTestnet.js'
 export { xrOne } from './definitions/xrOne.js'
+export { xrplevmTestnet } from './definitions/xrplevmTestnet.js'
 export { xrSepolia } from './definitions/xrSepolia.js'
 export { yooldoVerse } from './definitions/yooldoVerse.js'
 export { yooldoVerseTestnet } from './definitions/yooldoVerseTestnet.js'


### PR DESCRIPTION
# Add XRPLEVM Testnet chain definition

## Description

- Adds a new chain file `xrplEvmTestnet.ts` under `src/chains/definitions/`.
- Sets `chainId` to **1449000**, names it “XRPLEVM Testnet”, and includes RPC URLs, explorer, and `XRP` as native currency.
- Exports `xrplEvmTestnet` in `src/chains/index.ts`.

- Adds a patch changeset: “Added XRPLEVM Testnet chain.”
> **Verification**:
> - Chain tested locally in dev environment to confirm RPC and explorer availability.  
> - Multicall3 deployed manually (gas usage ~1.6M) at `0x82Cc144D7d0AD4B1c27cb41420e82b82Ad6e9B31`.  
> 
> **Any additional notes**:
> - The pre-signed Multicall3 transaction is not possible due to higher gas usage (over 1M).  
> - Please let me know if there are any adjustments needed!

---

