### PR TITLE
Add ens to hemi

### DIFF
--- a/src/chains/definitions/hemi.ts
+++ b/src/chains/definitions/hemi.ts
@@ -20,5 +20,17 @@ export const hemi = /*#__PURE__*/ defineChain({
       url: 'https://explorer.hemi.xyz',
     },
   },
+  contracts: {
+    multicall3: {
+      address: "0x3FBA66680F0F468089233bB14E40725eCB66AF7A",
+    },
+    ensRegistry: {
+      address: "0x099fee7f2ef53eb7ccc0e465a32f3aefa8d703c5"
+    },
+    ensUniversalResolver: {
+      address: "0x4bb8573ddb5b8369c87bd6d7e34137d7ce674f2b",
+      blockCreated: 1360113,
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
Add ensRegistry and ensUniversalResolver to Hemi Network using getHemiNames => https://getheminames.me


Contracts have been verified as requested by contributing guidelines.

Multicall => https://explorer.hemi.xyz/address/0x3FBA66680F0F468089233bB14E40725eCB66AF7A 
Registry => https://explorer.hemi.xyz/address/0x099Fee7f2EF53eB7CCC0e465a32f3aEfa8D703C5 
Universal Resolver => https://explorer.hemi.xyz/address/0x4bB8573dDb5B8369C87bd6D7e34137D7Ce674F2B

