### PR TITLE
fix: `decodeEventLog` mixing order of parameters

### DIFF
--- a/.changeset/tricky-hairs-pretend.md
+++ b/.changeset/tricky-hairs-pretend.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed decodeEventLog mixing the ordering of args for unnamed arg events with mixed indexed parameters
+Fixed ordering of decoded arguments in `decodeEventLog`.

--- a/.changeset/tricky-hairs-pretend.md
+++ b/.changeset/tricky-hairs-pretend.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed decodeEventLog mixing the ordering of args for unnamed arg events with mixed indexed parameters

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -169,6 +169,49 @@ test('unnamed args: Transfer(address,address,uint256)', () => {
   })
 })
 
+test('unnamed args: keep args ordered for mixed indexed args Transfer(address indexed,uint256,address indexed)', () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: false,
+            type: 'uint256',
+          },
+          {
+            indexed: true,
+            type: 'address',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+      '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    ],
+  })
+  assertType<typeof event>({
+    eventName: 'Transfer',
+    args: ['0x', 1n, '0x'],
+  })
+  expect(event).toEqual({
+    args: [
+      '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      1n,
+      '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    ],
+    eventName: 'Transfer',
+  })
+})
+
 test('Foo(string)', () => {
   const event = decodeEventLog({
     abi: [

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -169,7 +169,7 @@ test('unnamed args: Transfer(address,address,uint256)', () => {
   })
 })
 
-test('unnamed args: keep args ordered for mixed indexed args Transfer(address indexed,uint256,address indexed)', () => {
+test('unnamed args: mixed ordering of indexed args', () => {
   const event = decodeEventLog({
     abi: [
       {

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -158,15 +158,12 @@ export function decodeEventLog<
       try {
         const decodedData = decodeAbiParameters(nonIndexedInputs, data)
         if (decodedData) {
-          if (isUnnamed) {
-            for (let i = 0; i < inputs.length; i++) {
+          if (isUnnamed)
+            for (let i = 0; i < inputs.length; i++)
               args[i] = args[i] ?? decodedData.shift()
-            }
-          } else {
-            for (let i = 0; i < nonIndexedInputs.length; i++) {
+          else
+            for (let i = 0; i < nonIndexedInputs.length; i++)
               args[nonIndexedInputs[i].name!] = decodedData[i]
-            }
-          }
         }
       } catch (err) {
         if (strict) {

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -131,19 +131,24 @@ export function decodeEventLog<
   const { name, inputs } = abiItem
   const isUnnamed = inputs?.some((x) => !('name' in x && x.name))
 
-  let args: any = isUnnamed ? [] : {}
+  const args: any = isUnnamed ? [] : {}
 
   // Decode topics (indexed args).
-  const indexedInputs = inputs.filter((x) => 'indexed' in x && x.indexed)
+  const indexedInputs = inputs
+    .map((x, i) => [x, i] as const)
+    .filter(([x]) => 'indexed' in x && x.indexed)
   for (let i = 0; i < indexedInputs.length; i++) {
-    const param = indexedInputs[i]
+    const [param, argIndex] = indexedInputs[i]
     const topic = argTopics[i]
     if (!topic)
       throw new DecodeLogTopicsMismatch({
         abiItem,
         param: param as AbiParameter & { indexed: boolean },
       })
-    args[isUnnamed ? i : param.name || i] = decodeTopic({ param, value: topic })
+    args[isUnnamed ? argIndex : param.name || argIndex] = decodeTopic({
+      param,
+      value: topic,
+    })
   }
 
   // Decode data (non-indexed args).
@@ -153,8 +158,11 @@ export function decodeEventLog<
       try {
         const decodedData = decodeAbiParameters(nonIndexedInputs, data)
         if (decodedData) {
-          if (isUnnamed) args = [...args, ...decodedData]
-          else {
+          if (isUnnamed) {
+            for (let i = 0; i < inputs.length; i++) {
+              args[i] = args[i] ?? decodedData.shift()
+            }
+          } else {
             for (let i = 0; i < nonIndexedInputs.length; i++) {
               args[nonIndexedInputs[i].name!] = decodedData[i]
             }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

Hi!

Noticed that `decodedEventLog` is returning arguments in the wrong order for events with unnamed arguments where the indexed parameters are not placed at the start. 

Here is a reproduction
```typescript
import { parseAbi, decodeEventLog } from "viem/utils";

const event: {
  eventName: "Transfer";
  args: readonly [`0x${string}`, bigint, `0x${string}`]; // typed arguments
} = decodeEventLog({
  abi: parseAbi(["event Transfer(address indexed, uint256, address indexed)"]), // valid sol
  data: "0x0000000000000000000000000000000000000000000000000000000000000001",
  topics: [
    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
    "0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac",
    "0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac",
  ],
});

console.log(event);
// ^ actual decoded parameters
// {
//   eventName: 'Transfer',
//   args: [
//     '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
//     '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
//     1n
//   ]
// }
```

This PR fixes this aligning what's returned with what is indicated by the types
