### PR TITLE
fix: correct typo in erc721Abi from 'tokeId' to 'tokenId'

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 22.13.13
       '@vitest/coverage-v8':
         specifier: ^1.0.4
-        version: 1.0.4(vitest@1.0.4(@types/node@22.13.13)(@vitest/ui@1.0.4)(lightningcss@1.29.1)(terser@5.36.0))
+        version: 1.0.4(vitest@1.0.4)
       '@vitest/ui':
         specifier: ^1.0.4
         version: 1.0.4(vitest@1.0.4)
@@ -3334,7 +3334,6 @@ packages:
 
   bun@1.1.30:
     resolution: {integrity: sha512-ysRL1pq10Xba0jqVLPrKU3YIv0ohfp3cTajCPtpjCyppbn3lfiAVNpGoHfyaxS17OlPmWmR67UZRPw/EueQuug==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -6240,6 +6239,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.31.0:
+    resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -7770,7 +7777,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.30.6(typescript@5.8.2)(zod@3.23.8)
+      viem: 2.31.0(typescript@5.8.2)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -9144,7 +9151,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.0.4(vitest@1.0.4(@types/node@22.13.13)(@vitest/ui@1.0.4)(lightningcss@1.29.1)(terser@5.36.0))':
+  '@vitest/coverage-v8@1.0.4(vitest@1.0.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -13052,7 +13059,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.30.6(typescript@5.8.2)(zod@3.23.8):
+  viem@2.31.0(typescript@5.8.2)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -1413,7 +1413,7 @@ export const erc721Abi = [
         type: 'address',
       },
       {
-        name: 'tokeId',
+        name: 'tokenId',
         type: 'uint256',
       },
     ],


### PR DESCRIPTION
…ointer

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
<img width="1463" alt="Screenshot 2025-06-08 at 9 41 47 PM" src="https://github.com/user-attachments/assets/8ea2b385-a94a-4d58-a3d2-6c48fbf68e7c" />

Fixes a typo in the ERC721 ABI constant where tokenId was incorrectly spelled as tokeId.
Changes

Fix #3709  typo in src/constants/abis.ts line 1416
Changed tokeId to tokenId in the ERC721 ABI definition

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

