### PR TITLE
Fix ZKsync page description formatting

### DIFF
--- a/site/pages/zksync.mdx
+++ b/site/pages/zksync.mdx
@@ -1,5 +1,5 @@
 ---
-description:  Getting started with the ZKsync in Viem
+description: Getting started with ZKsync in Viem
 ---
 
 # Getting Started with ZKsync


### PR DESCRIPTION
## Summary
- Fixed formatting issue in site/pages/zksync.mdx description
- Removed extra space before the description text
- Removed unnecessary "the" article before "ZKsync" for grammatically correct phrasing

Before: `description:  Getting started with the ZKsync in Viem`
After: `description: Getting started with ZKsync in Viem`

## Test plan
- [x] Verified the description format is correct after the fix