### PR TITLE
fix: update Celo blocktime to 1 second

### DIFF
--- a/.changeset/mighty-lions-dance.md
+++ b/.changeset/mighty-lions-dance.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Updated Celo blocktime from 2 seconds to 1 second to reflect the actual network block time.

--- a/src/celo/chainConfig.ts
+++ b/src/celo/chainConfig.ts
@@ -4,7 +4,7 @@ import { formatters } from './formatters.js'
 import { serializers } from './serializers.js'
 
 export const chainConfig = {
-  blockTime: 2_000,
+  blockTime: 1_000,
   contracts,
   formatters,
   serializers,


### PR DESCRIPTION
## Summary
• Updated Celo chain configuration to use correct 1-second block time instead of previously configured 2 seconds
• Improves accuracy for time-based calculations and estimations when using Celo network

## Test plan
- [ ] Verify Celo chain configuration exports the updated blocktime
- [ ] Test time-based calculations with Celo network integration
- [ ] Confirm no regression in existing Celo functionality

🤖 Generated with [Claude Code](https://claude.ai/code)