### PR TITLE
Update KUB Chain and JB Chain

### DIFF
--- a/.changeset/thick-bees-nail.md
+++ b/.changeset/thick-bees-nail.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated KUB Chain and JB Chain

--- a/src/chains/definitions/bitkub.ts
+++ b/src/chains/definitions/bitkub.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const bitkub = /*#__PURE__*/ defineChain({
   id: 96,
-  name: 'Bitkub',
+  name: 'KUB Chain',
   nativeCurrency: { name: 'Bitkub', symbol: 'KUB', decimals: 18 },
   rpcUrls: {
     default: {
@@ -11,7 +11,7 @@ export const bitkub = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Bitkub Chain Mainnet Explorer',
+      name: 'KUB Chain Mainnet Explorer',
       url: 'https://www.bkcscan.com',
       apiUrl: 'https://www.bkcscan.com/api',
     },

--- a/src/chains/definitions/jbc.ts
+++ b/src/chains/definitions/jbc.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const jbc = /*#__PURE__*/ defineChain({
   id: 8899,
-  name: 'JIBCHAIN L1',
+  name: 'JB Chain',
   network: 'jbc',
   nativeCurrency: { name: 'JBC', symbol: 'JBC', decimals: 18 },
   rpcUrls: {


### PR DESCRIPTION
- Update the name of KUB Chain (rebranded from Bitkub chain; [new source](https://support.bitkub.com/en/support/solutions/articles/151000209397-rebranding-of-bitkub-chain-network-and-kub-coin))

- Update the name of JB Chain (rebranded from JIBCHAIN L1; [new source](https://medium.com/@jbchain/jb-chain-the-new-chapter-begins-7956c790ee9e)