### PR TITLE
update info (previous sepolia testnet deprecated)

### DIFF
--- a/src/chains/definitions/siliconSepolia.ts
+++ b/src/chains/definitions/siliconSepolia.ts
@@ -1,13 +1,13 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const siliconSepolia = /*#__PURE__*/ defineChain({
-  id: 1722641160,
+  id: 1414,
   name: 'Silicon Sepolia zkEVM',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
       http: [
-        'https://rpc-sepolia.silicon.network',
+        'https://rpc-sepolia.node.0xsilicon.net:8545',
         'https://silicon-testnet.nodeinfra.com',
       ],
     },


### PR DESCRIPTION
* This PR update support for the chain ID used by [SiliconSepolia](https://silicon.network)
---
# PR-Codex overview
* This PR  a update new chain called Silicon-Sepolia with specific configurations and includes it in the available chain.

# Detailed summary
* Updated `siliconSepolia` in `chains/definitions/siliconSepolia.ts`

<!-- start pr-codex -->