### PR TITLE
docs: fix wrong chain in initiateWitdrawal.md

### DIFF
--- a/site/pages/op-stack/actions/initiateWithdrawal.md
+++ b/site/pages/op-stack/actions/initiateWithdrawal.md
@@ -30,11 +30,11 @@ const hash = await walletClientL2.initiateWithdrawal({
 ```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { mainnet } from 'viem/chains'
+import { optimism } from 'viem/chains'
 import { walletActionsL2 } from 'viem/op-stack'
 
 export const walletClientL2 = createWalletClient({
-  chain: mainnet,
+  chain: optimism,
   transport: custom(window.ethereum)
 }).extend(walletActionsL2())
 


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

The `config.ts` section of the [Usage docs for initiateWithdrawal](https://viem.sh/op-stack/actions/initiateWithdrawal#usage) shows the `walletClientL2` to be created with the `mainnet` chain. However, this is incorrect because the `chain` shall be an L2. This is even stated below, in the documentation for the `chain` property 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

