### PR TITLE
updated the 0g v3 testnet details

### DIFF
--- a/src/chains/definitions/0g.ts
+++ b/src/chains/definitions/0g.ts
@@ -1,9 +1,9 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const zeroG = /*#__PURE__*/ defineChain({
-  id: 16_600,
-  name: '0G Newton Testnet',
-  nativeCurrency: { name: 'A0GI', symbol: 'A0GI', decimals: 18 },
+  id: 16_601,
+  name: '0G Galileo Testnet',
+  nativeCurrency: { name: 'OG', symbol: 'OG', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://evmrpc-testnet.0g.ai'],
@@ -12,7 +12,7 @@ export const zeroG = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: '0G BlockChain Explorer',
-      url: 'https://chainscan-newton.0g.ai',
+      url: 'https://chainscan-galileo.0g.ai',
     },
   },
   testnet: true,


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This pull request updates the `zeroG` chain definition in `src/chains/definitions/0g.ts` to reflect changes in the testnet configuration. The updates include modifications to the chain ID, name, native currency, and block explorer URL.

### Updates to `zeroG` chain definition:

* Changed the chain ID from `16_600` to `16_601` and updated the name from `0G Newton Testnet` to `0G Galileo Testnet`. Additionally, the native currency was updated from `{ name: 'A0GI', symbol: 'A0GI', decimals: 18 }` to `{ name: 'OG', symbol: 'OG', decimals: 18 }`.
* Updated the block explorer URL from `https://chainscan-newton.0g.ai` to `https://chainscan-galileo.0g.ai`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

Refer [Official docs](https://docs.0g.ai/run-a-node/testnet-information)

