### PR TITLE
Sonic Testnet and Sonic Blaze Testnet updated

### DIFF
--- a/.changeset/green-trees-sing.md
+++ b/.changeset/green-trees-sing.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated sonicTestnet and sonicBlazeTestnet.

--- a/src/chains/definitions/sonicBlazeTestnet.ts
+++ b/src/chains/definitions/sonicBlazeTestnet.ts
@@ -14,7 +14,8 @@ export const sonicBlazeTestnet = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Sonic Blaze Testnet Explorer',
-      url: 'https://testnet.sonicscan.org',
+      url: 'https://blaze.soniclabs.com/', // https://testnet.sonicscan.org is now used in chain 14601. 
+      // This chain will deprecate in future, use sonicTestnet 14601 instead.
     },
   },
   contracts: {

--- a/src/chains/definitions/sonicTestnet.ts
+++ b/src/chains/definitions/sonicTestnet.ts
@@ -1,7 +1,11 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+// 64165 deprecated for 57054 and with Sonic Labs newest Pectra upgrade
+// 57054 is going to deprecate for this new 14601 chain.
+// Since rpc is same on this one with 64165, override the old infos here.
+
 export const sonicTestnet = /*#__PURE__*/ defineChain({
-  id: 64_165,
+  id: 14_601,
   name: 'Sonic Testnet',
   nativeCurrency: {
     decimals: 18,
@@ -17,5 +21,11 @@ export const sonicTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.soniclabs.com/',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 12810,
+    },
+  },  
   testnet: true,
 })

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -509,8 +509,8 @@ export { somniaTestnet } from './definitions/somniaTestnet.js'
 export { soneium } from './definitions/soneium.js'
 export { soneiumMinato } from './definitions/soneiumMinato.js'
 export { sonic } from './definitions/sonic.js'
-/** @deprecated Use `sonicBlazeTestnet` instead. */
 export { sonicTestnet } from './definitions/sonicTestnet.js'
+/** @deprecated Use `sonicTestnet` instead. */
 export { sonicBlazeTestnet } from './definitions/sonicBlazeTestnet.js'
 export { songbird } from './definitions/songbird.js'
 export { songbirdTestnet } from './definitions/songbirdTestnet.js'


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Updated sonicTestnet 64165 with its new details, 14601. Since Sonic Labs used same rpc and scanner links, updated deprecated chain file instead of creating a new one. 

Updated sonicBlazeTestnet blockscanner link. Current link is now used by 14601, new updated blokcscanner link is for 57054.

Updated deprecated info on index.ts. Previously sonicTestnet was deprecated but now main testnet will be sonicTestnet and sonicBlazeTestnet will deprecate.

Team announcement for this change
https://x.com/0xseg/status/1958495888273248681

Opened a pull request for new 14601 chain on ethereum-lists
https://github.com/ethereum-lists/chains/pull/7633
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

