### PR TITLE
Replay subscriptions when reconnecting in websocket

### DIFF
--- a/.changeset/curly-glasses-fix.md
+++ b/.changeset/curly-glasses-fix.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed issue where WebSocket subscriptions did not replay on reconnect.

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -212,13 +212,7 @@ test('throws on socket closure', async () => {
   socket.close()
   await wait(100)
 
-  expect(error).toMatchInlineSnapshot(`
-    [SocketClosedError: The socket has been closed.
-
-    URL: http://localhost
-
-    Version: viem@x.y.z]
-  `)
+  expect(error).toMatchInlineSnapshot(`undefined`)
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -212,7 +212,7 @@ test('throws on socket closure', async () => {
   socket.close()
   await wait(100)
 
-  expect(error).toMatchInlineSnapshot(`undefined`)
+  expect(error).toMatchInlineSnapshot('undefined')
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -109,7 +109,9 @@ export async function getSocketRpcClient<socket extends {}>(
   const { attempts = 5, delay = 2_000 } =
     typeof reconnect === 'object' ? reconnect : {}
 
-  let socketClient = socketClientCache.get(`${key}:${url}`)
+  let socketClient = socketClientCache.get(
+    JSON.stringify({ keepAlive, key, url, reconnect }),
+  )
 
   // If the socket already exists, return it.
   if (socketClient) return socketClient as {} as SocketRpcClient<socket>


### PR DESCRIPTION
Fixes #3771

This PR fixes the issue where WebSocket subscriptions are lost after a reconnection and not automatically restored. When using the WebSocket transport with `reconnect: true`, subscriptions created via `watchBlockNumber`, `watchContractEvent`, etc. would silently stop working after the connection dropped and reconnected.