### PR TITLE
Add Multicall3 address to Ink Mainnet

### DIFF
--- a/.changeset/tough-apples-occur.md
+++ b/.changeset/tough-apples-occur.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Multicall3 address to Ink Mainnet.

--- a/src/chains/definitions/ink.ts
+++ b/src/chains/definitions/ink.ts
@@ -28,6 +28,10 @@ export const ink = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 0,
+    },
     ...chainConfig.contracts,
     disputeGameFactory: {
       [sourceId]: {


### PR DESCRIPTION
Multicall3 contract is listed in Ink docs [here](https://docs.inkonchain.com/useful-information/contracts#ink-mainnet-1), deployment block is set as `0` since the contract is a "preinstall" from the OP stack ([see here](https://specs.optimism.io/protocol/preinstalls.html)).