### PR TITLE
docs: add simple viem read contract example

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -273,6 +273,50 @@ Check out the following places for more viem-related content:
     <img alt="gemini logo" src="https://raw.githubusercontent.com/wevm/.github/main/content/sponsors/gemini-light.svg" width="auto" height="50">
   </picture>
 </a>
+## Simple Viem Read Contract Example
+
+This example shows how to use **Viem** to connect to an Ethereum network and read data from a deployed smart contract using a public client.
+
+### Prerequisites
+- Node.js v18+
+- A deployed smart contract with a `greeting()` view function
+- Contract address and ABI
+
+### Example Code
+
+```ts
+import { createPublicClient, http } from "viem";
+import { sepolia } from "viem/chains";
+
+const client = createPublicClient({
+  chain: sepolia,
+  transport: http(),
+});
+
+const contractAddress = "0xYourContractAddressHere";
+
+const abi = [
+  {
+    name: "greeting",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+];
+
+async function readGreeting() {
+  const result = await client.readContract({
+    address: contractAddress,
+    abi,
+    functionName: "greeting",
+  });
+
+  console.log("Greeting:", result);
+}
+
+readGreeting();
+
 
 ## Contributing
 


### PR DESCRIPTION
## What does this PR do?

This pull request adds a beginner-friendly example to the README that demonstrates how to use **Viem** to connect to an Ethereum network and read data from a deployed smart contract using a public client on the Sepolia testnet.

## Why is this change needed?

New developers often struggle to understand the minimal setup required to interact with a smart contract for read-only operations. This example provides a clear, step-by-step reference that helps lower the learning curve and improves the onboarding experience for first-time Viem users.

## What is included?

- A simple TypeScript example using `createPublicClient`
- A minimal ABI definition for a `greeting()` view function
- A clear demonstration of calling `readContract` and logging the result
- Notes on required prerequisites (Node.js, contract address, and ABI)

## Testing

This change is documentation-only and does not affect runtime behavior. The example was verified locally by running it against a deployed contract on the Sepolia testnet.

## Checklist

- [x] Read the contributing guidelines
- [x] Documentation updated accordingly
- [x] No breaking changes introduced
