### PR TITLE
add the rest of `eth_subscribe` params for ipc transport

### DIFF
--- a/src/clients/transports/ipc.ts
+++ b/src/clients/transports/ipc.ts
@@ -27,13 +27,27 @@ type IpcTransportSubscribeReturnType = {
 
 type IpcTransportSubscribe = {
   subscribe(
-    args: IpcTransportSubscribeParameters & {
-      /**
-       * @description Add information about compiled contracts
-       * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_addcompilationresult
-       */
-      params: ['newHeads']
-    },
+    args: IpcTransportSubscribeParameters &
+      (
+        | {
+            params: ['newHeads']
+          }
+        | {
+            params: ['newPendingTransactions']
+          }
+        | {
+            params: [
+              'logs',
+              {
+                address?: Address | Address[]
+                topics?: LogTopic[]
+              },
+            ]
+          }
+        | {
+            params: ['syncing']
+          }
+      ),
   ): Promise<IpcTransportSubscribeReturnType>
 }
 


### PR DESCRIPTION
add the rest of `eth_subscribe` params for ipc transport, such as `newPendingTransactions`, `logs` and `syncing`.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

