### PR TITLE
fix(celo): remove L2 check in fee estimation following the successful hardfork

### DIFF
--- a/.changeset/short-scissors-matter.md
+++ b/.changeset/short-scissors-matter.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**Celo:** remove check for L2 in fee estimation following the successful hardfork

--- a/.changeset/short-scissors-matter.md
+++ b/.changeset/short-scissors-matter.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-**Celo:** remove check for L2 in fee estimation following the successful hardfork
+**Celo:** Removed check for L2 in fee estimation following the successful hardfork.

--- a/src/celo/fees.test.ts
+++ b/src/celo/fees.test.ts
@@ -9,15 +9,15 @@ const client = createTestClient({
 })
 
 describe('celo/fees', () => {
-  const celoestimateFeesPerGasFn = celo.fees.estimateFeesPerGas
-  if (typeof celoestimateFeesPerGasFn !== 'function') return
+  const celoEstimateFeesPerGasFn = celo.fees.estimateFeesPerGas
+  if (typeof celoEstimateFeesPerGasFn !== 'function') return
 
   test("doesn't call the client when feeCurrency is not provided", async () => {
     const requestMock = vi.spyOn(client, 'request')
 
     expect(celo.fees.estimateFeesPerGas).toBeTypeOf('function')
 
-    const fees = await celoestimateFeesPerGasFn({
+    const fees = await celoEstimateFeesPerGasFn({
       client,
       request: {},
     } as any)
@@ -26,67 +26,13 @@ describe('celo/fees', () => {
     expect(requestMock).not.toHaveBeenCalled()
   })
 
-  test('calls the client when feeCurrency is provided celo L1', async () => {
+  test('calls the client when feeCurrency is provided', async () => {
     const requestMock = vi.spyOn(client, 'request')
 
     const baseFee = 15057755162n
     const priorityFee = 602286n
 
     expect(celo.fees.estimateFeesPerGas).toBeTypeOf('function')
-
-    // The check to determine if the chain is L1 or L2 is done by checking to
-    // see if there is code at the proxy admin address (by calling
-    // eth_getCode), if there is code then the chain is considered to be L2. A
-    // response of '0x' as used here is what is returned when there is no code
-    // at the address.
-
-    // @ts-ignore
-    requestMock.mockImplementation((request) => {
-      if (request.method === 'eth_gasPrice') return baseFee.toString()
-      if (request.method === 'eth_maxPriorityFeePerGas')
-        return priorityFee.toString()
-      if (request.method === 'eth_getCode') return '0x'
-      return
-    })
-
-    const fees = await celoestimateFeesPerGasFn({
-      client,
-      multiply: (value: bigint) => (value * 150n) / 100n,
-      request: {
-        feeCurrency: '0xfee',
-      },
-    } as any)
-
-    // For celo L1 the fees maxFeePerGas is calculated as `baseFee + maxPriorityFeePerGas`, the multiply method is not used.
-    expect(fees).toMatchInlineSnapshot(`
-        {
-          "maxFeePerGas": ${baseFee + priorityFee}n,
-          "maxPriorityFeePerGas": ${priorityFee}n,
-        }
-      `)
-    expect(requestMock).toHaveBeenCalledWith({
-      method: 'eth_maxPriorityFeePerGas',
-      params: ['0xfee'],
-    })
-    expect(requestMock).toHaveBeenCalledWith({
-      method: 'eth_gasPrice',
-      params: ['0xfee'],
-    })
-  })
-
-  test('calls the client when feeCurrency is provided celo L2', async () => {
-    const requestMock = vi.spyOn(client, 'request')
-
-    const baseFee = 15057755162n
-    const priorityFee = 602286n
-
-    expect(celo.fees.estimateFeesPerGas).toBeTypeOf('function')
-
-    // The check to determine if the chain is L1 or L2 is done by checking to
-    // see if there is code at the proxy admin address (by calling
-    // eth_getCode), if there is code then the chain is considered to be L2. A
-    // response longer than '0x' as used here is what is returned when there is
-    // code at the address.
 
     // @ts-ignore
     requestMock.mockImplementation((request) => {
@@ -94,12 +40,11 @@ describe('celo/fees', () => {
         return (baseFee + priorityFee).toString()
       if (request.method === 'eth_maxPriorityFeePerGas')
         return priorityFee.toString()
-      if (request.method === 'eth_getCode') return '0x00400400404040404040404'
-      return
+      throw new Error(`Unexpected method called: ${request.method}`)
     })
 
     const multiply = (value: bigint) => (value * 150n) / 100n
-    const feesCeloL1 = await celoestimateFeesPerGasFn({
+    const fees = await celoEstimateFeesPerGasFn({
       client,
       multiply: multiply,
       request: {
@@ -108,9 +53,9 @@ describe('celo/fees', () => {
     } as any)
 
     // For Celo L2 the fees maxFeePerGas is calculated as the following where
-    // multiply is the method passed to celoestimateFeesPerGasFn:
+    // multiply is the method passed to celoEstimateFeesPerGasFn:
     //    `multiply(baseFeePerGas - maxPriorityFeePerGas) + maxPriorityFeePerGas`.
-    expect(feesCeloL1).toMatchInlineSnapshot(`
+    expect(fees).toMatchInlineSnapshot(`
         {
           "maxFeePerGas": ${multiply(baseFee) + priorityFee}n,
           "maxPriorityFeePerGas": ${priorityFee}n,

--- a/src/celo/fees.ts
+++ b/src/celo/fees.ts
@@ -1,4 +1,3 @@
-import { getCode } from '../actions/public/getCode.js'
 import type { Client } from '../clients/createClient.js'
 import type {
   Address,
@@ -23,20 +22,17 @@ export const fees: ChainFees<typeof formatters> = {
   ) => {
     if (!params.request?.feeCurrency) return null
 
-    const [gasPrice, maxPriorityFeePerGas, cel2] = await Promise.all([
+    const [gasPrice, maxPriorityFeePerGas] = await Promise.all([
       estimateFeePerGasInFeeCurrency(params.client, params.request.feeCurrency),
       estimateMaxPriorityFeePerGasInFeeCurrency(
         params.client,
         params.request.feeCurrency,
       ),
-      isCel2(params.client),
     ])
 
-    const maxFeePerGas = cel2
-      ? // eth_gasPrice for cel2 returns baseFeePerGas + maxPriorityFeePerGas
-        params.multiply(gasPrice - maxPriorityFeePerGas) + maxPriorityFeePerGas
-      : // eth_gasPrice for Celo L1 returns (baseFeePerGas * multiplier), where the multiplier is 2 by default.
-        gasPrice + maxPriorityFeePerGas
+    // eth_gasPrice for cel2 returns baseFeePerGas + maxPriorityFeePerGas
+    const maxFeePerGas =
+      params.multiply(gasPrice - maxPriorityFeePerGas) + maxPriorityFeePerGas
 
     return {
       maxFeePerGas,
@@ -96,10 +92,4 @@ async function estimateMaxPriorityFeePerGasInFeeCurrency(
       params: [feeCurrency],
     })
   return BigInt(feesPerGas)
-}
-
-async function isCel2(client: Client) {
-  const proxyAdminAddress = '0x4200000000000000000000000000000000000018'
-  const code = await getCode(client, { address: proxyAdminAddress })
-  return Boolean(code)
 }


### PR DESCRIPTION
This removes the L2 chain detection check in Celo's fee estimation logic following the successful hardfork. 

Previously, the code would check if the chain was L2 by looking for code at the proxy admin address to determine which fee calculation method to use. This distinction is no longer needed and eliminates an extra `eth_getCode` request during fee estimation.

Changes:
- Removed `isCel2` function and L2 detection logic
- Simplified fee calculation to use a single formula
- Updated tests to remove L1/L2 specific cases
