### PR TITLE
feat: Add experimental ERC-8132: Gas Limit Override Capability support

### DIFF
--- a/.changeset/slow-beers-flow.md
+++ b/.changeset/slow-beers-flow.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added experimental ERC-8132 Gas Limit Override capability support.

--- a/site/pages/experimental/erc8132/client.md
+++ b/site/pages/experimental/erc8132/client.md
@@ -1,0 +1,27 @@
+# Extending Client with ERC-8132 Actions [Setting up your Viem Client]
+
+To use the experimental functionality of [ERC-8132](https://github.com/ethereum/ERCs/pull/1485), you can extend your existing (or new) Viem Client with experimental [ERC-8132](https://github.com/ethereum/ERCs/pull/1485) Actions.
+
+ERC-8132 introduces a capability that allows apps to specify gas limits for individual calls in an [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792) `wallet_sendCalls` batch.
+
+```ts
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+import { erc8132Actions } from 'viem/experimental' // [!code focus]
+
+const client = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum!),
+}).extend(erc8132Actions()) // [!code focus]
+
+const id = await client.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      data: '0xdeadbeef',
+      gas: 100000n, // ERC-8132 gas limit override
+    },
+  ],
+})
+```

--- a/site/pages/experimental/erc8132/sendCalls.md
+++ b/site/pages/experimental/erc8132/sendCalls.md
@@ -1,0 +1,215 @@
+---
+description: Sends a batch of calls with ERC-8132 gas limit override support.
+---
+
+# sendCalls
+
+Requests the connected wallet to send a batch of calls with [ERC-8132](https://github.com/ethereum/ERCs/pull/1485) gas limit override support.
+
+ERC-8132 introduces a call-level capability for [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792) that allows apps to specify gas limits for individual calls in a `wallet_sendCalls` batch. This is useful when apps have better context for gas estimation than wallets.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { walletClient } from './config'
+import { parseEther } from 'viem'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      data: '0xdeadbeef',
+      gas: 100000n, // ERC-8132 gas limit override
+    },
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      value: parseEther('1'),
+      // No gas specified - wallet will estimate
+    },
+  ],
+})
+```
+
+```ts twoslash [config.ts] filename="config.ts"
+import 'viem/window'
+// ---cut---
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+import { erc8132Actions } from 'viem/experimental'
+
+export const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum!),
+}).extend(erc8132Actions())
+```
+
+:::
+
+## Returns
+
+```ts
+type SendCallsReturnType = {
+  id: string
+  capabilities?: Record<string, any> | undefined
+}
+```
+
+The batch identifier and optional capabilities returned by the wallet.
+
+## Parameters
+
+### account
+
+- **Type:** `Account | Address`
+
+The Account to send the calls from.
+
+```ts twoslash
+import { walletClient } from './config'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', // [!code focus]
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      gas: 100000n,
+    },
+  ],
+})
+```
+
+### calls
+
+- **Type:** `Call[]`
+
+An array of calls to be sent. Each call can include:
+
+- `to`: The target address
+- `data`: The calldata (optional)
+- `value`: The value to send (optional)
+- `gas`: The gas limit override for this call (optional, ERC-8132)
+
+```ts twoslash
+import { walletClient } from './config'
+import { parseEther } from 'viem'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [ // [!code focus]
+    { // [!code focus]
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
+      data: '0xdeadbeef', // [!code focus]
+      gas: 100000n, // [!code focus]
+    }, // [!code focus]
+    { // [!code focus]
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
+      value: parseEther('1'), // [!code focus]
+    }, // [!code focus]
+  ], // [!code focus]
+})
+```
+
+### calls[].gas
+
+- **Type:** `bigint` (optional)
+
+The ERC-8132 gas limit override for a specific call. When provided, this value will be sent to the wallet as a `gasLimitOverride` capability for that call.
+
+If not provided, the wallet will estimate the gas for that call.
+
+```ts twoslash
+import { walletClient } from './config'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      data: '0xdeadbeef',
+      gas: 100000n, // [!code focus]
+    },
+  ],
+})
+```
+
+### capabilities (optional)
+
+- **Type:** `Record<string, any>`
+
+Batch-level capabilities to send with the request (e.g., `paymasterService`).
+
+```ts twoslash
+import { walletClient } from './config'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      gas: 100000n,
+    },
+  ],
+  capabilities: { // [!code focus]
+    paymasterService: { // [!code focus]
+      url: 'https://paymaster.example.com', // [!code focus]
+    }, // [!code focus]
+  }, // [!code focus]
+})
+```
+
+### chain (optional)
+
+- **Type:** `Chain`
+
+The target chain. If not provided, the client's chain will be used.
+
+### forceAtomic (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to force atomic execution of the batch.
+
+```ts twoslash
+import { walletClient } from './config'
+
+const id = await walletClient.sendCalls({
+  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+  calls: [
+    {
+      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      gas: 100000n,
+    },
+  ],
+  forceAtomic: true, // [!code focus]
+})
+```
+
+## How It Works
+
+When you specify a `gas` value on a call, the ERC-8132 action transforms it into a `gasLimitOverride` call-level capability:
+
+```ts
+// Your call
+{
+  to: '0x...',
+  data: '0xdeadbeef',
+  gas: 100000n,
+}
+
+// Sent to wallet as
+{
+  to: '0x...',
+  data: '0xdeadbeef',
+  capabilities: {
+    gasLimitOverride: {
+      value: '0x186a0', // 100000 in hex
+    },
+  },
+}
+```
+
+Wallets that support ERC-8132 will use the provided gas limit for that call's portion of the batch gas limit. Calls without a `gas` value will have their gas estimated by the wallet.

--- a/site/pages/experimental/erc8132/sendCalls.md
+++ b/site/pages/experimental/erc8132/sendCalls.md
@@ -48,69 +48,7 @@ export const walletClient = createWalletClient({
 
 :::
 
-## Returns
-
-```ts
-type SendCallsReturnType = {
-  id: string
-  capabilities?: Record<string, any> | undefined
-}
-```
-
-The batch identifier and optional capabilities returned by the wallet.
-
 ## Parameters
-
-### account
-
-- **Type:** `Account | Address`
-
-The Account to send the calls from.
-
-```ts twoslash
-import { walletClient } from './config'
-
-const id = await walletClient.sendCalls({
-  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e', // [!code focus]
-  calls: [
-    {
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      gas: 100000n,
-    },
-  ],
-})
-```
-
-### calls
-
-- **Type:** `Call[]`
-
-An array of calls to be sent. Each call can include:
-
-- `to`: The target address
-- `data`: The calldata (optional)
-- `value`: The value to send (optional)
-- `gas`: The gas limit override for this call (optional, ERC-8132)
-
-```ts twoslash
-import { walletClient } from './config'
-import { parseEther } from 'viem'
-
-const id = await walletClient.sendCalls({
-  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-  calls: [ // [!code focus]
-    { // [!code focus]
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
-      data: '0xdeadbeef', // [!code focus]
-      gas: 100000n, // [!code focus]
-    }, // [!code focus]
-    { // [!code focus]
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
-      value: parseEther('1'), // [!code focus]
-    }, // [!code focus]
-  ], // [!code focus]
-})
-```
 
 ### calls[].gas
 
@@ -135,58 +73,9 @@ const id = await walletClient.sendCalls({
 })
 ```
 
-### capabilities (optional)
-
-- **Type:** `Record<string, any>`
-
-Batch-level capabilities to send with the request (e.g., `paymasterService`).
-
-```ts twoslash
-import { walletClient } from './config'
-
-const id = await walletClient.sendCalls({
-  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-  calls: [
-    {
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      gas: 100000n,
-    },
-  ],
-  capabilities: { // [!code focus]
-    paymasterService: { // [!code focus]
-      url: 'https://paymaster.example.com', // [!code focus]
-    }, // [!code focus]
-  }, // [!code focus]
-})
-```
-
-### chain (optional)
-
-- **Type:** `Chain`
-
-The target chain. If not provided, the client's chain will be used.
-
-### forceAtomic (optional)
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Whether to force atomic execution of the batch.
-
-```ts twoslash
-import { walletClient } from './config'
-
-const id = await walletClient.sendCalls({
-  account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
-  calls: [
-    {
-      to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      gas: 100000n,
-    },
-  ],
-  forceAtomic: true, // [!code focus]
-})
-```
+:::tip
+For other parameters (`account`, `calls`, `capabilities`, etc.), see the [core sendCalls documentation](/docs/actions/wallet/sendCalls).
+:::
 
 ## How It Works
 

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1525,6 +1525,24 @@ export const sidebar = {
           },
         ],
       },
+      {
+        text: 'ERC-8132',
+        items: [
+          {
+            text: 'Client',
+            link: '/experimental/erc8132/client',
+          },
+          {
+            text: 'Actions',
+            items: [
+              {
+                text: 'sendCalls',
+                link: '/experimental/erc8132/sendCalls',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   '/op-stack': {

--- a/src/experimental/erc8132/actions/sendCalls.test.ts
+++ b/src/experimental/erc8132/actions/sendCalls.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from 'vitest'
+import { mainnet } from '../../../chains/index.js'
+import { createClient } from '../../../clients/createClient.js'
+import { custom } from '../../../clients/transports/custom.js'
+import { parseEther } from '../../../utils/index.js'
+import { sendCalls } from './sendCalls.js'
+
+const accounts = [
+  { address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' },
+  { address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8' },
+  { address: '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc' },
+  { address: '0x90f79bf6eb2c4f870365e785982e1f101e93b906' },
+] as const
+
+const getClient = ({
+  onRequest,
+}: {
+  onRequest({ method, params }: { method: string; params: unknown }): void
+}) =>
+  createClient({
+    chain: mainnet,
+    transport: custom({
+      async request({ method, params }) {
+        onRequest({ method, params })
+        if (method === 'wallet_sendCalls') {
+          return { id: 'test-id' }
+        }
+        return null
+      },
+    }),
+  })
+
+describe('sendCalls with gasLimitOverride', () => {
+  test('calls without gas - no gasLimitOverride capability', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = getClient({
+      onRequest(request) {
+        requests.push(request)
+      },
+    })
+
+    await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+        },
+        {
+          to: accounts[2].address,
+          data: '0xcafebabe',
+        },
+      ],
+    })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].method).toBe('wallet_sendCalls')
+
+    const params = (requests[0].params as any)[0]
+    expect(params.calls[0].capabilities).toBeUndefined()
+    expect(params.calls[1].capabilities).toBeUndefined()
+  })
+
+  test('calls with gas - gasLimitOverride capability added', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = getClient({
+      onRequest(request) {
+        requests.push(request)
+      },
+    })
+
+    await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+          gas: 100000n,
+        },
+        {
+          to: accounts[2].address,
+          data: '0xcafebabe',
+          gas: 200000n,
+        },
+      ],
+    })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].method).toBe('wallet_sendCalls')
+
+    const params = (requests[0].params as any)[0]
+    expect(params.calls[0].capabilities).toEqual({
+      gasLimitOverride: { value: '0x186a0' }, // 100000 in hex
+    })
+    expect(params.calls[1].capabilities).toEqual({
+      gasLimitOverride: { value: '0x30d40' }, // 200000 in hex
+    })
+  })
+
+  test('mixed calls - some with gas, some without', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = getClient({
+      onRequest(request) {
+        requests.push(request)
+      },
+    })
+
+    await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+          gas: 100000n,
+        },
+        {
+          to: accounts[2].address,
+          data: '0xcafebabe',
+          // No gas - wallet should estimate
+        },
+        {
+          to: accounts[3].address,
+          value: parseEther('0.5'),
+          gas: 50000n,
+        },
+      ],
+    })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].method).toBe('wallet_sendCalls')
+
+    const params = (requests[0].params as any)[0]
+    expect(params.calls[0].capabilities).toEqual({
+      gasLimitOverride: { value: '0x186a0' }, // 100000 in hex
+    })
+    expect(params.calls[1].capabilities).toBeUndefined()
+    expect(params.calls[2].capabilities).toEqual({
+      gasLimitOverride: { value: '0xc350' }, // 50000 in hex
+    })
+  })
+
+  test('returns response id', async () => {
+    const client = getClient({
+      onRequest() {},
+    })
+
+    const result = await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+          gas: 100000n,
+        },
+      ],
+    })
+
+    expect(result).toEqual({ id: 'test-id' })
+  })
+
+  test('batch-level capabilities are preserved', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = getClient({
+      onRequest(request) {
+        requests.push(request)
+      },
+    })
+
+    await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+          gas: 100000n,
+        },
+      ],
+      capabilities: {
+        paymasterService: {
+          url: 'https://paymaster.example.com',
+        },
+      },
+    })
+
+    expect(requests).toHaveLength(1)
+    const params = (requests[0].params as any)[0]
+
+    // Call-level capabilities
+    expect(params.calls[0].capabilities).toEqual({
+      gasLimitOverride: { value: '0x186a0' },
+    })
+
+    // Batch-level capabilities
+    expect(params.capabilities).toEqual({
+      paymasterService: {
+        url: 'https://paymaster.example.com',
+      },
+    })
+  })
+
+  test('with abi encoding', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = getClient({
+      onRequest(request) {
+        requests.push(request)
+      },
+    })
+
+    await sendCalls(client, {
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          abi: [
+            {
+              name: 'transfer',
+              type: 'function',
+              inputs: [
+                { name: 'to', type: 'address' },
+                { name: 'amount', type: 'uint256' },
+              ],
+              outputs: [{ type: 'bool' }],
+            },
+          ] as const,
+          functionName: 'transfer',
+          args: [accounts[2].address, parseEther('1')],
+          gas: 100000n,
+        },
+      ],
+    })
+
+    expect(requests).toHaveLength(1)
+    const params = (requests[0].params as any)[0]
+
+    // Data should be encoded
+    expect(params.calls[0].data).toBeDefined()
+    expect(params.calls[0].data.startsWith('0xa9059cbb')).toBe(true) // transfer selector
+
+    // Gas capability should be present
+    expect(params.calls[0].capabilities).toEqual({
+      gasLimitOverride: { value: '0x186a0' },
+    })
+  })
+})

--- a/src/experimental/erc8132/actions/sendCalls.test.ts
+++ b/src/experimental/erc8132/actions/sendCalls.test.ts
@@ -1,16 +1,10 @@
 import { describe, expect, test } from 'vitest'
+import { accounts } from '~test/constants.js'
 import { mainnet } from '../../../chains/index.js'
 import { createClient } from '../../../clients/createClient.js'
 import { custom } from '../../../clients/transports/custom.js'
 import { parseEther } from '../../../utils/index.js'
 import { sendCalls } from './sendCalls.js'
-
-const accounts = [
-  { address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' },
-  { address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8' },
-  { address: '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc' },
-  { address: '0x90f79bf6eb2c4f870365e785982e1f101e93b906' },
-] as const
 
 const getClient = ({
   onRequest,
@@ -32,7 +26,7 @@ const getClient = ({
 
 describe('sendCalls with gasLimitOverride', () => {
   test('calls without gas - no gasLimitOverride capability', async () => {
-    const requests: { method: string; params: unknown }[] = []
+    const requests: unknown[] = []
 
     const client = getClient({
       onRequest(request) {
@@ -54,16 +48,41 @@ describe('sendCalls with gasLimitOverride', () => {
       ],
     })
 
-    expect(requests).toHaveLength(1)
-    expect(requests[0].method).toBe('wallet_sendCalls')
-
-    const params = (requests[0].params as any)[0]
-    expect(params.calls[0].capabilities).toBeUndefined()
-    expect(params.calls[1].capabilities).toBeUndefined()
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "wallet_sendCalls",
+          "params": [
+            {
+              "atomicRequired": false,
+              "calls": [
+                {
+                  "capabilities": undefined,
+                  "data": undefined,
+                  "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                  "value": "0xde0b6b3a7640000",
+                },
+                {
+                  "capabilities": undefined,
+                  "data": "0xcafebabe",
+                  "to": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+                  "value": undefined,
+                },
+              ],
+              "capabilities": undefined,
+              "chainId": "0x1",
+              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "id": undefined,
+              "version": "2.0.0",
+            },
+          ],
+        },
+      ]
+    `)
   })
 
   test('calls with gas - gasLimitOverride capability added', async () => {
-    const requests: { method: string; params: unknown }[] = []
+    const requests: unknown[] = []
 
     const client = getClient({
       onRequest(request) {
@@ -87,20 +106,49 @@ describe('sendCalls with gasLimitOverride', () => {
       ],
     })
 
-    expect(requests).toHaveLength(1)
-    expect(requests[0].method).toBe('wallet_sendCalls')
-
-    const params = (requests[0].params as any)[0]
-    expect(params.calls[0].capabilities).toEqual({
-      gasLimitOverride: { value: '0x186a0' }, // 100000 in hex
-    })
-    expect(params.calls[1].capabilities).toEqual({
-      gasLimitOverride: { value: '0x30d40' }, // 200000 in hex
-    })
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "wallet_sendCalls",
+          "params": [
+            {
+              "atomicRequired": false,
+              "calls": [
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0x186a0",
+                    },
+                  },
+                  "data": undefined,
+                  "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                  "value": "0xde0b6b3a7640000",
+                },
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0x30d40",
+                    },
+                  },
+                  "data": "0xcafebabe",
+                  "to": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+                  "value": undefined,
+                },
+              ],
+              "capabilities": undefined,
+              "chainId": "0x1",
+              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "id": undefined,
+              "version": "2.0.0",
+            },
+          ],
+        },
+      ]
+    `)
   })
 
   test('mixed calls - some with gas, some without', async () => {
-    const requests: { method: string; params: unknown }[] = []
+    const requests: unknown[] = []
 
     const client = getClient({
       onRequest(request) {
@@ -119,7 +167,6 @@ describe('sendCalls with gasLimitOverride', () => {
         {
           to: accounts[2].address,
           data: '0xcafebabe',
-          // No gas - wallet should estimate
         },
         {
           to: accounts[3].address,
@@ -129,17 +176,51 @@ describe('sendCalls with gasLimitOverride', () => {
       ],
     })
 
-    expect(requests).toHaveLength(1)
-    expect(requests[0].method).toBe('wallet_sendCalls')
-
-    const params = (requests[0].params as any)[0]
-    expect(params.calls[0].capabilities).toEqual({
-      gasLimitOverride: { value: '0x186a0' }, // 100000 in hex
-    })
-    expect(params.calls[1].capabilities).toBeUndefined()
-    expect(params.calls[2].capabilities).toEqual({
-      gasLimitOverride: { value: '0xc350' }, // 50000 in hex
-    })
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "wallet_sendCalls",
+          "params": [
+            {
+              "atomicRequired": false,
+              "calls": [
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0x186a0",
+                    },
+                  },
+                  "data": undefined,
+                  "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                  "value": "0xde0b6b3a7640000",
+                },
+                {
+                  "capabilities": undefined,
+                  "data": "0xcafebabe",
+                  "to": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+                  "value": undefined,
+                },
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0xc350",
+                    },
+                  },
+                  "data": undefined,
+                  "to": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+                  "value": "0x6f05b59d3b20000",
+                },
+              ],
+              "capabilities": undefined,
+              "chainId": "0x1",
+              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "id": undefined,
+              "version": "2.0.0",
+            },
+          ],
+        },
+      ]
+    `)
   })
 
   test('returns response id', async () => {
@@ -158,11 +239,15 @@ describe('sendCalls with gasLimitOverride', () => {
       ],
     })
 
-    expect(result).toEqual({ id: 'test-id' })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "id": "test-id",
+      }
+    `)
   })
 
   test('batch-level capabilities are preserved', async () => {
-    const requests: { method: string; params: unknown }[] = []
+    const requests: unknown[] = []
 
     const client = getClient({
       onRequest(request) {
@@ -186,24 +271,43 @@ describe('sendCalls with gasLimitOverride', () => {
       },
     })
 
-    expect(requests).toHaveLength(1)
-    const params = (requests[0].params as any)[0]
-
-    // Call-level capabilities
-    expect(params.calls[0].capabilities).toEqual({
-      gasLimitOverride: { value: '0x186a0' },
-    })
-
-    // Batch-level capabilities
-    expect(params.capabilities).toEqual({
-      paymasterService: {
-        url: 'https://paymaster.example.com',
-      },
-    })
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "wallet_sendCalls",
+          "params": [
+            {
+              "atomicRequired": false,
+              "calls": [
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0x186a0",
+                    },
+                  },
+                  "data": undefined,
+                  "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                  "value": "0xde0b6b3a7640000",
+                },
+              ],
+              "capabilities": {
+                "paymasterService": {
+                  "url": "https://paymaster.example.com",
+                },
+              },
+              "chainId": "0x1",
+              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "id": undefined,
+              "version": "2.0.0",
+            },
+          ],
+        },
+      ]
+    `)
   })
 
   test('with abi encoding', async () => {
-    const requests: { method: string; params: unknown }[] = []
+    const requests: unknown[] = []
 
     const client = getClient({
       onRequest(request) {
@@ -234,16 +338,34 @@ describe('sendCalls with gasLimitOverride', () => {
       ],
     })
 
-    expect(requests).toHaveLength(1)
-    const params = (requests[0].params as any)[0]
-
-    // Data should be encoded
-    expect(params.calls[0].data).toBeDefined()
-    expect(params.calls[0].data.startsWith('0xa9059cbb')).toBe(true) // transfer selector
-
-    // Gas capability should be present
-    expect(params.calls[0].capabilities).toEqual({
-      gasLimitOverride: { value: '0x186a0' },
-    })
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "method": "wallet_sendCalls",
+          "params": [
+            {
+              "atomicRequired": false,
+              "calls": [
+                {
+                  "capabilities": {
+                    "gasLimitOverride": {
+                      "value": "0x186a0",
+                    },
+                  },
+                  "data": "0xa9059cbb0000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                  "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+                  "value": undefined,
+                },
+              ],
+              "capabilities": undefined,
+              "chainId": "0x1",
+              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "id": undefined,
+              "version": "2.0.0",
+            },
+          ],
+        },
+      ]
+    `)
   })
 })

--- a/src/experimental/erc8132/actions/sendCalls.ts
+++ b/src/experimental/erc8132/actions/sendCalls.ts
@@ -62,7 +62,7 @@ export type SendCallsErrorType = RequestErrorType | ErrorType
  *     {
  *       data: '0xdeadbeef',
  *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
- *       gas: 100000n, // ERC-8132 gas limit override
+ *       gas: 100000n,
  *     },
  *     {
  *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
@@ -119,13 +119,8 @@ export async function sendCalls<
         })
       : call.data
 
-    // Build call-level capabilities with gasLimitOverride if gas is specified
     const callCapabilities = call.gas
-      ? {
-          gasLimitOverride: {
-            value: numberToHex(call.gas),
-          },
-        }
+      ? { gasLimitOverride: { value: numberToHex(call.gas) } }
       : undefined
 
     return {

--- a/src/experimental/erc8132/actions/sendCalls.ts
+++ b/src/experimental/erc8132/actions/sendCalls.ts
@@ -1,0 +1,158 @@
+import type { Address, Narrow } from 'abitype'
+import { parseAccount } from '../../../accounts/utils/parseAccount.js'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { ErrorType } from '../../../errors/utils.js'
+import type { Account, GetAccountParameter } from '../../../types/account.js'
+import type { Call, Calls } from '../../../types/calls.js'
+import type { ExtractCapabilities } from '../../../types/capabilities.js'
+import type { Chain, DeriveChain } from '../../../types/chain.js'
+import type { WalletSendCallsParameters } from '../../../types/eip1193.js'
+import type { Prettify } from '../../../types/utils.js'
+import { encodeFunctionData } from '../../../utils/abi/encodeFunctionData.js'
+import type { RequestErrorType } from '../../../utils/buildRequest.js'
+import { concat } from '../../../utils/data/concat.js'
+import { numberToHex } from '../../../utils/encoding/toHex.js'
+
+export type SendCallsParameters<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends Chain | undefined = Chain | undefined,
+  calls extends readonly unknown[] = readonly unknown[],
+  //
+  _chain extends Chain | undefined = DeriveChain<chain, chainOverride>,
+> = {
+  chain?: chainOverride | Chain | undefined
+  calls: Calls<Narrow<calls>, { gas?: bigint | undefined }>
+  capabilities?: ExtractCapabilities<'sendCalls', 'Request'> | undefined
+  forceAtomic?: boolean | undefined
+  id?: string | undefined
+  version?: WalletSendCallsParameters[number]['version'] | undefined
+} & GetAccountParameter<account, Account | Address, false, true>
+
+export type SendCallsReturnType = Prettify<{
+  capabilities?: ExtractCapabilities<'sendCalls', 'ReturnType'> | undefined
+  id: string
+}>
+
+export type SendCallsErrorType = RequestErrorType | ErrorType
+
+/**
+ * Requests the connected wallet to send a batch of calls with ERC-8132 gas limit override support.
+ *
+ * - Docs: https://viem.sh/experimental/erc8132/sendCalls
+ * - JSON-RPC Methods: [`wallet_sendCalls`](https://eips.ethereum.org/EIPS/eip-5792)
+ * - ERC-8132: https://github.com/ethereum/ERCs/pull/1485
+ *
+ * @param client - Client to use
+ * @returns Transaction identifier. {@link SendCallsReturnType}
+ *
+ * @example
+ * import { createWalletClient, custom } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ * import { sendCalls } from 'viem/experimental/erc8132'
+ *
+ * const client = createWalletClient({
+ *   chain: mainnet,
+ *   transport: custom(window.ethereum),
+ * })
+ * const id = await sendCalls(client, {
+ *   account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+ *   calls: [
+ *     {
+ *       data: '0xdeadbeef',
+ *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *       gas: 100000n, // ERC-8132 gas limit override
+ *     },
+ *     {
+ *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *       value: 69420n,
+ *     },
+ *   ],
+ * })
+ */
+export async function sendCalls<
+  const calls extends readonly unknown[],
+  chain extends Chain | undefined,
+  account extends Account | undefined = undefined,
+  chainOverride extends Chain | undefined = undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: SendCallsParameters<chain, account, chainOverride, calls>,
+): Promise<SendCallsReturnType> {
+  const {
+    account: account_ = client.account,
+    chain = client.chain,
+    forceAtomic = false,
+    id,
+    version = '2.0.0',
+  } = parameters
+
+  const account = account_ ? parseAccount(account_) : null
+
+  let capabilities = parameters.capabilities
+
+  if (client.dataSuffix && !parameters.capabilities?.dataSuffix) {
+    if (typeof client.dataSuffix === 'string')
+      capabilities = {
+        ...parameters.capabilities,
+        dataSuffix: { value: client.dataSuffix, optional: true },
+      }
+    else
+      capabilities = {
+        ...parameters.capabilities,
+        dataSuffix: {
+          value: client.dataSuffix.value,
+          ...(client.dataSuffix.required ? {} : { optional: true }),
+        },
+      }
+  }
+
+  const calls = parameters.calls.map((call_: unknown) => {
+    const call = call_ as Call & { gas?: bigint | undefined }
+
+    const data = call.abi
+      ? encodeFunctionData({
+          abi: call.abi,
+          functionName: call.functionName,
+          args: call.args,
+        })
+      : call.data
+
+    // Build call-level capabilities with gasLimitOverride if gas is specified
+    const callCapabilities = call.gas
+      ? {
+          gasLimitOverride: {
+            value: numberToHex(call.gas),
+          },
+        }
+      : undefined
+
+    return {
+      capabilities: callCapabilities,
+      data: call.dataSuffix && data ? concat([data, call.dataSuffix]) : data,
+      to: call.to,
+      value: call.value ? numberToHex(call.value) : undefined,
+    }
+  })
+
+  const response = await client.request(
+    {
+      method: 'wallet_sendCalls',
+      params: [
+        {
+          atomicRequired: forceAtomic,
+          calls,
+          capabilities,
+          chainId: numberToHex(chain!.id),
+          from: account?.address,
+          id,
+          version,
+        },
+      ],
+    },
+    { retryCount: 0 },
+  )
+  if (typeof response === 'string') return { id: response }
+  return response as never
+}

--- a/src/experimental/erc8132/actions/sendCalls.ts
+++ b/src/experimental/erc8132/actions/sendCalls.ts
@@ -2,6 +2,7 @@ import type { Address, Narrow } from 'abitype'
 import { parseAccount } from '../../../accounts/utils/parseAccount.js'
 import type { Client } from '../../../clients/createClient.js'
 import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { BaseError } from '../../../errors/base.js'
 import type { ErrorType } from '../../../errors/utils.js'
 import type { Account, GetAccountParameter } from '../../../types/account.js'
 import type { Call, Calls } from '../../../types/calls.js'
@@ -13,6 +14,7 @@ import { encodeFunctionData } from '../../../utils/abi/encodeFunctionData.js'
 import type { RequestErrorType } from '../../../utils/buildRequest.js'
 import { concat } from '../../../utils/data/concat.js'
 import { numberToHex } from '../../../utils/encoding/toHex.js'
+import { getTransactionError } from '../../../utils/errors/getTransactionError.js'
 
 export type SendCallsParameters<
   chain extends Chain | undefined = Chain | undefined,
@@ -108,7 +110,7 @@ export async function sendCalls<
       }
   }
 
-  const calls = parameters.calls.map((call_: unknown) => {
+  const calls = parameters.calls.map((call_) => {
     const call = call_ as Call & { gas?: bigint | undefined }
 
     const data = call.abi
@@ -131,23 +133,31 @@ export async function sendCalls<
     }
   })
 
-  const response = await client.request(
-    {
-      method: 'wallet_sendCalls',
-      params: [
-        {
-          atomicRequired: forceAtomic,
-          calls,
-          capabilities,
-          chainId: numberToHex(chain!.id),
-          from: account?.address,
-          id,
-          version,
-        },
-      ],
-    },
-    { retryCount: 0 },
-  )
-  if (typeof response === 'string') return { id: response }
-  return response as never
+  try {
+    const response = await client.request(
+      {
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            atomicRequired: forceAtomic,
+            calls,
+            capabilities,
+            chainId: numberToHex(chain!.id),
+            from: account?.address,
+            id,
+            version,
+          },
+        ],
+      },
+      { retryCount: 0 },
+    )
+    if (typeof response === 'string') return { id: response }
+    return response as never
+  } catch (err) {
+    throw getTransactionError(err as BaseError, {
+      ...(parameters as any),
+      account,
+      chain: parameters.chain!,
+    })
+  }
 }

--- a/src/experimental/erc8132/decorators/erc8132.test.ts
+++ b/src/experimental/erc8132/decorators/erc8132.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import { mainnet } from '../../../chains/index.js'
+import { createClient } from '../../../clients/createClient.js'
+import { custom } from '../../../clients/transports/custom.js'
+import { parseEther } from '../../../utils/index.js'
+import { erc8132Actions } from './erc8132.js'
+
+const accounts = [
+  { address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' },
+  { address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8' },
+] as const
+
+describe('erc8132Actions', () => {
+  test('extends client with sendCalls', async () => {
+    const requests: { method: string; params: unknown }[] = []
+
+    const client = createClient({
+      chain: mainnet,
+      transport: custom({
+        async request({ method, params }) {
+          requests.push({ method, params })
+          if (method === 'wallet_sendCalls') {
+            return { id: 'test-id' }
+          }
+          return null
+        },
+      }),
+    }).extend(erc8132Actions())
+
+    const result = await client.sendCalls({
+      account: accounts[0].address,
+      calls: [
+        {
+          to: accounts[1].address,
+          value: parseEther('1'),
+          gas: 100000n,
+        },
+      ],
+    })
+
+    expect(result).toEqual({ id: 'test-id' })
+    expect(requests).toHaveLength(1)
+    expect(requests[0].method).toBe('wallet_sendCalls')
+
+    const params = (requests[0].params as any)[0]
+    expect(params.calls[0].capabilities).toEqual({
+      gasLimitOverride: { value: '0x186a0' },
+    })
+  })
+})

--- a/src/experimental/erc8132/decorators/erc8132.ts
+++ b/src/experimental/erc8132/decorators/erc8132.ts
@@ -38,7 +38,7 @@ export type Erc8132Actions<
    *     {
    *       data: '0xdeadbeef',
    *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-   *       gas: 100000n, // ERC-8132 gas limit override
+   *       gas: 100000n,
    *     },
    *   ],
    * })
@@ -75,12 +75,11 @@ export type Erc8132Actions<
  *     {
  *       data: '0xdeadbeef',
  *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
- *       gas: 100000n, // ERC-8132 gas limit override
+ *       gas: 100000n,
  *     },
  *     {
  *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
  *       value: 69420n,
- *       // No gas override - wallet will estimate
  *     },
  *   ],
  * })

--- a/src/experimental/erc8132/decorators/erc8132.ts
+++ b/src/experimental/erc8132/decorators/erc8132.ts
@@ -1,0 +1,100 @@
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import type { Account } from '../../../types/account.js'
+import type { Chain } from '../../../types/chain.js'
+import {
+  type SendCallsParameters,
+  type SendCallsReturnType,
+  sendCalls,
+} from '../actions/sendCalls.js'
+
+export type Erc8132Actions<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = {
+  /**
+   * Requests the connected wallet to send a batch of calls with ERC-8132 gas limit override support.
+   *
+   * - Docs: https://viem.sh/experimental/erc8132/sendCalls
+   * - JSON-RPC Methods: [`wallet_sendCalls`](https://eips.ethereum.org/EIPS/eip-5792)
+   * - ERC-8132: https://github.com/ethereum/ERCs/pull/1485
+   *
+   * @param parameters - {@link SendCallsParameters}
+   * @returns Transaction identifier. {@link SendCallsReturnType}
+   *
+   * @example
+   * import { createWalletClient, custom } from 'viem'
+   * import { mainnet } from 'viem/chains'
+   * import { erc8132Actions } from 'viem/experimental'
+   *
+   * const client = createWalletClient({
+   *   chain: mainnet,
+   *   transport: custom(window.ethereum),
+   * }).extend(erc8132Actions())
+   *
+   * const id = await client.sendCalls({
+   *   account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+   *   calls: [
+   *     {
+   *       data: '0xdeadbeef',
+   *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+   *       gas: 100000n, // ERC-8132 gas limit override
+   *     },
+   *   ],
+   * })
+   */
+  sendCalls: <
+    chainOverride extends Chain | undefined = undefined,
+    const calls extends readonly unknown[] = readonly unknown[],
+  >(
+    parameters: SendCallsParameters<chain, account, chainOverride, calls>,
+  ) => Promise<SendCallsReturnType>
+}
+
+/**
+ * A suite of ERC-8132 Wallet Actions.
+ *
+ * ERC-8132 introduces a capability that allows apps to specify gas limits
+ * for individual calls in an EIP-5792 batch.
+ *
+ * @see https://github.com/ethereum/ERCs/pull/1485
+ *
+ * @example
+ * import { createWalletClient, custom } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ * import { erc8132Actions } from 'viem/experimental'
+ *
+ * const client = createWalletClient({
+ *   chain: mainnet,
+ *   transport: custom(window.ethereum),
+ * }).extend(erc8132Actions())
+ *
+ * const id = await client.sendCalls({
+ *   account: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e',
+ *   calls: [
+ *     {
+ *       data: '0xdeadbeef',
+ *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *       gas: 100000n, // ERC-8132 gas limit override
+ *     },
+ *     {
+ *       to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *       value: 69420n,
+ *       // No gas override - wallet will estimate
+ *     },
+ *   ],
+ * })
+ */
+export function erc8132Actions() {
+  return <
+    transport extends Transport,
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  >(
+    client: Client<transport, chain, account>,
+  ): Erc8132Actions<chain, account> => {
+    return {
+      sendCalls: (parameters) => sendCalls(client, parameters),
+    }
+  }
+}

--- a/src/experimental/erc8132/index.ts
+++ b/src/experimental/erc8132/index.ts
@@ -1,0 +1,14 @@
+// biome-ignore lint/performance/noBarrelFile: entrypoint
+export {
+  type SendCallsErrorType,
+  type SendCallsParameters,
+  type SendCallsReturnType,
+  sendCalls,
+} from './actions/sendCalls.js'
+
+export { type Erc8132Actions, erc8132Actions } from './decorators/erc8132.js'
+
+export type {
+  GasLimitOverrideCallCapability,
+  GasLimitOverrideCapability,
+} from './types.js'

--- a/src/experimental/erc8132/package.json
+++ b/src/experimental/erc8132/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "types": "../../_types/experimental/erc8132/index.d.ts",
+  "module": "../../_esm/experimental/erc8132/index.js",
+  "main": "../../_cjs/experimental/erc8132/index.js"
+}

--- a/src/experimental/erc8132/types.ts
+++ b/src/experimental/erc8132/types.ts
@@ -15,6 +15,5 @@ export type GasLimitOverrideCapability = {
  * @see https://github.com/ethereum/ERCs/pull/1485
  */
 export type GasLimitOverrideCallCapability = {
-  /** Hex-encoded gas limit for the call */
   value: Hex
 }

--- a/src/experimental/erc8132/types.ts
+++ b/src/experimental/erc8132/types.ts
@@ -1,0 +1,20 @@
+import type { Hex } from '../../types/misc.js'
+
+/**
+ * ERC-8132 gasLimitOverride capability for wallet_getCapabilities response.
+ *
+ * @see https://github.com/ethereum/ERCs/pull/1485
+ */
+export type GasLimitOverrideCapability = {
+  supported: boolean
+}
+
+/**
+ * ERC-8132 gasLimitOverride call-level capability for wallet_sendCalls.
+ *
+ * @see https://github.com/ethereum/ERCs/pull/1485
+ */
+export type GasLimitOverrideCallCapability = {
+  /** Hex-encoded gas limit for the call */
+  value: Hex
+}

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -187,3 +187,12 @@ export {
   type Erc7895Actions,
   erc7895Actions,
 } from './erc7895/decorators/erc7895.js'
+
+export {
+  type Erc8132Actions,
+  erc8132Actions,
+} from './erc8132/decorators/erc8132.js'
+export type {
+  GasLimitOverrideCallCapability,
+  GasLimitOverrideCapability,
+} from './erc8132/types.js'

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -189,6 +189,12 @@ export {
 } from './erc7895/decorators/erc7895.js'
 
 export {
+  type SendCallsErrorType as Erc8132SendCallsErrorType,
+  type SendCallsParameters as Erc8132SendCallsParameters,
+  type SendCallsReturnType as Erc8132SendCallsReturnType,
+  sendCalls as erc8132SendCalls,
+} from './erc8132/actions/sendCalls.js'
+export {
   type Erc8132Actions,
   erc8132Actions,
 } from './erc8132/decorators/erc8132.js'


### PR DESCRIPTION
This PR adds experimental support for [ERC-8132: Gas Limit Override Capability](https://github.com/ethereum/ERCs/pull/1485).
ERC-8132 introduces a call-level capability for EIP-5792 that allows apps to specify gas limits for individual calls in a wallet_sendCalls batch. This addresses cases where apps have better context for gas estimation than wallets (e.g., calls with nondeterministic behavior).