### PR TITLE
docs: add introduction to bundler actions

### DIFF
--- a/site/pages/account-abstraction/actions/bundler/introduction.md
+++ b/site/pages/account-abstraction/actions/bundler/introduction.md
@@ -1,1 +1,7 @@
-# TODO
+# Introduction to Bundler Actions
+
+Bundler Actions are actions that interact with Account Abstraction bundlers to manage User Operations. They are used with a [Bundler Client](/account-abstraction/clients/bundler).
+
+Bundler Actions enable you to prepare, send, and monitor User Operations through Account Abstraction infrastructure. Examples of Bundler Actions include [preparing a User Operation](/account-abstraction/actions/bundler/prepareUserOperation) for execution, [sending a User Operation](/account-abstraction/actions/bundler/sendUserOperation) to the bundler, and [waiting for User Operation receipts](/account-abstraction/actions/bundler/waitForUserOperationReceipt).
+
+Bundler Actions provide a comprehensive interface for Account Abstraction workflows, allowing you to estimate gas costs, handle paymaster integration, and manage the complete User Operation lifecycle. They are essential for building applications that leverage smart accounts and gasless transactions.


### PR DESCRIPTION
Add comprehensive introduction page for bundler actions documentation.

- Explains what bundler actions are and their purpose
- Links to key bundler actions (prepareUserOperation, sendUserOperation, waitForUserOperationReceipt)
- Describes integration with bundler client and account abstraction workflows
- Replaces TODO placeholder with proper documentation