### PR TITLE
Add dataSuffix to calls in sendCalls and simulateBlocks

### DIFF
--- a/.changeset/perfect-snakes-lick.md
+++ b/.changeset/perfect-snakes-lick.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added dataSuffix to sendCalls and simulateBlocks

--- a/site/pages/docs/actions/public/simulateCalls.md
+++ b/site/pages/docs/actions/public/simulateCalls.md
@@ -386,6 +386,37 @@ const { results } = await client.simulateCalls({
 })
 ```
 
+#### calls.dataSuffix
+
+- **Type:** Hex
+
+Data to append to the end of the calldata.
+
+```ts twoslash [example.ts]
+import { parseAbi } from 'viem'
+import { client } from './config'
+
+const abi = parseAbi([
+  'function approve(address, uint256) returns (bool)',
+])
+ // ---cut---
+const { id } = await client.simulateCalls({
+  calls: [
+    {
+      to: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi,
+      functionName: 'approve',
+      args: [
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 
+        100n
+      ],
+      dataSuffix: '0xdeadbeef' // [!code focus]
+    }
+  ],
+})
+```
+
+
 ### account (optional)
 
 - **Type:** `Account | Address`

--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -409,6 +409,36 @@ const { id } = await walletClient.sendCalls({
 })
 ```
 
+#### calls.dataSuffix
+
+- **Type:** Hex
+
+Data to append to the end of the calldata. Useful for adding a "domain" tag.
+
+```ts twoslash [example.ts]
+import { parseAbi } from 'viem'
+import { walletClient } from './config'
+
+const abi = parseAbi([
+  'function approve(address, uint256) returns (bool)',
+])
+ // ---cut---
+const { id } = await walletClient.sendCalls({
+  calls: [
+    {
+      to: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi,
+      functionName: 'approve',
+      args: [
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 
+        100n
+      ],
+      dataSuffix: '0xdeadbeef' // [!code focus]
+    }
+  ],
+})
+```
+
 ### capabilities 
 
 - **Type:** `WalletCapabilities`

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -30,6 +30,7 @@ import {
   type EncodeFunctionDataErrorType,
   encodeFunctionData,
 } from '../../utils/abi/encodeFunctionData.js'
+import { concat } from '../../utils/data/concat.js'
 import {
   type NumberToHexErrorType,
   numberToHex,
@@ -201,9 +202,12 @@ export async function simulateBlocks<
       const calls = block.calls.map((call_) => {
         const call = call_ as Call<unknown, CallExtraProperties>
         const account = call.account ? parseAccount(call.account) : undefined
+        const data = call.abi ? encodeFunctionData(call) : call.data
         const request = {
           ...call,
-          data: call.abi ? encodeFunctionData(call) : call.data,
+          data: call.dataSuffix
+            ? concat([data || '0x', call.dataSuffix])
+            : data,
           from: call.from ?? account?.address,
         } as const
         assertRequest(request)

--- a/src/actions/wallet/sendCalls.test.ts
+++ b/src/actions/wallet/sendCalls.test.ts
@@ -687,3 +687,49 @@ test('error: insufficient funds', async () => {
     Version: viem@x.y.z]
   `)
 })
+
+test('args: dataSuffix', async () => {
+  const requests: unknown[] = []
+
+  const client = getClient({
+    onRequest({ params }) {
+      requests.push(params)
+    },
+  })
+
+  const response = await sendCalls(client, {
+    account: accounts[0].address,
+    chain: mainnet,
+    calls: [
+      {
+        abi: wagmiContractConfig.abi,
+        functionName: 'mint',
+        to: wagmiContractConfig.address,
+        dataSuffix: '0x12345678',
+      },
+    ],
+  })
+
+  expect(response.id).toBeDefined()
+  expect(requests).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "atomicRequired": false,
+          "calls": [
+            {
+              "data": "0x1249c58b12345678",
+              "to": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+              "value": undefined,
+            },
+          ],
+          "capabilities": undefined,
+          "chainId": "0x1",
+          "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+          "id": undefined,
+          "version": "2.0.0",
+        },
+      ],
+    ]
+  `)
+})

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -120,7 +120,7 @@ export async function sendCalls<
       : call.data
 
     return {
-      data,
+      data: call.dataSuffix && data ? concat([data, call.dataSuffix]) : data,
       to: call.to,
       value: call.value ? numberToHex(call.value) : undefined,
     }

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -10,6 +10,7 @@ export type Call<
   | Assign<
       {
         data?: Hex | undefined
+        dataSuffix?: Hex | undefined
         to: Address
         value?: bigint | undefined
       },
@@ -22,6 +23,7 @@ export type Call<
       > & {
         to: Address
         value?: bigint | undefined
+        dataSuffix?: Hex | undefined
       },
       extraProperties
     >


### PR DESCRIPTION
As discussed in https://github.com/wevm/viem/discussions/3703

- Updated `call` type to include `dataSuffix`
- Updated `sendCalls` to append this `dataSuffix` if included, added simple test to validate inclusion
- Updated `simulateBlocks` (used by `simulateCalls`) so that users can simulate and then sendCalls, added simple test to validate inclusion
- Updated docs for `sendCalls` and `simulateCalls`

