### PR TITLE
docs: fix `encodeFunctionResult` signature

### DIFF
--- a/site/pages/docs/contract/encodeFunctionResult.md
+++ b/site/pages/docs/contract/encodeFunctionResult.md
@@ -25,7 +25,7 @@ import { wagmiAbi } from './abi.ts'
 const data = encodeFunctionResult({
   abi: wagmiAbi,
   functionName: 'ownerOf',
-  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+  result: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac',
 });
 // '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac'
 ```
@@ -56,17 +56,15 @@ import { decodeFunctionResult } from 'viem'
 const data = decodeFunctionResult({
   abi: wagmiAbi,
   functionName: 'getInfo',
-  value: [
-    {
-      foo: {
-        sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-        x: 69420n,
-        y: true
-      },
+  result: {
+    foo: {
       sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-      z: 69
-    }
-  ]
+      x: 69420n,
+      y: true
+    },
+    sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    z: 69
+  }
 })
 // 0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac0000000000000000000000000000000000000000000000000000000000000045
 ```
@@ -138,7 +136,7 @@ const abiItem = {
 const data = encodeFunctionResult({
   abi: wagmiAbi,
   functionName: 'ownerOf', // [!code --]
-  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+  result: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac',
 });
 // '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac'
 ```
@@ -159,7 +157,7 @@ The contract's ABI.
 const data = encodeFunctionResult({
   abi: wagmiAbi, // [!code focus]
   functionName: 'ownerOf',
-  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+  result: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac',
 });
 ```
 
@@ -173,7 +171,7 @@ The function to encode from the ABI.
 const data = encodeFunctionResult({
   abi: wagmiAbi,
   functionName: 'ownerOf', // [!code focus]
-  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+  result: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac',
 });
 ```
 
@@ -187,6 +185,6 @@ Return values to encode.
 const data = encodeFunctionResult({
   abi: wagmiAbi,
   functionName: 'ownerOf',
-  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'], // [!code focus]
+  result: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac', // [!code focus]
 });
 ```


### PR DESCRIPTION
The documentation currently uses the incorrect `value` argument on the `encodeFunctionResult` function, and also uses the wrong format (array notation instead of string or object).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

