### PR TITLE
Fix broken deposits.md link

### DIFF
--- a/site/pages/op-stack/actions/buildDepositTransaction.md
+++ b/site/pages/op-stack/actions/buildDepositTransaction.md
@@ -5,7 +5,7 @@ description: Builds & prepares parameters for a deposit transaction to be initia
 
 # buildDepositTransaction
 
-Builds & prepares parameters for a [deposit transaction](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md) to be initiated on an L1 and executed on the L2.
+Builds & prepares parameters for a [deposit transaction]([https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md) to be initiated on an L1 and executed on the L2.
 
 ## Usage
 

--- a/site/pages/op-stack/actions/depositTransaction.md
+++ b/site/pages/op-stack/actions/depositTransaction.md
@@ -5,7 +5,7 @@ description: Initiates a deposit transaction on an L1, which executes a transact
 
 # depositTransaction
 
-Initiates a [deposit transaction](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md) on an L1, which executes a transaction on an L2. 
+Initiates a [deposit transaction](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md) on an L1, which executes a transaction on an L2. 
 
 Internally performs a contract write to the [`depositTransaction` function](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L378) on the [Optimism Portal contract](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OptimismPortal.sol).
 

--- a/site/pages/op-stack/actions/estimateDepositTransactionGas.md
+++ b/site/pages/op-stack/actions/estimateDepositTransactionGas.md
@@ -5,7 +5,7 @@ description: Estimates gas to initiate a deposit transaction on an L1, which exe
 
 # estimateDepositTransactionGas
 
-Estimates gas to initiate a [deposit transaction](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md) on an L1, which executes a transaction on an L2. 
+Estimates gas to initiate a [deposit transaction](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md) on an L1, which executes a transaction on an L2. 
 
 ## Usage
 

--- a/site/pages/op-stack/actions/estimateInitiateWithdrawalGas.md
+++ b/site/pages/op-stack/actions/estimateInitiateWithdrawalGas.md
@@ -5,7 +5,7 @@ description: Estimates gas required to initiate a withdrawal on an L2 to the L1.
 
 # estimateInitiateWithdrawalGas
 
-Estimates gas required to initiate a [withdrawal](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md) on an L2 to the L1. 
+Estimates gas required to initiate a [withdrawal](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md) on an L2 to the L1. 
 
 ## Usage
 

--- a/site/pages/op-stack/actions/initiateWithdrawal.md
+++ b/site/pages/op-stack/actions/initiateWithdrawal.md
@@ -5,7 +5,7 @@ description: Initiates a withdrawal on an L2 to the L1.
 
 # initiateWithdrawal
 
-Initiates a [withdrawal](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md) on an L2 to the L1. 
+Initiates a [withdrawal](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md) on an L2 to the L1. 
 
 Internally performs a contract write to the [`initiateWithdrawal` function](https://github.com/ethereum-optimism/optimism/blob/283f0aa2e3358ced30ff7cbd4028c0c0c3faa140/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol#L73) on the [Optimism L2ToL1MessagePasser predeploy contract](https://github.com/ethereum-optimism/optimism/blob/283f0aa2e3358ced30ff7cbd4028c0c0c3faa140/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol).
 

--- a/site/pages/op-stack/utilities/getSourceHash.md
+++ b/site/pages/op-stack/utilities/getSourceHash.md
@@ -4,7 +4,7 @@ description: Computes source hash of a deposit transaction.
 
 # getSourceHash
 
-Computes the [source hash](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#source-hash-computation) of a deposit transaction.
+Computes the [source hash](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#source-hash-computation) of a deposit transaction.
 
 ## Import
 ```ts


### PR DESCRIPTION
Replaced outdated links to deposits.md that pointed to the old optimism repo.
Now they point to the correct file in the specs repo.

Old:
github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md
New:
github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md

