### PR TITLE
feat: deprecate old Taiko testnets and add Taiko Hoodi

### DIFF
--- a/.changeset/taiko-hoodi-deprecate-old-testnets.md
+++ b/.changeset/taiko-hoodi-deprecate-old-testnets.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `taikoHoodi` chain and deprecated old Taiko testnet chains (`taikoHekla`, `taikoJolnir`, `taikoKatla`, `taikoTestnetSepolia`).

--- a/src/chains/definitions/taikoHoodi.ts
+++ b/src/chains/definitions/taikoHoodi.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const taikoHoodi = /*#__PURE__*/ defineChain({
+  id: 167_013,
+  name: 'Taiko Hoodi L2',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.hoodi.taiko.xyz'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Taikoscan',
+      url: 'https://hoodi.taikoscan.io',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -582,9 +582,14 @@ export { syscoinTestnet } from './definitions/syscoinTestnet.js'
 export { tac } from './definitions/tac.js'
 export { tacSPB } from './definitions/tacSPB.js'
 export { taiko } from './definitions/taiko.js'
+/** @deprecated Use `taikoHoodi` instead. */
 export { taikoHekla } from './definitions/taikoHekla.js'
+export { taikoHoodi } from './definitions/taikoHoodi.js'
+/** @deprecated Use `taikoHoodi` instead. */
 export { taikoJolnir } from './definitions/taikoJolnir.js'
+/** @deprecated Use `taikoHoodi` instead. */
 export { taikoKatla } from './definitions/taikoKatla.js'
+/** @deprecated Use `taikoHoodi` instead. */
 export { taikoTestnetSepolia } from './definitions/taikoTestnetSepolia.js'
 export { taraxa } from './definitions/taraxa.js'
 export { taraxaTestnet } from './definitions/taraxaTestnet.js'


### PR DESCRIPTION
- Deprecated `taikoHekla`, `taikoJolnir`, `taikoKatla`, and `taikoTestnetSepolia` chains
- Added new `taikoHoodi` chain (Taiko Hoodi L2 testnet)
- All deprecated chains remain functional for backward compatibility
- Users will see deprecation warnings guiding them to use `taikoHoodi`

Resolves feedback to deprecate chains instead of removing them.

