### PR TITLE
Add Multicall3 contract to EDU Chain mainnet

### DIFF
--- a/.changeset/tasty-fireants-smoke.md
+++ b/.changeset/tasty-fireants-smoke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated EDU Chain details to include multicall3 deployment

--- a/src/chains/definitions/eduChain.ts
+++ b/src/chains/definitions/eduChain.ts
@@ -19,5 +19,11 @@ export const eduChain = /*#__PURE__*/ defineChain({
       url: 'https://educhain.blockscout.com/',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 16410660,
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
## Summary
Added Multicall3 contract details to EDU Chain mainnet configuration.

## Changes
- Updated `src/chains/definitions/eduChain.ts` to include multicall3 contract configuration
- Added contract address: `0xcA11bde05977b3631167028862bE2a173976CA11`
- Added deployment block: `16410660`

## Verification
- Contract deployed today on EDU Chain mainnet
- Uses standard Multicall3 address consistent with other chains
- Can be verified on [EDU Chain Explorer](https://educhain.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11)

## Testing
- Follows established pattern used by other chains in the repository
- Changeset created for proper versioning

Resolves the missing multicall3 functionality for EDU Chain users.