### PR TITLE
fix(tempo): increase hardcoded gas limit for webcrypto tests

### DIFF
--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -515,7 +515,7 @@ describe('sendTransaction', () => {
           }),
         ],
         // TODO: remove once `eth_estimateGas` supports passing key type.
-        gas: 100_000n,
+        gas: 300_000n,
       })
 
       const {
@@ -793,7 +793,7 @@ describe('sendTransaction', () => {
           }),
         ],
         // TODO: remove once `eth_estimateGas` supports passing key type.
-        gas: 100_000n,
+        gas: 300_000n,
       })
 
       const {
@@ -999,7 +999,7 @@ describe('sendTransaction', () => {
           }),
         ],
         // TODO: remove once `eth_estimateGas` supports passing key type.
-        gas: 100_000n,
+        gas: 300_000n,
       })
 
       const {


### PR DESCRIPTION
## Summary

Fixes webcrypto test failures caused by TIP-1000 gas repricing.

## Problem

The `sendTransaction > webcrypto > behavior: with 'calls'` tests fail with:

```
Insufficient gas for AA transaction: gas limit 100000 is less than intrinsic gas 278572
```

TIP-1000 increases intrinsic gas for new P256 account creation to ~278k.

## Fix

Update hardcoded gas from `100_000n` → `300_000n` at 3 locations:

- Line 518
- Line 796  
- Line 1002

## Related

- TIP-1000: Mainnet Gas Parameters