### PR TITLE
fix: use tempoDevnet chain for devnet environment

### DIFF
--- a/test/src/tempo/config.ts
+++ b/test/src/tempo/config.ts
@@ -2,7 +2,11 @@ import { Mnemonic } from 'ox'
 import { generateMnemonic } from '../../../src/accounts/generateMnemonic.js'
 import { english } from '../../../src/accounts/wordlists.js'
 import { sendTransactionSync } from '../../../src/actions/index.js'
-import { tempoLocalnet, tempoTestnet } from '../../../src/chains/index.js'
+import {
+  tempoDevnet,
+  tempoLocalnet,
+  tempoTestnet,
+} from '../../../src/chains/index.js'
 import {
   type Address,
   type Chain,
@@ -41,8 +45,14 @@ export const addresses = {
 } as const
 
 export const chain = (() => {
-  if (nodeEnv === 'testnet' || nodeEnv === 'devnet') return tempoTestnet
-  return tempoLocalnet
+  switch (nodeEnv) {
+    case 'testnet':
+      return tempoTestnet
+    case 'devnet':
+      return tempoDevnet
+    default:
+      return tempoLocalnet
+  }
 })()
 
 export function debugOptions({


### PR DESCRIPTION
### motivation

When running tests with `VITE_TEMPO_ENV=devnet`, the test configuration incorrectly uses `tempoTestnet` (chain ID 42429) instead of `tempoDevnet` (chain ID 31318). This causes tests to run against the wrong chain definition despite connecting to the correct devnet RPC URL.

### change

- Import `tempoDevnet` chain definition in test config
- Update chain selection logic to return `tempoDevnet` when `nodeEnv === "devnet"`
- Refactor to switch statement for clearer environment-to-chain mapping

### testing

```bash
VITE_TEMPO_ENV=devnet VITE_TEMPO_HTTP_LOG=true pnpm test --project tempo e2e
```

example log output from ^ verified client hits devnet URL
```
stdout | src/tempo/e2e.test.ts > signTransaction > default
curl \
https://rpc.devnet.tempoxyz.dev \
-X POST \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","id":252,"method":"eth_fillTransaction","params":[{"from":"0x740474977E01d056f04A314b5537e4Dd88f35952","type":"0x76","calls":[{"to":"0xcafebabecafebabecafebabecafebabecafebabe","value":"0x","data":"0xdeadbeef"}],"feePayer":true}]}'
```

### what's next?

Uncomment `devnet` in `.github/workflows/verify.yml` to enable CI testing against devnet.