### PR TITLE
Harden address validation in validateSiweMessage

### DIFF
--- a/.changeset/rotten-mails-join.md
+++ b/.changeset/rotten-mails-join.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-hardened address validation in validateSiweMessage
+Hardened address validation in `validateSiweMessage`.

--- a/.changeset/rotten-mails-join.md
+++ b/.changeset/rotten-mails-join.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+hardened address validation in validateSiweMessage

--- a/src/utils/siwe/validateSiweMessage.test.ts
+++ b/src/utils/siwe/validateSiweMessage.test.ts
@@ -49,6 +49,16 @@ test('behavior: invalid address', () => {
   ).toBeFalsy()
 })
 
+test('behavior: invalid address', () => {
+  expect(
+    validateSiweMessage({
+      message: {
+        address: '0xfoobarbaz',
+      },
+    }),
+  ).toBeFalsy()
+})
+
 test('behavior: domain mismatch', () => {
   expect(
     validateSiweMessage({

--- a/src/utils/siwe/validateSiweMessage.ts
+++ b/src/utils/siwe/validateSiweMessage.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'abitype'
 
 import type { ExactPartial } from '../../types/utils.js'
+import { isAddress } from '../address/isAddress.js'
 import { isAddressEqual } from '../address/isAddressEqual.js'
 import type { SiweMessage } from './types.js'
 
@@ -61,6 +62,7 @@ export function validateSiweMessage(
 
   try {
     if (!message.address) return false
+    if (!isAddress(message.address, { strict: false })) return false
     if (address && !isAddressEqual(message.address, address)) return false
   } catch {
     return false


### PR DESCRIPTION
`validateSiweMessage` would return true if `message.address` was invalid but no top-level `address` was passed
