### PR TITLE
feat(chains): add XGR Mainnet

### DIFF
--- a/.changeset/dull-swans-bake.md
+++ b/.changeset/dull-swans-bake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add XGR Mainnet chain

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6276,6 +6276,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.45.1:
+    resolution: {integrity: sha512-LN6Pp7vSfv50LgwhkfSbIXftAM5J89lP9x8TeDa8QM7o41IxlHrDh0F9X+FfnCWtsz11pEVV5sn+yBUoOHNqYA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@file:src:
     resolution: {directory: src, type: directory}
     peerDependencies:
@@ -8294,7 +8302,7 @@ snapshots:
       pino-pretty: 10.3.1
       prom-client: 14.2.0
       type-fest: 4.39.0
-      viem: 2.45.0(typescript@5.9.3)(zod@3.23.8)
+      viem: 2.45.1(typescript@5.9.3)(zod@3.23.8)
       yargs: 17.7.2
       zod: 3.23.8
       zod-validation-error: 1.5.0(zod@3.23.8)
@@ -13118,7 +13126,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.45.0(typescript@5.9.3)(zod@3.23.8):
+  viem@2.45.1(typescript@5.9.3)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/src/chains/definitions/xgr.ts
+++ b/src/chains/definitions/xgr.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xgr = /*#__PURE__*/ defineChain({
+  id: 1643,
+  name: 'XGR Mainnet',
+  nativeCurrency: {
+    name: 'XGR',
+    symbol: 'XGR',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.xgr.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'XGR Explorer',
+      url: 'https://explorer.xgr.network',
+    },
+  },
+})
+

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -688,6 +688,7 @@ export { xai } from './definitions/xai.js'
 export { xaiTestnet } from './definitions/xaiTestnet.js'
 export { xdc } from './definitions/xdc.js'
 export { xdcTestnet } from './definitions/xdcTestnet.js'
+export { xgr } from './definitions/xgr.js'
 export { xLayer } from './definitions/xLayer.js'
 export {
   /** @deprecated Use `xLayerTestnet` */


### PR DESCRIPTION
Adds `xgr` chain definition to `viem/chains`.

- Name: XGR Mainnet
- Chain ID: 1643 (0x66B)
- RPC: https://rpc.xgr.network
- Explorer: https://explorer.xgr.network
- Native currency: XGR (18)

No existing PR found. No docs/tests needed for adding a new chain definition.


