### PR TITLE
fix: Fix fill transaction pre check

### DIFF
--- a/.changeset/stale-planets-tease.md
+++ b/.changeset/stale-planets-tease.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix checkup for supporting fillTransaction

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -267,7 +267,7 @@ export async function prepareTransactionRequest<
 > {
   const attemptFill =
     // Do not attempt if `eth_fillTransaction` is not supported.
-    supportsFillTransaction.get(client.uid) !== false &&
+    supportsFillTransaction.get(client.uid) !== undefined &&
     // Should attempt `eth_fillTransaction` if "fees" or "gas" are required to be populated,
     // otherwise, can just use the other individual calls.
     ['fees', 'gas'].some((parameter) =>


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Related to #4117 

`supportsFillTransaction.get(client.uid)` returns `undefined` if `fillTransaction` is not supported. 
Since `undefined !== false` is true, the whole expression `attemptFill` becomes true if `gas` or `fees` are required. 

This PR adjusts the logic and correctly uses `undefined` now. 

Note: Also the TSDoc for `LruMap.get` states that: 
>@returns — Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

