### PR TITLE
Add blockTime property to base chain definition

### DIFF
--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -7,6 +7,7 @@ export const base = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 8453,
   name: 'Base',
+  blockTime: 2000,
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {


### PR DESCRIPTION
The regular blockTime is 2s, the flashblocks are emitted at 200ms, but are only available at certain flashblock-aware RPCs.

Docs: https://docs.base.org/base-chain/flashblocks/docs#is-there-any-difference-in-tx-inclusion-for-flashblocks-vs-2s-block%3F
