### PR TITLE
Fix broken link to Solidity ABI types specification

### DIFF
--- a/site/pages/docs/abi/encodeAbiParameters.md
+++ b/site/pages/docs/abi/encodeAbiParameters.md
@@ -64,7 +64,7 @@ The ABI encoded data.
 
 The set of ABI parameters to encode, in the shape of the `inputs` or `outputs` attribute of an ABI event/function.
 
-These parameters must include valid [ABI types](https://docs.soliditylang.org/en/develop/abi-spec#types).
+These parameters must include valid [ABI types](https://docs.soliditylang.org/en/latest/abi-spec.html#types).
 
 ```ts
 encodeAbiParameters(


### PR DESCRIPTION
Updated the outdated link to the Solidity ABI types specification in the encodeAbiParameters.md documentation. The link now points to the current and correct section: https://docs.soliditylang.org/en/latest/abi-spec.html#types. This ensures users are directed to the latest Solidity documentation for ABI types.