### PR TITLE
Support magic.link with sendCalls fallback

### DIFF
--- a/.changeset/nine-comics-doubt.md
+++ b/.changeset/nine-comics-doubt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for magic.link in `sendCalls` fallback.

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -155,7 +155,6 @@ export async function sendCalls<
       experimental_fallback &&
       (error.name === 'MethodNotFoundRpcError' ||
         error.name === 'MethodNotSupportedRpcError' ||
-        error.name === 'InternalRpcError' ||
         error.name === 'UnknownRpcError' ||
         error.details
           .toLowerCase()
@@ -168,7 +167,8 @@ export async function sendCalls<
           .toLowerCase()
           .includes('account upgraded to unsupported contract') ||
         error.details.toLowerCase().includes('eip-7702 not supported') ||
-        error.details.toLowerCase().includes('unsupported wc_ method'))
+        error.details.toLowerCase().includes('unsupported wc_ method') ||
+        error.details.toLowerCase().includes("feature toggled misconfigured"))
     ) {
       if (capabilities) {
         const hasNonOptionalCapability = Object.values(capabilities).some(

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -155,6 +155,7 @@ export async function sendCalls<
       experimental_fallback &&
       (error.name === 'MethodNotFoundRpcError' ||
         error.name === 'MethodNotSupportedRpcError' ||
+        error.name === 'InternalRpcError' ||
         error.name === 'UnknownRpcError' ||
         error.details
           .toLowerCase()


### PR DESCRIPTION
Add support for sendCalls fallback with magic.link

Improved version of https://github.com/wevm/viem/pull/3845

The full error from magic.link
```
InternalRpcError: An internal error was received.

Details: Magic RPC Error: [-32603] Feature toggled misconfigured
Version: viem@2.33.3
    at delay.count.count (buildRequest.ts:170:25)
    at async attemptRetry (withRetry.ts:44:22)Caused by: r: Magic RPC Error: [-32603] Feature toggled misconfigured
```

How I got the error.
```typescript
console.log(error);
```