### PR TITLE
Fix handling of empty WebSocket messages

### DIFF
--- a/.changeset/empty-ws-messages.md
+++ b/.changeset/empty-ws-messages.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed handling of empty websocket messages from Erigon clients

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -554,6 +554,21 @@ describe.runIf(process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket')(
     `,
       )
     })
+
+    test('empty message', async () => {
+      const socketClient = await getWebSocketRpcClient(anvilMainnet.rpcUrl.ws)
+
+      // send a malformed message
+      const messageEvent = new MessageEvent('message', { data: '' })
+      socketClient.socket.dispatchEvent(messageEvent)
+
+      // Send a legitimate message and subscribe to the error event
+      await expect(
+        socketClient.requestAsync({
+          body: { method: 'web3_clientVersion' },
+        }),
+      ).resolves.toBeTruthy()
+    })
   },
 )
 

--- a/src/utils/rpc/webSocket.ts
+++ b/src/utils/rpc/webSocket.ts
@@ -36,6 +36,9 @@ export async function getWebSocketRpcClient(
         onClose()
       }
       function onMessage({ data }: MessageEvent) {
+        // ignore empty messages
+        if (typeof data === 'string' && data.trim().length === 0) return
+
         try {
           const _data = JSON.parse(data)
           onResponse(_data)


### PR DESCRIPTION
I noticed that we are getting intermittent errors on some networks, specifically observed on Gnosis and Polygon when connecting to an Erigon client using a websocket transport (so I'm assuming this is specific to Erigon). This error happens in about 1% of requests sent - randomly.
After debugging, I realized the problem was that the server was sending an empty string as a message on the connection, which viem then attempts to parse into JSON and fails with `Unexpected end of JSON input`

The problem is that Viem attributes this failure to one of the requests and makes it fail.
I then tested whether ignoring the message makes the original request succeed, and it does.

So I wrote a test that reproduces the issue and then added handling to simply ignore empty messages or messages that just contain a new line.
This works because the node proceeds to send the correct response immediately following the empty message.

<img width="859" height="518" alt="Screenshot 2025-09-26 at 18 39 47" src="https://github.com/user-attachments/assets/d5abc690-b922-407c-a32b-d2a8477ae2c7" />

credit to The.Lows on Discord - I found his message from 1/27/25, and that helped me pinpoint and validate the issue