### PR TITLE
fix: fix zksync default calldata

### DIFF
--- a/.changeset/stale-kings-return.md
+++ b/.changeset/stale-kings-return.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**ZKsync Extension:** Fixed default data value.

--- a/src/zksync/utils/getEip712Domain.test.ts
+++ b/src/zksync/utils/getEip712Domain.test.ts
@@ -118,6 +118,15 @@ test('default', () => {
   `)
 })
 
+test('default calldata', async () => {
+  const transaction = {
+    ...baseEip712,
+    data: undefined,
+  }
+
+  expect(getEip712Domain(transaction).message.data).toEqual('0x');
+})
+
 test('signed', async () => {
   const signed = await signTransaction({
     privateKey: accounts[0].privateKey,

--- a/src/zksync/utils/getEip712Domain.test.ts
+++ b/src/zksync/utils/getEip712Domain.test.ts
@@ -124,7 +124,7 @@ test('default calldata', async () => {
     data: undefined,
   }
 
-  expect(getEip712Domain(transaction).message.data).toEqual('0x');
+  expect(getEip712Domain(transaction).message.data).toEqual('0x')
 })
 
 test('signed', async () => {

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -79,7 +79,7 @@ function transactionToMessage(
     paymaster: paymaster ? BigInt(paymaster) : 0n,
     nonce: nonce ? BigInt(nonce) : 0n,
     value: value ?? 0n,
-    data: data ? data : '0x0',
+    data: data ?? '0x',
     factoryDeps: factoryDeps?.map((dep) => toHex(hashBytecode(dep))) ?? [],
     paymasterInput: paymasterInput ? paymasterInput : '0x',
   }


### PR DESCRIPTION
Changes default calldata in zksync from being a single zero byte to being empty.

Related to #3456