### PR TITLE
fix(tempo): include keyData for access key gas estimation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -223,7 +223,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -236,7 +236,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -249,7 +249,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -262,7 +262,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -281,7 +281,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -309,7 +309,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -331,7 +331,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -344,7 +344,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -363,7 +363,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -385,7 +385,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -398,7 +398,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -411,7 +411,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -424,7 +424,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -471,7 +471,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -499,7 +499,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -521,7 +521,7 @@ importers:
     dependencies:
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.0.3
@@ -540,7 +540,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       viem:
         specifier: latest
-        version: 2.43.5(typescript@5.6.2)(zod@3.25.76)
+        version: 2.43.4(typescript@5.6.2)(zod@3.25.76)
     devDependencies:
       '@types/react':
         specifier: ^19
@@ -6856,6 +6856,14 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  viem@2.43.4:
+    resolution: {integrity: sha512-PSoML7uG5es/SA1v2988grfcHdMDIogqC0LftdX74q8ZUHj3E7uiAXypNQiUxRZBuyoD5LO1nGEgTU9AGRvuHA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   viem@2.43.5:
     resolution: {integrity: sha512-QuJpuEMEPM3EreN+vX4mVY68Sci0+zDxozYfbh/WfV+SSy/Gthm74PH8XmitXdty1xY54uTCJ+/Gbbd1IiMPSA==}
@@ -14394,7 +14402,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  viem@2.43.5(typescript@5.6.2)(zod@3.25.76):
+  viem@2.43.4(typescript@5.6.2)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/src/tempo/Formatters.test.ts
+++ b/src/tempo/Formatters.test.ts
@@ -159,4 +159,37 @@ describe('formatTransactionRequest', () => {
     } as never)
     expect((rpc as Record<string, unknown>).feePayer).toBeDefined()
   })
+
+  test('behavior: access key account populates keyType, keyId, and keyData', () => {
+    const rpc = Formatters.formatTransactionRequest({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      account: {
+        address: '0x0000000000000000000000000000000000000000',
+        type: 'local',
+        keyType: 'p256',
+        accessKeyAddress: '0x1111111111111111111111111111111111111111',
+      },
+    } as never)
+    expect((rpc as Record<string, unknown>).keyType).toBe('p256')
+    expect((rpc as Record<string, unknown>).keyId).toBe(
+      '0x1111111111111111111111111111111111111111',
+    )
+    expect((rpc as Record<string, unknown>).keyData).toBe(`0x${'ff'.repeat(151)}`)
+  })
+
+  test('behavior: p256 account without access key does not populate keyData', () => {
+    const rpc = Formatters.formatTransactionRequest({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      account: {
+        address: '0x0000000000000000000000000000000000000000',
+        type: 'local',
+        keyType: 'p256',
+      },
+    } as never)
+    expect((rpc as Record<string, unknown>).keyType).toBe('p256')
+    expect((rpc as Record<string, unknown>).keyId).toBeUndefined()
+    expect((rpc as Record<string, unknown>).keyData).toBeUndefined()
+  })
 })


### PR DESCRIPTION
### motivation

Fee-sponsored transactions using **access keys** (P256 keys granted via `grantAccessKey: true`) are reverted with "out of gas" errors. The same payment flow works correctly when using WebAuthn directly without access keys.

**Repro:** https://github.com/tempoxyz/tempo-ts/compare/struong/repro-fp-gas-error

> **Note:** Used AI to try and figure out what the root cause was, this is what it found. Thought process was
> 1. Why is there not enough gas?
> 2. How does viem set gas amount on transaction before submission?
> 3. Should fix be in viem? Or in estimateGas / "helper" RPCs that determine transaction gas amount?
> 
> AI findings below
> Original repro gist: https://gist.github.com/struong/81a31584b6f280ce95c14ba8949fcfba

The root cause is that gas estimation does not account for the **keychain signature envelope** overhead when using access keys. Access key signatures are wrapped in a keychain envelope that adds 21 bytes (type byte + 20-byte userAddress), requiring ~3,336 additional gas for validation.

### change

- Modified `formatTransactionRequest` in `src/tempo/Formatters.ts` to include `keyData` when an access key is detected (`keyId` present)
- The `keyData` is set to 151 bytes to represent the full keychain envelope: type(1) + userAddress(20) + inner P256 signature(130)
- This ensures `eth_estimateGas` correctly accounts for the keychain signature size and validation overhead
- Added two unit tests to verify the behavior

**Before:** P256 access keys returned `keyType` and `keyId` but no `keyData`, causing underestimated gas.

**After:** P256 access keys return `keyType`, `keyId`, and a 151-byte `keyData` dummy for proper gas estimation.

### testing

- Added unit test: `behavior: access key account populates keyType, keyId, and keyData` ✓
- Added unit test: `behavior: p256 account without access key does not populate keyData` ✓
- End-to-end verification with the payments example using `grantAccessKey: true`