### PR TITLE
feat: support async rpc headers

### DIFF
--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,4 +1,4 @@
-import type { MessageEvent } from 'isows'
+import type { MessageEvent } from "isows";
 
 import {
   HttpRequestError,
@@ -6,58 +6,58 @@ import {
   TimeoutError,
   type TimeoutErrorType,
   WebSocketRequestError,
-} from '../errors/request.js'
-import type { ErrorType } from '../errors/utils.js'
+} from "../errors/request.js";
+import type { ErrorType } from "../errors/utils.js";
 import {
   type CreateBatchSchedulerErrorType,
   createBatchScheduler,
-} from './promise/createBatchScheduler.js'
+} from "./promise/createBatchScheduler.js";
 import {
   type WithTimeoutErrorType,
   withTimeout,
-} from './promise/withTimeout.js'
-import { stringify } from './stringify.js'
+} from "./promise/withTimeout.js";
+import { stringify } from "./stringify.js";
 
-let id = 0
+let id = 0;
 
 type SuccessResult<T> = {
-  method?: never
-  result: T
-  error?: never
-}
+  method?: never;
+  result: T;
+  error?: never;
+};
 type ErrorResult<T> = {
-  method?: never
-  result?: never
-  error: T
-}
+  method?: never;
+  result?: never;
+  error: T;
+};
 type Subscription<TResult, TError> = {
-  method: 'eth_subscription'
-  error?: never
-  result?: never
+  method: "eth_subscription";
+  error?: never;
+  result?: never;
   params: {
-    subscription: string
+    subscription: string;
   } & (
     | {
-        result: TResult
-        error?: never
+        result: TResult;
+        error?: never;
       }
     | {
-        result?: never
-        error: TError
+        result?: never;
+        error: TError;
       }
-  )
-}
+  );
+};
 
-export type RpcRequest = { method: string; params?: any; id?: number }
+export type RpcRequest = { method: string; params?: any; id?: number };
 
 export type RpcResponse<TResult = any, TError = any> = {
-  jsonrpc: `${number}`
-  id: number
+  jsonrpc: `${number}`;
+  id: number;
 } & (
   | SuccessResult<TResult>
   | ErrorResult<TError>
   | Subscription<TResult, TError>
-)
+);
 
 ///////////////////////////////////////////////////
 // HTTP
@@ -65,63 +65,72 @@ export type RpcResponse<TResult = any, TError = any> = {
 export type HttpOptions<TBody extends RpcRequest | RpcRequest[] = RpcRequest> =
   {
     // The RPC request body.
-    body: TBody
+    body: TBody;
     // Request configuration to pass to `fetch`.
-    fetchOptions?: Omit<RequestInit, 'body'>
+    fetchOptions?: Omit<RequestInit, "body">;
     // The timeout (in ms) for the request.
-    timeout?: number
-  }
+    timeout?: number;
+    // Async headers, which might be based on the body of the message
+    asyncHeaders?: (body: string) => Promise<HeadersInit>;
+  };
 
 export type HttpReturnType<
-  TBody extends RpcRequest | RpcRequest[] = RpcRequest,
-> = TBody extends RpcRequest[] ? RpcResponse[] : RpcResponse
+  TBody extends RpcRequest | RpcRequest[] = RpcRequest
+> = TBody extends RpcRequest[] ? RpcResponse[] : RpcResponse;
 
 export type HttpErrorType =
   | HttpRequestErrorType
   | TimeoutErrorType
   | WithTimeoutErrorType
-  | ErrorType
+  | ErrorType;
 
 async function http<TBody extends RpcRequest | RpcRequest[]>(
   url: string,
-  { body, fetchOptions = {}, timeout = 10_000 }: HttpOptions<TBody>,
+  {
+    body,
+    fetchOptions = {},
+    timeout = 10_000,
+    asyncHeaders,
+  }: HttpOptions<TBody>
 ): Promise<HttpReturnType<TBody>> {
-  const { headers, method, signal: signal_ } = fetchOptions
+  const { headers, method, signal: signal_ } = fetchOptions;
   try {
     const response = await withTimeout(
       async ({ signal }) => {
+        const requestBody = Array.isArray(body)
+          ? stringify(
+              body.map((body) => ({
+                jsonrpc: "2.0",
+                id: body.id ?? id++,
+                ...body,
+              }))
+            )
+          : stringify({ jsonrpc: "2.0", id: body.id ?? id++, ...body });
         const response = await fetch(url, {
           ...fetchOptions,
-          body: Array.isArray(body)
-            ? stringify(
-                body.map((body) => ({
-                  jsonrpc: '2.0',
-                  id: body.id ?? id++,
-                  ...body,
-                })),
-              )
-            : stringify({ jsonrpc: '2.0', id: body.id ?? id++, ...body }),
+          body: requestBody,
           headers: {
             ...headers,
-            'Content-Type': 'application/json',
+            ...(asyncHeaders ? await asyncHeaders(requestBody) : {}),
+            "Content-Type": "application/json",
           },
-          method: method || 'POST',
+          method: method || "POST",
           signal: signal_ || (timeout > 0 ? signal : undefined),
-        })
-        return response
+        });
+        return response;
       },
       {
         errorInstance: new TimeoutError({ body, url }),
         timeout,
         signal: true,
-      },
-    )
+      }
+    );
 
-    let data: any
-    if (response.headers.get('Content-Type')?.startsWith('application/json')) {
-      data = await response.json()
+    let data: any;
+    if (response.headers.get("Content-Type")?.startsWith("application/json")) {
+      data = await response.json();
     } else {
-      data = await response.text()
+      data = await response.text();
     }
 
     if (!response.ok) {
@@ -131,112 +140,114 @@ async function http<TBody extends RpcRequest | RpcRequest[]>(
         headers: response.headers,
         status: response.status,
         url,
-      })
+      });
     }
 
-    return data
+    return data;
   } catch (err) {
-    if (err instanceof HttpRequestError) throw err
-    if (err instanceof TimeoutError) throw err
+    if (err instanceof HttpRequestError) throw err;
+    if (err instanceof TimeoutError) throw err;
     throw new HttpRequestError({
       body,
       details: (err as Error).message,
       url,
-    })
+    });
   }
 }
 
 ///////////////////////////////////////////////////
 // WebSocket
 
-type Id = string | number
-type CallbackFn = (message: any) => void
-type CallbackMap = Map<Id, CallbackFn>
+type Id = string | number;
+type CallbackFn = (message: any) => void;
+type CallbackMap = Map<Id, CallbackFn>;
 
 export type Socket = WebSocket & {
-  requests: CallbackMap
-  subscriptions: CallbackMap
-}
+  requests: CallbackMap;
+  subscriptions: CallbackMap;
+};
 
-export type GetSocketErrorType = CreateBatchSchedulerErrorType | ErrorType
+export type GetSocketErrorType = CreateBatchSchedulerErrorType | ErrorType;
 
-export const socketsCache = /*#__PURE__*/ new Map<string, Socket>()
+export const socketsCache = /*#__PURE__*/ new Map<string, Socket>();
 
 export async function getSocket(url: string) {
-  let socket = socketsCache.get(url)
+  let socket = socketsCache.get(url);
 
   // If the socket already exists, return it.
-  if (socket) return socket
+  if (socket) return socket;
 
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      const WebSocket = await import('isows').then((module) => module.WebSocket)
-      const webSocket = new WebSocket(url)
+      const WebSocket = await import("isows").then(
+        (module) => module.WebSocket
+      );
+      const webSocket = new WebSocket(url);
 
       // Set up a cache for incoming "synchronous" requests.
-      const requests = new Map<Id, CallbackFn>()
+      const requests = new Map<Id, CallbackFn>();
 
       // Set up a cache for subscriptions (eth_subscribe).
-      const subscriptions = new Map<Id, CallbackFn>()
+      const subscriptions = new Map<Id, CallbackFn>();
 
       const onMessage: (event: MessageEvent) => void = ({ data }) => {
-        const message: RpcResponse = JSON.parse(data as string)
-        const isSubscription = message.method === 'eth_subscription'
-        const id = isSubscription ? message.params.subscription : message.id
-        const cache = isSubscription ? subscriptions : requests
-        const callback = cache.get(id)
-        if (callback) callback({ data })
-        if (!isSubscription) cache.delete(id)
-      }
+        const message: RpcResponse = JSON.parse(data as string);
+        const isSubscription = message.method === "eth_subscription";
+        const id = isSubscription ? message.params.subscription : message.id;
+        const cache = isSubscription ? subscriptions : requests;
+        const callback = cache.get(id);
+        if (callback) callback({ data });
+        if (!isSubscription) cache.delete(id);
+      };
       const onClose = () => {
-        socketsCache.delete(url)
-        webSocket.removeEventListener('close', onClose)
-        webSocket.removeEventListener('message', onMessage)
-      }
+        socketsCache.delete(url);
+        webSocket.removeEventListener("close", onClose);
+        webSocket.removeEventListener("message", onMessage);
+      };
 
       // Setup event listeners for RPC & subscription responses.
-      webSocket.addEventListener('close', onClose)
-      webSocket.addEventListener('message', onMessage)
+      webSocket.addEventListener("close", onClose);
+      webSocket.addEventListener("message", onMessage);
 
       // Wait for the socket to open.
       if (webSocket.readyState === WebSocket.CONNECTING) {
         await new Promise((resolve, reject) => {
-          if (!webSocket) return
-          webSocket.onopen = resolve
-          webSocket.onerror = reject
-        })
+          if (!webSocket) return;
+          webSocket.onopen = resolve;
+          webSocket.onerror = reject;
+        });
       }
 
       // Create a new socket instance.
       socket = Object.assign(webSocket, {
         requests,
         subscriptions,
-      })
-      socketsCache.set(url, socket)
+      });
+      socketsCache.set(url, socket);
 
-      return [socket]
+      return [socket];
     },
-  })
+  });
 
-  const [_, [socket_]] = await schedule()
-  return socket_
+  const [_, [socket_]] = await schedule();
+  return socket_;
 }
 
 export type WebSocketOptions = {
   /** The RPC request body. */
-  body: RpcRequest
+  body: RpcRequest;
   /** The callback to invoke on response. */
-  onResponse?: (message: RpcResponse) => void
-}
+  onResponse?: (message: RpcResponse) => void;
+};
 
-export type WebSocketReturnType = Socket
+export type WebSocketReturnType = Socket;
 
-export type WebSocketErrorType = WebSocketRequestError | ErrorType
+export type WebSocketErrorType = WebSocketRequestError | ErrorType;
 
 function webSocket(
   socket: Socket,
-  { body, onResponse }: WebSocketOptions,
+  { body, onResponse }: WebSocketOptions
 ): WebSocketReturnType {
   if (
     socket.readyState === socket.CLOSED ||
@@ -245,54 +256,54 @@ function webSocket(
     throw new WebSocketRequestError({
       body,
       url: socket.url,
-      details: 'Socket is closed.',
-    })
+      details: "Socket is closed.",
+    });
 
-  const id_ = id++
+  const id_ = id++;
 
   const callback = ({ data }: { data: any }) => {
-    const message: RpcResponse = JSON.parse(data)
+    const message: RpcResponse = JSON.parse(data);
 
-    if (typeof message.id === 'number' && id_ !== message.id) return
+    if (typeof message.id === "number" && id_ !== message.id) return;
 
-    onResponse?.(message)
+    onResponse?.(message);
 
     // If we are subscribing to a topic, we want to set up a listener for incoming
     // messages.
-    if (body.method === 'eth_subscribe' && typeof message.result === 'string') {
-      socket.subscriptions.set(message.result, callback)
+    if (body.method === "eth_subscribe" && typeof message.result === "string") {
+      socket.subscriptions.set(message.result, callback);
     }
 
     // If we are unsubscribing from a topic, we want to remove the listener.
-    if (body.method === 'eth_unsubscribe') {
-      socket.subscriptions.delete(body.params?.[0])
+    if (body.method === "eth_unsubscribe") {
+      socket.subscriptions.delete(body.params?.[0]);
     }
-  }
-  socket.requests.set(id_, callback)
+  };
+  socket.requests.set(id_, callback);
 
-  socket.send(JSON.stringify({ jsonrpc: '2.0', ...body, id: id_ }))
+  socket.send(JSON.stringify({ jsonrpc: "2.0", ...body, id: id_ }));
 
-  return socket
+  return socket;
 }
 
 export type WebSocketAsyncOptions = {
   /** The RPC request body. */
-  body: RpcRequest
+  body: RpcRequest;
   /** The timeout (in ms) for the request. */
-  timeout?: number
-}
+  timeout?: number;
+};
 
-export type WebSocketAsyncReturnType = RpcResponse
+export type WebSocketAsyncReturnType = RpcResponse;
 
 export type WebSocketAsyncErrorType =
   | WebSocketErrorType
   | TimeoutErrorType
   | WithTimeoutErrorType
-  | ErrorType
+  | ErrorType;
 
 async function webSocketAsync(
   socket: Socket,
-  { body, timeout = 10_000 }: WebSocketAsyncOptions,
+  { body, timeout = 10_000 }: WebSocketAsyncOptions
 ): Promise<WebSocketAsyncReturnType> {
   return withTimeout(
     () =>
@@ -300,13 +311,13 @@ async function webSocketAsync(
         rpc.webSocket(socket, {
           body,
           onResponse,
-        }),
+        })
       ),
     {
       errorInstance: new TimeoutError({ body, url: socket.url }),
       timeout,
-    },
-  )
+    }
+  );
 }
 
 ///////////////////////////////////////////////////
@@ -315,4 +326,4 @@ export const rpc = {
   http,
   webSocket,
   webSocketAsync,
-}
+};

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,4 +1,4 @@
-import type { MessageEvent } from "isows";
+import type { MessageEvent } from 'isows'
 
 import {
   HttpRequestError,
@@ -6,58 +6,58 @@ import {
   TimeoutError,
   type TimeoutErrorType,
   WebSocketRequestError,
-} from "../errors/request.js";
-import type { ErrorType } from "../errors/utils.js";
+} from '../errors/request.js'
+import type { ErrorType } from '../errors/utils.js'
 import {
   type CreateBatchSchedulerErrorType,
   createBatchScheduler,
-} from "./promise/createBatchScheduler.js";
+} from './promise/createBatchScheduler.js'
 import {
   type WithTimeoutErrorType,
   withTimeout,
-} from "./promise/withTimeout.js";
-import { stringify } from "./stringify.js";
+} from './promise/withTimeout.js'
+import { stringify } from './stringify.js'
 
-let id = 0;
+let id = 0
 
 type SuccessResult<T> = {
-  method?: never;
-  result: T;
-  error?: never;
-};
+  method?: never
+  result: T
+  error?: never
+}
 type ErrorResult<T> = {
-  method?: never;
-  result?: never;
-  error: T;
-};
+  method?: never
+  result?: never
+  error: T
+}
 type Subscription<TResult, TError> = {
-  method: "eth_subscription";
-  error?: never;
-  result?: never;
+  method: 'eth_subscription'
+  error?: never
+  result?: never
   params: {
-    subscription: string;
+    subscription: string
   } & (
     | {
-        result: TResult;
-        error?: never;
+        result: TResult
+        error?: never
       }
     | {
-        result?: never;
-        error: TError;
+        result?: never
+        error: TError
       }
-  );
-};
+  )
+}
 
-export type RpcRequest = { method: string; params?: any; id?: number };
+export type RpcRequest = { method: string; params?: any; id?: number }
 
 export type RpcResponse<TResult = any, TError = any> = {
-  jsonrpc: `${number}`;
-  id: number;
+  jsonrpc: `${number}`
+  id: number
 } & (
   | SuccessResult<TResult>
   | ErrorResult<TError>
   | Subscription<TResult, TError>
-);
+)
 
 ///////////////////////////////////////////////////
 // HTTP
@@ -65,24 +65,24 @@ export type RpcResponse<TResult = any, TError = any> = {
 export type HttpOptions<TBody extends RpcRequest | RpcRequest[] = RpcRequest> =
   {
     // The RPC request body.
-    body: TBody;
+    body: TBody
     // Request configuration to pass to `fetch`.
-    fetchOptions?: Omit<RequestInit, "body">;
+    fetchOptions?: Omit<RequestInit, 'body'>
     // The timeout (in ms) for the request.
-    timeout?: number;
+    timeout?: number
     // Async headers, which might be based on the body of the message
-    asyncHeaders?: (body: string) => Promise<HeadersInit>;
-  };
+    asyncHeaders?: (body: string) => Promise<HeadersInit>
+  }
 
 export type HttpReturnType<
-  TBody extends RpcRequest | RpcRequest[] = RpcRequest
-> = TBody extends RpcRequest[] ? RpcResponse[] : RpcResponse;
+  TBody extends RpcRequest | RpcRequest[] = RpcRequest,
+> = TBody extends RpcRequest[] ? RpcResponse[] : RpcResponse
 
 export type HttpErrorType =
   | HttpRequestErrorType
   | TimeoutErrorType
   | WithTimeoutErrorType
-  | ErrorType;
+  | ErrorType
 
 async function http<TBody extends RpcRequest | RpcRequest[]>(
   url: string,
@@ -91,46 +91,46 @@ async function http<TBody extends RpcRequest | RpcRequest[]>(
     fetchOptions = {},
     timeout = 10_000,
     asyncHeaders,
-  }: HttpOptions<TBody>
+  }: HttpOptions<TBody>,
 ): Promise<HttpReturnType<TBody>> {
-  const { headers, method, signal: signal_ } = fetchOptions;
+  const { headers, method, signal: signal_ } = fetchOptions
   try {
     const response = await withTimeout(
       async ({ signal }) => {
         const requestBody = Array.isArray(body)
           ? stringify(
               body.map((body) => ({
-                jsonrpc: "2.0",
+                jsonrpc: '2.0',
                 id: body.id ?? id++,
                 ...body,
-              }))
+              })),
             )
-          : stringify({ jsonrpc: "2.0", id: body.id ?? id++, ...body });
+          : stringify({ jsonrpc: '2.0', id: body.id ?? id++, ...body })
         const response = await fetch(url, {
           ...fetchOptions,
           body: requestBody,
           headers: {
             ...headers,
             ...(asyncHeaders ? await asyncHeaders(requestBody) : {}),
-            "Content-Type": "application/json",
+            'Content-Type': 'application/json',
           },
-          method: method || "POST",
+          method: method || 'POST',
           signal: signal_ || (timeout > 0 ? signal : undefined),
-        });
-        return response;
+        })
+        return response
       },
       {
         errorInstance: new TimeoutError({ body, url }),
         timeout,
         signal: true,
-      }
-    );
+      },
+    )
 
-    let data: any;
-    if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-      data = await response.json();
+    let data: any
+    if (response.headers.get('Content-Type')?.startsWith('application/json')) {
+      data = await response.json()
     } else {
-      data = await response.text();
+      data = await response.text()
     }
 
     if (!response.ok) {
@@ -140,114 +140,112 @@ async function http<TBody extends RpcRequest | RpcRequest[]>(
         headers: response.headers,
         status: response.status,
         url,
-      });
+      })
     }
 
-    return data;
+    return data
   } catch (err) {
-    if (err instanceof HttpRequestError) throw err;
-    if (err instanceof TimeoutError) throw err;
+    if (err instanceof HttpRequestError) throw err
+    if (err instanceof TimeoutError) throw err
     throw new HttpRequestError({
       body,
       details: (err as Error).message,
       url,
-    });
+    })
   }
 }
 
 ///////////////////////////////////////////////////
 // WebSocket
 
-type Id = string | number;
-type CallbackFn = (message: any) => void;
-type CallbackMap = Map<Id, CallbackFn>;
+type Id = string | number
+type CallbackFn = (message: any) => void
+type CallbackMap = Map<Id, CallbackFn>
 
 export type Socket = WebSocket & {
-  requests: CallbackMap;
-  subscriptions: CallbackMap;
-};
+  requests: CallbackMap
+  subscriptions: CallbackMap
+}
 
-export type GetSocketErrorType = CreateBatchSchedulerErrorType | ErrorType;
+export type GetSocketErrorType = CreateBatchSchedulerErrorType | ErrorType
 
-export const socketsCache = /*#__PURE__*/ new Map<string, Socket>();
+export const socketsCache = /*#__PURE__*/ new Map<string, Socket>()
 
 export async function getSocket(url: string) {
-  let socket = socketsCache.get(url);
+  let socket = socketsCache.get(url)
 
   // If the socket already exists, return it.
-  if (socket) return socket;
+  if (socket) return socket
 
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      const WebSocket = await import("isows").then(
-        (module) => module.WebSocket
-      );
-      const webSocket = new WebSocket(url);
+      const WebSocket = await import('isows').then((module) => module.WebSocket)
+      const webSocket = new WebSocket(url)
 
       // Set up a cache for incoming "synchronous" requests.
-      const requests = new Map<Id, CallbackFn>();
+      const requests = new Map<Id, CallbackFn>()
 
       // Set up a cache for subscriptions (eth_subscribe).
-      const subscriptions = new Map<Id, CallbackFn>();
+      const subscriptions = new Map<Id, CallbackFn>()
 
       const onMessage: (event: MessageEvent) => void = ({ data }) => {
-        const message: RpcResponse = JSON.parse(data as string);
-        const isSubscription = message.method === "eth_subscription";
-        const id = isSubscription ? message.params.subscription : message.id;
-        const cache = isSubscription ? subscriptions : requests;
-        const callback = cache.get(id);
-        if (callback) callback({ data });
-        if (!isSubscription) cache.delete(id);
-      };
+        const message: RpcResponse = JSON.parse(data as string)
+        const isSubscription = message.method === 'eth_subscription'
+        const id = isSubscription ? message.params.subscription : message.id
+        const cache = isSubscription ? subscriptions : requests
+        const callback = cache.get(id)
+        if (callback) callback({ data })
+        if (!isSubscription) cache.delete(id)
+      }
       const onClose = () => {
-        socketsCache.delete(url);
-        webSocket.removeEventListener("close", onClose);
-        webSocket.removeEventListener("message", onMessage);
-      };
+        socketsCache.delete(url)
+        webSocket.removeEventListener('close', onClose)
+        webSocket.removeEventListener('message', onMessage)
+      }
 
       // Setup event listeners for RPC & subscription responses.
-      webSocket.addEventListener("close", onClose);
-      webSocket.addEventListener("message", onMessage);
+      webSocket.addEventListener('close', onClose)
+      webSocket.addEventListener('message', onMessage)
 
       // Wait for the socket to open.
       if (webSocket.readyState === WebSocket.CONNECTING) {
         await new Promise((resolve, reject) => {
-          if (!webSocket) return;
-          webSocket.onopen = resolve;
-          webSocket.onerror = reject;
-        });
+          if (!webSocket) return
+          webSocket.onopen = resolve
+          webSocket.onerror = reject
+        })
       }
 
       // Create a new socket instance.
       socket = Object.assign(webSocket, {
         requests,
         subscriptions,
-      });
-      socketsCache.set(url, socket);
+      })
+      socketsCache.set(url, socket)
 
-      return [socket];
+      return [socket]
     },
-  });
+  })
 
-  const [_, [socket_]] = await schedule();
-  return socket_;
+  const [_, [socket_]] = await schedule()
+  return socket_
 }
 
 export type WebSocketOptions = {
   /** The RPC request body. */
-  body: RpcRequest;
+  body: RpcRequest
   /** The callback to invoke on response. */
-  onResponse?: (message: RpcResponse) => void;
-};
+  onResponse?: (message: RpcResponse) => void
+}
 
-export type WebSocketReturnType = Socket;
+export type WebSocketReturnType = Socket
 
-export type WebSocketErrorType = WebSocketRequestError | ErrorType;
+export type WebSocketErrorType = WebSocketRequestError | ErrorType
 
 function webSocket(
   socket: Socket,
-  { body, onResponse }: WebSocketOptions
+  { body, onResponse }: WebSocketOptions,
 ): WebSocketReturnType {
   if (
     socket.readyState === socket.CLOSED ||
@@ -256,54 +254,54 @@ function webSocket(
     throw new WebSocketRequestError({
       body,
       url: socket.url,
-      details: "Socket is closed.",
-    });
+      details: 'Socket is closed.',
+    })
 
-  const id_ = id++;
+  const id_ = id++
 
   const callback = ({ data }: { data: any }) => {
-    const message: RpcResponse = JSON.parse(data);
+    const message: RpcResponse = JSON.parse(data)
 
-    if (typeof message.id === "number" && id_ !== message.id) return;
+    if (typeof message.id === 'number' && id_ !== message.id) return
 
-    onResponse?.(message);
+    onResponse?.(message)
 
     // If we are subscribing to a topic, we want to set up a listener for incoming
     // messages.
-    if (body.method === "eth_subscribe" && typeof message.result === "string") {
-      socket.subscriptions.set(message.result, callback);
+    if (body.method === 'eth_subscribe' && typeof message.result === 'string') {
+      socket.subscriptions.set(message.result, callback)
     }
 
     // If we are unsubscribing from a topic, we want to remove the listener.
-    if (body.method === "eth_unsubscribe") {
-      socket.subscriptions.delete(body.params?.[0]);
+    if (body.method === 'eth_unsubscribe') {
+      socket.subscriptions.delete(body.params?.[0])
     }
-  };
-  socket.requests.set(id_, callback);
+  }
+  socket.requests.set(id_, callback)
 
-  socket.send(JSON.stringify({ jsonrpc: "2.0", ...body, id: id_ }));
+  socket.send(JSON.stringify({ jsonrpc: '2.0', ...body, id: id_ }))
 
-  return socket;
+  return socket
 }
 
 export type WebSocketAsyncOptions = {
   /** The RPC request body. */
-  body: RpcRequest;
+  body: RpcRequest
   /** The timeout (in ms) for the request. */
-  timeout?: number;
-};
+  timeout?: number
+}
 
-export type WebSocketAsyncReturnType = RpcResponse;
+export type WebSocketAsyncReturnType = RpcResponse
 
 export type WebSocketAsyncErrorType =
   | WebSocketErrorType
   | TimeoutErrorType
   | WithTimeoutErrorType
-  | ErrorType;
+  | ErrorType
 
 async function webSocketAsync(
   socket: Socket,
-  { body, timeout = 10_000 }: WebSocketAsyncOptions
+  { body, timeout = 10_000 }: WebSocketAsyncOptions,
 ): Promise<WebSocketAsyncReturnType> {
   return withTimeout(
     () =>
@@ -311,13 +309,13 @@ async function webSocketAsync(
         rpc.webSocket(socket, {
           body,
           onResponse,
-        })
+        }),
       ),
     {
       errorInstance: new TimeoutError({ body, url: socket.url }),
       timeout,
-    }
-  );
+    },
+  )
 }
 
 ///////////////////////////////////////////////////
@@ -326,4 +324,4 @@ export const rpc = {
   http,
   webSocket,
   webSocketAsync,
-};
+}


### PR DESCRIPTION
Currently it's not easily possible to use flashbots / mev-share with viem.

While generally i guess it would be nice to support `eth_sendPrivateTransaction`,  `eth_sendBundle` etc. as a `actions` extension, the "root issue" making userland solutions to the problem currently very difficult is the lack of dynamic headers.
On flashbots/mev-share you need to [sign your transaction body](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#authentication), which is currently not possible.

This pr tackles the issue by adding a `asyncHeaders` property which receives the request body and returns asyncHeaders.

https://github.com/wevm/viem/discussions/1746#discussioncomment-12608465

