### PR TITLE
Update API URLs for various chains to use Etherscan v2 endpoints

### DIFF
--- a/src/chains/definitions/arbitrum.ts
+++ b/src/chains/definitions/arbitrum.ts
@@ -13,7 +13,7 @@ export const arbitrum = /*#__PURE__*/ defineChain({
     default: {
       name: 'Arbiscan',
       url: 'https://arbiscan.io',
-      apiUrl: 'https://api.arbiscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=42161',
     },
   },
   contracts: {

--- a/src/chains/definitions/arbitrumNova.ts
+++ b/src/chains/definitions/arbitrumNova.ts
@@ -13,7 +13,7 @@ export const arbitrumNova = /*#__PURE__*/ defineChain({
     default: {
       name: 'Arbiscan',
       url: 'https://nova.arbiscan.io',
-      apiUrl: 'https://api-nova.arbiscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=42170',
     },
   },
   contracts: {

--- a/src/chains/definitions/avalanche.ts
+++ b/src/chains/definitions/avalanche.ts
@@ -15,7 +15,7 @@ export const avalanche = /*#__PURE__*/ defineChain({
     default: {
       name: 'SnowTrace',
       url: 'https://snowtrace.io',
-      apiUrl: 'https://api.snowtrace.io',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=43114',
     },
   },
   contracts: {

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -17,7 +17,7 @@ export const base = /*#__PURE__*/ defineChain({
     default: {
       name: 'Basescan',
       url: 'https://basescan.org',
-      apiUrl: 'https://api.basescan.org/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=8453',
     },
   },
   contracts: {

--- a/src/chains/definitions/blast.ts
+++ b/src/chains/definitions/blast.ts
@@ -19,7 +19,7 @@ export const blast = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blastscan',
       url: 'https://blastscan.io',
-      apiUrl: 'https://api.blastscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=81457',
     },
   },
   contracts: {

--- a/src/chains/definitions/bsc.ts
+++ b/src/chains/definitions/bsc.ts
@@ -15,7 +15,7 @@ export const bsc = /*#__PURE__*/ defineChain({
     default: {
       name: 'BscScan',
       url: 'https://bscscan.com',
-      apiUrl: 'https://api.bscscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=52',
     },
   },
   contracts: {

--- a/src/chains/definitions/celo.ts
+++ b/src/chains/definitions/celo.ts
@@ -17,7 +17,7 @@ export const celo = /*#__PURE__*/ defineChain({
     default: {
       name: 'Celo Explorer',
       url: 'https://celoscan.io',
-      apiUrl: 'https://api.celoscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=42220',
     },
   },
   contracts: {

--- a/src/chains/definitions/cronos.ts
+++ b/src/chains/definitions/cronos.ts
@@ -15,7 +15,7 @@ export const cronos = /*#__PURE__*/ defineChain({
     default: {
       name: 'Cronos Explorer',
       url: 'https://explorer.cronos.org',
-      apiUrl: 'https://explorer-api.cronos.org/mainnet/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=25',
     },
   },
   contracts: {

--- a/src/chains/definitions/fraxtal.ts
+++ b/src/chains/definitions/fraxtal.ts
@@ -17,7 +17,7 @@ export const fraxtal = /*#__PURE__*/ defineChain({
     default: {
       name: 'fraxscan',
       url: 'https://fraxscan.com',
-      apiUrl: 'https://api.fraxscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=252',
     },
   },
   contracts: {

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -18,7 +18,7 @@ export const gnosis = /*#__PURE__*/ defineChain({
     default: {
       name: 'Gnosisscan',
       url: 'https://gnosisscan.io',
-      apiUrl: 'https://api.gnosisscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=100',
     },
   },
   contracts: {

--- a/src/chains/definitions/linea.ts
+++ b/src/chains/definitions/linea.ts
@@ -16,7 +16,7 @@ export const linea = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://lineascan.build',
-      apiUrl: 'https://api.lineascan.build/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=59144',
     },
   },
   contracts: {

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -13,7 +13,7 @@ export const mainnet = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://etherscan.io',
-      apiUrl: 'https://api.etherscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=1',
     },
   },
   contracts: {

--- a/src/chains/definitions/mantle.ts
+++ b/src/chains/definitions/mantle.ts
@@ -15,7 +15,7 @@ export const mantle = /*#__PURE__*/ defineChain({
     default: {
       name: 'Mantle Explorer',
       url: 'https://mantlescan.xyz/',
-      apiUrl: 'https://api.mantlescan.xyz/api',
+      apiUrl: 'https://api.mantlescan.xyz/v2/api?chainid=5000',
     },
   },
   contracts: {

--- a/src/chains/definitions/moonbeam.ts
+++ b/src/chains/definitions/moonbeam.ts
@@ -18,7 +18,7 @@ export const moonbeam = /*#__PURE__*/ defineChain({
     default: {
       name: 'Moonscan',
       url: 'https://moonscan.io',
-      apiUrl: 'https://api-moonbeam.moonscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=1284',
     },
   },
   contracts: {

--- a/src/chains/definitions/moonriver.ts
+++ b/src/chains/definitions/moonriver.ts
@@ -18,7 +18,7 @@ export const moonriver = /*#__PURE__*/ defineChain({
     default: {
       name: 'Moonscan',
       url: 'https://moonriver.moonscan.io',
-      apiUrl: 'https://api-moonriver.moonscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=1285',
     },
   },
   contracts: {

--- a/src/chains/definitions/opBNB.ts
+++ b/src/chains/definitions/opBNB.ts
@@ -18,7 +18,7 @@ export const opBNB = /*#__PURE__*/ defineChain({
     default: {
       name: 'opBNB (BSCScan)',
       url: 'https://opbnb.bscscan.com',
-      apiUrl: 'https://api-opbnb.bscscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=204',
     },
   },
   contracts: {

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -17,7 +17,7 @@ export const optimism = /*#__PURE__*/ defineChain({
     default: {
       name: 'Optimism Explorer',
       url: 'https://optimistic.etherscan.io',
-      apiUrl: 'https://api-optimistic.etherscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=10',
     },
   },
   contracts: {

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -13,7 +13,7 @@ export const polygon = /*#__PURE__*/ defineChain({
     default: {
       name: 'PolygonScan',
       url: 'https://polygonscan.com',
-      apiUrl: 'https://api.polygonscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=137',
     },
   },
   contracts: {

--- a/src/chains/definitions/scroll.ts
+++ b/src/chains/definitions/scroll.ts
@@ -14,7 +14,7 @@ export const scroll = /*#__PURE__*/ defineChain({
     default: {
       name: 'Scrollscan',
       url: 'https://scrollscan.com',
-      apiUrl: 'https://api.scrollscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=534352',
     },
   },
   contracts: {

--- a/src/chains/definitions/taiko.ts
+++ b/src/chains/definitions/taiko.ts
@@ -18,7 +18,7 @@ export const taiko = /*#__PURE__*/ defineChain({
     default: {
       name: 'Taikoscan',
       url: 'https://taikoscan.io',
-      apiUrl: 'https://api.taikoscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=167000',
     },
   },
   contracts: {

--- a/src/chains/definitions/worldchain.ts
+++ b/src/chains/definitions/worldchain.ts
@@ -16,7 +16,7 @@ export const worldchain = /*#__PURE__*/ defineChain({
     default: {
       name: 'Worldscan',
       url: 'https://worldscan.org',
-      apiUrl: 'https://api.worldscan.org/api',
+      apiUrl: 'https://api.worldscan.org/v2/api?chainid=480',
     },
     blockscout: {
       name: 'Blockscout',

--- a/src/chains/definitions/xai.ts
+++ b/src/chains/definitions/xai.ts
@@ -13,6 +13,7 @@ export const xai = /*#__PURE__*/ defineChain({
     default: {
       name: 'Blockscout',
       url: 'https://explorer.xai-chain.net',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=660279',
     },
   },
   contracts: {

--- a/src/chains/definitions/zksync.ts
+++ b/src/chains/definitions/zksync.ts
@@ -21,7 +21,7 @@ export const zksync = /*#__PURE__*/ defineChain({
     default: {
       name: 'Etherscan',
       url: 'https://era.zksync.network/',
-      apiUrl: 'https://api-era.zksync.network/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=324',
     },
     native: {
       name: 'ZKsync Explorer',


### PR DESCRIPTION
This PR replaces the soon-to-be-deprecated Etherscan v1 API URLs with new v2 multichain API URLs. Read about it here: https://docs.etherscan.io/etherscan-v2/v2-quickstart

Did not add tests, as this is just a data update.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

