### PR TITLE
Add blockTime property to optimism chain definition

### DIFF
--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -7,6 +7,7 @@ export const optimism = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 10,
   name: 'OP Mainnet',
+  blockTime: 2000,
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {


### PR DESCRIPTION
According to the [docs](https://docs.optimism.io/connect/resources/glossary#block-time), the block time for optimism should be 2 seconds.


