### PR TITLE
fix(op-stack): `unproven` is contextually a ready-to-prove case

### DIFF
--- a/.changeset/olive-kings-burn.md
+++ b/.changeset/olive-kings-burn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**OP Stack:** Fixed `Unproven` case.

--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -284,7 +284,6 @@ export async function getWithdrawalStatus<
       // All potential error causes listed here, can either be the error string or the error name
       // if custom error types are returned.
       const errorCauses = {
-        'waiting-to-prove': ['Unproven'],
         'ready-to-prove': [
           'OptimismPortal: invalid game type',
           'OptimismPortal: withdrawal has not been proven yet',
@@ -292,6 +291,7 @@ export async function getWithdrawalStatus<
           'OptimismPortal: dispute game created before respected game type was updated',
           'InvalidGameType',
           'LegacyGame',
+          'Unproven',
         ],
         'waiting-to-finalize': [
           'OptimismPortal: proven withdrawal has not matured yet',
@@ -306,10 +306,6 @@ export async function getWithdrawalStatus<
         error.cause.data?.errorName,
         error.cause.data?.args?.[0] as string,
       ]
-      if (
-        errorCauses['waiting-to-prove'].some((cause) => errors.includes(cause))
-      )
-        return 'waiting-to-prove'
       if (errorCauses['ready-to-prove'].some((cause) => errors.includes(cause)))
         return 'ready-to-prove'
       if (


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->
The Optimism Portal contract can revert with `Unproven()` after a state transition root on L2 has been processed on L1 but before a withdrawal proof has been submitted. I believe that, in the context of `getWithdrawalStatus()`, since we first check the dispute game factory to see whether a state proof has been made which would include the withdrawal initiated at the input `l2BlockNumber`, if `disputeGameResult` is _not_ rejected and the withdrawal status result _is_ rejected due to an `Unproven()` revert, then the withdrawal _is_ ready to be proven.