### PR TITLE
feat(chains): add LuxePorts chain (LXP, chainId 1122)

### DIFF
--- a/src/chains/definitions/luxeports.ts
+++ b/src/chains/definitions/luxeports.ts
@@ -1,0 +1,28 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const luxeports = /*#__PURE__*/ defineChain({
+  id: 1122,
+  name: 'LuxePorts',
+  network: 'luxeports',
+  nativeCurrency: {
+    name: 'LuxePorts',
+    symbol: 'LXP',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.luxeports.com'],
+    },
+    public: {
+      http: ['https://rpc.luxeports.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'lxpscan',
+      url: 'https://lxpscan.com',
+    },
+  },
+  testnet: false,
+})
+

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -306,6 +306,8 @@ export { liskSepolia } from './definitions/liskSepolia.js'
 export { localhost } from './definitions/localhost.js'
 export { loop } from './definitions/loop.js'
 export { lukso } from './definitions/lukso.js'
+export { luxeports } from './definitions/luxeports.js'
+
 export { luksoTestnet } from './definitions/luksoTestnet.js'
 export { lumiaMainnet } from './definitions/lumiaMainnet.js'
 export { lumiaTestnet } from './definitions/lumiaTestnet.js'


### PR DESCRIPTION
 Adds support for **LuxePorts Network (LXP)** – a luxury asset tokenization EVM chain.

 * **Chain ID**: 1122
 * **RPC**: [https://rpc.luxeports.com/](https://rpc.luxeports.com)
 * **Explorer**: [https://lxpscan.com/](https://lxpscan.com) (EIP-3091 compliant)
 * **Currency**: LXP
 * **Logo**: ipfs\://QmZRg6LmyU4jJie3VPd7xacBf6qwkbsnHDgCgRkr7iwgKP
 * **Contact**: support@luxeports.com

 Looking forward to your review and merge!