### PR TITLE
fix: correct `eth_createAccessList` method documentation in eip1193 types

### DIFF
--- a/.changeset/wild-brooms-teach.md
+++ b/.changeset/wild-brooms-teach.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-fix: correct eth_createAccessList method documentation in eip1193 types
+Corrected `eth_createAccessList` JSDoc in EIP-1193 types.

--- a/.changeset/wild-brooms-teach.md
+++ b/.changeset/wild-brooms-teach.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix: correct eth_createAccessList method documentation in eip1193 types

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -662,11 +662,14 @@ export type PublicRpcSchema = [
     ReturnType: Hex
   },
   /**
-   * @description Executes a new message call immediately without submitting a transaction to the network
+   * @description Creates an EIP-2930 access list that can be included in a transaction.
    *
    * @example
-   * provider.request({ method: 'eth_call', params: [{ to: '0x...', data: '0x...' }] })
-   * // => '0x...'
+   * provider.request({ method: 'eth_createAccessList', params: [{ to: '0x...', data: '0x...' }] })
+   * // => {
+   * //   accessList: ['0x...', '0x...'],
+   * //   gasUsed: '0x123',
+   * // }
    */
   {
     Method: 'eth_createAccessList'


### PR DESCRIPTION
The documentation was incorrectly describing eth_call behaviour instead of eth_createAccessList.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

