### PR TITLE
fix: update story explorer & deprecate old story testnets

### DIFF
--- a/src/chains/definitions/story.ts
+++ b/src/chains/definitions/story.ts
@@ -28,8 +28,8 @@ export const story = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Story explorer',
-      url: 'https://storyscan.xyz',
-      apiUrl: 'https://storyscan.xyz/api/v2',
+      url: 'https://storyscan.io',
+      apiUrl: 'https://storyscan.io/api/v2',
     },
   },
   ensTlds: ['.ip'],

--- a/src/chains/definitions/storyAeneid.ts
+++ b/src/chains/definitions/storyAeneid.ts
@@ -29,8 +29,8 @@ export const storyAeneid = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Story Aeneid Explorer',
-      url: 'https://aeneid.storyscan.xyz',
-      apiUrl: 'https://aeneid.storyscan.xyz/api/v2',
+      url: 'https://aeneid.storyscan.io',
+      apiUrl: 'https://aeneid.storyscan.io/api/v2',
     },
   },
   ensTlds: ['.ip'],

--- a/src/chains/definitions/storyOdyssey.ts
+++ b/src/chains/definitions/storyOdyssey.ts
@@ -1,5 +1,6 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+/** @deprecated Use `storyAeneid` instead  */
 export const storyOdyssey = /*#__PURE__*/ defineChain({
   id: 1516,
   name: 'Story Odyssey',

--- a/src/chains/definitions/storyTestnet.ts
+++ b/src/chains/definitions/storyTestnet.ts
@@ -1,5 +1,6 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+/** @deprecated Use `storyAeneid` instead  */
 export const storyTestnet = /*#__PURE__*/ defineChain({
   id: 1513,
   name: 'Story Testnet',


### PR DESCRIPTION
- Update explorer links for Story mainnet and Story Aeneid testnet
- Deprecate the old Story testnet and the unsupported Story testnet

Fixed based on requests from #3828