### PR TITLE
chore: fixed broken link in `readContract.md`

### DIFF
--- a/site/pages/docs/contract/readContract.md
+++ b/site/pages/docs/contract/readContract.md
@@ -191,7 +191,7 @@ export const publicClient = createPublicClient({
 :::
 
 :::note
-This example utilizes the [SimpleAccountFactory](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccountFactory.sol).
+This example utilizes the [SimpleAccountFactory](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/accounts/SimpleAccountFactory.sol).
 :::
 
 ## Return Value


### PR DESCRIPTION
Hi! I fixed a broken link in the `readContract.md` docs. The example was pointing to the old `samples/` directory for `SimpleAccountFactory.sol`, but it has since been moved to `contracts/accounts/`.
