### PR TITLE
feat: add rns registry contract address

### DIFF
--- a/.changeset/chilly-vans-pay.md
+++ b/.changeset/chilly-vans-pay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+add rns registry contract address

--- a/src/chains/definitions/rootstock.ts
+++ b/src/chains/definitions/rootstock.ts
@@ -18,7 +18,11 @@ export const rootstock = /*#__PURE__*/ defineChain({
       url: 'https://explorer.rsk.co',
     },
   },
+  ensTlds: ['.rsk'],
   contracts: {
+    ensRegistry: {
+      address: '0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5',
+    },
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
       blockCreated: 4249540,


### PR DESCRIPTION
### PR Description

This PR adds the RNS Registry contract address for Rootstock Mainnet.

By including this address, Rootstock becomes compatible with ENS-related operations offered by the **wagmi** library. Since RNS is protocol-compatible with ENS, developers will now be able to use standard ENS methods (e.g., `getEnsAddress`, `resolveName`, etc.) when interacting with `.rsk` domains on Rootstock.

This is an important step toward improving interoperability and enhancing the developer experience across the Rootstock ecosystem.