### PR TITLE
Fix broken Fault Proofs docs links

### DIFF
--- a/site/pages/op-stack/actions/getL2Output.md
+++ b/site/pages/op-stack/actions/getL2Output.md
@@ -10,7 +10,7 @@ Retrieves the first L2 output proposal that occurred after a provided block numb
 :::warning
 **This Action will be deprecated in the future.**
 
-Use [`getGame`](/op-stack/actions/getGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+Use [`getGame`](/op-stack/actions/getGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage

--- a/site/pages/op-stack/actions/getTimeToNextGame.md
+++ b/site/pages/op-stack/actions/getTimeToNextGame.md
@@ -8,7 +8,7 @@ description: Returns the time until the next L2 dispute game is submitted.
 Returns the time until the next L2 dispute game (after the provided block number) is submitted. Used for the [Withdrawal](/op-stack/guides/withdrawals) flow.
 
 :::info
-This Action is only compatible with OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+This Action is only compatible with OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage

--- a/site/pages/op-stack/actions/getTimeToNextL2Output.md
+++ b/site/pages/op-stack/actions/getTimeToNextL2Output.md
@@ -10,7 +10,7 @@ Returns the time until the next L2 output (after a provided block number) is sub
 :::warning
 **This Action will be deprecated in the future.**
 
-Use [`getTimeToNextGame`](/op-stack/actions/getTimeToNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+Use [`getTimeToNextGame`](/op-stack/actions/getTimeToNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage

--- a/site/pages/op-stack/actions/waitForNextGame.md
+++ b/site/pages/op-stack/actions/waitForNextGame.md
@@ -10,7 +10,7 @@ Waits for the next dispute game (after the provided block number) to be submitte
 Internally calls [`getTimeToNextGame`](/op-stack/actions/getTimeToNextGame) and waits the returned `seconds`.
 
 :::info
-This Action is only compatible with OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+This Action is only compatible with OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage

--- a/site/pages/op-stack/actions/waitForNextL2Output.md
+++ b/site/pages/op-stack/actions/waitForNextL2Output.md
@@ -12,7 +12,7 @@ Internally calls [`getTimeToNextL2Output`](/op-stack/actions/getTimeToNextL2Outp
 :::warning
 **This Action will be deprecated in the future.**
 
-Use [`waitForNextGame`](/op-stack/actions/waitForNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+Use [`waitForNextGame`](/op-stack/actions/waitForNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage


### PR DESCRIPTION
Replaced old docs links:
/fault-proofs/overview → /fault-proofs

Old links are dead (404). New ones point to the up-to-date Fault Proofs hub.
