### PR TITLE
Add `extraProperties` to infer the param types

### DIFF
--- a/.changeset/plenty-donkeys-type.md
+++ b/.changeset/plenty-donkeys-type.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed inferrence on `Calls` type.

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -48,7 +48,7 @@ export type Calls<
         ? calls
         : // If `calls` is *some* array but we couldn't assign `unknown[]` to it, then it must hold some known/homogenous type!
           // use this to infer the param types in the case of Array.map() argument
-          calls extends readonly (infer call extends OneOf<Call>)[]
+          calls extends readonly (infer call extends OneOf<Call<unknown, extraProperties>>)[]
           ? readonly Prettify<call>[]
           : // Fallback
             readonly OneOf<Call>[]


### PR DESCRIPTION
when passing args to `simulateBlocks` through `Array.map()`, `extraProperties` does not participate in infer.
#3743
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

