### PR TITLE
fix(simulateBlocks): decode errors from returnData when error field is absent

### DIFF
--- a/.changeset/quiet-planes-glow.md
+++ b/.changeset/quiet-planes-glow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed error decoding in `simulateBlocks` when RPC returns revert data in `returnData` instead of `error.data`.

--- a/src/actions/public/simulateBlocks.ts
+++ b/src/actions/public/simulateBlocks.ts
@@ -263,8 +263,8 @@ export async function simulateBlocks<
           if (status === 'success') return undefined
 
           let error: Error | undefined
-          if (call.error?.data === '0x') error = new AbiDecodingZeroDataError()
-          else if (call.error) error = new RawContractError(call.error)
+          if (data === '0x') error = new AbiDecodingZeroDataError()
+          else if (data) error = new RawContractError({ data })
 
           if (!error) return undefined
           return getContractError(error, {


### PR DESCRIPTION
some rpc implementations return revert data in `call.returnData` instead of `call.error.data`. the data extraction already handled both locations, but error object creation only checked `call.error`, causing custom errors to not be decoded in those cases.