### PR TITLE
feat: fall back to `eth_sendTransaction` on `sendCalls`

### DIFF
--- a/.changeset/odd-books-push.md
+++ b/.changeset/odd-books-push.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added support for `sendCalls`, `getCallsStatus`, and `waitForCallsStatus` for wallets that do not support EIP-5792 (falls back to `eth_sendTransaction`).
+Added `experimental_fallback` property to `sendCalls` for wallets that do not support EIP-5792 (falls back to `eth_sendTransaction`).

--- a/.changeset/odd-books-push.md
+++ b/.changeset/odd-books-push.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added support for `sendCalls` for wallets that do not support EIP-5792 (falls back to `eth_sendTransaction`).
+Added support for `sendCalls`, `getCallsStatus`, and `waitForCallsStatus` for wallets that do not support EIP-5792 (falls back to `eth_sendTransaction`).

--- a/.changeset/odd-books-push.md
+++ b/.changeset/odd-books-push.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added support for `sendCalls` for wallets that do not support EIP-5792 (falls back to `eth_sendTransaction`).

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     {
       "name": "import * from 'viem' (esm)",
       "path": "./src/_esm/index.js",
-      "limit": "71 kB",
+      "limit": "72 kB",
       "import": "*"
     },
     {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     {
       "name": "import * from 'viem/ens'",
       "path": "./src/_esm/ens/index.js",
-      "limit": "49 kB",
+      "limit": "50 kB",
       "import": "*"
     },
     {

--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -173,7 +173,7 @@ export const walletClient = createWalletClient({
 ### Compatibility Fallback
 
 If the Wallet does not support EIP-5792 and `wallet_sendCalls`, passing the `experimental_fallback` 
-flag to `sendCalls` will indicate for Viem to fall back to executing the calls sequentially
+flag to `sendCalls` will allow Viem to fall back to executing the calls sequentially
 via `eth_sendTransaction`. 
 
 :::code-group

--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -170,6 +170,50 @@ export const walletClient = createWalletClient({
 
 :::
 
+### Compatibility Fallback
+
+If the Wallet does not support EIP-5792 and `wallet_sendCalls`, passing the `experimental_fallback` 
+flag to `sendCalls` will indicate for Viem to fall back to executing the calls sequentially
+via `eth_sendTransaction`. 
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { parseEther } from 'viem'
+import { account, walletClient } from './config'
+ 
+const { id } = await walletClient.sendCalls({
+  account,
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      value: parseEther('1')
+    },
+    {
+      data: '0xdeadbeef',
+      to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    },
+  ],
+  experimental_fallback: true, // [!code focus]
+})
+```
+
+```ts twoslash [config.ts] filename="config.ts"
+import 'viem/window'
+// ---cut---
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+
+export const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum!),
+})
+
+export const [account] = await walletClient.getAddresses()
+```
+
+:::
+
 ## Returns
 
 `{ id: string, capabilities?: WalletCapabilities }`

--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -176,6 +176,12 @@ If the Wallet does not support EIP-5792 and `wallet_sendCalls`, passing the `exp
 flag to `sendCalls` will allow Viem to fall back to executing the calls sequentially
 via `eth_sendTransaction`. 
 
+:::warning
+When using `experimental_fallback` with a wallet that does not support EIP-5792, 
+Viem will return a custom bundle identifier (`id`). While this identifier works with Viem's [`getCallsStatus` 
+Action](/docs/actions/wallet/getCallsStatus), it cannot be used with the native `wallet_getCallsStatus` RPC method.
+:::
+
 :::code-group
 
 ```ts twoslash [example.ts]

--- a/src/actions/wallet/getCallsStatus.ts
+++ b/src/actions/wallet/getCallsStatus.ts
@@ -5,10 +5,15 @@ import type { Account } from '../../types/account.js'
 import type { ExtractCapabilities } from '../../types/capabilities.js'
 import type { Chain } from '../../types/chain.js'
 import type { WalletGetCallsStatusReturnType } from '../../types/eip1193.js'
+import type { Hex } from '../../types/misc.js'
+import type { RpcTransactionReceipt } from '../../types/rpc.js'
 import type { Prettify } from '../../types/utils.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
+import { sliceHex } from '../../utils/data/slice.js'
+import { trim } from '../../utils/data/trim.js'
 import { hexToBigInt, hexToNumber } from '../../utils/encoding/fromHex.js'
 import { receiptStatuses } from '../../utils/formatters/transactionReceipt.js'
+import { transactionMagicIdentifier } from './sendCalls.js'
 
 export type GetCallsStatusParameters = { id: string }
 
@@ -56,16 +61,54 @@ export async function getCallsStatus<
   client: Client<Transport, chain, account>,
   parameters: GetCallsStatusParameters,
 ): Promise<GetCallsStatusReturnType> {
+  async function getStatus(id: Hex) {
+    const isTransactions = id.startsWith(transactionMagicIdentifier)
+    if (isTransactions) {
+      const chainId = trim(sliceHex(id, 32, 64))
+      const hashes = sliceHex(id, 64)
+        .slice(2)
+        .match(/.{1,64}/g)
+
+      const receipts = await Promise.all(
+        hashes!.map((hash) =>
+          client.request(
+            {
+              method: 'eth_getTransactionReceipt',
+              params: [`0x${hash}`],
+            },
+            { dedupe: true },
+          ),
+        ),
+      )
+
+      const status = (() => {
+        if (receipts.some((r) => r === null)) return 100 // pending
+        if (receipts.every((r) => r?.status === '0x1')) return 200 // success
+        if (receipts.every((r) => r?.status === '0x0')) return 500 // complete failure
+        return 600 // partial failure
+      })()
+
+      return {
+        atomic: false,
+        chainId: hexToNumber(chainId),
+        receipts: receipts.filter(Boolean) as RpcTransactionReceipt[],
+        status,
+        version: '2.0.0',
+      }
+    }
+    return client.request({
+      method: 'wallet_getCallsStatus',
+      params: [id],
+    })
+  }
+
   const {
     atomic = false,
     chainId,
     receipts,
     version = '2.0.0',
     ...response
-  } = await client.request({
-    method: 'wallet_getCallsStatus',
-    params: [parameters.id],
-  })
+  } = await getStatus(parameters.id as Hex)
   const [status, statusCode] = (() => {
     const statusCode = response.status
     if (statusCode >= 100 && statusCode < 200)

--- a/src/actions/wallet/getCallsStatus.ts
+++ b/src/actions/wallet/getCallsStatus.ts
@@ -13,7 +13,7 @@ import { sliceHex } from '../../utils/data/slice.js'
 import { trim } from '../../utils/data/trim.js'
 import { hexToBigInt, hexToNumber } from '../../utils/encoding/fromHex.js'
 import { receiptStatuses } from '../../utils/formatters/transactionReceipt.js'
-import { transactionMagicIdentifier } from './sendCalls.js'
+import { fallbackMagicIdentifier } from './sendCalls.js'
 
 export type GetCallsStatusParameters = { id: string }
 
@@ -62,10 +62,10 @@ export async function getCallsStatus<
   parameters: GetCallsStatusParameters,
 ): Promise<GetCallsStatusReturnType> {
   async function getStatus(id: Hex) {
-    const isTransactions = id.startsWith(transactionMagicIdentifier)
+    const isTransactions = id.endsWith(fallbackMagicIdentifier.slice(2))
     if (isTransactions) {
-      const chainId = trim(sliceHex(id, 32, 64))
-      const hashes = sliceHex(id, 64)
+      const chainId = trim(sliceHex(id, -64, -32))
+      const hashes = sliceHex(id, 0, -64)
         .slice(2)
         .match(/.{1,64}/g)
 

--- a/src/actions/wallet/sendCalls.test.ts
+++ b/src/actions/wallet/sendCalls.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { wagmiContractConfig } from '../../../test/src/abis.js'
 import { anvilMainnet } from '../../../test/src/anvil.js'
 import { accounts } from '../../../test/src/constants.js'

--- a/src/actions/wallet/sendCalls.test.ts
+++ b/src/actions/wallet/sendCalls.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { wagmiContractConfig } from '../../../test/src/abis.js'
 import { anvilMainnet } from '../../../test/src/anvil.js'
 import { accounts } from '../../../test/src/constants.js'
@@ -421,6 +421,191 @@ test('behavior: capability: paymasterService', async () => {
       ],
     ]
   `)
+})
+
+describe('behavior: eth_sendTransaction fallback', () => {
+  const client = anvilMainnet.getClient()
+
+  test('default', async () => {
+    const response = await sendCalls(client, {
+      account: accounts[0].address,
+      chain: mainnet,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+        },
+        {
+          to: accounts[2].address,
+        },
+        {
+          data: '0xcafebabe',
+          to: accounts[3].address,
+          value: parseEther('100'),
+        },
+        {
+          abi: wagmiContractConfig.abi,
+          functionName: 'mint',
+          to: wagmiContractConfig.address,
+        },
+      ],
+      experimental_fallback: true,
+    })
+
+    expect(response.id).toMatchInlineSnapshot(
+      `"0xb0fd8d440a3cb766200a237ad236241a70660e6f13398c880ed913fce620e8e5386fc7a922e91f765fc5034631f96c76a801071d0285fec1c43f856eb4445566e7941d94f9057aca5978cbeda09c96f6772ca5762c257867382a4da0cdea36dd6c1959f1051e01bb652246da0bb803ba6e678864cd6382b40c0bfb1ae1c3202600000000000000000000000000000000000000000000000000000000000000015792579257925792579257925792579257925792579257925792579257925792"`,
+    )
+  })
+
+  test('behavior: optional capabilities', async () => {
+    const response = await sendCalls(client, {
+      account: accounts[0].address,
+      chain: mainnet,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+        },
+        {
+          to: accounts[2].address,
+        },
+        {
+          data: '0xcafebabe',
+          to: accounts[3].address,
+          value: parseEther('100'),
+        },
+        {
+          abi: wagmiContractConfig.abi,
+          functionName: 'mint',
+          to: wagmiContractConfig.address,
+        },
+      ],
+      experimental_fallback: true,
+      capabilities: {
+        paymasterService: {
+          optional: true,
+          url: 'https://example.com',
+        },
+      },
+    })
+
+    expect(response.id).toBeDefined()
+  })
+
+  test('behavior: non-optional capabilities', async () => {
+    await expect(() =>
+      sendCalls(client, {
+        account: accounts[0].address,
+        chain: mainnet,
+        calls: [
+          {
+            to: accounts[1].address,
+            value: parseEther('1'),
+          },
+          {
+            to: accounts[2].address,
+          },
+          {
+            data: '0xcafebabe',
+            to: accounts[3].address,
+            value: parseEther('100'),
+          },
+          {
+            abi: wagmiContractConfig.abi,
+            functionName: 'mint',
+            to: wagmiContractConfig.address,
+          },
+        ],
+        experimental_fallback: true,
+        capabilities: {
+          paymasterService: {
+            url: 'https://example.com',
+          },
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [UnsupportedNonOptionalCapabilityError: This Wallet does not support a capability that was not marked as optional.
+
+      Details: non-optional \`capabilities\` are not supported on fallback to \`eth_sendTransaction\`.
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('behavior: atomic', async () => {
+    await expect(() =>
+      sendCalls(client, {
+        account: accounts[0].address,
+        chain: mainnet,
+        calls: [
+          {
+            to: accounts[1].address,
+            value: parseEther('1'),
+          },
+          {
+            to: accounts[2].address,
+          },
+          {
+            data: '0xcafebabe',
+            to: accounts[3].address,
+            value: parseEther('100'),
+          },
+          {
+            abi: wagmiContractConfig.abi,
+            functionName: 'mint',
+            to: wagmiContractConfig.address,
+          },
+        ],
+        experimental_fallback: true,
+        forceAtomic: true,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [AtomicityNotSupportedError: The wallet does not support atomic execution but the request requires it.
+
+      Details: \`forceAtomic\` is not supported on fallback to \`eth_sendTransaction\`.
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('behavior: absent `experimental_fallback`', async () => {
+    await expect(() =>
+      sendCalls(client, {
+        account: accounts[0].address,
+        chain: mainnet,
+        calls: [
+          {
+            to: accounts[1].address,
+            value: parseEther('1'),
+          },
+          {
+            to: accounts[2].address,
+          },
+          {
+            data: '0xcafebabe',
+            to: accounts[3].address,
+            value: parseEther('100'),
+          },
+          {
+            abi: wagmiContractConfig.abi,
+            functionName: 'mint',
+            to: wagmiContractConfig.address,
+          },
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [TransactionExecutionError: Invalid parameters were provided to the RPC method.
+      Double check you have provided the correct parameters.
+
+      URL: http://localhost
+      Request body: {"method":"wallet_sendCalls","params":[{"atomicRequired":false,"calls":[{"to":"0x70997970c51812dc3a010c7d01b50e0d17dc79c8","value":"0xde0b6b3a7640000"},{"to":"0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc"},{"data":"0xcafebabe","to":"0x90f79bf6eb2c4f870365e785982e1f101e93b906","value":"0x56bc75e2d63100000"},{"data":"0x1249c58b","to":"0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2"}],"chainId":"0x1","from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","version":"2.0.0"}]}
+       
+      Request Arguments:
+        chain:  Ethereum (id: 1)
+        from:   0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+
+      Details: data did not match any variant of untagged enum EthRpcCall
+      Version: viem@x.y.z]
+    `)
+  })
 })
 
 test('error: no account', async () => {

--- a/src/actions/wallet/sendCalls.test.ts
+++ b/src/actions/wallet/sendCalls.test.ts
@@ -565,47 +565,6 @@ describe('behavior: eth_sendTransaction fallback', () => {
       Version: viem@x.y.z]
     `)
   })
-
-  test('behavior: absent `experimental_fallback`', async () => {
-    await expect(() =>
-      sendCalls(client, {
-        account: accounts[0].address,
-        chain: mainnet,
-        calls: [
-          {
-            to: accounts[1].address,
-            value: parseEther('1'),
-          },
-          {
-            to: accounts[2].address,
-          },
-          {
-            data: '0xcafebabe',
-            to: accounts[3].address,
-            value: parseEther('100'),
-          },
-          {
-            abi: wagmiContractConfig.abi,
-            functionName: 'mint',
-            to: wagmiContractConfig.address,
-          },
-        ],
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [TransactionExecutionError: Invalid parameters were provided to the RPC method.
-      Double check you have provided the correct parameters.
-
-      URL: http://localhost
-      Request body: {"method":"wallet_sendCalls","params":[{"atomicRequired":false,"calls":[{"to":"0x70997970c51812dc3a010c7d01b50e0d17dc79c8","value":"0xde0b6b3a7640000"},{"to":"0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc"},{"data":"0xcafebabe","to":"0x90f79bf6eb2c4f870365e785982e1f101e93b906","value":"0x56bc75e2d63100000"},{"data":"0x1249c58b","to":"0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2"}],"chainId":"0x1","from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","version":"2.0.0"}]}
-       
-      Request Arguments:
-        chain:  Ethereum (id: 1)
-        from:   0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-
-      Details: data did not match any variant of untagged enum EthRpcCall
-      Version: viem@x.y.z]
-    `)
-  })
 })
 
 test('error: no account', async () => {

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -148,8 +148,10 @@ export async function sendCalls<
     if (
       error.name === 'MethodNotFoundRpcError' ||
       error.name === 'MethodNotSupportedRpcError' ||
-      error.details.toLowerCase().includes('does not exist') ||
-      error.details.toLowerCase().includes('missing or invalid')
+      error.details
+        .toLowerCase()
+        .includes('does not exist / is not available') ||
+      error.details.toLowerCase().includes('missing or invalid. request()')
     ) {
       const promises: Promise<Hex>[] = []
       for (const call of calls) {

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -3,7 +3,11 @@ import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
-import type { BaseError } from '../../errors/base.js'
+import { BaseError } from '../../errors/base.js'
+import {
+  AtomicityNotSupportedError,
+  UnsupportedNonOptionalCapabilityError,
+} from '../../errors/rpc.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Account, GetAccountParameter } from '../../types/account.js'
 import type { Call, Calls } from '../../types/calls.js'
@@ -20,8 +24,8 @@ import { numberToHex } from '../../utils/encoding/toHex.js'
 import { getTransactionError } from '../../utils/errors/getTransactionError.js'
 import { sendTransaction } from './sendTransaction.js'
 
-export const transactionMagicIdentifier =
-  '0x0000000000000000000000000000000000000000000000000000000000000000'
+export const fallbackMagicIdentifier =
+  '0x5792579257925792579257925792579257925792579257925792579257925792'
 
 export type SendCallsParameters<
   chain extends Chain | undefined = Chain | undefined,
@@ -34,6 +38,7 @@ export type SendCallsParameters<
   chain?: chainOverride | Chain | undefined
   calls: Calls<Narrow<calls>>
   capabilities?: ExtractCapabilities<'sendCalls', 'Request'> | undefined
+  experimental_fallback?: boolean | undefined
   forceAtomic?: boolean | undefined
   id?: string | undefined
   version?: WalletSendCallsParameters[number]['version'] | undefined
@@ -91,6 +96,7 @@ export async function sendCalls<
     account: account_ = client.account,
     capabilities,
     chain = client.chain,
+    experimental_fallback,
     forceAtomic = false,
     id,
     version = '2.0.0',
@@ -146,13 +152,41 @@ export async function sendCalls<
     // If the transport does not support EIP-5792, fall back to
     // `eth_sendTransaction`.
     if (
-      error.name === 'MethodNotFoundRpcError' ||
-      error.name === 'MethodNotSupportedRpcError' ||
-      error.details
-        .toLowerCase()
-        .includes('does not exist / is not available') ||
-      error.details.toLowerCase().includes('missing or invalid. request()')
+      experimental_fallback &&
+      (error.name === 'MethodNotFoundRpcError' ||
+        error.name === 'MethodNotSupportedRpcError' ||
+        error.details
+          .toLowerCase()
+          .includes('does not exist / is not available') ||
+        error.details.toLowerCase().includes('missing or invalid. request()') ||
+        error.details
+          .toLowerCase()
+          .includes('did not match any variant of untagged enum'))
     ) {
+      if (capabilities) {
+        const hasNonOptionalCapability = Object.values(capabilities).some(
+          (capability) => !capability.optional,
+        )
+        if (hasNonOptionalCapability) {
+          const message =
+            'non-optional `capabilities` are not supported on fallback to `eth_sendTransaction`.'
+          throw new UnsupportedNonOptionalCapabilityError(
+            new BaseError(message, {
+              details: message,
+            }),
+          )
+        }
+      }
+      if (forceAtomic) {
+        const message =
+          '`forceAtomic` is not supported on fallback to `eth_sendTransaction`.'
+        throw new AtomicityNotSupportedError(
+          new BaseError(message, {
+            details: message,
+          }),
+        )
+      }
+
       const promises: Promise<Hex>[] = []
       for (const call of calls) {
         const promise = sendTransaction(client, {
@@ -168,9 +202,9 @@ export async function sendCalls<
       const hashes = await Promise.all(promises)
       return {
         id: concat([
-          transactionMagicIdentifier,
-          numberToHex(chain!.id, { size: 32 }),
           ...hashes,
+          numberToHex(chain!.id, { size: 32 }),
+          fallbackMagicIdentifier,
         ]),
       }
     }

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -177,7 +177,7 @@ export async function sendCalls<
           )
         }
       }
-      if (forceAtomic) {
+      if (forceAtomic && calls.length > 1) {
         const message =
           '`forceAtomic` is not supported on fallback to `eth_sendTransaction`.'
         throw new AtomicityNotSupportedError(


### PR DESCRIPTION
Adds `experimental_fallback` property to `sendCalls` to indicate for Viem to fall back to executing the calls sequentially
via `eth_sendTransaction` if the wallet does not support EIP-5792.

The `experimental_fallback` property enables [this behavior](https://eips.ethereum.org/EIPS/eip-5792#specification) on the spec:
> Apps may begin using these first three methods immediately, falling back to eth_sendTransaction and eth_getTransactionReceipt when they are not available.