### PR TITLE
Update Katana block explorer URL

### DIFF
--- a/src/chains/definitions/katana.ts
+++ b/src/chains/definitions/katana.ts
@@ -17,7 +17,7 @@ export const katana = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'katana explorer',
-      url: 'https://explorer.katanarpc.com',
+      url: 'https://katanascan.com',
     },
   },
   testnet: false,


### PR DESCRIPTION
Katana now supports Etherscan and is the preferred provider: https://docs.katana.network/katana/technical-reference/infra-partners/

It has better integration support and should be used as the default, right?
