### PR TITLE
make watchBlocks with `emitMissed` work from genesis block

### DIFF
--- a/.changeset/spotty-beds-grow.md
+++ b/.changeset/spotty-beds-grow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix `watchBlocks` to also work from genesis blocks using `emitMissed`

--- a/.changeset/spotty-beds-grow.md
+++ b/.changeset/spotty-beds-grow.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated `watchBlocks` to also work from genesis blocks using `emitMissed`
+Updated `watchBlocks` to also work from genesis blocks using `emitMissed`.

--- a/.changeset/spotty-beds-grow.md
+++ b/.changeset/spotty-beds-grow.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fix `watchBlocks` to also work from genesis blocks using `emitMissed`
+Updated `watchBlocks` to also work from genesis blocks using `emitMissed`

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -152,7 +152,7 @@ export function watchBlocks<
               blockTag,
               includeTransactions,
             })
-            if (block.number && prevBlock?.number) {
+            if (block.number !== null && prevBlock?.number != null) {
               // If the current block number is the same as the previous,
               // we can skip.
               if (block.number === prevBlock.number) return
@@ -177,12 +177,12 @@ export function watchBlocks<
 
             if (
               // If no previous block exists, emit.
-              !prevBlock?.number ||
+              prevBlock?.number == null ||
               // If the block tag is "pending" with no block number, emit.
-              (blockTag === 'pending' && !block?.number) ||
+              (blockTag === 'pending' && block?.number == null) ||
               // If the next block number is greater than the previous block number, emit.
               // We don't want to emit blocks in the past.
-              (block.number && block.number > prevBlock.number)
+              (block.number !== null && block.number > prevBlock.number)
             ) {
               emit.onBlock(block as any, prevBlock as any)
               prevBlock = block as any

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,5 +1,6 @@
 import type { DefaultCapabilitiesSchema } from './capabilities.js'
 
+/** @internal */
 // biome-ignore lint/suspicious/noEmptyInterface:
 export interface Register {}
 

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,6 +1,5 @@
 import type { DefaultCapabilitiesSchema } from './capabilities.js'
 
-/** @internal */
 // biome-ignore lint/suspicious/noEmptyInterface:
 export interface Register {}
 


### PR DESCRIPTION
This currently doesn't work when `block.number` is `0` (boolish false)