### PR TITLE
Add block time for Arbitrum chain

### DIFF
--- a/.changeset/famous-pans-act.md
+++ b/.changeset/famous-pans-act.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add `blockTime` to Arbitrum chains.

--- a/src/chains/definitions/arbitrum.ts
+++ b/src/chains/definitions/arbitrum.ts
@@ -4,6 +4,7 @@ export const arbitrum = /*#__PURE__*/ defineChain({
   id: 42_161,
   name: 'Arbitrum One',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  blockTime: 250,
   rpcUrls: {
     default: {
       http: ['https://arb1.arbitrum.io/rpc'],

--- a/src/chains/definitions/arbitrumSepolia.ts
+++ b/src/chains/definitions/arbitrumSepolia.ts
@@ -3,6 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const arbitrumSepolia = /*#__PURE__*/ defineChain({
   id: 421_614,
   name: 'Arbitrum Sepolia',
+  blockTime: 250,
   nativeCurrency: {
     name: 'Arbitrum Sepolia Ether',
     symbol: 'ETH',


### PR DESCRIPTION
Adds block time for Arbitrum - based on [docs](https://docs.arbitrum.io/how-arbitrum-works/timeboost/gentle-introduction#:~:text=It's%20important%20to%20note%20that,to%20100%20milliseconds%20if%20desired) and block times it is 250 ms.

Should we remove Arbitrum Goerli? It's deactivated since March 18th, 2024 - https://docs.arbitrum.io/build-decentralized-apps/public-chains#arbitrum-goerli.