### PR TITLE
Make WebSocket transport correctly serialize bigints

### DIFF
--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -916,9 +916,7 @@ describe('requestAsync', () => {
           { name: 'chainId', type: 'uint256' },
           { name: 'verifyingContract', type: 'address' },
         ],
-        Number: [
-          { name: 'value', type: 'uint256' },
-        ],
+        Number: [{ name: 'value', type: 'uint256' }],
       },
       primaryType: 'Number',
       domain: {
@@ -929,12 +927,13 @@ describe('requestAsync', () => {
       },
       message: {
         value: 1n,
-      }
+      },
     }
     const encodedSignature = await client.requestAsync({
-      body: { method: 'eth_signTypedData_v4',
-        params: [account.address, typedData]
-       },
+      body: {
+        method: 'eth_signTypedData_v4',
+        params: [account.address, typedData],
+      },
     })
     expect(encodedSignature).toBeDefined()
     expect(client.requests.size).toBe(0)

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -11,6 +11,7 @@ import {
   type SocketRpcClient,
   getSocketRpcClient,
 } from './socket.js'
+import { stringify } from '../stringify.js'
 
 export type GetWebSocketRpcClientOptions = Pick<
   GetSocketRpcClientParameters,
@@ -82,7 +83,7 @@ export async function getWebSocketRpcClient(
               method: 'net_version',
               params: [],
             }
-            socket.send(JSON.stringify(body))
+            socket.send(stringify(body))
           } catch (error) {
             onError(error as Error)
           }
@@ -98,7 +99,7 @@ export async function getWebSocketRpcClient(
               cause: new SocketClosedError({ url: socket.url }),
             })
 
-          return socket.send(JSON.stringify(body))
+          return socket.send(stringify(body))
         },
       } as Socket<WebSocket>)
     },

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -5,13 +5,13 @@ import {
   WebSocketRequestError,
 } from '../../errors/request.js'
 import type { RpcRequest } from '../../types/rpc.js'
+import { stringify } from '../stringify.js'
 import {
   type GetSocketRpcClientParameters,
   type Socket,
   type SocketRpcClient,
   getSocketRpcClient,
 } from './socket.js'
-import { stringify } from '../stringify.js'
 
 export type GetWebSocketRpcClientOptions = Pick<
   GetSocketRpcClientParameters,


### PR DESCRIPTION
First of all thank you to all the maintainers for doing such a tremendous job. viem is a beautiful project

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
**Problem**
When sending data with `BigInt`s over WebSocket Transport, viem will throw this error:
```
TypeError: Do not know how to serialize a BigInt
```

This behaves correctly using HTTP Transport, because HTTP transport uses `stringify` instead of the built-in `JSON.stringify`

**Proposed fix**
Use `stringify` in the WebSocket client, just like in the HTTP client

**Notes**
- I understand that this behaviour might be intentional; if so I won't be sad if you close my PR
- I added one test that mimics the use case that led me to find this
    - It should fail now but succeed with this patch
- After more struggling than I'd like to admit, I was unable to get the test suite running locally