### PR TITLE
fix: error on hexToNumber if out of safe range

### DIFF
--- a/.changeset/cool-crabs-agree.md
+++ b/.changeset/cool-crabs-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `hexToNumber` silent error when the value exceeds the safe range.

--- a/src/utils/encoding/fromHex.test.ts
+++ b/src/utils/encoding/fromHex.test.ts
@@ -66,6 +66,23 @@ describe('converts hex to number', () => {
       Version: viem@x.y.z]
     `)
   })
+
+  test('error: integer out of range', () => {
+    expect(() =>
+      hexToNumber('0x20000000000000'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [IntegerOutOfRangeError: Number "9007199254740992n" is not in safe integer range (-9007199254740991 to 9007199254740991)
+
+      Version: viem@x.y.z]
+    `)
+    expect(() =>
+      hexToNumber('0xffdfffffffffffff', { signed: true }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [IntegerOutOfRangeError: Number "-9007199254740993n" is not in safe integer range (-9007199254740991 to 9007199254740991)
+
+      Version: viem@x.y.z]
+    `)
+  })
 })
 
 describe('converts hex to bigint', () => {

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -1,4 +1,6 @@
 import {
+  IntegerOutOfRangeError,
+  type IntegerOutOfRangeErrorType,
   InvalidHexBooleanError,
   type InvalidHexBooleanErrorType,
   SizeOverflowError,
@@ -185,7 +187,10 @@ export function hexToBool(hex_: Hex, opts: HexToBoolOpts = {}): boolean {
 
 export type HexToNumberOpts = HexToBigIntOpts
 
-export type HexToNumberErrorType = HexToBigIntErrorType | ErrorType
+export type HexToNumberErrorType =
+  | HexToBigIntErrorType
+  | IntegerOutOfRangeErrorType
+  | ErrorType
 
 /**
  * Decodes a hex string into a number.
@@ -207,7 +212,17 @@ export type HexToNumberErrorType = HexToBigIntErrorType | ErrorType
  * // 420
  */
 export function hexToNumber(hex: Hex, opts: HexToNumberOpts = {}): number {
-  return Number(hexToBigInt(hex, opts))
+  const value = hexToBigInt(hex, opts)
+  const number = Number(value)
+  if (!Number.isSafeInteger(number))
+    throw new IntegerOutOfRangeError({
+      max: `${Number.MAX_SAFE_INTEGER}`,
+      min: `${Number.MIN_SAFE_INTEGER}`,
+      signed: opts.signed,
+      size: opts.size,
+      value: `${value}n`,
+    })
+  return number
 }
 
 export type HexToStringOpts = {


### PR DESCRIPTION
`hexToNumber` may currently silently return a different number than intended if it lies outside the safe range for the Number type. The function should throw an error in this case.