### PR TITLE
chore: use Tempo testnet tag for changesets verification

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -9,12 +9,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-tempo-testnet-tag:
+    name: Get Testnet Tempo Version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.fetch-tag.outputs.tag }}
+    steps:
+      - name: Fetch testnet Tempo SHA
+        id: fetch-tag
+        continue-on-error: true
+        run: |
+          SHA=$(curl -s https://rpc.testnet.tempo.xyz -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' | \
+            jq -r '.result // empty' | grep -oP 'v[\d.]+-\K[a-f0-9]+') || true
+          echo "tag=sha-${SHA:-latest}" >> $GITHUB_OUTPUT
+
   verify:
     name: Verify
+    needs: get-tempo-testnet-tag
     uses: ./.github/workflows/verify.yml
     secrets: inherit
     permissions:
       contents: read
+    with:
+      tempo-tag: ${{ needs.get-tempo-testnet-tag.outputs.tag }}
 
   changesets:
     name: Create version pull request

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,10 @@
 name: Verify
 on:
   workflow_call:
+    inputs:
+      tempo-tag:
+        type: string
+        required: false
   workflow_dispatch:
 
 jobs:
@@ -133,7 +137,7 @@ jobs:
           VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}
           VITE_SHARD_ID: ${{ matrix.shard }}
           VITE_TEMPO_ENV: localnet
-          VITE_TEMPO_TAG: latest
+          VITE_TEMPO_TAG: ${{ inputs.tempo-tag || 'latest' }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
### motivation

Tempo tests in the changesets CI workflow were failing because they were using the `latest` Docker image tag for prool, which currently has breaking changes with what's in testnet. This blocks version cuts. 

Following a similar pattern from [tempo-apps#363](https://github.com/tempoxyz/tempo-apps/pull/363), we can fetch the current testnet Tempo version and use that for testing to ensure compatibility.

### change

- Added `get-tempo-testnet-tag` job to the changesets workflow that fetches the current testnet Tempo image SHA
- Updated the `verify` workflow to accept an optional `tempo-tag` input parameter
- Test job in `verify` consumes testnet tag when available, otherwise defaults to `latest`

### what's next?

If non-changeset tests should also run against current testnet we can apply the same strategy in the verify workflow and/or local tests as well. 