### PR TITLE
fix: use getAction within waitForCallsStatus

### DIFF
--- a/.changeset/kind-boxes-walk.md
+++ b/.changeset/kind-boxes-walk.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Use `getAction` within `waitForCallsStatus`
+Added `getAction` to `waitForCallsStatus`.

--- a/.changeset/kind-boxes-walk.md
+++ b/.changeset/kind-boxes-walk.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Use getAction within waitForCallsStatus

--- a/.changeset/kind-boxes-walk.md
+++ b/.changeset/kind-boxes-walk.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Use getAction within waitForCallsStatus
+Use `getAction` within `waitForCallsStatus`

--- a/src/actions/wallet/waitForCallsStatus.ts
+++ b/src/actions/wallet/waitForCallsStatus.ts
@@ -4,6 +4,7 @@ import { BaseError } from '../../errors/base.js'
 import { BundleFailedError } from '../../errors/calls.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
+import { getAction } from '../../utils/getAction.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
 import { withResolvers } from '../../utils/promise/withResolvers.js'
@@ -123,7 +124,11 @@ export async function waitForCallsStatus<chain extends Chain | undefined>(
         try {
           const result = await withRetry(
             async () => {
-              const result = await getCallsStatus(client, { id })
+              const result = await getAction(
+                client,
+                getCallsStatus,
+                'getCallsStatus'
+              )({ id })
               if (throwOnFailure && result.status === 'failure')
                 throw new BundleFailedError(result)
               return result


### PR DESCRIPTION
We'd like to use a custom implementation of the `getCallsStatus` from the `client` within `waitForCallsStatus`.
