### PR TITLE
Update Fault Proofs documentation link to current URL

### DIFF
--- a/site/pages/op-stack/actions/getTimeToNextL2Output.md
+++ b/site/pages/op-stack/actions/getTimeToNextL2Output.md
@@ -10,7 +10,7 @@ Returns the time until the next L2 output (after a provided block number) is sub
 :::warning
 **This Action will be deprecated in the future.**
 
-Use [`getTimeToNextGame`](/op-stack/actions/getTimeToNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/protocol/fault-proofs/overview) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
+Use [`getTimeToNextGame`](/op-stack/actions/getTimeToNextGame) for OP Stack chains that have upgraded to [Fault Proofs](https://docs.optimism.io/stack/fault-proofs/explainer) and have a deployed [DisputeGameFactoryProxy contract](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/addresses.json).
 :::
 
 ## Usage


### PR DESCRIPTION
Replaced the outdated link to the Fault Proofs overview in the OP Stack documentation with the new, correct URL: https://docs.optimism.io/stack/fault-proofs/explainer. This ensures users are directed to the latest and most relevant information about Fault Proofs in the Optimism ecosystem.