### PR TITLE
fix: Update getWithdrawalStatus.ts to include new custom errors

### DIFF
--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -286,6 +286,7 @@ export async function getWithdrawalStatus<
       const errorCauses = {
         'ready-to-prove': [
           'OptimismPortal: invalid game type',
+          'OptimismPortal_Unproven',
           'OptimismPortal: withdrawal has not been proven yet',
           'OptimismPortal: withdrawal has not been proven by proof submitter address yet',
           'OptimismPortal: dispute game created before respected game type was updated',
@@ -294,6 +295,7 @@ export async function getWithdrawalStatus<
           'Unproven',
         ],
         'waiting-to-finalize': [
+          'OptimismPortal_ProofNotOldEnough',
           'OptimismPortal: proven withdrawal has not matured yet',
           'OptimismPortal: output proposal has not been finalized yet',
           'OptimismPortal: output proposal in air-gap',


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

The recent OptimismPortal2 upgrade has broken this part of the code because the error messages, read by the SDK here to determine the withdrawal status, can no longer decipher the error reasons.

This PR is incomplete because the custom Error's also need to be added to the ABI files. I'll let someone else take them over, I just wanted to open this PR to highlight this urgent issue.

