### PR TITLE
feat: add `waitAsRateLimit` option on `http` transport

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6240,6 +6240,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.30.6:
+    resolution: {integrity: sha512-N3vGy3pZ+EVgQRuWqQhZPFXxQE8qMRrBd3uM+KLc1Ub2w6+vkyr7umeWQCM4c+wlsCdByUgh2630MDMLquMtpg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -7770,7 +7778,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.30.5(typescript@5.8.2)(zod@3.23.8)
+      viem: 2.30.6(typescript@5.8.2)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -13052,7 +13060,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.30.5(typescript@5.8.2)(zod@3.23.8):
+  viem@2.30.6(typescript@5.8.2)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/site/pages/docs/clients/transports/http.md
+++ b/site/pages/docs/clients/transports/http.md
@@ -75,14 +75,6 @@ const client = createPublicClient({
     },
   }),
 })
-// ---cut---
-// Each batch will be sent at most once every 100 milliseconds.
-const [blockNumber, balance, ensName] = await Promise.all([
-  client.getBlockNumber(),
-  client.getBalance({ address: '0xd2135CfB216b74109775236E36d4b433F1DF507B' }),
-  client.getEnsName({ address: '0xd2135CfB216b74109775236E36d4b433F1DF507B' }),
-  // client.get....
-]);
 ```
 
 ## Parameters

--- a/site/pages/docs/clients/transports/http.md
+++ b/site/pages/docs/clients/transports/http.md
@@ -59,6 +59,32 @@ const [blockNumber, balance, ensName] = await Promise.all([
 ])
 ```
 
+You can also use the `waitAsRateLimit` option to send one batch per `wait` milliseconds if the batch size is reached.
+
+```ts twoslash
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http('https://1.rpc.thirdweb.com/...', {
+    batch: {
+      batchSize: 3,
+      wait: 100,
+      waitAsRateLimit: true, // [!code focus]
+    },
+  }),
+})
+// ---cut---
+// Each batch will be sent at most once every 100 milliseconds.
+const [blockNumber, balance, ensName] = await Promise.all([
+  client.getBlockNumber(),
+  client.getBalance({ address: '0xd2135CfB216b74109775236E36d4b433F1DF507B' }),
+  client.getEnsName({ address: '0xd2135CfB216b74109775236E36d4b433F1DF507B' }),
+  // client.get....
+]);
+```
+
 ## Parameters
 
 ### url (optional)
@@ -119,6 +145,25 @@ import { http } from 'viem'
 const transport = http('https://1.rpc.thirdweb.com/...', {
   batch: {
     wait: 16 // [!code focus]
+  }
+})
+```
+
+### batch.waitAsRateLimit (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Send one batch per `wait` milliseconds if the batch size is reached. By default, multiple batches are sent at once each `wait` milliseconds.
+
+Warning: This can lead to a high number of pending requests if the batch size is constantly exceeded without enough time to clear the queue.
+
+```ts twoslash
+import { http } from 'viem'
+// ---cut---
+const transport = http('https://1.rpc.thirdweb.com/...', {
+  batch: {
+    waitAsRateLimit: true // [!code focus]
   }
 })
 ```

--- a/src/utils/promise/createBatchScheduler.test.ts
+++ b/src/utils/promise/createBatchScheduler.test.ts
@@ -117,13 +117,13 @@ test('args: wait', async () => {
   expect(x10).toEqual([10, [8, 9, 10]])
 })
 
-test('args: shouldSplitBatch', async () => {
+test('args: getBatchSize', async () => {
   const fn = vi.fn()
   const { schedule } = createBatchScheduler({
     id: uid(),
     // biome-ignore lint/style/noCommaOperator:
     fn: async (args: number[]) => (fn(), args),
-    shouldSplitBatch: (args) => args.length > 3,
+    getBatchSize: () => 3,
   })
 
   const p = []
@@ -163,6 +163,47 @@ test('args: shouldSplitBatch', async () => {
   expect(fn).toBeCalledTimes(6)
 })
 
+test('args: waitAsRateLimit', async () => {
+  const date = Date.now()
+
+  const fn = vi.fn()
+  const { schedule } = createBatchScheduler({
+    id: uid(),
+    getBatchSize: () => 3,
+    wait: 500,
+    waitAsRateLimit: true,
+    // biome-ignore lint/style/noCommaOperator:
+    fn: async (args: number[]) => (fn(), args),
+  })
+
+  const p = []
+
+  p.push(schedule(1))
+  p.push(schedule(2))
+  p.push(schedule(3))
+  p.push(schedule(4))
+  p.push(schedule(5))
+  p.push(schedule(6))
+  p.push(schedule(7))
+  p.push(schedule(8))
+  p.push(schedule(9))
+
+  const [x1, x2, x3, x4, x5, x6, x7, x8, x9] = await Promise.all(p)
+
+  expect(x1).toEqual([1, [1, 2, 3]])
+  expect(x2).toEqual([2, [1, 2, 3]])
+  expect(x3).toEqual([3, [1, 2, 3]])
+  expect(x4).toEqual([4, [4, 5, 6]])
+  expect(x5).toEqual([5, [4, 5, 6]])
+  expect(x6).toEqual([6, [4, 5, 6]])
+  expect(x7).toEqual([7, [7, 8, 9]])
+  expect(x8).toEqual([8, [7, 8, 9]])
+  expect(x9).toEqual([9, [7, 8, 9]])
+
+  const elapsed = Date.now() - date
+  expect(elapsed).toBeGreaterThanOrEqual(1500)
+})
+
 describe('behavior', () => {
   test('complex args', async () => {
     const { schedule } = createBatchScheduler({
@@ -186,51 +227,6 @@ describe('behavior', () => {
       { x: 4, y: [1, 2] },
       [{ x: 1 }, [1, 2], { x: 4, y: [1, 2] }],
     ])
-  })
-
-  test('complex split batch', async () => {
-    const fn = vi.fn()
-    const { schedule } = createBatchScheduler({
-      id: uid(),
-      wait: 16,
-      // biome-ignore lint/style/noCommaOperator:
-      fn: async (args: string[]) => (fn(), args),
-      shouldSplitBatch: (args) =>
-        args.reduce((acc, x) => acc + x.length, 0) > 20,
-    })
-
-    const p = []
-    p.push(schedule('hello'))
-    p.push(schedule('world'))
-    p.push(schedule('this is me'))
-    p.push(schedule('life should be'))
-    p.push(schedule('fun for everyone'))
-    await wait(1)
-    p.push(schedule('hello world'))
-    p.push(schedule('come and see'))
-    p.push(schedule('come'))
-    p.push(schedule('and'))
-    await wait(16)
-    p.push(schedule('see'))
-    p.push(schedule('smile'))
-    p.push(schedule('just be yourself'))
-    p.push(schedule('be happy'))
-
-    const [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11] = await Promise.all(p)
-
-    expect(x1).toEqual(['hello', ['hello', 'world', 'this is me']])
-    expect(x2).toEqual(['world', ['hello', 'world', 'this is me']])
-    expect(x3).toEqual(['this is me', ['hello', 'world', 'this is me']])
-    expect(x4).toEqual(['life should be', ['life should be']])
-    expect(x5).toEqual(['fun for everyone', ['fun for everyone']])
-    expect(x6).toEqual(['hello world', ['hello world']])
-    expect(x7).toEqual(['come and see', ['come and see', 'come', 'and']])
-    expect(x8).toEqual(['come', ['come and see', 'come', 'and']])
-    expect(x9).toEqual(['and', ['come and see', 'come', 'and']])
-    expect(x10).toEqual(['see', ['see', 'smile']])
-    expect(x11).toEqual(['smile', ['see', 'smile']])
-
-    expect(fn).toBeCalledTimes(8)
   })
 
   test('throws error', async () => {

--- a/src/utils/promise/createBatchScheduler.ts
+++ b/src/utils/promise/createBatchScheduler.ts
@@ -71,18 +71,6 @@ export function createBatchScheduler<
           const { resolve } = items[i]
           resolve?.([data[i], data])
         }
-
-        if (waitAsRateLimit) {
-          if (args.length === 0) {
-            flush()
-            return
-          }
-          setTimeout(() => {
-            clearBatchItems(items.length)
-            exec()
-          }, wait)
-          return
-        }
       })
       .catch((err) => {
         for (let i = 0; i < items.length; i++) {
@@ -91,10 +79,16 @@ export function createBatchScheduler<
         }
       })
 
-    if (!waitAsRateLimit) {
-      clearBatchItems(items.length)
-      exec()
+    if (waitAsRateLimit) {
+      setTimeout(() => {
+        clearBatchItems(items.length)
+        exec()
+      }, wait)
+      return
     }
+
+    clearBatchItems(items.length)
+    exec()
   }
 
   const flush = () => schedulerCache.delete(id)


### PR DESCRIPTION
This PR introduces an option to enable a batch queue system by setting `batch.waitAsRateLimit` to `true`. I was searching for a solution until I discovered #1305, which motivated me to explore ways to update the HTTP client.

The core idea is to modify the `batchScheduler` by changing the `shouldSplitBatch` parameter to a `getBatchSize` parameter. Once the scheduler can determine the batch size, it becomes capable of queuing requests.
I also updated multicall to utilize `getBatchSize` with behavior similar to the previous version.

The main drawback is that if too many requests are queued, the queue could continuously grow, potentially causing delays or triggering cache limits. I have added a warning about this in the documentation.

Therefore, for users interacting with rate-limited endpoints, this option could be extremely beneficial for managing such interactions.