### PR TITLE
feat: tweak `chainId` check

### DIFF
--- a/.changeset/giant-crews-jog.md
+++ b/.changeset/giant-crews-jog.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Modify `chainId` check on `sendTransaction` to only perform `eth_chainId` check when a `chain` is set on client.

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -265,30 +265,6 @@ test('inferred account', async () => {
   ).toBeDefined()
 })
 
-test('no chain', async () => {
-  const client = createWalletClient({
-    transport: http(anvilMainnet.rpcUrl.http),
-  })
-  await expect(() =>
-    // @ts-expect-error
-    sendTransaction(client, {
-      account: sourceAccount.address,
-      to: targetAccount.address,
-      value: parseEther('1'),
-    }),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [TransactionExecutionError: No chain was provided to the request.
-    Please provide a chain with the \`chain\` argument on the Action, or by supplying a \`chain\` to WalletClient.
-
-    Request Arguments:
-      from:   0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-      to:     0x70997970c51812dc3a010c7d01b50e0d17dc79c8
-      value:  1 ETH
-
-    Version: viem@x.y.z]
-  `)
-})
-
 describe('args: gasPrice', () => {
   test('sends transaction', async () => {
     await setup()

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -208,7 +208,7 @@ export async function sendTransaction<
 
     if (account?.type === 'json-rpc' || account === null) {
       let chainId: number | undefined
-      if (chain !== null) {
+      if (client.chain && chain !== null) {
         chainId = await getAction(client, getChainId, 'getChainId')({})
         assertCurrentChain({
           currentChainId: chainId,
@@ -225,7 +225,7 @@ export async function sendTransaction<
         accessList,
         authorizationList,
         blobs,
-        chainId,
+        chainId: chain?.id,
         data,
         from: account?.address,
         gas,

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -77,36 +77,6 @@ test('client chain mismatch', async () => {
   `)
 })
 
-test('no chain', async () => {
-  const client = createWalletClient({
-    transport: http(anvilMainnet.rpcUrl.http),
-  })
-  await expect(() =>
-    // @ts-expect-error
-    writeContract(client, {
-      ...wagmiContractConfig,
-      account: accounts[0].address,
-      functionName: 'mint',
-    }),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [ContractFunctionExecutionError: No chain was provided to the request.
-    Please provide a chain with the \`chain\` argument on the Action, or by supplying a \`chain\` to WalletClient.
-
-    Request Arguments:
-      from:  0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-      to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
-      data:  0x1249c58b
-     
-    Contract Call:
-      address:   0x0000000000000000000000000000000000000000
-      function:  mint()
-      sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-
-    Docs: https://viem.sh/docs/contract/writeContract
-    Version: viem@x.y.z]
-  `)
-})
-
 describe('args: chain', () => {
   test('default', async () => {
     const client = createWalletClient({


### PR DESCRIPTION
Modified `chainId` check on `sendTransaction` to only perform `eth_chainId` check when a `chain` is set on client.

We do not want to perform this check otherwise as we want to defer the check to the wallet (via `chainId` to `eth_sendTransaction`).