### PR TITLE
Mention ZeroDev for using bundler RPC as paymaster

### DIFF
--- a/site/pages/account-abstraction.mdx
+++ b/site/pages/account-abstraction.mdx
@@ -318,7 +318,7 @@ export const account = await toCoinbaseSmartAccount({
 :::
 
 ::::tip
-If your Bundler also accepts Paymaster sponsorship (like [Pimlico](https://www.pimlico.io)), you can set `paymaster: true` instead of declaring a separate Paymaster Client.
+If your Bundler also accepts Paymaster sponsorship (like [Pimlico](https://www.pimlico.io) or [ZeroDev](https://zerodev.app/)), you can set `paymaster: true` instead of declaring a separate Paymaster Client.
 
 :::code-group
 


### PR DESCRIPTION
We recently added support for using ZeroDev bundler RPC as paymaster so I wanted to add a mention here.