### PR TITLE
Fix typo: sponsorshop to sponsorship

### DIFF
--- a/site/pages/account-abstraction/guides/sending-user-operations.md
+++ b/site/pages/account-abstraction/guides/sending-user-operations.md
@@ -342,7 +342,7 @@ export const account = await toCoinbaseSmartAccount({
 :::
 
 ::::tip
-If your Bundler also supports Paymaster sponsorshop (`pm_` JSON-RPC methods), you can set `paymaster: true` instead of declaring a separate Paymaster Client.
+If your Bundler also supports Paymaster sponsorship (`pm_` JSON-RPC methods), you can set `paymaster: true` instead of declaring a separate Paymaster Client.
 
 :::code-group
 


### PR DESCRIPTION
## Summary
- Fixed typo "sponsorshop" to "sponsorship" in the account abstraction guide (site/pages/account-abstraction/guides/sending-user-operations.md)

## Test plan
- [x] Verified the spelling is correct after the fix