### PR TITLE
fix: update error signature URL to Sourcify

### DIFF
--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.test.ts
@@ -288,7 +288,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
        
       Request Arguments:
@@ -373,7 +373,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -419,7 +419,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -465,7 +465,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -511,7 +511,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -557,7 +557,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000
@@ -603,7 +603,7 @@ describe('entryPointVersion: 0.8', async () => {
 
       Unable to decode signature "0x5a154675" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x5a154675.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0x5a154675.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000

--- a/src/account-abstraction/utils/errors/getUserOperationError.test.ts
+++ b/src/account-abstraction/utils/errors/getUserOperationError.test.ts
@@ -435,7 +435,7 @@ test('contract error (multiple calls - unknown error)', () => {
 
     Unable to decode signature "0xdeadbeef" as it was not found on the provided ABI.
     Make sure you are using the correct ABI and that the error exists on it.
-    You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xdeadbeef.
+    You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xdeadbeef.
      
      
     Request Arguments:

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -795,7 +795,7 @@ describe('errors', async () => {
 
         Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
         Make sure you are using the correct ABI and that the error exists on it.
-        You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
+        You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xf9006398.
          
         Contract Call:
           function:  simpleCustomRead()
@@ -1145,7 +1145,7 @@ describe('errors', async () => {
 
       Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xf9006398.
        
       Contract Call:
         function:  simpleCustomRead()

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -498,7 +498,7 @@ describe('contract errors', () => {
 
       Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xf9006398.
        
       Contract Call:
         address:   0x0000000000000000000000000000000000000000

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -215,7 +215,7 @@ export class AbiErrorSignatureNotFoundError extends BaseError {
       [
         `Encoded error signature "${signature}" not found on ABI.`,
         'Make sure you are using the correct ABI and that the error exists on it.',
-        `You can look up the decoded signature here: https://openchain.xyz/signatures?query=${signature}.`,
+        `You can look up the decoded signature here: https://4byte.sourcify.dev/?q=${signature}.`,
       ].join('\n'),
       {
         docsPath,
@@ -249,7 +249,7 @@ export class AbiEventSignatureNotFoundError extends BaseError {
       [
         `Encoded event signature "${signature}" not found on ABI.`,
         'Make sure you are using the correct ABI and that the event exists on it.',
-        `You can look up the signature here: https://openchain.xyz/signatures?query=${signature}.`,
+        `You can look up the signature here: https://4byte.sourcify.dev/?q=${signature}.`,
       ].join('\n'),
       {
         docsPath,
@@ -331,7 +331,7 @@ export class AbiFunctionSignatureNotFoundError extends BaseError {
       [
         `Encoded function signature "${signature}" not found on ABI.`,
         'Make sure you are using the correct ABI and that the function exists on it.',
-        `You can look up the signature here: https://openchain.xyz/signatures?query=${signature}.`,
+        `You can look up the signature here: https://4byte.sourcify.dev/?q=${signature}.`,
       ].join('\n'),
       {
         docsPath,

--- a/src/errors/contract.test.ts
+++ b/src/errors/contract.test.ts
@@ -419,7 +419,7 @@ describe('ContractFunctionRevertedError', () => {
 
       Unable to decode signature "0xdb731cfa" as it was not found on the provided ABI.
       Make sure you are using the correct ABI and that the error exists on it.
-      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xdb731cfa.
+      You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xdb731cfa.
 
       Docs: https://viem.sh/docs/contract/decodeErrorResult
       Version: viem@x.y.z]

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -232,7 +232,7 @@ export class ContractFunctionRevertedError extends BaseError {
       metaMessages = [
         `Unable to decode signature "${signature}" as it was not found on the provided ABI.`,
         'Make sure you are using the correct ABI and that the error exists on it.',
-        `You can look up the decoded signature here: https://openchain.xyz/signatures?query=${signature}.`,
+        `You can look up the decoded signature here: https://4byte.sourcify.dev/?q=${signature}.`,
       ]
     }
 

--- a/src/utils/abi/decodeErrorResult.test.ts
+++ b/src/utils/abi/decodeErrorResult.test.ts
@@ -211,7 +211,7 @@ test("errors: error doesn't exist", () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [AbiErrorSignatureNotFoundError: Encoded error signature "0xa3741467" not found on ABI.
     Make sure you are using the correct ABI and that the error exists on it.
-    You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xa3741467.
+    You can look up the decoded signature here: https://4byte.sourcify.dev/?q=0xa3741467.
 
     Docs: https://viem.sh/docs/contract/decodeErrorResult
     Version: viem@x.y.z]

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -1366,7 +1366,7 @@ test("errors: event doesn't exist", () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [AbiEventSignatureNotFoundError: Encoded event signature "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef" not found on ABI.
     Make sure you are using the correct ABI and that the event exists on it.
-    You can look up the signature here: https://openchain.xyz/signatures?query=0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+    You can look up the signature here: https://4byte.sourcify.dev/?q=0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
 
     Docs: https://viem.sh/docs/contract/decodeEventLog
     Version: viem@x.y.z]

--- a/src/utils/abi/decodeFunctionData.test.ts
+++ b/src/utils/abi/decodeFunctionData.test.ts
@@ -215,7 +215,7 @@ test("errors: function doesn't exist", () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     [AbiFunctionSignatureNotFoundError: Encoded function signature "0xa3741467" not found on ABI.
     Make sure you are using the correct ABI and that the function exists on it.
-    You can look up the signature here: https://openchain.xyz/signatures?query=0xa3741467.
+    You can look up the signature here: https://4byte.sourcify.dev/?q=0xa3741467.
 
     Docs: https://viem.sh/docs/contract/decodeFunctionData
     Version: viem@x.y.z]


### PR DESCRIPTION
The Openchain URL now redirects to `4byte.sourcify.dev`, but the query format used in Viem is broken as a result.
This PR fixes the error hint to use the new URL everywhere.

I replaced [all mentions in the repo](https://github.com/search?q=repo%3Awevm%2Fviem+%22https%3A%2F%2Fopenchain.xyz%2Fsignatures%3Fquery%3D%22&type=code) with the new URL format.

* Previous link example: https://openchain.xyz/signatures?query=0x5a154675
* Current link example: https://4byte.sourcify.dev/?q=0x5a154675