### PR TITLE
Fix wagmi references to viem in homepage

### DIFF
--- a/site/pages/index.mdx
+++ b/site/pages/index.mdx
@@ -143,7 +143,7 @@ viem supports all these features out-of-the-box:
 
 ## Community
 
-Check out the following places for more wagmi-related content:
+Check out the following places for more viem-related content:
 
 - Follow [@wevm_dev](https://twitter.com/wevm_dev), [@_jxom](https://twitter.com/_jxom), and [@awkweb](https://twitter.com/awkweb) on Twitter for project updates
 - Join the [discussions on GitHub](https://github.com/wevm/viem/discussions)
@@ -151,7 +151,7 @@ Check out the following places for more wagmi-related content:
 
 ## Support
 
-Help support future development and make wagmi a sustainable open-source project:
+Help support future development and make viem a sustainable open-source project:
 
 - [GitHub Sponsors](https://github.com/sponsors/wevm?metadata_campaign=docs_support)
 - [Gitcoin Grant](https://wagmi.sh/gitcoin)


### PR DESCRIPTION
## Summary
- Fixed incorrect "wagmi" references that should be "viem" in the documentation homepage (site/pages/index.mdx)
- Changed "wagmi-related content" to "viem-related content"
- Changed "make wagmi a sustainable open-source project" to "make viem a sustainable open-source project"

## Test plan
- [x] Verified text now correctly references viem instead of wagmi