### PR TITLE
ENH: Add Blast contracts for op-stack compatability

### DIFF
--- a/.changeset/seven-balloons-visit.md
+++ b/.changeset/seven-balloons-visit.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Blast OP Stack addresses.

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -28,6 +28,24 @@ export const blast = /*#__PURE__*/ defineChain({
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 212929,
     },
+    l2OutputOracle: {
+      [sourceId]: {
+        address: "0x826D1B0D4111Ad9146Eb8941D7Ca2B6a44215c76",
+        blockCreated: 19300358
+      }
+    },
+    portal: {
+      [sourceId]: {
+        address: '0x0Ec68c5B10F21EFFb74f2A5C61DFe6b08C0Db6Cb',
+        blockCreated: 19300357
+      }
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0x697402166Fbf2F22E970df8a6486Ef171dbfc524',
+        blockCreated: 19300360
+      },
+    },
   },
   sourceId,
 })


### PR DESCRIPTION
This PR adds the contract addresses to Blast to improve ability to interact with withdrawal functionality.

These contract addresses are pulled from https://docs.blast.io/building/contracts