### PR TITLE
fix: getAbiItem for tuple with additional tuples

### DIFF
--- a/.changeset/few-bugs-unite.md
+++ b/.changeset/few-bugs-unite.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getAbiItem` for overloaded tuples with additional child tuple components beyond the number of args

--- a/src/utils/abi/getAbiItem.test.ts
+++ b/src/utils/abi/getAbiItem.test.ts
@@ -449,6 +449,46 @@ test('overloads: tuple', () => {
           stateMutability: 'nonpayable',
           type: 'function',
         },
+        {
+          inputs: [
+            { name: 'foo', type: 'uint256' },
+            {
+              name: 'bar',
+              type: 'tuple',
+              components: [
+                { name: 'a', type: 'string' },
+                {
+                  name: 'b',
+                  type: 'tuple',
+                  components: [
+                    { name: 'merp', type: 'string' },
+                    { name: 'meep', type: 'string' },
+                  ],
+                },
+                {
+                  name: 'c',
+                  type: 'tuple',
+                  components: [
+                    { name: 'merp', type: 'string' },
+                    { name: 'meep', type: 'string' },
+                  ],
+                },
+                {
+                  name: 'd',
+                  type: 'tuple',
+                  components: [
+                    { name: 'merp', type: 'string' },
+                    { name: 'meep', type: 'string' },
+                  ],
+                },
+              ],
+            },
+          ],
+          name: 'foo',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
       ],
       name: 'foo',
       args: [

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -171,9 +171,14 @@ export function isArgOfType(arg: unknown, abiParameter: AbiParameter): boolean {
       if (abiParameterType === 'tuple' && 'components' in abiParameter)
         return Object.values(abiParameter.components).every(
           (component, index) => {
-            return isArgOfType(
-              Object.values(arg as unknown[] | Record<string, unknown>)[index],
-              component as AbiParameter,
+            return (
+              argType === 'object' &&
+              isArgOfType(
+                Object.values(arg as unknown[] | Record<string, unknown>)[
+                  index
+                ],
+                component as AbiParameter,
+              )
             )
           },
         )


### PR DESCRIPTION
Fixes an error when tuples have additional tuples (more than the args). Those would result in `arg` being `undefined` and `Object.values` throw:

```
Uncaught TypeError: Cannot convert undefined or null to object
```

Fixed by ensuring that `argType === 'object'`. Could be fixed in a lot of ways, but this most closely aligns with existing code IMO.

I edited an existing test case to cover this.