### PR TITLE
Fix docs regarding the `wallet_switchEthereumChain` method.

### DIFF
--- a/site/pages/docs/actions/wallet/prepareTransactionRequest.md
+++ b/site/pages/docs/actions/wallet/prepareTransactionRequest.md
@@ -271,6 +271,25 @@ const request = await walletClient.prepareTransactionRequest({
 })
 ```
 
+### gas (optional)
+
+- **Type:** `bigint`
+
+The gas limit of the transaction. If missing, it will be estimated.
+
+```ts twoslash
+// [!include config.ts]
+// ---cut---
+import { parseEther, parseGwei } from 'viem'
+
+const request = await walletClient.prepareTransactionRequest({
+  account,
+  gas: 21000n, // [!code focus]
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  value: parseEther('1') 
+})
+```
+
 ### gasPrice (optional)
 
 - **Type:** `bigint`

--- a/site/pages/docs/actions/wallet/sendTransaction.md
+++ b/site/pages/docs/actions/wallet/sendTransaction.md
@@ -243,6 +243,24 @@ const hash = await walletClient.sendTransaction({
 })
 ```
 
+### gas (optional)
+
+- **Type:** `bigint`
+
+The gas limit of the transaction. If missing, it will be estimated.
+
+```ts twoslash
+// [!include ~/snippets/walletClient.ts]
+// ---cut---
+// @noErrors
+const hash = await walletClient.sendTransaction({
+  account,
+  gas: 21000n, // [!code focus]
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  value: parseEther('1') 
+})
+```
+
 ### gasPrice (optional)
 
 - **Type:** `bigint`

--- a/site/pages/docs/actions/wallet/signTransaction.md
+++ b/site/pages/docs/actions/wallet/signTransaction.md
@@ -251,6 +251,24 @@ const signature = await walletClient.signTransaction({
 })
 ```
 
+### gas (optional)
+
+- **Type:** `bigint`
+
+The gas limit of the transaction. If missing, it will be estimated.
+
+```ts twoslash
+// [!include ~/snippets/walletClient.ts]
+// ---cut---
+// @noErrors
+const signature = await walletClient.signTransaction({
+  account,
+  gas: 21000n, // [!code focus]
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  value: parseEther('1') 
+})
+```
+
 ### gasPrice (optional)
 
 - **Type:** `bigint`

--- a/site/pages/docs/actions/wallet/switchChain.md
+++ b/site/pages/docs/actions/wallet/switchChain.md
@@ -34,4 +34,4 @@ The Chain ID.
 
 ## JSON-RPC Methods
 
-[`eth_switchEthereumChain`](https://eips.ethereum.org/EIPS/eip-3326)
+[`wallet_switchEthereumChain`](https://eips.ethereum.org/EIPS/eip-3326)

--- a/src/actions/wallet/switchChain.ts
+++ b/src/actions/wallet/switchChain.ts
@@ -23,7 +23,7 @@ export type SwitchChainErrorType =
  * Switch the target chain in a wallet.
  *
  * - Docs: https://viem.sh/docs/actions/wallet/switchChain
- * - JSON-RPC Methods: [`eth_switchEthereumChain`](https://eips.ethereum.org/EIPS/eip-3326)
+ * - JSON-RPC Methods: [`wallet_switchEthereumChain`](https://eips.ethereum.org/EIPS/eip-3326)
  *
  * @param client - Client to use
  * @param parameters - {@link SwitchChainParameters}


### PR DESCRIPTION
Fix docs regarding the `wallet_switchEthereumChain` method. You can easily verify that is should start with "wallet" instead of "eth".