### PR TITLE
feat: add optional `fetchFn` override to http transport to allow full fetch interception

### DIFF
--- a/.changeset/fifty-coins-act.md
+++ b/.changeset/fifty-coins-act.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `fetchFn` parameter to `http` transport configuration.

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -351,6 +351,26 @@ describe('request', () => {
     vi.unstubAllGlobals()
   })
 
+  test('fetch override', async () => {
+    const fetchOverride = vi.fn(fetch)
+
+    const client = getHttpRpcClient(anvilMainnet.rpcUrl.http, {
+      fetchOverride,
+    })
+
+    await client.request({
+      body: { method: 'web3_clientVersion' },
+    })
+
+    expect(fetchOverride).toHaveBeenCalledWith(anvilMainnet.rpcUrl.http, {
+      body: JSON.stringify({ method: 'web3_clientVersion' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    })
+  })
+
   // TODO: This is flaky.
   test.skip('timeout', async () => {
     const client = getHttpRpcClient(anvilMainnet.rpcUrl.http)

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -355,7 +355,7 @@ describe('request', () => {
     const fetchOverride = vi.fn(fetch)
 
     const client = getHttpRpcClient(anvilMainnet.rpcUrl.http, {
-      fetchOverride,
+      fetchFn: fetchOverride,
     })
 
     await client.request({

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -29,7 +29,9 @@ export type HttpRpcClientOptions = {
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
   /** Override for the fetch function used to make requests. */
-  fetchOverride?: typeof fetch | undefined
+  fetchOverride?:
+    | ((input: string | URL | Request, init?: RequestInit) => Promise<Response>)
+    | undefined
   /** The timeout (in ms) for the request. */
   timeout?: number | undefined
 }
@@ -53,9 +55,7 @@ export type HttpRequestParameters<
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
   /** Override for the fetch function used to make requests. */
-  fetchOverride?:
-    | ((input: string | URL | Request, init?: RequestInit) => Promise<Response>)
-    | undefined
+  fetchOverride?: HttpRpcClientOptions['fetchOverride'] | undefined
   /** The timeout (in ms) for the request. */
   timeout?: HttpRpcClientOptions['timeout'] | undefined
 }

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -84,10 +84,10 @@ export function getHttpRpcClient(
     async request(params) {
       const {
         body,
+        fetchFn = options.fetchFn ?? fetch,
         onRequest = options.onRequest,
         onResponse = options.onResponse,
         timeout = options.timeout ?? 10_000,
-        fetchFn = options.fetchFn ?? fetch,
       } = params
 
       const fetchOptions = {

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -28,6 +28,8 @@ export type HttpRpcClientOptions = {
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
+  /** Override for the fetch function used to make requests. */
+  fetchOverride?: typeof fetch | undefined
   /** The timeout (in ms) for the request. */
   timeout?: number | undefined
 }
@@ -50,6 +52,10 @@ export type HttpRequestParameters<
     | undefined
   /** A callback to handle the response. */
   onResponse?: ((response: Response) => Promise<void> | void) | undefined
+  /** Override for the fetch function used to make requests. */
+  fetchOverride?:
+    | ((input: string | URL | Request, init?: RequestInit) => Promise<Response>)
+    | undefined
   /** The timeout (in ms) for the request. */
   timeout?: HttpRpcClientOptions['timeout'] | undefined
 }
@@ -81,6 +87,7 @@ export function getHttpRpcClient(
         onRequest = options.onRequest,
         onResponse = options.onResponse,
         timeout = options.timeout ?? 10_000,
+        fetchOverride: fetch_ = options.fetchOverride ?? fetch,
       } = params
 
       const fetchOptions = {
@@ -117,7 +124,7 @@ export function getHttpRpcClient(
             }
             const request = new Request(url, init)
             const args = (await onRequest?.(request, init)) ?? { ...init, url }
-            const response = await fetch(args.url ?? url, args)
+            const response = await fetch_(args.url ?? url, args)
             return response
           },
           {


### PR DESCRIPTION
adds optional `fetchFn` parameter to http transport config to allow full interception/decorator/mocking of fetch

this is useful for a number of scenarios including:
- applying a decorator to node fetch for capturing metrics
- easier testing by passing a mock fetch instead of overwriting global fetch
- any scenario where the client needs to be able to process hooks before and after a fetch, while maintaining the same context. This can't be done with the current onRequest/onResponse as there is no way to link the two calls to the same request/response cycle

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

