### PR TITLE
chore: remove deprecated etherscan zksync explorer references

### DIFF
--- a/src/chains/definitions/zksync.ts
+++ b/src/chains/definitions/zksync.ts
@@ -20,11 +20,6 @@ export const zksync = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Etherscan',
-      url: 'https://era.zksync.network/',
-      apiUrl: 'https://api-era.zksync.network/api',
-    },
-    native: {
       name: 'ZKsync Explorer',
       url: 'https://explorer.zksync.io/',
       apiUrl: 'https://block-explorer-api.mainnet.zksync.io/api',

--- a/src/chains/definitions/zksyncSepoliaTestnet.ts
+++ b/src/chains/definitions/zksyncSepoliaTestnet.ts
@@ -16,11 +16,6 @@ export const zksyncSepoliaTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Etherscan',
-      url: 'https://sepolia-era.zksync.network/',
-      apiUrl: 'https://api-sepolia-era.zksync.network/api',
-    },
-    native: {
       name: 'ZKsync Explorer',
       url: 'https://sepolia.explorer.zksync.io/',
       blockExplorerApi: 'https://block-explorer-api.sepolia.zksync.dev/api',


### PR DESCRIPTION
## Description

- ZKsync Etherscan explorer is now deprecated: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/1133
- This PR removes the Etherscan reference to the chain definitions for testnet / mainnet 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

