### PR TITLE
Fix SIWE message formatting with statement spacing

### DIFF
--- a/src/utils/siwe/createSiweMessage.test.ts
+++ b/src/utils/siwe/createSiweMessage.test.ts
@@ -21,7 +21,6 @@ test('default', () => {
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
 
-
     URI: https://example.com/path
     Version: 1
     Chain ID: 1
@@ -45,7 +44,6 @@ test('parameters: domain', () => {
     "foo.example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
 
-
     URI: https://example.com/path
     Version: 1
     Chain ID: 1
@@ -61,7 +59,6 @@ test('parameters: domain', () => {
   ).toMatchInlineSnapshot(`
     "example.co.uk wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
-
 
     URI: https://example.com/path
     Version: 1
@@ -85,7 +82,6 @@ test('parameters: scheme', () => {
   ).toMatchInlineSnapshot(`
     "https://example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
-
 
     URI: https://example.com/path
     Version: 1
@@ -129,7 +125,6 @@ test('parameters: issuedAt', () => {
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
 
-
     URI: https://example.com/path
     Version: 1
     Chain ID: 1
@@ -150,7 +145,6 @@ test('parameters: expirationTime', () => {
   ).toMatchInlineSnapshot(`
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
-
 
     URI: https://example.com/path
     Version: 1
@@ -176,7 +170,6 @@ test('parameters: notBefore', () => {
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
 
-
     URI: https://example.com/path
     Version: 1
     Chain ID: 1
@@ -200,7 +193,6 @@ test('parameters: requestId', () => {
   ).toMatchInlineSnapshot(`
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
-
 
     URI: https://example.com/path
     Version: 1
@@ -229,7 +221,6 @@ test('parameters: resources', () => {
   ).toMatchInlineSnapshot(`
     "example.com wants you to sign in with your Ethereum account:
     0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
-
 
     URI: https://example.com/path
     Version: 1

--- a/src/utils/siwe/createSiweMessage.ts
+++ b/src/utils/siwe/createSiweMessage.ts
@@ -138,7 +138,7 @@ export function createSiweMessage(
   })()
   const statement = (() => {
     if (!parameters.statement) return ''
-    return `${parameters.statement}\n`
+    return `${parameters.statement}\n\n`
   })()
   const prefix = `${origin} wants you to sign in with your Ethereum account:\n${address}\n\n${statement}`
 
@@ -166,7 +166,7 @@ export function createSiweMessage(
     suffix += content
   }
 
-  return `${prefix}\n${suffix}`
+  return `${prefix}${suffix}`
 }
 
 const domainRegex =


### PR DESCRIPTION
Fixing issue: 
https://github.com/wevm/viem/issues/4150 - bug: createSiweMessage generates invalid SIWE messages with extra newline when no statement is provided

* Adjusts the formatting in createSiweMessage to add an extra newline after the statement, ensuring correct message structure
* Updates tests to match the new formatting.


