### PR TITLE
update monad mainnet: add multicall3 address, websocket, second RPC url, second block explorer

### DIFF
--- a/.changeset/modern-walls-cough.md
+++ b/.changeset/modern-walls-cough.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated Monad mainnet to add websocket urls, multicall3, second block explorer, second rpc url; and update the primary block explorer url
+Updated Monad block explorer URL and added WebSocket URLs, Multicall3 contract, second block explorer, and second RPC URL.

--- a/src/chains/definitions/monad.ts
+++ b/src/chains/definitions/monad.ts
@@ -11,20 +11,14 @@ export const monad = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: [
-       'https://rpc.monad.xyz',
-       'https://rpc1.monad.xyz',
-      ],
-      webSocket: [
-        'wss://rpc.monad.xyz',
-        'wss://rpc1.monad.xyz',
-      ],
+      http: ['https://rpc.monad.xyz', 'https://rpc1.monad.xyz'],
+      webSocket: ['wss://rpc.monad.xyz', 'wss://rpc1.monad.xyz'],
     },
   },
   blockExplorers: {
     default: {
       name: 'MonadVision',
-      url: 'https://monadvision.com'
+      url: 'https://monadvision.com',
     },
     monadscan: {
       name: 'Monadscan',


### PR DESCRIPTION
* adds a second RPC URL
* adds two websocket URLs
* renames the first block explorer (monvision.io redirects to monadvision.com anyway)
* adds a second block explorer
* adds multicall3 address