### PR TITLE
add note about using encodeFunctionData to data of estimateGas

### DIFF
--- a/site/pages/docs/actions/public/estimateGas.md
+++ b/site/pages/docs/actions/public/estimateGas.md
@@ -67,7 +67,7 @@ const gas = await publicClient.estimateGas({
 
 - **Type:** `0x${string}`
 
-Contract code or a hashed method call with encoded args.
+Contract code or a hashed method call with encoded args.  The args can be encoded using [encodeFunctionData](/docs/contract/encodeFunctionData).
 
 ```ts twoslash
 // [!include ~/snippets/publicClient.ts]

--- a/site/pages/docs/actions/public/estimateGas.md
+++ b/site/pages/docs/actions/public/estimateGas.md
@@ -67,7 +67,7 @@ const gas = await publicClient.estimateGas({
 
 - **Type:** `0x${string}`
 
-Contract code or a hashed method call with encoded args.  The args can be encoded using [encodeFunctionData](/docs/contract/encodeFunctionData).
+Contract code or a hashed method call with encoded args which can be generated using [encodeFunctionData](/docs/contract/encodeFunctionData).
 
 ```ts twoslash
 // [!include ~/snippets/publicClient.ts]


### PR DESCRIPTION
This documentation update is for the `estimateGas` `data` parameter.  It adds a reference to `encodeFunctionData` to provide guidance on its usage. 
