### PR TITLE
fix: getUserOperationHash calculation for EIP-7702 UserOperations (#4197)fix: correct EIP-7702 UserOperation hash calculation

### DIFF
--- a/.changeset/fuzzy-cats-jump.md
+++ b/.changeset/fuzzy-cats-jump.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getUserOperationHash` calculation for EIP-7702 UserOperations.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6864,6 +6864,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.43.3:
+    resolution: {integrity: sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -8591,7 +8599,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.43.2(typescript@5.9.3)(zod@3.23.8)
+      viem: 2.43.3(typescript@5.9.3)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -12922,21 +12930,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.10.6(typescript@5.9.3)(zod@3.23.8):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.23.8)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.11.1(typescript@5.6.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
@@ -12949,6 +12942,21 @@ snapshots:
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.6.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.11.1(typescript@5.9.3)(zod@3.23.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.23.8)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
@@ -14410,7 +14418,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.43.2(typescript@5.9.3)(zod@3.23.8):
+  viem@2.43.3(typescript@5.9.3)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -14418,7 +14426,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.23.8)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.10.6(typescript@5.9.3)(zod@3.23.8)
+      ox: 0.11.1(typescript@5.9.3)(zod@3.23.8)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.3

--- a/src/account-abstraction/utils/userOperation/getInitCode.ts
+++ b/src/account-abstraction/utils/userOperation/getInitCode.ts
@@ -6,15 +6,21 @@ export function getInitCode(
     UserOperation,
     'authorization' | 'factory' | 'factoryData'
   >,
+  options?: { forHash?: boolean },
 ) {
   const { authorization, factory, factoryData } = userOperation
   if (
     factory === '0x7702' ||
     factory === '0x7702000000000000000000000000000000000000'
   ) {
+    // For hash calculation: substitute delegate address
+    // For packing (ABI call): keep raw factory
+    if (options?.forHash && authorization) {
+      const delegation = authorization.address
+      return concat([delegation, factoryData ?? '0x'])
+    }
     if (!authorization) return '0x7702000000000000000000000000000000000000'
-    const delegation = authorization.address
-    return concat([delegation, factoryData ?? '0x'])
+    return concat([factory, factoryData ?? '0x'])
   }
   if (!factory) return '0x'
   return concat([factory, factoryData ?? '0x'])

--- a/src/account-abstraction/utils/userOperation/getUserOperationHash.ts
+++ b/src/account-abstraction/utils/userOperation/getUserOperationHash.ts
@@ -54,11 +54,14 @@ export function getUserOperationHash<
     if (entryPointVersion === '0.6') {
       const factory = userOperation.initCode?.slice(0, 42) as Hex
       const factoryData = userOperation.initCode?.slice(42) as Hex | undefined
-      const initCode = getInitCode({
-        authorization,
-        factory,
-        factoryData,
-      })
+      const initCode = getInitCode(
+        {
+          authorization,
+          factory,
+          factoryData,
+        },
+        { forHash: true },
+      )
       return encodeAbiParameters(
         [
           { type: 'address' },
@@ -88,7 +91,9 @@ export function getUserOperationHash<
     }
 
     if (entryPointVersion === '0.7') {
-      const packedUserOp = toPackedUserOperation(userOperation)
+      const packedUserOp = toPackedUserOperation(userOperation, {
+        forHash: true,
+      })
       return encodeAbiParameters(
         [
           { type: 'address' },

--- a/src/account-abstraction/utils/userOperation/getUserOperationTypedData.ts
+++ b/src/account-abstraction/utils/userOperation/getUserOperationTypedData.ts
@@ -33,7 +33,7 @@ export function getUserOperationTypedData(
 ): GetUserOperationTypedDataReturnType {
   const { chainId, entryPointAddress, userOperation } = parameters
 
-  const packedUserOp = toPackedUserOperation(userOperation)
+  const packedUserOp = toPackedUserOperation(userOperation, { forHash: true })
 
   return {
     types,

--- a/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts
+++ b/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts
@@ -9,6 +9,7 @@ import { getInitCode } from './getInitCode.js'
 
 export function toPackedUserOperation(
   userOperation: UserOperation,
+  options?: { forHash?: boolean },
 ): PackedUserOperation {
   const {
     callGasLimit,
@@ -29,7 +30,8 @@ export function toPackedUserOperation(
     pad(numberToHex(verificationGasLimit || 0n), { size: 16 }),
     pad(numberToHex(callGasLimit || 0n), { size: 16 }),
   ])
-  const initCode = getInitCode(userOperation)
+  const initCode = getInitCode(userOperation, options)
+
   const gasFees = concat([
     pad(numberToHex(maxPriorityFeePerGas || 0n), { size: 16 }),
     pad(numberToHex(maxFeePerGas || 0n), { size: 16 }),


### PR DESCRIPTION
fixes #4197

## Description
This PR fixes the [getUserOperationHash](cci:1://file:///viem/src/account-abstraction/utils/userOperation/getUserOperationHash.ts:23:0-129:1) calculation for EIP-7702 UserOperations.

Previously, `viem` was substituting the factory address with the delegate address (`authorization.address`) during both packing (bundling) and hashing (signing).

This caused a mismatch because:
1. **Bundling**: Requires the raw factory address `0x7702` (2 bytes) to be present in `initCode` so the chain recognizes it as an EIP-7702 transaction.
2. **Signing/Hashing**: Requires the specific delegate address to be hashed in `initCode` for security.

## Changes
- Modified [getInitCode](cci:1://file://viem/src/account-abstraction/utils/userOperation/getInitCode.ts:3:0-20:1) to accept an `options.forHash` parameter.
- Updated [toPackedUserOperation](cci:1://file:///viem/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts:9:0-67:1) to pass this option through.
- Updated [getUserOperationHash](cci:1://file://open/viem/src/account-abstraction/utils/userOperation/getUserOperationHash.ts:23:0-129:1) (v0.6, v0.7) and [getUserOperationTypedData](cci:1://file:////viem/src/account-abstraction/utils/userOperation/getUserOperationTypedData.ts:30:0-48:1) (v0.8, v0.9) to pass `{ forHash: true }`.

## Verification
- Ran existing tests successfully: 
  `pnpm test src/account-abstraction/utils/userOperation/getUserOperationHash.test.ts`
- Verified that v0.6, v0.7, v0.8, and v0.9 EntryPoints all calculate the correct hash while enabling correct packing for Bundlers.