### PR TITLE
fix(tempo): update gas snapshot for TIP-1000 gas repricing

### DIFF
--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -762,7 +762,7 @@ describe('sendTransaction', () => {
           ],
           "data": undefined,
           "feePayerSignature": undefined,
-          "gas": 26406n,
+          "gas": 279422n,
           "maxFeePerBlobGas": undefined,
           "to": null,
           "type": "tempo",


### PR DESCRIPTION
## Summary

Updates the gas snapshot in `src/tempo/e2e.test.ts` to reflect TIP-1000 gas repricing.

## Changes

- Line 765: `26406n` → `279422n` (sendTransaction > webcrypto > default)

TIP-1000 adds +250k gas for new P256 account creation, which affects this test case.

Line 1297 (`21326n`) remains unchanged as it uses an existing account.

## Related

- TIP-1000: Mainnet Gas Parameters