### PR TITLE
feat: add `client.experimental_blockTag` + `chain.experimental_preconfirmationTime`

### DIFF
--- a/.changeset/happy-ducks-destroy.md
+++ b/.changeset/happy-ducks-destroy.md
@@ -1,0 +1,16 @@
+---
+"viem": minor
+---
+
+Added `blockTag` config option to the Client. 
+
+This will be used as the default block tag for the following actions:
+
+- `call`
+- `estimateGas`
+- `getBalance`
+- `getBlock`
+- `simulateBlocks`
+- `waitForTransactionReceipt`
+- `watchBlocks`
+

--- a/.changeset/happy-ducks-destroy.md
+++ b/.changeset/happy-ducks-destroy.md
@@ -2,7 +2,7 @@
 "viem": minor
 ---
 
-Added `blockTag` config option to the Client. 
+**Experimental:** Added `experimental_blockTag` config option to the Client. 
 
 This will be used as the default block tag for the following actions:
 

--- a/.changeset/happy-ducks-destroy.md
+++ b/.changeset/happy-ducks-destroy.md
@@ -13,4 +13,3 @@ This will be used as the default block tag for the following actions:
 - `simulateBlocks`
 - `waitForTransactionReceipt`
 - `watchBlocks`
-

--- a/.changeset/honest-rice-protect.md
+++ b/.changeset/honest-rice-protect.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added an `experimental_preconfirmationTime` property to the Chain configuration for chains that support pre-confirmations (e.g. "Flashblocks").
+**Experimental:** Added an `experimental_preconfirmationTime` property to the Chain configuration for chains that support pre-confirmations (e.g. "Flashblocks").

--- a/.changeset/honest-rice-protect.md
+++ b/.changeset/honest-rice-protect.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added an `experimental_preconfirmationTime` property to the Chain configuration for chains that support pre-confirmations (e.g. "Flashblocks").

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -218,6 +218,10 @@ This will be used as the default block tag for the following Actions:
 - `waitForTransactionReceipt`
 - `watchBlocks`
 
+:::note
+If the chain supports a pre-confirmation mechanism (set via `chain.experimental_preconfirmationTime`), 
+the default block tag will be `'pending'`.
+:::
 
 ```ts twoslash
 // [!include ~/snippets/publicClient.ts:imports]

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -201,38 +201,6 @@ const publicClient = createPublicClient({
 })
 ```
 
-### blockTag (optional)
-
-- **Type:** `BlockTag`
-- **Default:** `'latest'`
-
-The default block tag to use for Actions.
-
-This will be used as the default block tag for the following Actions:
-
-- `call`
-- `estimateGas`
-- `getBalance`
-- `getBlock`
-- `simulateBlocks`
-- `waitForTransactionReceipt`
-- `watchBlocks`
-
-:::note
-If the chain supports a pre-confirmation mechanism (set via `chain.experimental_preconfirmationTime`), 
-the default block tag will be `'pending'`.
-:::
-
-```ts twoslash
-// [!include ~/snippets/publicClient.ts:imports]
-// ---cut---
-const publicClient = createPublicClient({
-  blockTag: 'pending', // [!code focus]
-  chain: mainnet,
-  transport: http(),
-})
-```
-
 ### cacheTime (optional)
 
 - **Type:** `number`
@@ -289,6 +257,39 @@ const publicClient = createPublicClient({
   transport: http(),
 })
 ```
+
+### experimental_blockTag (optional)
+
+- **Type:** `BlockTag`
+- **Default:** `'latest'`
+
+The default block tag to use for Actions.
+
+This will be used as the default block tag for the following Actions:
+
+- `call`
+- `estimateGas`
+- `getBalance`
+- `getBlock`
+- `simulateBlocks`
+- `waitForTransactionReceipt`
+- `watchBlocks`
+
+:::note
+If the chain supports a pre-confirmation mechanism (set via `chain.experimental_preconfirmationTime`), 
+the default block tag will be `'pending'`.
+:::
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts:imports]
+// ---cut---
+const publicClient = createPublicClient({
+  blockTag: 'pending', // [!code focus]
+  chain: mainnet,
+  transport: http(),
+})
+```
+
 
 ### key (optional)
 

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -206,7 +206,18 @@ const publicClient = createPublicClient({
 - **Type:** `BlockTag`
 - **Default:** `'latest'`
 
-The default block tag to use for RPC requests.
+The default block tag to use for Actions.
+
+This will be used as the default block tag for the following Actions:
+
+- `call`
+- `estimateGas`
+- `getBalance`
+- `getBlock`
+- `simulateBlocks`
+- `waitForTransactionReceipt`
+- `watchBlocks`
+
 
 ```ts twoslash
 // [!include ~/snippets/publicClient.ts:imports]

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -284,7 +284,7 @@ the default block tag will be `'pending'`.
 // [!include ~/snippets/publicClient.ts:imports]
 // ---cut---
 const publicClient = createPublicClient({
-  blockTag: 'pending', // [!code focus]
+  experimental_blockTag: 'pending', // [!code focus]
   chain: mainnet,
   transport: http(),
 })

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -201,6 +201,23 @@ const publicClient = createPublicClient({
 })
 ```
 
+### blockTag (optional)
+
+- **Type:** `BlockTag`
+- **Default:** `'latest'`
+
+The default block tag to use for RPC requests.
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts:imports]
+// ---cut---
+const publicClient = createPublicClient({
+  blockTag: 'pending', // [!code focus]
+  chain: mainnet,
+  transport: http(),
+})
+```
+
 ### cacheTime (optional)
 
 - **Type:** `number`

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,7 +160,7 @@ export async function call<chain extends Chain | undefined>(
     authorizationList,
     batch = Boolean(client.batch?.multicall),
     blockNumber,
-    blockTag = client.blockTag,
+    blockTag = client.experimental_blockTag,
     accessList,
     blobs,
     blockOverrides,
@@ -351,7 +351,7 @@ async function scheduleMulticall<chain extends Chain | undefined>(
     typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
   const {
     blockNumber,
-    blockTag = client.blockTag,
+    blockTag = client.experimental_blockTag,
     data,
     multicallAddress: multicallAddress_,
     to,

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,7 +160,7 @@ export async function call<chain extends Chain | undefined>(
     authorizationList,
     batch = Boolean(client.batch?.multicall),
     blockNumber,
-    blockTag = 'latest',
+    blockTag = client.blockTag ?? 'latest',
     accessList,
     blobs,
     blockOverrides,
@@ -351,7 +351,7 @@ async function scheduleMulticall<chain extends Chain | undefined>(
     typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
   const {
     blockNumber,
-    blockTag = 'latest',
+    blockTag = client.blockTag ?? 'latest',
     data,
     multicallAddress: multicallAddress_,
     to,

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,7 +160,7 @@ export async function call<chain extends Chain | undefined>(
     authorizationList,
     batch = Boolean(client.batch?.multicall),
     blockNumber,
-    blockTag = client.blockTag ?? 'latest',
+    blockTag = client.blockTag,
     accessList,
     blobs,
     blockOverrides,
@@ -351,7 +351,7 @@ async function scheduleMulticall<chain extends Chain | undefined>(
     typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
   const {
     blockNumber,
-    blockTag = client.blockTag ?? 'latest',
+    blockTag = client.blockTag,
     data,
     multicallAddress: multicallAddress_,
     to,

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -160,7 +160,7 @@ export async function call<chain extends Chain | undefined>(
     authorizationList,
     batch = Boolean(client.batch?.multicall),
     blockNumber,
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
     accessList,
     blobs,
     blockOverrides,
@@ -351,7 +351,7 @@ async function scheduleMulticall<chain extends Chain | undefined>(
     typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
   const {
     blockNumber,
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
     data,
     multicallAddress: multicallAddress_,
     to,

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -194,7 +194,7 @@ export async function estimateGas<
       return client.request({
         method: 'eth_estimateGas',
         params: rpcStateOverride
-          ? [request, block ?? client.blockTag, rpcStateOverride]
+          ? [request, block ?? client.experimental_blockTag, rpcStateOverride]
           : block
             ? [request, block]
             : [request],

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -194,7 +194,11 @@ export async function estimateGas<
       return client.request({
         method: 'eth_estimateGas',
         params: rpcStateOverride
-          ? [request, block ?? client.experimental_blockTag, rpcStateOverride]
+          ? [
+              request,
+              block ?? client.experimental_blockTag ?? 'latest',
+              rpcStateOverride,
+            ]
           : block
             ? [request, block]
             : [request],

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -194,7 +194,7 @@ export async function estimateGas<
       return client.request({
         method: 'eth_estimateGas',
         params: rpcStateOverride
-          ? [request, block ?? client.blockTag ?? 'latest', rpcStateOverride]
+          ? [request, block ?? client.blockTag, rpcStateOverride]
           : block
             ? [request, block]
             : [request],

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -194,7 +194,7 @@ export async function estimateGas<
       return client.request({
         method: 'eth_estimateGas',
         params: rpcStateOverride
-          ? [request, block ?? 'latest', rpcStateOverride]
+          ? [request, block ?? client.blockTag ?? 'latest', rpcStateOverride]
           : block
             ? [request, block]
             : [request],

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -71,7 +71,11 @@ export type GetBalanceErrorType =
  */
 export async function getBalance<chain extends Chain | undefined>(
   client: Client<Transport, chain>,
-  { address, blockNumber, blockTag = 'latest' }: GetBalanceParameters,
+  {
+    address,
+    blockNumber,
+    blockTag = client.blockTag ?? 'latest',
+  }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex =
     typeof blockNumber === 'bigint' ? numberToHex(blockNumber) : undefined

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -74,7 +74,7 @@ export async function getBalance<chain extends Chain | undefined>(
   {
     address,
     blockNumber,
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
   }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex =

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -71,11 +71,7 @@ export type GetBalanceErrorType =
  */
 export async function getBalance<chain extends Chain | undefined>(
   client: Client<Transport, chain>,
-  {
-    address,
-    blockNumber,
-    blockTag = client.blockTag ?? 'latest',
-  }: GetBalanceParameters,
+  { address, blockNumber, blockTag = client.blockTag }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex =
     typeof blockNumber === 'bigint' ? numberToHex(blockNumber) : undefined

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -71,7 +71,11 @@ export type GetBalanceErrorType =
  */
 export async function getBalance<chain extends Chain | undefined>(
   client: Client<Transport, chain>,
-  { address, blockNumber, blockTag = client.blockTag }: GetBalanceParameters,
+  {
+    address,
+    blockNumber,
+    blockTag = client.experimental_blockTag,
+  }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex =
     typeof blockNumber === 'bigint' ? numberToHex(blockNumber) : undefined

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -97,11 +97,10 @@ export async function getBlock<
   {
     blockHash,
     blockNumber,
-    blockTag: blockTag_,
+    blockTag = client.blockTag ?? 'latest',
     includeTransactions: includeTransactions_,
   }: GetBlockParameters<includeTransactions, blockTag> = {},
 ): Promise<GetBlockReturnType<chain, includeTransactions, blockTag>> {
-  const blockTag = blockTag_ ?? 'latest'
   const includeTransactions = includeTransactions_ ?? false
 
   const blockNumberHex =

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -97,7 +97,7 @@ export async function getBlock<
   {
     blockHash,
     blockNumber,
-    blockTag = client.blockTag,
+    blockTag = client.experimental_blockTag,
     includeTransactions: includeTransactions_,
   }: GetBlockParameters<includeTransactions, blockTag> = {},
 ): Promise<GetBlockReturnType<chain, includeTransactions, blockTag>> {

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -97,7 +97,7 @@ export async function getBlock<
   {
     blockHash,
     blockNumber,
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
     includeTransactions: includeTransactions_,
   }: GetBlockParameters<includeTransactions, blockTag> = {},
 ): Promise<GetBlockReturnType<chain, includeTransactions, blockTag>> {

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -97,7 +97,7 @@ export async function getBlock<
   {
     blockHash,
     blockNumber,
-    blockTag = client.blockTag ?? 'latest',
+    blockTag = client.blockTag,
     includeTransactions: includeTransactions_,
   }: GetBlockParameters<includeTransactions, blockTag> = {},
 ): Promise<GetBlockReturnType<chain, includeTransactions, blockTag>> {

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -186,7 +186,7 @@ export async function simulateBlocks<
 ): Promise<SimulateBlocksReturnType<calls>> {
   const {
     blockNumber,
-    blockTag = 'latest',
+    blockTag = client.blockTag ?? 'latest',
     blocks,
     returnFullTransactions,
     traceTransfers,

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -186,7 +186,7 @@ export async function simulateBlocks<
 ): Promise<SimulateBlocksReturnType<calls>> {
   const {
     blockNumber,
-    blockTag = client.blockTag,
+    blockTag = client.experimental_blockTag,
     blocks,
     returnFullTransactions,
     traceTransfers,

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -186,7 +186,7 @@ export async function simulateBlocks<
 ): Promise<SimulateBlocksReturnType<calls>> {
   const {
     blockNumber,
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
     blocks,
     returnFullTransactions,
     traceTransfers,

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -186,7 +186,7 @@ export async function simulateBlocks<
 ): Promise<SimulateBlocksReturnType<calls>> {
   const {
     blockNumber,
-    blockTag = client.blockTag ?? 'latest',
+    blockTag = client.blockTag,
     blocks,
     returnFullTransactions,
     traceTransfers,

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -147,13 +147,19 @@ export async function waitForTransactionReceipt<
     confirmations = 1,
     hash,
     onReplaced,
-    pollingInterval = client.pollingInterval,
     retryCount = 6,
     retryDelay = ({ count }) => ~~(1 << count) * 200, // exponential backoff
     timeout = 180_000,
   } = parameters
 
   const observerId = stringify(['waitForTransactionReceipt', client.uid, hash])
+
+  const pollingInterval = (() => {
+    if (parameters.pollingInterval) return parameters.pollingInterval
+    if (client.chain?.experimental_preconfirmationTime)
+      return client.chain.experimental_preconfirmationTime
+    return client.pollingInterval
+  })()
 
   let transaction: GetTransactionReturnType<chain> | undefined
   let replacedTransaction: GetTransactionReturnType<chain> | undefined

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -103,7 +103,7 @@ export function watchBlocks<
 >(
   client: Client<transport, chain>,
   {
-    blockTag = client.experimental_blockTag,
+    blockTag = client.experimental_blockTag ?? 'latest',
     emitMissed = false,
     emitOnBegin = false,
     onBlock,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -103,7 +103,7 @@ export function watchBlocks<
 >(
   client: Client<transport, chain>,
   {
-    blockTag = client.blockTag,
+    blockTag = client.experimental_blockTag,
     emitMissed = false,
     emitOnBegin = false,
     onBlock,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -103,7 +103,7 @@ export function watchBlocks<
 >(
   client: Client<transport, chain>,
   {
-    blockTag = 'latest',
+    blockTag = client.blockTag ?? 'latest',
     emitMissed = false,
     emitOnBegin = false,
     onBlock,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -103,7 +103,7 @@ export function watchBlocks<
 >(
   client: Client<transport, chain>,
   {
-    blockTag = client.blockTag ?? 'latest',
+    blockTag = client.blockTag,
     emitMissed = false,
     emitOnBegin = false,
     onBlock,

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -51,3 +51,13 @@ export const base = /*#__PURE__*/ defineChain({
   },
   sourceId,
 })
+
+export const baseFlashblocks = /*#__PURE__*/ defineChain({
+  ...base,
+  experimental_preconfirmationTime: 200,
+  rpcUrls: {
+    default: {
+      http: ['https://mainnet-preconf.base.org'],
+    },
+  },
+})

--- a/src/chains/definitions/baseSepolia.ts
+++ b/src/chains/definitions/baseSepolia.ts
@@ -53,3 +53,13 @@ export const baseSepolia = /*#__PURE__*/ defineChain({
   testnet: true,
   sourceId,
 })
+
+export const baseSepoliaFlashblocks = /*#__PURE__*/ defineChain({
+  ...baseSepolia,
+  experimental_preconfirmationTime: 200,
+  rpcUrls: {
+    default: {
+      http: ['https://sepolia-preconf.base.org'],
+    },
+  },
+})

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -30,6 +30,7 @@ test('creates', () => {
     {
       "account": undefined,
       "batch": undefined,
+      "blockTag": "latest",
       "cacheTime": 4000,
       "ccipRead": undefined,
       "chain": undefined,
@@ -65,6 +66,7 @@ describe('transports', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": {
@@ -119,6 +121,7 @@ describe('transports', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": {
@@ -173,6 +176,7 @@ describe('transports', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -198,6 +202,89 @@ describe('transports', () => {
 })
 
 describe('config', () => {
+  test('blockTag', () => {
+    const mockTransport = () =>
+      createTransport({
+        key: 'mock',
+        name: 'Mock Transport',
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
+        type: 'mock',
+      })
+    const { uid, ...client } = createClient({
+      blockTag: 'safe',
+      transport: mockTransport,
+    })
+
+    expect(uid).toBeDefined()
+    expect(client.blockTag).toBe('safe')
+    expect(client).toMatchInlineSnapshot(`
+      {
+        "account": undefined,
+        "batch": undefined,
+        "blockTag": "safe",
+        "cacheTime": 4000,
+        "ccipRead": undefined,
+        "chain": undefined,
+        "extend": [Function],
+        "key": "base",
+        "name": "Base Client",
+        "pollingInterval": 4000,
+        "request": [Function],
+        "transport": {
+          "key": "mock",
+          "methods": undefined,
+          "name": "Mock Transport",
+          "request": [MockFunction spy],
+          "retryCount": 3,
+          "retryDelay": 150,
+          "timeout": undefined,
+          "type": "mock",
+        },
+        "type": "base",
+      }
+    `)
+  })
+
+  test('blockTag: defaults to latest', () => {
+    const mockTransport = () =>
+      createTransport({
+        key: 'mock',
+        name: 'Mock Transport',
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
+        type: 'mock',
+      })
+    const { uid, ...client } = createClient({
+      transport: mockTransport,
+    })
+
+    expect(uid).toBeDefined()
+    expect(client.blockTag).toBe('latest')
+  })
+
+  test('blockTag: defaults to pending when chain has experimental_preconfirmationTime', () => {
+    const mockTransport = () =>
+      createTransport({
+        key: 'mock',
+        name: 'Mock Transport',
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
+        type: 'mock',
+      })
+    const mockChain = {
+      id: 1337,
+      name: 'Mock Chain',
+      nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+      rpcUrls: { default: { http: ['http://localhost:8545'] } },
+      experimental_preconfirmationTime: 1000,
+    }
+    const { uid, ...client } = createClient({
+      chain: mockChain,
+      transport: mockTransport,
+    })
+
+    expect(uid).toBeDefined()
+    expect(client.blockTag).toBe('pending')
+  })
+
   test('cacheTime', () => {
     const mockTransport = () =>
       createTransport({
@@ -216,6 +303,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 10000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -261,6 +349,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": {
           "request": [Function],
@@ -305,6 +394,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -347,6 +437,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -389,6 +480,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 10000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -431,6 +523,7 @@ describe('config', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "ccipRead": undefined,
         "chain": undefined,
@@ -487,6 +580,7 @@ describe('extends', () => {
       {
         "account": undefined,
         "batch": undefined,
+        "blockTag": "latest",
         "cacheTime": 4000,
         "call": [Function],
         "ccipRead": undefined,

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -211,7 +211,7 @@ describe('config', () => {
         type: 'mock',
       })
     const { uid, ...client } = createClient({
-      blockTag: 'safe',
+      experimental_blockTag: 'safe',
       transport: mockTransport,
     })
 
@@ -261,7 +261,7 @@ describe('config', () => {
     expect(client.experimental_blockTag).toBe('latest')
   })
 
-  test('blockTag: defaults to pending when chain has experimental_preconfirmationTime', () => {
+  test('blockTag: defaults to pending when chain has `experimental_preconfirmationTime`', () => {
     const mockTransport = () =>
       createTransport({
         key: 'mock',

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -216,7 +216,7 @@ describe('config', () => {
     })
 
     expect(uid).toBeDefined()
-    expect(client.blockTag).toBe('safe')
+    expect(client.experimental_blockTag).toBe('safe')
     expect(client).toMatchInlineSnapshot(`
       {
         "account": undefined,
@@ -258,7 +258,7 @@ describe('config', () => {
     })
 
     expect(uid).toBeDefined()
-    expect(client.blockTag).toBe('latest')
+    expect(client.experimental_blockTag).toBe('latest')
   })
 
   test('blockTag: defaults to pending when chain has experimental_preconfirmationTime', () => {
@@ -282,7 +282,7 @@ describe('config', () => {
     })
 
     expect(uid).toBeDefined()
-    expect(client.blockTag).toBe('pending')
+    expect(client.experimental_blockTag).toBe('pending')
   })
 
   test('cacheTime', () => {

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -50,7 +50,7 @@ export type ClientConfig<
    *
    * @default 'latest'
    */
-  blockTag?: BlockTag | undefined
+  experimental_blockTag?: BlockTag | undefined
   /**
    * Time (in ms) that cached data will remain in memory.
    * @default chain.blockTime / 3
@@ -165,14 +165,14 @@ type Client_Base<
   account: account
   /** Flags for batch settings. */
   batch?: ClientConfig['batch'] | undefined
-  /** Default block tag to use for RPC requests. */
-  blockTag: BlockTag
   /** Time (in ms) that cached data will remain in memory. */
   cacheTime: number
   /** [CCIP Read](https://eips.ethereum.org/EIPS/eip-3668) configuration. */
   ccipRead?: ClientConfig['ccipRead'] | undefined
   /** Chain for the client. */
   chain: chain
+  /** Default block tag to use for RPC requests. */
+  experimental_blockTag: BlockTag
   /** A key for the client. */
   key: string
   /** A name for the client. */
@@ -235,8 +235,8 @@ export function createClient(parameters: ClientConfig): Client {
     type = 'base',
   } = parameters
 
-  const blockTag =
-    parameters.blockTag ??
+  const experimental_blockTag =
+    parameters.experimental_blockTag ??
     (typeof chain?.experimental_preconfirmationTime === 'number'
       ? 'pending'
       : 'latest')
@@ -261,10 +261,10 @@ export function createClient(parameters: ClientConfig): Client {
   const client = {
     account,
     batch,
-    blockTag,
     cacheTime,
     ccipRead,
     chain,
+    experimental_blockTag,
     key,
     name,
     pollingInterval,

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -172,7 +172,7 @@ type Client_Base<
   /** Chain for the client. */
   chain: chain
   /** Default block tag to use for RPC requests. */
-  experimental_blockTag: BlockTag
+  experimental_blockTag?: BlockTag | undefined
   /** A key for the client. */
   key: string
   /** A name for the client. */

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -166,7 +166,7 @@ type Client_Base<
   /** Flags for batch settings. */
   batch?: ClientConfig['batch'] | undefined
   /** Default block tag to use for RPC requests. */
-  blockTag?: BlockTag | undefined
+  blockTag: BlockTag
   /** Time (in ms) that cached data will remain in memory. */
   cacheTime: number
   /** [CCIP Read](https://eips.ethereum.org/EIPS/eip-3668) configuration. */

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -54,6 +54,8 @@ export type Chain<
   name: string
   /** Currency used by chain */
   nativeCurrency: ChainNativeCurrency
+  /** Preconfirmation time in milliseconds. */
+  experimental_preconfirmationTime?: number | undefined
   /** Collection of RPC endpoints */
   rpcUrls: {
     [key: string]: ChainRpcUrls


### PR DESCRIPTION
Brings back https://github.com/wevm/viem/commit/530f0f1693983c7de1676873f9f234033e5267e1 via a Client option (`client.experimental_blockTag`), and a `chain.experimental_preconfirmationTime` for chains that support preconfirmations (e.g. "Flashblocks").