### PR TITLE
Remove deprecated astarzkevm and astarzkyoto

### DIFF
--- a/.changeset/tall-peas-doubt.md
+++ b/.changeset/tall-peas-doubt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed deprecated astarzkevm and astarzkyoto chains.

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -31,7 +31,9 @@ export { artheraTestnet } from './definitions/artheraTestnet.js'
 export { assetChain } from './definitions/assetChain.js'
 export { assetChainTestnet } from './definitions/assetChainTestnet.js'
 export { astar } from './definitions/astar.js'
+/** @deprecated */
 export { astarZkEVM } from './definitions/astarZkEVM.js'
+/** @deprecated */
 export { astarZkyoto } from './definitions/astarZkyoto.js'
 export { atletaOlympia } from './definitions/atletaOlympia.js'
 export { aurora } from './definitions/aurora.js'


### PR DESCRIPTION
AstarZkEVM and AstarZkyoto have been deprecated for some time.
https://web.archive.org/web/20250118215916/https://forum.astar.network/t/astar-zkevm-sunsetting-migration-plan/7780

https://github.com/wevm/viem/pull/3829

Instead of a rebase I had to do git reset hard from main, and then cherry-pick the specific commits. 

@jxom 