### PR TITLE
Update and Deprecate SKALE Network Chains

### DIFF
--- a/.changeset/brown-ducks-smell.md
+++ b/.changeset/brown-ducks-smell.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Update and Deprecate SKALE Network Chains
+Updated SKALE Network Chains.

--- a/.changeset/brown-ducks-smell.md
+++ b/.changeset/brown-ducks-smell.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Update and Deprecate SKALE Network Chains

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6228,6 +6228,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.26.5:
+    resolution: {integrity: sha512-padHks2XVeYF9B4m2ieEbzARrcGcQHMuwYrvda4jwqt93qYqPNaV3J0/nZqV8+fGRYh/HqBD+kVO5j83/IdVZg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -7750,7 +7758,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.26.4(typescript@5.8.2)(zod@3.23.8)
+      viem: 2.26.5(typescript@5.8.2)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -13029,7 +13037,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.26.4(typescript@5.8.2)(zod@3.23.8):
+  viem@2.26.5(typescript@5.8.2)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1

--- a/src/chains/definitions/skale/calypso.ts
+++ b/src/chains/definitions/skale/calypso.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleCalypso = /*#__PURE__*/ defineChain({
   id: 1_564_830_818,
-  name: 'SKALE | Calypso NFT Hub',
+  name: 'SKALE Calypso Hub',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
@@ -21,7 +21,7 @@ export const skaleCalypso = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-      blockCreated: 3107626,
+      blockCreated: 3_107_626,
     },
   },
 })

--- a/src/chains/definitions/skale/europa.ts
+++ b/src/chains/definitions/skale/europa.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleEuropa = /*#__PURE__*/ defineChain({
   id: 2_046_399_126,
-  name: 'SKALE | Europa Liquidity Hub',
+  name: 'SKALE Europa Hub',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
@@ -19,7 +19,7 @@ export const skaleEuropa = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-      blockCreated: 3113495,
+      blockCreated: 3_113_495,
     },
   },
 })

--- a/src/chains/definitions/skale/exorde.ts
+++ b/src/chains/definitions/skale/exorde.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleExorde = /*#__PURE__*/ defineChain({
   id: 2_139_927_552,
-  name: 'SKALE | Exorde',
+  name: 'Exorde Network',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {

--- a/src/chains/definitions/skale/nebula.ts
+++ b/src/chains/definitions/skale/nebula.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleNebula = /*#__PURE__*/ defineChain({
   id: 1_482_601_649,
-  name: 'SKALE | Nebula Gaming Hub',
+  name: 'SKALE Nebula Hub',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
@@ -19,7 +19,7 @@ export const skaleNebula = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-      blockCreated: 2372986,
+      blockCreated: 2_372_986,
     },
   },
 })

--- a/src/chains/definitions/skale/titan.ts
+++ b/src/chains/definitions/skale/titan.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleTitan = /*#__PURE__*/ defineChain({
   id: 1_350_216_234,
-  name: 'SKALE | Titan Community Hub',
+  name: 'SKALE Titan Hub',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
@@ -19,7 +19,7 @@ export const skaleTitan = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-      blockCreated: 2076458,
+      blockCreated: 2_076_458,
     },
   },
 })

--- a/src/chains/definitions/skale/titanTestnet.ts
+++ b/src/chains/definitions/skale/titanTestnet.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../../utils/chain/defineChain.js'
 
 export const skaleTitanTestnet = /*#__PURE__*/ defineChain({
   id: 1_020_352_220,
-  name: 'SKALE Titan Hub',
+  name: 'SKALE Titan Testnet',
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -463,7 +463,7 @@ export { skaleCryptoBlades } from './definitions/skale/cryptoBlades.js'
 /** @deprecated */
 export { skaleCryptoColosseum } from './definitions/skale/cryptoColosseum.js'
 export { skaleEuropa } from './definitions/skale/europa.js'
-export { skaleEuropaTestnet } from './definitions/skale/europaTestnet.js' 
+export { skaleEuropaTestnet } from './definitions/skale/europaTestnet.js'
 export { skaleExorde } from './definitions/skale/exorde.js'
 /** @deprecated */
 export { skaleHumanProtocol } from './definitions/skale/humanProtocol.js'

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -460,13 +460,16 @@ export { skaleBlockBrawlers } from './definitions/skale/brawl.js'
 export { skaleCalypso } from './definitions/skale/calypso.js'
 export { skaleCalypsoTestnet } from './definitions/skale/calypsoTestnet.js'
 export { skaleCryptoBlades } from './definitions/skale/cryptoBlades.js'
+/** @deprecated */
 export { skaleCryptoColosseum } from './definitions/skale/cryptoColosseum.js'
 export { skaleEuropa } from './definitions/skale/europa.js'
-export { skaleEuropaTestnet } from './definitions/skale/europaTestnet.js'
+export { skaleEuropaTestnet } from './definitions/skale/europaTestnet.js' 
 export { skaleExorde } from './definitions/skale/exorde.js'
+/** @deprecated */
 export { skaleHumanProtocol } from './definitions/skale/humanProtocol.js'
 export { skaleNebula } from './definitions/skale/nebula.js'
 export { skaleNebulaTestnet } from './definitions/skale/nebulaTestnet.js'
+/** @deprecated Use `skaleEuropa` instead.*/
 export { skaleRazor } from './definitions/skale/razor.js'
 export { skaleTitan } from './definitions/skale/titan.js'
 export { skaleTitanTestnet } from './definitions/skale/titanTestnet.js'


### PR DESCRIPTION
- Deprecates Unused SKALE Chains: Razor, Human Protocol, CryptoColosseum
- Simplifies Names for SKALE Chains

