### PR TITLE
feat(chains): Add Subtensor EVM chain

### DIFF
--- a/.changeset/add-subtensor-evm.md
+++ b/.changeset/add-subtensor-evm.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Subtensor EVM chain.

--- a/src/chains/definitions/subtensorEvm.ts
+++ b/src/chains/definitions/subtensorEvm.ts
@@ -1,0 +1,24 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const subtensorEvm = /*#__PURE__*/ defineChain({
+  id: 964,
+  name: 'Subtensor EVM',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'TAO',
+    symbol: 'TAO',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://lite.chain.opentensor.ai'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Taostats EVM Explorer',
+      url: 'https://evm.taostats.io',
+      apiUrl: 'https://evm.taostats.io/api',
+    },
+  },
+  testnet: false,
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -591,6 +591,7 @@ export { storyOdyssey } from './definitions/storyOdyssey.js'
 /** @deprecated Use `storyAeneid` instead. */
 export { storyTestnet } from './definitions/storyTestnet.js'
 export { stratis } from './definitions/stratis.js'
+export { subtensorEvm } from './definitions/subtensorEvm.js'
 export { superlumio } from './definitions/superlumio.js'
 export { superposition } from './definitions/superposition.js'
 export { superseed } from './definitions/superseed.js'


### PR DESCRIPTION
## Summary

Added Subtensor EVM chain (Bittensor network).

- Chain ID: 964
- Native currency: TAO (18 decimals)
- RPC: https://lite.chain.opentensor.ai
- Explorer: https://evm.taostats.io

## References

- ethereum-lists/chains: [eip155-964.json](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-964.json)
- Bittensor docs: https://docs.learnbittensor.org/evm-tutorials
- ChainList: https://chainlist.org/chain/964