### PR TITLE
fix: update block explorer for Hoodi chain from Blockscout to Etherscan

### DIFF
--- a/.changeset/shaggy-seas-walk.md
+++ b/.changeset/shaggy-seas-walk.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Hoodi chain: Changed the default block explorer from Blockscout to Etherscan
+Changed Hoodi block explorer to Etherscan.

--- a/.changeset/shaggy-seas-walk.md
+++ b/.changeset/shaggy-seas-walk.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Hoodi chain: Changed the default block explorer from Blockscout to Etherscan

--- a/src/chains/definitions/hoodi.ts
+++ b/src/chains/definitions/hoodi.ts
@@ -11,8 +11,8 @@ export const hoodi = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Blockscout',
-      url: 'https://hoodi.cloud.blockscout.com',
+      name: 'Etherscan',
+      url: 'https://hoodi.etherscan.io',
     },
   },
   testnet: true,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

This pull request includes a small but important change to the `src/chains/definitions/hoodi.ts` file. The change updates the default block explorer for the `hoodi` chain.

* [`src/chains/definitions/hoodi.ts`](diffhunk://#diff-a981608fda38859c68217e9202435d039fc69639c309f7811f761ece07f89331L14-R15): Changed the default block explorer from Blockscout to Etherscan.

