### PR TITLE
fix: `webSocket()` transport ignores `keepAlive`, `reconnect`

### DIFF
--- a/.changeset/metal-moose-report.md
+++ b/.changeset/metal-moose-report.md
@@ -1,0 +1,7 @@
+---
+"viem": patch
+---
+
+Ensure that the `keepAlive` and `reconnect` parameters are passed through to 
+the underlying implementation (`getWebSocketRpcClient()`) when the top level
+`webSocket()` transport factory function is called with them specified.

--- a/.changeset/metal-moose-report.md
+++ b/.changeset/metal-moose-report.md
@@ -2,6 +2,6 @@
 "viem": patch
 ---
 
-Ensure that the `keepAlive` and `reconnect` parameters are passed through to 
+Ensured that the `keepAlive` and `reconnect` parameters are passed through to 
 the underlying implementation (`getWebSocketRpcClient()`) when the top level
 `webSocket()` transport factory function is called with them specified.

--- a/src/clients/createPublicClient.test.ts
+++ b/src/clients/createPublicClient.test.ts
@@ -3,6 +3,7 @@ import { assertType, describe, expect, test, vi } from 'vitest'
 import { anvilMainnet } from '../../test/src/anvil.js'
 import { localhost } from '../chains/index.js'
 import type { EIP1193RequestFn, PublicRpcSchema } from '../index.js'
+import * as utilsRpcWebSocket from '../utils/rpc/webSocket.js'
 import { createPublicClient } from './createPublicClient.js'
 import { testActions } from './decorators/test.js'
 import { walletActions } from './decorators/wallet.js'
@@ -360,6 +361,49 @@ describe('transports', () => {
         "watchPendingTransactions": [Function],
       }
     `)
+  })
+
+  test('webSocket - getRpcClient() - keepAlive & reconnect disabled', async () => {
+    const wsRpcClientOpts = { keepAlive: false, reconnect: false }
+    const { uid, ...client } = createPublicClient({
+      chain: localhost,
+      transport: webSocket(anvilMainnet.rpcUrl.ws, wsRpcClientOpts),
+    })
+    const spy = vi.spyOn(utilsRpcWebSocket, 'getWebSocketRpcClient')
+
+    await client.transport.getRpcClient()
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(anvilMainnet.rpcUrl.ws, wsRpcClientOpts)
+  })
+
+  test('webSocket - subscribe() - keepAlive & reconnect disabled', async () => {
+    const wsRpcClientOpts = { keepAlive: false, reconnect: false }
+    const { uid, ...client } = createPublicClient({
+      chain: localhost,
+      transport: webSocket(anvilMainnet.rpcUrl.ws, wsRpcClientOpts),
+    })
+    const spy = vi.spyOn(utilsRpcWebSocket, 'getWebSocketRpcClient')
+
+    await client.transport.subscribe({
+      params: ['newHeads'],
+      onData: () => {},
+      onError: () => {},
+    })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(anvilMainnet.rpcUrl.ws, wsRpcClientOpts)
+  })
+
+  test('webSocket - request() - keepAlive & reconnect disabled', async () => {
+    const wsRpcClientOpts = { keepAlive: false, reconnect: false }
+    const { uid, ...client } = createPublicClient({
+      chain: localhost,
+      transport: webSocket(anvilMainnet.rpcUrl.ws, wsRpcClientOpts),
+    })
+    const spy = vi.spyOn(utilsRpcWebSocket, 'getWebSocketRpcClient')
+
+    await client.transport.request({ method: 'eth_blockNumber', params: [] })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(anvilMainnet.rpcUrl.ws, wsRpcClientOpts)
   })
 
   test('custom', () => {

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -103,6 +103,7 @@ export function webSocket(
     const retryCount = config.retryCount ?? retryCount_
     const timeout = timeout_ ?? config.timeout ?? 10_000
     const url_ = url || chain?.rpcUrls.default.webSocket?.[0]
+    const wsRpcClientOpts = { keepAlive, reconnect }
     if (!url_) throw new UrlRequiredError()
     return createTransport(
       {
@@ -111,10 +112,7 @@ export function webSocket(
         name,
         async request({ method, params }) {
           const body = { method, params }
-          const rpcClient = await getWebSocketRpcClient(url_, {
-            keepAlive,
-            reconnect,
-          })
+          const rpcClient = await getWebSocketRpcClient(url_, wsRpcClientOpts)
           const { error, result } = await rpcClient.requestAsync({
             body,
             timeout,
@@ -137,10 +135,10 @@ export function webSocket(
           return getSocket(url_)
         },
         getRpcClient() {
-          return getWebSocketRpcClient(url_)
+          return getWebSocketRpcClient(url_, wsRpcClientOpts)
         },
         async subscribe({ params, onData, onError }: any) {
-          const rpcClient = await getWebSocketRpcClient(url_)
+          const rpcClient = await getWebSocketRpcClient(url_, wsRpcClientOpts)
           const { result: subscriptionId } = await new Promise<any>(
             (resolve, reject) =>
               rpcClient.request({


### PR DESCRIPTION
Fixes #3521

This will ensure that the `keepAlive` and `reconnect` parameters are passed through to the underlying implementation in all cases.

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>



