### PR TITLE
update info (previous sepolia testnet deprecated)

### DIFF
--- a/src/chains/definitions/siliconTestnet.ts
+++ b/src/chains/definitions/siliconTestnet.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const siliconSepolia = /*#__PURE__*/ defineChain({
+  id: 1414,
+  name: 'Silicon Sepolia zkEVM',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: [
+        'https://rpc-sepolia.node.0xsilicon.net:8545',
+        'https://rpc-sepolia.node.0xsilicon.net',
+        'https://silicon-testnet.nodeinfra.com',
+      ],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'SiliconSepoliaScope',
+      url: 'https://scope-sepolia.silicon.network',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -466,6 +466,7 @@ export { shimmer } from './definitions/shimmer.js'
 export { shimmerTestnet } from './definitions/shimmerTestnet.js'
 export { sidraChain } from './definitions/sidra.js'
 export { silicon } from './definitions/silicon.js'
+/** @deprecated Use `siliconTestnet` instead. */
 export { siliconSepolia } from './definitions/siliconSepolia.js'
 export { sixProtocol } from './definitions/sixProtocol.js'
 export { skaleBlockBrawlers } from './definitions/skale/brawl.js'


### PR DESCRIPTION
* This PR update support for the chain ID used by [SiliconSepolia](https://silicon.network)
---
# PR-Codex overview
* This PR  a update new chain called Silicon-Sepolia with specific configurations and includes it in the available chain.

# Detailed summary
* Updated `siliconSepolia` in `chains/definitions/siliconSepolia.ts`

<!-- start pr-codex -->