### PR TITLE
feat: universalresolver v3 support

### DIFF
--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from 'vitest'
+import { beforeAll, expect, test } from 'vitest'
 
 import { createHttpServer, setVitalikResolver } from '~test/src/utils.js'
 import { anvilMainnet } from '../../../test/src/anvil.js'
@@ -12,7 +12,7 @@ const client = anvilMainnet.getClient()
 
 beforeAll(async () => {
   await reset(client, {
-    blockNumber: 19_258_213n,
+    blockNumber: 22_138_945n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
   await setVitalikResolver()
@@ -52,7 +52,7 @@ test('gets address that starts with 0s for name', async () => {
 
 test('gets address for name with coinType', async () => {
   await expect(
-    getEnsAddress(client, { name: 'awkweb.eth', coinType: 60 }),
+    getEnsAddress(client, { name: 'awkweb.eth', coinType: 60n }),
   ).resolves.toMatchInlineSnapshot(
     '"0xa0cf798816d4b9b9866b5330eea46a18382f251e"',
   )
@@ -60,7 +60,21 @@ test('gets address for name with coinType', async () => {
 
 test('name without address with coinType', async () => {
   await expect(
-    getEnsAddress(client, { name: 'awkweb.eth', coinType: 61 }),
+    getEnsAddress(client, { name: 'awkweb.eth', coinType: 61n }),
+  ).resolves.toBeNull()
+})
+
+test('name with address with chainId', async () => {
+  await expect(
+    getEnsAddress(client, { name: 'taytems.eth', chainId: 10 }),
+  ).resolves.toMatchInlineSnapshot(
+    '"0x8e8db5ccef88cca9d624701db544989c996e3216"',
+  )
+})
+
+test('name without address with chainId', async () => {
+  await expect(
+    getEnsAddress(client, { name: 'awkweb.eth', chainId: 10 }),
   ).resolves.toBeNull()
 })
 
@@ -82,7 +96,7 @@ test('name with resolver that does not support addr - strict', async () => {
   ).rejects.toMatchInlineSnapshot(`
     [ContractFunctionExecutionError: The contract function "resolve" reverted.
 
-    Error: ResolverError(bytes returnData)
+    Error: ResolverError(bytes errorData)
                         (0x)
      
     Contract Call:
@@ -132,7 +146,7 @@ test('offchain: name without address', async () => {
     getEnsAddress(client, {
       name: 'loalsdsladasdhjasgdhasjdghasgdjgasjdasd.cb.id',
     }),
-  ).resolves.toMatchInlineSnapshot('null')
+  ).resolves.toBeNull()
 })
 
 test('offchain: aggregated', async () => {
@@ -170,25 +184,6 @@ test('custom universal resolver address', async () => {
   ).resolves.toMatchInlineSnapshot(
     '"0xA0Cf798816D4b9b9866b5330EEa46a18382f251e"',
   )
-})
-
-describe('universal resolver with custom errors', () => {
-  test('name without resolver', async () => {
-    await expect(
-      getEnsAddress(client, {
-        name: 'random123.zzz',
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
-      }),
-    ).resolves.toBeNull()
-  })
-  test('name with invalid wildcard resolver', async () => {
-    await expect(
-      getEnsAddress(client, {
-        name: 'another-unregistered-name.eth',
-        universalResolverAddress: '0x9380F1974D2B7064eA0c0EC251968D8c69f0Ae31',
-      }),
-    ).resolves.toBeNull()
-  })
 })
 
 test('chain not provided', async () => {
@@ -230,7 +225,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Ethereum (Local)" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 19258213 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 22138945 (current block 14353601).
 
     Version: viem@x.y.z]
   `)

--- a/src/actions/ens/getEnsAvatar.test.ts
+++ b/src/actions/ens/getEnsAvatar.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
     address: address.vitalik,
   })
   await reset(client, {
-    blockNumber: 19_258_213n,
+    blockNumber: 22_138_945n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
 })

--- a/src/actions/ens/getEnsName.test.ts
+++ b/src/actions/ens/getEnsName.test.ts
@@ -23,7 +23,7 @@ const client = anvilMainnet.getClient()
 
 beforeAll(async () => {
   await reset(client, {
-    blockNumber: 19_258_213n,
+    blockNumber: 22_138_945n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
   await setVitalikResolver()
@@ -79,12 +79,13 @@ test('address with primary name that has no resolver - strict', async () => {
   ).rejects.toMatchInlineSnapshot(`
     [ContractFunctionExecutionError: The contract function "reverse" reverted.
 
-    Error: ResolverWildcardNotSupported()
+    Error: ResolverNotFound(bytes name)
+                           (0x0b726574e286a9efb88f726e0365746800)
      
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
-      function:  reverse(bytes reverseName)
-      args:             (0x28303030303030303030303030363161643865653139303731303530386138313861653533323563330461646472077265766572736500)
+      function:  reverse(bytes reverseName, uint256 coinType)
+      args:             (0x00000000000061aD8EE190710508A818aE5325C3, 60)
 
     Docs: https://viem.sh/docs/contract/readContract
     Version: viem@x.y.z]
@@ -111,13 +112,13 @@ describe('primary name with resolver that does not support text()', () => {
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "reverse" reverted.
 
-      Error: ResolverError(bytes returnData)
+      Error: ResolverError(bytes errorData)
                           (0x)
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
-        function:  reverse(bytes reverseName)
-        args:             (0x28643864613662663236393634616639643765656439653033653533343135643337616139363034350461646472077265766572736500)
+        function:  reverse(bytes reverseName, uint256 coinType)
+        args:             (0xd8da6bf26964af9d7eed9e03e53415d37aa96045, 60)
 
       Docs: https://viem.sh/docs/contract/readContract
       Version: viem@x.y.z]
@@ -145,12 +146,13 @@ describe('primary name with non-contract resolver', () => {
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "reverse" reverted.
 
-      Error: ResolverNotContract()
+      Error: ResolverNotContract(bytes name, address resolver)
+                                (0x08766275746572696e0365746800, 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045)
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
-        function:  reverse(bytes reverseName)
-        args:             (0x28643864613662663236393634616639643765656439653033653533343135643337616139363034350461646472077265766572736500)
+        function:  reverse(bytes reverseName, uint256 coinType)
+        args:             (0xd8da6bf26964af9d7eed9e03e53415d37aa96045, 60)
 
       Docs: https://viem.sh/docs/contract/readContract
       Version: viem@x.y.z]
@@ -165,7 +167,7 @@ describe('http error', () => {
     server = await createHttpServer((_, res) => {
       const parsed = parseAbi([
         'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
-        'error HttpError((uint16,string)[])',
+        'error HttpError(uint16,string)',
       ])
 
       const encoded = encodeFunctionResult({
@@ -177,7 +179,7 @@ describe('http error', () => {
             encodeErrorResult({
               abi: parsed,
               errorName: 'HttpError',
-              args: [[[404, 'Not Found']]],
+              args: [404, 'Not Found'],
             }),
           ],
         ],
@@ -205,9 +207,9 @@ describe('http error', () => {
         gatewayUrls: [server!.url],
         strict: true,
       }),
-    ).rejects.toThrowError(`The contract function "reverse" reverted.
+    ).rejects.toThrowError(`The contract function "reverseWithGateways" reverted.
 
-Error: HttpError((uint16 status, string message)[])`)
+Error: HttpError(uint16 status, string message)`)
   })
 })
 
@@ -215,40 +217,9 @@ test('custom universal resolver address', async () => {
   await expect(
     getEnsName(client, {
       address: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-      universalResolverAddress: '0x74E20Bd2A1fE0cdbe45b9A1d89cb7e0a45b36376',
+      universalResolverAddress: '0x64969fb44091A7E5fA1213D30D7A7e8488edf693',
     }),
   ).resolves.toMatchInlineSnapshot('"awkweb.eth"')
-})
-
-describe('universal resolver with generic errors', () => {
-  test('address with primary name that has no resolver', async () => {
-    await expect(
-      getEnsName(client, {
-        address: '0x00000000000061aD8EE190710508A818aE5325C3',
-        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
-      }),
-    ).resolves.toMatchInlineSnapshot('null')
-  })
-  test('address with primary name that has no resolver - strict', async () => {
-    await expect(
-      getEnsName(client, {
-        address: '0x00000000000061aD8EE190710508A818aE5325C3',
-        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
-        strict: true,
-      }),
-    ).rejects.toMatchInlineSnapshot(`
-      [ContractFunctionExecutionError: The contract function "reverse" reverted with the following reason:
-      UniversalResolver: Wildcard on non-extended resolvers is not supported
-
-      Contract Call:
-        address:   0x0000000000000000000000000000000000000000
-        function:  reverse(bytes reverseName)
-        args:             (0x28303030303030303030303030363161643865653139303731303530386138313861653533323563330461646472077265766572736500)
-
-      Docs: https://viem.sh/docs/contract/readContract
-      Version: viem@x.y.z]
-    `)
-  })
 })
 
 test('chain not provided', async () => {
@@ -295,7 +266,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Ethereum (Local)" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 19258213 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 22138945 (current block 14353601).
 
     Version: viem@x.y.z]
   `)
@@ -312,8 +283,8 @@ test('invalid universal resolver address', async () => {
 
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
-      function:  reverse(bytes reverseName)
-      args:             (0x28613063663739383831366434623962393836366235333330656561343661313833383266323531650461646472077265766572736500)
+      function:  reverse(bytes reverseName, uint256 coinType)
+      args:             (0xA0Cf798816D4b9b9866b5330EEa46a18382f251e, 60)
 
     Docs: https://viem.sh/docs/contract/readContract
     Version: viem@x.y.z]

--- a/src/actions/ens/getEnsResolver.test.ts
+++ b/src/actions/ens/getEnsResolver.test.ts
@@ -13,7 +13,7 @@ const client = anvilMainnet.getClient()
 
 beforeAll(async () => {
   await reset(client, {
-    blockNumber: 19_258_213n,
+    blockNumber: 22_138_945n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
 })
@@ -35,7 +35,7 @@ test('custom universal resolver address', async () => {
   await expect(
     getEnsResolver(client, {
       name: 'awkweb.eth',
-      universalResolverAddress: '0x74E20Bd2A1fE0cdbe45b9A1d89cb7e0a45b36376',
+      universalResolverAddress: '0x64969fb44091A7E5fA1213D30D7A7e8488edf693',
     }),
   ).resolves.toMatchInlineSnapshot(
     '"0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41"',
@@ -86,7 +86,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Ethereum (Local)" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 19258213 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 22138945 (current block 14353601).
 
     Version: viem@x.y.z]
   `)

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -98,7 +98,11 @@ export async function getEnsResolver<chain extends Chain | undefined>(
       {
         inputs: [{ type: 'bytes' }],
         name: 'findResolver',
-        outputs: [{ type: 'address' }, { type: 'bytes32' }],
+        outputs: [
+          { type: 'address' },
+          { type: 'bytes32' },
+          { type: 'uint256' },
+        ],
         stateMutability: 'view',
         type: 'function',
       },

--- a/src/actions/ens/getEnsText.test.ts
+++ b/src/actions/ens/getEnsText.test.ts
@@ -19,7 +19,7 @@ const client = anvilMainnet.getClient()
 
 beforeAll(async () => {
   await reset(client, {
-    blockNumber: 19_258_213n,
+    blockNumber: 22_138_945n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
   await setVitalikResolver()
@@ -76,7 +76,7 @@ test('name with resolver that does not support text() - strict', async () => {
   ).rejects.toMatchInlineSnapshot(`
     [ContractFunctionExecutionError: The contract function "resolve" reverted.
 
-    Error: ResolverError(bytes returnData)
+    Error: ResolverError(bytes errorData)
                         (0x)
      
     Contract Call:
@@ -108,7 +108,8 @@ test('name without resolver - strict', async () => {
   ).rejects.toMatchInlineSnapshot(`
     [ContractFunctionExecutionError: The contract function "resolve" reverted.
 
-    Error: ResolverWildcardNotSupported()
+    Error: ResolverNotFound(bytes name)
+                           (0x1072616e646f6d313232333233323232320365746800)
      
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
@@ -138,7 +139,8 @@ test('name with non-contract resolver - strict', async () => {
   ).rejects.toMatchInlineSnapshot(`
     [ContractFunctionExecutionError: The contract function "resolve" reverted.
 
-    Error: ResolverNotContract()
+    Error: ResolverNotContract(bytes name, address resolver)
+                              (0x08766275746572696e0365746800, 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045)
      
     Contract Call:
       address:   0x0000000000000000000000000000000000000000
@@ -156,7 +158,7 @@ describe('http error', () => {
     server = await createHttpServer((_, res) => {
       const parsed = parseAbi([
         'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
-        'error HttpError((uint16,string)[])',
+        'error HttpError(uint16,string)',
       ])
 
       const encoded = encodeFunctionResult({
@@ -168,7 +170,7 @@ describe('http error', () => {
             encodeErrorResult({
               abi: parsed,
               errorName: 'HttpError',
-              args: [[[404, 'Not Found']]],
+              args: [404, 'Not Found'],
             }),
           ],
         ],
@@ -198,10 +200,10 @@ describe('http error', () => {
         gatewayUrls: [server!.url],
         strict: true,
       }),
-    ).rejects.toThrowError(`The contract function "resolve" reverted.
+    ).rejects.toThrowError(`The contract function "resolveWithGateways" reverted.
 
-Error: HttpError((uint16 status, string message)[])
-                ([{"status":404,"message":"Not Found"}])`)
+Error: HttpError(uint16 status, string message)
+                (404, Not Found)`)
   })
 })
 
@@ -213,39 +215,6 @@ test('custom universal resolver address', async () => {
       universalResolverAddress: '0x74E20Bd2A1fE0cdbe45b9A1d89cb7e0a45b36376',
     }),
   ).resolves.toMatchInlineSnapshot('"wagmi_sh"')
-})
-
-describe('universal resolver with generic errors', () => {
-  test('wildcard error', async () => {
-    await expect(
-      getEnsText(client, {
-        name: 'random1223232222.eth',
-        key: 'com.twitter',
-        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
-      }),
-    ).resolves.toBeNull()
-  })
-  test('wildcard error - strict', async () => {
-    await expect(
-      getEnsText(client, {
-        name: 'random1223232222.eth',
-        key: 'com.twitter',
-        strict: true,
-        universalResolverAddress: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [ContractFunctionExecutionError: The contract function "resolve" reverted with the following reason:
-      UniversalResolver: Wildcard on non-extended resolvers is not supported
-
-      Contract Call:
-        address:   0x0000000000000000000000000000000000000000
-        function:  resolve(bytes name, bytes data)
-        args:             (0x1072616e646f6d313232333233323232320365746800, 0x59d1d43c08e69c7f3b86ec46d8fb6fcebf6b6512306f0171375c6309b751a585ab24864b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b636f6d2e74776974746572000000000000000000000000000000000000000000)
-
-      Docs: https://viem.sh/docs/contract/readContract
-      Version: viem@x.y.z]
-    `)
-  })
 })
 
 test('chain not provided', async () => {
@@ -297,7 +266,7 @@ test('universal resolver contract deployed on later block', async () => {
     [ChainDoesNotSupportContract: Chain "Ethereum (Local)" does not support contract "ensUniversalResolver".
 
     This could be due to any of the following:
-    - The contract "ensUniversalResolver" was not deployed until block 19258213 (current block 14353601).
+    - The contract "ensUniversalResolver" was not deployed until block 22138945 (current block 14353601).
 
     Version: viem@x.y.z]
   `)

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -119,7 +119,6 @@ export async function getEnsText<chain extends Chain | undefined>(
     const readContractParameters = {
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,
-      functionName: 'resolve',
       args: [
         toHex(packetToBytes(name)),
         encodeFunctionData({
@@ -137,9 +136,13 @@ export async function getEnsText<chain extends Chain | undefined>(
     const res = gatewayUrls
       ? await readContractAction({
           ...readContractParameters,
+          functionName: 'resolveWithGateways',
           args: [...readContractParameters.args, gatewayUrls],
         })
-      : await readContractAction(readContractParameters)
+      : await readContractAction({
+          ...readContractParameters,
+          functionName: 'resolve',
+        })
 
     if (res[0] === '0x') return null
 

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -26,8 +26,8 @@ export const holesky = /*#__PURE__*/ defineChain({
       blockCreated: 801613,
     },
     ensUniversalResolver: {
-      address: '0xa6AC935D4971E3CD133b950aE053bECD16fE7f3b',
-      blockCreated: 973484,
+      address: '0x4be8eaE8d104125ECdCAD406bD370d69479d497e',
+      blockCreated: 3_561_398,
     },
   },
   testnet: true,

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -21,8 +21,8 @@ export const mainnet = /*#__PURE__*/ defineChain({
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0xce01f8eee7E479C928F8919abD53E553a36CeF67',
-      blockCreated: 19_258_213,
+      address: '0x64969fb44091A7E5fA1213D30D7A7e8488edf693',
+      blockCreated: 22_138_945,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -23,8 +23,8 @@ export const sepolia = /*#__PURE__*/ defineChain({
     },
     ensRegistry: { address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' },
     ensUniversalResolver: {
-      address: '0xc8Af999e38273D658BE1b921b88A9Ddf005769cC',
-      blockCreated: 5_317_080,
+      address: '0xC087fF4e7D743c3ae6673FF5d42391b741369169',
+      blockCreated: 7_985_523,
     },
   },
   testnet: true,

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -45,24 +45,53 @@ export const multicall3Abi = [
 
 const universalResolverErrors = [
   {
-    inputs: [],
-    name: 'ResolverNotFound',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'ResolverWildcardNotSupported',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'ResolverNotContract',
+    inputs: [
+      {
+        name: 'dns',
+        type: 'bytes',
+      },
+    ],
+    name: 'DNSDecodingFailed',
     type: 'error',
   },
   {
     inputs: [
       {
-        name: 'returnData',
+        name: 'ens',
+        type: 'string',
+      },
+    ],
+    name: 'DNSEncodingFailed',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'EmptyAddress',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        name: 'status',
+        type: 'uint16',
+      },
+      {
+        name: 'message',
+        type: 'string',
+      },
+    ],
+    name: 'HttpError',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidBatchGatewayResponse',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        name: 'errorData',
         type: 'bytes',
       },
     ],
@@ -72,21 +101,50 @@ const universalResolverErrors = [
   {
     inputs: [
       {
-        components: [
-          {
-            name: 'status',
-            type: 'uint16',
-          },
-          {
-            name: 'message',
-            type: 'string',
-          },
-        ],
-        name: 'errors',
-        type: 'tuple[]',
+        name: 'name',
+        type: 'bytes',
+      },
+      {
+        name: 'resolver',
+        type: 'address',
       },
     ],
-    name: 'HttpError',
+    name: 'ResolverNotContract',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        name: 'name',
+        type: 'bytes',
+      },
+    ],
+    name: 'ResolverNotFound',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        name: 'primary',
+        type: 'string',
+      },
+      {
+        name: 'primaryAddress',
+        type: 'bytes',
+      },
+    ],
+    name: 'ReverseAddressMismatch',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'selector',
+        type: 'bytes4',
+      },
+    ],
+    name: 'UnsupportedResolverProfile',
     type: 'error',
   },
 ] as const
@@ -107,7 +165,7 @@ export const universalResolverResolveAbi = [
     ],
   },
   {
-    name: 'resolve',
+    name: 'resolveWithGateways',
     type: 'function',
     stateMutability: 'view',
     inputs: [
@@ -128,27 +186,32 @@ export const universalResolverReverseAbi = [
     name: 'reverse',
     type: 'function',
     stateMutability: 'view',
-    inputs: [{ type: 'bytes', name: 'reverseName' }],
+    inputs: [
+      { type: 'bytes', name: 'reverseName' },
+      {
+        type: 'uint256',
+        name: 'coinType',
+      },
+    ],
     outputs: [
       { type: 'string', name: 'resolvedName' },
-      { type: 'address', name: 'resolvedAddress' },
-      { type: 'address', name: 'reverseResolver' },
       { type: 'address', name: 'resolver' },
+      { type: 'address', name: 'reverseResolver' },
     ],
   },
   {
-    name: 'reverse',
+    name: 'reverseWithGateways',
     type: 'function',
     stateMutability: 'view',
     inputs: [
       { type: 'bytes', name: 'reverseName' },
+      { type: 'uint256', name: 'coinType' },
       { type: 'string[]', name: 'gateways' },
     ],
     outputs: [
       { type: 'string', name: 'resolvedName' },
-      { type: 'address', name: 'resolvedAddress' },
-      { type: 'address', name: 'reverseResolver' },
       { type: 'address', name: 'resolver' },
+      { type: 'address', name: 'reverseResolver' },
     ],
   },
 ] as const

--- a/src/errors/ens.ts
+++ b/src/errors/ens.ts
@@ -55,3 +55,17 @@ export class EnsAvatarUnsupportedNamespaceError extends BaseError {
     )
   }
 }
+
+export type EnsInvalidChainIdErrorType = EnsInvalidChainIdError & {
+  name: 'EnsInvalidChainIdError'
+}
+export class EnsInvalidChainIdError extends BaseError {
+  constructor({ chainId }: { chainId: number }) {
+    super(
+      `Invalid ENSIP-11 chainId: ${chainId}. Must be between 0 and 0x7fffffff.`,
+      {
+        name: 'EnsInvalidChainIdError',
+      },
+    )
+  }
+}

--- a/src/utils/ens/errors.ts
+++ b/src/utils/ens/errors.ts
@@ -16,11 +16,14 @@ export function isNullUniversalResolverError(
   if (!(err instanceof BaseError)) return false
   const cause = err.walk((e) => e instanceof ContractFunctionRevertedError)
   if (!(cause instanceof ContractFunctionRevertedError)) return false
-  if (cause.data?.errorName === 'ResolverNotFound') return true
-  if (cause.data?.errorName === 'ResolverWildcardNotSupported') return true
-  if (cause.data?.errorName === 'ResolverNotContract') return true
-  if (cause.data?.errorName === 'ResolverError') return true
+
   if (cause.data?.errorName === 'HttpError') return true
+  if (cause.data?.errorName === 'ResolverError') return true
+  if (cause.data?.errorName === 'ResolverNotContract') return true
+  if (cause.data?.errorName === 'ResolverNotFound') return true
+  if (cause.data?.errorName === 'ReverseAddressMismatch') return true
+  if (cause.data?.errorName === 'UnsupportedResolverProfile') return true
+
   // Backwards compatibility for older UniversalResolver contracts
   if (
     cause.reason?.includes(

--- a/src/utils/ens/evmChainIdToCoinType.test.ts
+++ b/src/utils/ens/evmChainIdToCoinType.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+
+import { evmChainIdToCoinType } from './evmChainIdToCoinType.js'
+
+test.each([
+  {
+    chainId: 0,
+    expected: 2147483648n,
+  },
+  {
+    chainId: 1,
+    expected: 2147483649n,
+  },
+  {
+    chainId: 8453,
+    expected: 2147492101n,
+  },
+  {
+    chainId: 0x7fffffff,
+    expected: 4294967295n,
+  },
+])('evmChainIdToCoinType($chainId) -> $expected', ({ chainId, expected }) => {
+  expect(evmChainIdToCoinType(chainId)).toBe(expected)
+})
+
+test('only positive chainIds', () => {
+  expect(() => evmChainIdToCoinType(-1)).toThrowErrorMatchingInlineSnapshot(`
+    [EnsInvalidChainIdError: Invalid ENSIP-11 chainId: -1. Must be between 0 and 0x7fffffff.
+
+    Version: viem@x.y.z]
+  `)
+})
+
+test('less than 0x80000000', () => {
+  expect(() =>
+    evmChainIdToCoinType(0x80000000),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [EnsInvalidChainIdError: Invalid ENSIP-11 chainId: 2147483648. Must be between 0 and 0x7fffffff.
+
+    Version: viem@x.y.z]
+  `)
+})

--- a/src/utils/ens/evmChainIdToCoinType.ts
+++ b/src/utils/ens/evmChainIdToCoinType.ts
@@ -1,0 +1,22 @@
+import {
+  EnsInvalidChainIdError,
+  type EnsInvalidChainIdErrorType,
+} from '../../errors/ens.js'
+import type { ErrorType } from '../../errors/utils.js'
+
+export type EvmChainIdToCoinTypeError = EnsInvalidChainIdErrorType | ErrorType
+
+const SLIP44_MSB = 0x80000000
+
+/**
+ * @description Converts an EVM chainId to a ENSIP-9 compliant coinType
+ *
+ * @example
+ * evmChainIdToCoinType(10)
+ * 2147483658n
+ */
+export function evmChainIdToCoinType(chainId: number): bigint {
+  if (chainId >= SLIP44_MSB || chainId < 0)
+    throw new EnsInvalidChainIdError({ chainId })
+  return BigInt((0x80000000 | chainId) >>> 0)
+}

--- a/test/src/abis.ts
+++ b/test/src/abis.ts
@@ -3459,7 +3459,7 @@ export const seaportContractConfig = {
 } as const
 
 export const ensPublicResolverConfig = {
-  address: '0x4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+  address: '0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63',
   abi: [
     {
       inputs: [{ name: '_ens', type: 'address' }],


### PR DESCRIPTION
This PR uses the [Universal Resolution ENSIP](https://github.com/ensdomains/ensips/pull/11) for a stable `UniversalResolver` API, which will become the canonical entrypoint to ENS. The API, when used with the UniversalResolver proxy (TBC) will allow clients to migrate automatically to ENSv2 on launch. For reverse resolution, the new API also enables [ENSIP-19](#)'s chain-specific reverse resolution process by providing a coinType.

Changes:
- Added `evmChainIdToCoinType` helper func
- Added `chainId` and `coinType` param to `getEnsName()` for L2 reverse lookups
- Added `chainId` param to `getEnsAddress()` for parity
- Removed legacy `UniversalResolver` error handling 

Remaining tasks:
- [ ] Add UniversalResolver proxy address (currently using hardcoded)
- [ ] Add tests for chainId-specific `getEnsName()` requests (not yet deployed on mainnet)