### PR TITLE
fix: correct paymasterSignature encoding in toPackedUserOperation

### DIFF
--- a/.changeset/bright-dogs-swim.md
+++ b/.changeset/bright-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed encoding of `paymasterSignature` in `toPackedUserOperation` to use the correct ERC-4337 format with magic suffix and length prefix.

--- a/src/account-abstraction/utils/userOperation/getUserOperationHash.test.ts
+++ b/src/account-abstraction/utils/userOperation/getUserOperationHash.test.ts
@@ -399,7 +399,7 @@ describe('entryPoint: 0.9', () => {
         },
       }),
     ).toMatchInlineSnapshot(
-      `"0x9a538c5deb10298bcc09baa188099e5a3935ec20d92f211a1d838ab214b260ba"`,
+      `"0x802c25af5d98cd349b2118227faa93172fb791c4130a482272095cec45c4fc6e"`,
     )
   })
 

--- a/src/account-abstraction/utils/userOperation/toPackedUserOperation.test.ts
+++ b/src/account-abstraction/utils/userOperation/toPackedUserOperation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+
+import { toPackedUserOperation } from './toPackedUserOperation.js'
+import type { UserOperation } from '../../types/userOperation.js'
+
+const paymasterSignatureMagic = '0x22e325a297439656'
+
+describe('toPackedUserOperation', () => {
+  const baseUserOp: UserOperation<'0.9'> = {
+    callData: '0x',
+    callGasLimit: 6942069n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 69n,
+    nonce: 0n,
+    preVerificationGas: 6942069n,
+    sender: '0x1234567890123456789012345678901234567890',
+    signature: '0x',
+    verificationGasLimit: 6942069n,
+  }
+
+  test('default', () => {
+    const packed = toPackedUserOperation(baseUserOp)
+    expect(packed.paymasterAndData).toBe('0x')
+  })
+
+  test('paymaster without signature', () => {
+    const userOp: UserOperation<'0.9'> = {
+      ...baseUserOp,
+      paymaster: '0x1234567890123456789012345678901234567890',
+      paymasterVerificationGasLimit: 6942069n,
+      paymasterPostOpGasLimit: 6942069n,
+      paymasterData: '0xdeadbeef',
+    }
+    const packed = toPackedUserOperation(userOp)
+    expect(packed.paymasterAndData).toMatchInlineSnapshot(
+      `"0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeef"`,
+    )
+  })
+
+  describe('paymasterSignature encoding', () => {
+    const userOpWithPaymasterSig: UserOperation<'0.9'> = {
+      ...baseUserOp,
+      paymaster: '0x1234567890123456789012345678901234567890',
+      paymasterVerificationGasLimit: 6942069n,
+      paymasterPostOpGasLimit: 6942069n,
+      paymasterData: '0xdeadbeef',
+      paymasterSignature: '0xcafebabe',
+    }
+
+    test('forHash: true - uses magic only', () => {
+      const packed = toPackedUserOperation(userOpWithPaymasterSig, {
+        forHash: true,
+      })
+      expect(packed.paymasterAndData).toMatchInlineSnapshot(
+        `"0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeef22e325a297439656"`,
+      )
+      expect(packed.paymasterAndData.endsWith(paymasterSignatureMagic.slice(2))).toBe(true)
+    })
+
+    test('forHash: false - includes signature + length + magic', () => {
+      const packed = toPackedUserOperation(userOpWithPaymasterSig, {
+        forHash: false,
+      })
+      expect(packed.paymasterAndData).toMatchInlineSnapshot(
+        `"0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeefcafebabe000422e325a297439656"`,
+      )
+      expect(packed.paymasterAndData.endsWith(paymasterSignatureMagic.slice(2))).toBe(true)
+      expect(packed.paymasterAndData).toContain('cafebabe')
+      expect(packed.paymasterAndData).toContain('0004')
+    })
+
+    test('default (no options) - includes signature + length + magic', () => {
+      const packed = toPackedUserOperation(userOpWithPaymasterSig)
+      expect(packed.paymasterAndData).toMatchInlineSnapshot(
+        `"0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeefcafebabe000422e325a297439656"`,
+      )
+    })
+
+    test('longer signature encodes correct length', () => {
+      const longSig =
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef00'
+      const userOp: UserOperation<'0.9'> = {
+        ...baseUserOp,
+        paymaster: '0x1234567890123456789012345678901234567890',
+        paymasterVerificationGasLimit: 1n,
+        paymasterPostOpGasLimit: 1n,
+        paymasterSignature: longSig,
+      }
+      const packed = toPackedUserOperation(userOp)
+      expect(packed.paymasterAndData).toContain('0041')
+    })
+  })
+})

--- a/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts
+++ b/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts
@@ -1,11 +1,15 @@
 import { concat } from '../../../utils/data/concat.js'
 import { pad } from '../../../utils/data/pad.js'
+import { size } from '../../../utils/data/size.js'
 import { numberToHex } from '../../../utils/index.js'
 import type {
   PackedUserOperation,
   UserOperation,
 } from '../../types/userOperation.js'
 import { getInitCode } from './getInitCode.js'
+
+/** Magic suffix for paymaster signature encoding (keccak256("PaymasterSignature")[:8]) */
+const paymasterSignatureMagic = '0x22e325a297439656' as const
 
 export type ToPackedUserOperationOptions = {
   /** Prepare the packed user operation for hashing. */
@@ -43,7 +47,10 @@ export function toPackedUserOperation(
   ])
   const nonce = userOperation.nonce ?? 0n
 
-  // For v0.9, paymasterSignature can be provided separately and appended after paymasterData
+  // For v0.9, paymasterSignature can be provided separately and appended after paymasterData.
+  // The encoding uses a magic suffix and length prefix as per ERC-4337 spec:
+  // - forHash: just append the magic (signature is not part of hash)
+  // - !forHash: append signature + length (2 bytes) + magic
   const paymasterAndData = paymaster
     ? concat([
         paymaster,
@@ -54,7 +61,15 @@ export function toPackedUserOperation(
           size: 16,
         }),
         paymasterData || '0x',
-        ...(paymasterSignature ? [paymasterSignature as `0x${string}`] : []),
+        ...(paymasterSignature
+          ? options.forHash
+            ? [paymasterSignatureMagic]
+            : [
+                paymasterSignature as `0x${string}`,
+                pad(numberToHex(size(paymasterSignature)), { size: 2 }),
+                paymasterSignatureMagic,
+              ]
+          : []),
       ])
     : '0x'
   const preVerificationGas = userOperation.preVerificationGas ?? 0n


### PR DESCRIPTION
Fixes #4207

The previous implementation simply appended `paymasterSignature` to `paymasterData`, which broke the `userOpHash` calculation.

This PR implements the correct encoding as per [ERC-4337 spec](https://github.com/eth-infinitism/account-abstraction/blob/develop/test/UserOp.ts):

- **For hashing** (`forHash: true`): Appends only the magic suffix (`0x22e325a297439656`)
- **For submission** (`forHash: false`): Appends `signature + length (2 bytes) + magic`

Added tests for both encoding modes in `toPackedUserOperation.test.ts`.