### PR TITLE
fix: correct RPC URL configuration for Metis chains

### DIFF
--- a/.changeset/thin-steaks-knock.md
+++ b/.changeset/thin-steaks-knock.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Metis & Metis Sepolia rpcUrls config

--- a/src/chains/definitions/metis.ts
+++ b/src/chains/definitions/metis.ts
@@ -17,11 +17,10 @@ export const metis = /*#__PURE__*/ defineChain({
         'https://metis-andromeda.rpc.thirdweb.com',
         'https://metis-andromeda.gateway.tenderly.co',
         'https://metis.api.onfinality.io/public',
-        'wss://metis-rpc.publicnode.com',
         'https://andromeda.metis.io/?owner=1088',
-        'wss://metis.drpc.org',
         'https://metis-mainnet.public.blastapi.io',
       ],
+      webSocket: ['wss://metis-rpc.publicnode.com', 'wss://metis.drpc.org'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/metisSepolia.ts
+++ b/src/chains/definitions/metisSepolia.ts
@@ -11,11 +11,11 @@ export const metisSepolia = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: [
-        'wss://metis-sepolia-rpc.publicnode.com',
         'https://sepolia.metisdevops.link',
         'https://metis-sepolia-rpc.publicnode.com',
         'https://metis-sepolia.gateway.tenderly.co',
       ],
+      webSocket: ['wss://metis-sepolia-rpc.publicnode.com'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Fixed misconfigured `rpcUrls` for **Metis** and **Metis Sepolia** chains.  `wss://` websocket urls were incorrectly placed in the `rpcUrls.default.http` property along with `http` rpc urls.  This  was causing issues when adding or switching to Metis chains.

`MetaMask - RPC Error: Expected an array with at least one valid string HTTPS url 'rpcUrls', Received:
wss://metis-sepolia-rpc.publicnode.com `