### PR TITLE
Add ENS to Linea Sepolia and Mainnet

### DIFF
--- a/.changeset/fair-donuts-fry.md
+++ b/.changeset/fair-donuts-fry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ENS contracts to Linea Sepolia and Mainnet.

--- a/src/chains/definitions/linea.ts
+++ b/src/chains/definitions/linea.ts
@@ -24,6 +24,14 @@ export const linea = /*#__PURE__*/ defineChain({
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 42,
     },
+    ensRegistry: {
+      address: '0x50130b669B28C339991d8676FA73CF122a121267',
+      blockCreated: 6682888,
+    },
+    ensUniversalResolver: {
+      address: '0x3aA974fb3f8C1E02796048BDCdeD79e9D53a6965',
+      blockCreated: 6683000,
+    },
   },
   testnet: false,
 })

--- a/src/chains/definitions/lineaSepolia.ts
+++ b/src/chains/definitions/lineaSepolia.ts
@@ -24,6 +24,14 @@ export const lineaSepolia = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 227427,
     },
+    ensRegistry: {
+      address: '0x5B2636F0f2137B4aE722C01dd5122D7d3e9541f7',
+      blockCreated: 2395094,
+    },
+    ensUniversalResolver: {
+      address: '0x72560a31B3DAEE82B984a7F51c6b3b1bb7CC9F50',
+      blockCreated: 2395255,
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
Add `ensRegistry` and `ensUniversalResolver` to Linea Sepolia and Mainnet using Linea Name Service: https://names.linea.build

Contracts have been verified as requested by contributing guidelines.

Contracts Addresses:
1. Linea Sepolia
   1. EnsRegistry: https://sepolia.lineascan.build/address/0x5B2636F0f2137B4aE722C01dd5122D7d3e9541f7
   2. EnsUniversalResolver: https://sepolia.lineascan.build/address/0x72560a31B3DAEE82B984a7F51c6b3b1bb7CC9F50
2. Linea Mainnet
   1. EnsRegistry: https://lineascan.build/address/0x50130b669B28C339991d8676FA73CF122a121267
   2. EnsUniversalResolver: https://lineascan.build/address/0x3aA974fb3f8C1E02796048BDCdeD79e9D53a6965

Documentation: https://support.linea.build/explore/ens