### PR TITLE
fix: newton chain rpc url typo

### DIFF
--- a/.changeset/two-bees-build.md
+++ b/.changeset/two-bees-build.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Newton chain rpc url typo

--- a/src/chains/definitions/newton.ts
+++ b/src/chains/definitions/newton.ts
@@ -10,7 +10,7 @@ export const newton = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['hhttps://global.rpc.mainnet.newtonproject.org'],
+      http: ['https://global.rpc.mainnet.newtonproject.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Fix typo in **Newton** chain definition.  Default rpc url contains an extra letter in protocol _hhttps_.