### PR TITLE
Fix Typo in Anvil Automining Test Comments

### DIFF
--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -71,7 +71,7 @@ describe('smoke test', () => {
     expect(await testClient.dropTransaction({ hash })).toBeUndefined()
   })
 
-  // TODO: Anvil sometimes stops interval mining when automining is programatically set.
+  // TODO: Anvil sometimes stops interval mining when automining is programmatically set.
   test.skip('getAutomine', async () => {
     expect(await testClient.getAutomine()).toBeDefined()
   })
@@ -133,7 +133,7 @@ describe('smoke test', () => {
     ).toBeDefined()
   })
 
-  // TODO: Anvil sometimes stops interval mining when automining is programatically set.
+  // TODO: Anvil sometimes stops interval mining when automining is programmatically set.
   test.skip('setAutomine', async () => {
     expect(await testClient.setAutomine(true)).toBeUndefined()
   })


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the test comments for Anvil automining. The word "programatically" has been updated to the correct spelling "programmatically" for improved clarity and professionalism. 