### PR TITLE
Update Fraxtal and Fraxtal testnet gas token to FRAX 

### DIFF
--- a/.changeset/purple-dingos-swim.md
+++ b/.changeset/purple-dingos-swim.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Fraxtal and Fraxtal testnet native currency to FRAX.

--- a/src/chains/definitions/fraxtal.ts
+++ b/src/chains/definitions/fraxtal.ts
@@ -7,7 +7,7 @@ export const fraxtal = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 252,
   name: 'Fraxtal',
-  nativeCurrency: { name: 'Frax Ether', symbol: 'frxETH', decimals: 18 },
+  nativeCurrency: { name: 'Frax', symbol: 'FRAX', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://rpc.frax.com'],

--- a/src/chains/definitions/fraxtalTestnet.ts
+++ b/src/chains/definitions/fraxtalTestnet.ts
@@ -7,7 +7,7 @@ export const fraxtalTestnet = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 2522,
   name: 'Fraxtal Testnet',
-  nativeCurrency: { name: 'Frax Ether', symbol: 'frxETH', decimals: 18 },
+  nativeCurrency: { name: 'Frax', symbol: 'FRAX', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://rpc.testnet.frax.com'],


### PR DESCRIPTION
This PR updates the gas token for both the Fraxtal mainnet and Fraxtal testnet from the previous token to FRAX, aligning with the latest network configuration and token standard.

Changes:
Updated gas token symbol to FRAX for Fraxtal mainnet.

Updated gas token symbol to FRAX for Fraxtal testnet.

Reason for Change:
Fraxtal has transitioned to using FRAX as the native gas token on both mainnet and testnet. This update ensures consistency with the current network specifications and prevents confusion or misconfigurations.