### PR TITLE
update plumenetwork.xyz to plume.org

### DIFF
--- a/src/chains/definitions/plumeMainnet.ts
+++ b/src/chains/definitions/plumeMainnet.ts
@@ -12,15 +12,15 @@ export const plumeMainnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://phoenix-rpc.plumenetwork.xyz'],
-      webSocket: ['wss://phoenix-rpc.plumenetwork.xyz'],
+      http: ['https://rpc.plume.org'],
+      webSocket: ['wss://rpc.plume.org'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://phoenix-explorer.plumenetwork.xyz',
-      apiUrl: 'https://phoenix-explorer.plumenetwork.xyz/api',
+      url: 'https://explorer.plume.org',
+      apiUrl: 'https://explorer.plume.org/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/plumeSepolia.ts
+++ b/src/chains/definitions/plumeSepolia.ts
@@ -12,15 +12,15 @@ export const plumeSepolia = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://testnet-rpc.plumenetwork.xyz'],
-      webSocket: ['wss://testnet-rpc.plumenetwork.xyz'],
+      http: ['https://testnet-rpc.plume.org'],
+      webSocket: ['wss://testnet-rpc.plume.org'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Blockscout',
-      url: 'https://testnet-explorer.plumenetwork.xyz',
-      apiUrl: 'https://testnet-explorer.plumenetwork.xyz/api',
+      url: 'https://testnet-explorer.plume.org',
+      apiUrl: 'https://testnet-explorer.plume.org/api',
     },
   },
   contracts: {


### PR DESCRIPTION
Plume is migrating all of our RPC URLs from https://phoenix-rpc.plumenetwork.xyz to https://rpc.plume.org.