### PR TITLE
Add Luxeports Network Support ( ChainID : 1122 )

### DIFF
--- a/.changeset/lovely-kings-sell.md
+++ b/.changeset/lovely-kings-sell.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+"Added LuxePorts chain."

--- a/src/chains/definitions/luxeports.ts
+++ b/src/chains/definitions/luxeports.ts
@@ -1,0 +1,29 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const luxeports = /*#__PURE__*/ defineChain({
+  id: 1122,
+  name: 'LuxePorts',
+  network: 'luxeports',
+  nativeCurrency: {
+    name: 'LuxePorts',
+    symbol: 'LXP',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.luxeports.com',
+         'https://erpc.luxeports.com'],
+      webSocket: ['wss://rpc.luxeports.com/ws',
+         'wss://erpc.luxeports.com/ws'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'LXPScan',
+      url: 'https://lxpscan.com',
+    },
+  },
+  testnet: false,
+})
+
+

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -637,6 +637,7 @@ export {
 export { zora } from './definitions/zora.js'
 export { zoraSepolia } from './definitions/zoraSepolia.js'
 export { zoraTestnet } from './definitions/zoraTestnet.js'
+export { luxeports } from './definitions/luxeports.js'
 
 //////////////////////////////////////////////////////////////////////////////////////
 // Required type exports to prevent TypeScript error "TS2742".


### PR DESCRIPTION
## Description

This PR adds support for the **LuxePorts** network (Chain ID: 1122).

## Changes

- Added `luxeports.ts` chain definition in `src/chains/definitions/`
- Exported `luxeports` in `src/chains/index.ts`
- Added changeset for version tracking

## Chain Details

- **Chain ID:** 1122
- **Name:** LuxePorts
- **Symbol:** LXP
- **RPC URLs:** 
  - https://rpc.luxeports.com
  - https://erpc.luxeports.com
- **WebSocket URLs:**
  - wss://rpc.luxeports.com/ws
  - wss://erpc.luxeports.com/ws
- **Block Explorer:** https://lxpscan.com
- **Status:** Mainnet (live)

## Checklist

- [x] Chain is live on mainnet
- [x] Public RPC URLs provided
- [x] Block explorer available
- [x] Changeset created
- [x] Chain definition follows Viem standards

## References

- Explorer: https://lxpscan.com
- Website: https://luxeports.com