### PR TITLE
feat: add transaction type to formatted transaction in `sendTransaction`

### DIFF
--- a/.changeset/khaki-nails-eat.md
+++ b/.changeset/khaki-nails-eat.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `type` parameter to `sendTransaction`.

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -17,8 +17,11 @@ import {
 import { BaseError } from '../../errors/base.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { GetAccountParameter } from '../../types/account.js'
-import type { Chain, DeriveChain } from '../../types/chain.js'
-import type { GetChainParameter } from '../../types/chain.js'
+import type {
+  Chain,
+  DeriveChain,
+  GetChainParameter,
+} from '../../types/chain.js'
 import type { GetTransactionRequestKzgParameter } from '../../types/kzg.js'
 import type { Hash } from '../../types/misc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
@@ -167,6 +170,7 @@ export async function sendTransaction<
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
+    type,
     value,
     ...rest
   } = parameters
@@ -231,6 +235,7 @@ export async function sendTransaction<
         maxPriorityFeePerGas,
         nonce,
         to,
+        type,
         value,
       } as TransactionRequest)
 
@@ -310,6 +315,7 @@ export async function sendTransaction<
         nonce,
         nonceManager: account.nonceManager,
         parameters: [...defaultParameters, 'sidecars'],
+        type,
         value,
         ...rest,
         to,


### PR DESCRIPTION
Currently when using `sendTransaction` with MetaMask as the client, if `accessList` is specified alongside `maxFeePerGas` and `maxPriorityFeePerGas` the call will fail. This is due to MetaMask incorrectly deriving a transaction type of `0x01` (see https://github.com/MetaMask/core/issues/5720), but `sendTransaction` can easily be tweaked to ensure compatibility with all existing MetaMask clients. Making the transaction type explicit ensures that it isn't derived, and bypasses the issue entirely.

Changes:
- Added `type` to the formatted transaction in `sendTransaction`.