### PR TITLE
fix: update ConfluxScan URLs for mainnet and testnet

### DIFF
--- a/.changeset/six-donuts-matter.md
+++ b/.changeset/six-donuts-matter.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated ConfluxScan links

--- a/src/chains/definitions/confluxESpace.ts
+++ b/src/chains/definitions/confluxESpace.ts
@@ -13,7 +13,7 @@ export const confluxESpace = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'ConfluxScan',
-      url: 'https://evm.confluxscan.io',
+      url: 'https://evm.confluxscan.org',
     },
   },
   contracts: {

--- a/src/chains/definitions/confluxESpaceTestnet.ts
+++ b/src/chains/definitions/confluxESpaceTestnet.ts
@@ -15,7 +15,7 @@ export const confluxESpaceTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'ConfluxScan',
-      url: 'https://evmtestnet.confluxscan.io',
+      url: 'https://evmtestnet.confluxscan.org',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

ConfluxScan is using new domain link. This pull request updates the conflux explorer link.
Check official announcement here:
https://forum.conflux.fun/t/confluxscan-domain-update-announcement-march-28-2025/21920

