### PR TITLE
feat: add multicall3 contract to Hoodi chain

### DIFF
--- a/.changeset/healthy-crews-appear.md
+++ b/.changeset/healthy-crews-appear.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added multicall3 contract to Hoodi chain

--- a/src/chains/definitions/hoodi.ts
+++ b/src/chains/definitions/hoodi.ts
@@ -15,5 +15,11 @@ export const hoodi = /*#__PURE__*/ defineChain({
       url: 'https://hoodi.etherscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2589,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Added multicall3 contract to Hoodi chain

This PR adds the multicall3 contract address to the Hoodi chain definition, enabling multicall functionality for the chain.

Changes:
- Added multicall3 contract configuration to Hoodi chain definition
- Contract address: 0xca11bde05977b3631167028862be2a173976ca11