### PR TITLE
fix: prevent duplicate WebSocket subscriptions after reconnect

### DIFF
--- a/.changeset/brave-clouds-swim.md
+++ b/.changeset/brave-clouds-swim.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed WebSocket subscriptions being duplicated after reconnection when unwatching and rewatching.

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -717,3 +717,174 @@ test('requestAsync (error on close)', async () => {
     Version: viem@x.y.z]
   `)
 })
+
+test('behavior: eth_unsubscribe removes subscription immediately', async () => {
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onResponse }) {
+      return {
+        close() {},
+        request({ body }) {
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: '0xabc' })
+        },
+      }
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  // Subscribe first
+  await new Promise((res) => {
+    socketClient.request({
+      body: { method: 'eth_subscribe' },
+      onResponse: res,
+    })
+  })
+  expect(socketClient.subscriptions.size).toBe(1)
+
+  // Unsubscribe - subscription should be removed immediately, before response
+  let responseReceived = false
+  socketClient.request({
+    body: { method: 'eth_unsubscribe', params: ['0xabc'] },
+    onResponse: () => {
+      responseReceived = true
+    },
+  })
+
+  // Subscription should be removed immediately, not after response
+  expect(socketClient.subscriptions.size).toBe(0)
+  expect(responseReceived).toBe(true)
+
+  socketClient.close()
+})
+
+test('behavior: eth_unsubscribe removes subscription even when socket throws', async () => {
+  let shouldThrow = false
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onResponse }) {
+      return {
+        close() {},
+        request({ body }) {
+          if (shouldThrow) {
+            throw new Error('socket closed')
+          }
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: '0xabc' })
+        },
+      }
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  // Subscribe first
+  await new Promise((res) => {
+    socketClient.request({
+      body: { method: 'eth_subscribe' },
+      onResponse: res,
+    })
+  })
+  expect(socketClient.subscriptions.size).toBe(1)
+
+  // Now make socket throw on next request
+  shouldThrow = true
+
+  // Unsubscribe - should still remove subscription even though socket throws
+  await new Promise<void>((res) => {
+    socketClient.request({
+      body: { method: 'eth_unsubscribe', params: ['0xabc'] },
+      onError: () => res(),
+      onResponse: () => res(),
+    })
+  })
+
+  // Subscription should still be removed
+  expect(socketClient.subscriptions.size).toBe(0)
+
+  socketClient.close()
+})
+
+test('behavior: unsubscribed subscription is not re-subscribed on reconnect', async () => {
+  let active = true
+  let count = -1
+  let subscribeCount = 0
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onError, onOpen, onResponse }) {
+      count++
+
+      // reopen on 2nd attempt
+      if (active || count === 2) {
+        onOpen()
+        active = true
+      } else {
+        setTimeout(() => onError(new Error('connection failed.')), 50)
+        active = false
+      }
+
+      return {
+        close() {},
+        request({ body }) {
+          if (!active) {
+            throw new Error('socket closed')
+          }
+
+          if (body.method === 'eth_subscribe') {
+            subscribeCount++
+          }
+
+          wait(10).then(() => {
+            if (!active) return
+            onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: '0xabc' })
+
+            // Trigger disconnect after first subscribe
+            if (count === 0 && body.method === 'eth_subscribe') {
+              wait(10).then(() => {
+                onError(new Error('connection failed.'))
+                active = false
+              })
+            }
+          })
+        },
+      }
+    },
+    reconnect: {
+      delay: 50,
+      attempts: 5,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  // Subscribe
+  await new Promise((res, rej) => {
+    socketClient.request({
+      body: { method: 'eth_subscribe', params: ['newHeads'] },
+      onResponse: res,
+      onError: rej,
+    })
+  })
+  expect(socketClient.subscriptions.size).toBe(1)
+  expect(subscribeCount).toBe(1)
+
+  // Wait for disconnect
+  await wait(100)
+
+  // Unsubscribe while disconnected (will throw but should still remove from map)
+  await new Promise<void>((res) => {
+    socketClient.request({
+      body: { method: 'eth_unsubscribe', params: ['0xabc'] },
+      onError: () => res(),
+      onResponse: () => res(),
+    })
+  })
+  expect(socketClient.subscriptions.size).toBe(0)
+
+  // Wait for reconnect
+  await wait(300)
+
+  // The subscription should NOT have been re-subscribed
+  // (subscribeCount should still be 1, not 2)
+  expect(subscribeCount).toBe(1)
+
+  socketClient.close()
+})

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -247,12 +247,13 @@ export async function getSocketRpcClient<socket extends {}>(
                 body,
               })
 
-            // If we are unsubscribing from a topic, we want to remove the listener.
-            if (body.method === 'eth_unsubscribe')
-              subscriptions.delete(body.params?.[0])
-
             onResponse(response)
           }
+
+          // If we are unsubscribing from a topic, remove the listener immediately
+          // to prevent it from being re-subscribed on reconnect.
+          if (body.method === 'eth_unsubscribe')
+            subscriptions.delete(body.params?.[0])
 
           requests.set(id, { onResponse: callback, onError })
           try {


### PR DESCRIPTION
## Summary

Fixes #3957

When using `watchBlockNumber` (or other WebSocket subscriptions) and the connection fails and reconnects, calling `unwatch()` and then `watch()` again would cause duplicate callbacks for the same block numbers.
