### PR TITLE
Add Ethereum mainnet block time

### DIFF
--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -4,6 +4,7 @@ export const mainnet = /*#__PURE__*/ defineChain({
   id: 1,
   name: 'Ethereum',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  blockTime: 12_000,
   rpcUrls: {
     default: {
       http: ['https://eth.merkle.io'],


### PR DESCRIPTION
Adds Ethereum mainnet block time (12s - https://ycharts.com/indicators/ethereum_average_block_time)