### PR TITLE
docs: fix page title not displaying on some pages

### DIFF
--- a/site/pages/docs/migration-guide.mdx
+++ b/site/pages/docs/migration-guide.mdx
@@ -1,16 +1,3 @@
----
-head:
-  - - meta
-    - property: og:title
-      content: Migration Guide
-  - - meta
-    - name: description
-      content: Guide to migrate to newer versions of viem.
-  - - meta
-    - property: og:description
-      content: Guide to migrate to newer versions of viem.
----
-
 # Migration Guide
 
 If you are coming from an earlier version of `viem`, you will need to make sure to update the following APIs listed below.

--- a/site/pages/op-stack/guides/deposits.md
+++ b/site/pages/op-stack/guides/deposits.md
@@ -1,17 +1,3 @@
----
-head:
-  - - meta
-    - property: og:title
-      content: Deposits
-  - - meta
-    - name: description
-      content: How to deposit from Mainnet to OP Stack chains.
-  - - meta
-    - property: og:description
-      content: How to deposit from Mainnet to OP Stack chains.
-
----
-
 # Deposits
 
 This guide will demonstrate how to deposit (bridge) **1 Ether** from **Mainnet** to **[Optimism (OP Mainnet)](https://www.optimism.io/)**.

--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -1,17 +1,3 @@
----
-head:
-  - - meta
-    - property: og:title
-      content: Withdrawals
-  - - meta
-    - name: description
-      content: How to withdraw from OP Stack chains to Mainnet.
-  - - meta
-    - property: og:description
-      content: How to withdraw from OP Stack chains to Mainnet.
-
----
-
 # Withdrawals
 
 This guide will demonstrate how to withdraw **1 Ether** from **[Optimism (OP Mainnet)](https://www.optimism.io/)** to **Mainnet**.


### PR DESCRIPTION
In some pages of the docs, the title was not displaying correctly, it was rendering as "Viem" instead.

These pages had hardcoded metadata in their headers, which caused the issue. After removing that metadata, the `<h1>` content now loads correctly as the page title.

Prior to the fix:

<img width="144" height="37" alt="image" src="https://github.com/user-attachments/assets/e3ae3d8b-a5be-455c-872e-59070c6a2f2c" />

After the fix:

<img width="168" height="31" alt="image" src="https://github.com/user-attachments/assets/f69763ac-f744-476b-95a3-78a4f1c64b03" />
