### PR TITLE
Set correct block time for `unichain`

### DIFF
--- a/src/chains/definitions/unichain.ts
+++ b/src/chains/definitions/unichain.ts
@@ -8,6 +8,7 @@ export const unichain = /*#__PURE__*/ defineChain({
   id: 130,
   name: 'Unichain',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  blockTime: 1_000,
   rpcUrls: {
     default: {
       http: ['https://mainnet.unichain.org/'],

--- a/src/chains/definitions/unichainSepolia.ts
+++ b/src/chains/definitions/unichainSepolia.ts
@@ -12,6 +12,7 @@ export const unichainSepolia = /*#__PURE__*/ defineChain({
     symbol: 'ETH',
     decimals: 18,
   },
+  blockTime: 1_000,
   rpcUrls: {
     default: {
       http: ['https://sepolia.unichain.org'],


### PR DESCRIPTION
The block time for Unichain is 1s according to [their docs](https://docs.unichain.org/docs#instant-transactions)

> Unichain will launch with 1-second block times

The [uniscout's latest blocks page](https://uniscan.xyz/blocks) matches 1-second block times