### PR TITLE
feat(chains): add Xphere Chain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6241,6 +6241,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.31.7:
+    resolution: {integrity: sha512-mpB8Hp6xK77E/b/yJmpAIQcxcOfpbrwWNItjnXaIA8lxZYt4JS433Pge2gg6Hp3PwyFtaUMh01j5L8EXnLTjQQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -7771,7 +7779,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.31.6(typescript@5.8.3)(zod@3.23.8)
+      viem: 2.31.7(typescript@5.8.3)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -13031,7 +13039,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.31.6(typescript@5.8.3)(zod@3.23.8):
+  viem@2.31.7(typescript@5.8.3)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0

--- a/src/chains/definitions/xphereMainnet.ts
+++ b/src/chains/definitions/xphereMainnet.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xphereMainnet = /*#__PURE__*/ defineChain({
+  id: 20250217,
+  name: 'Xphere Mainnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'XP',
+    symbol: 'XP',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://en-bkk.x-phere.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Xphere Tamsa Explorer',
+      url: 'https://xp.tamsa.io/',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/definitions/xphereTestnet.ts
+++ b/src/chains/definitions/xphereTestnet.ts
@@ -1,0 +1,24 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xphereTestnet = /*#__PURE__*/ defineChain({
+  id: 1998991,
+  name: 'Xphere Mainnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'XPT',
+    symbol: 'XPT',
+  },
+  rpcUrls: {
+    default: {
+      http: ['http://testnet.x-phere.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Xphere Tamsa Explorer',
+      url: 'https://xpt.tamsa.io/',
+    },
+  },
+  testnet: true,
+})
+

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -592,6 +592,8 @@ export {
   x1Testnet,
   xLayerTestnet,
 } from './definitions/xLayerTestnet.js'
+export { xphereMainnet } from './definitions/xphereMainnet.js'
+export { xphereTestnet } from './definitions/xphereTestnet.js'
 export { xrOne } from './definitions/xrOne.js'
 export { xrplevmDevnet } from './definitions/xrplevmDevnet.js'
 export { xrplevmTestnet } from './definitions/xrplevmTestnet.js'


### PR DESCRIPTION
This PR adds support for Xphere Chain to the Viem repository, enabling developers to interact with Xphere's infrastructure using Viem.

Xphere Chain Details
Hyper-connected blockchain for vertical industry excellence

Mainnet Details

Chain ID: 20250217
Native Currency: XP (Symbol: XP)
RPC URLs: https://en-bkk.x-phere.com/
Block Explorer: https://xp.tamsa.io/

Testnet Details

Chain ID: 1998991
Native Currency: XPT (Symbol: XPT)
RPC URLs: http://testnet.x-phere.com
Block Explorer: https://xpt.tamsa.io/

This PR adds support for Xphere Chain to the Viem repository, enabling developers to interact with Xphere's infrastructure using Viem.