### PR TITLE
Fix duplicate "the the" typo in sendCalls docs

### DIFF
--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -330,7 +330,7 @@ const { id } = await walletClient.sendCalls({
 })
 ```
 
-When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
+When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
 
 ```ts twoslash
 import { parseAbi } from 'viem'

--- a/site/pages/docs/actions/wallet/sendCallsSync.mdx
+++ b/site/pages/docs/actions/wallet/sendCallsSync.mdx
@@ -336,7 +336,7 @@ const status = await walletClient.sendCallsSync({
 })
 ```
 
-When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
+When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
 
 ```ts twoslash
 import { parseAbi } from 'viem'


### PR DESCRIPTION
## Summary
- Fixed duplicate word "the the" to "the" in two documentation files:
  - site/pages/docs/actions/wallet/sendCalls.mdx
  - site/pages/docs/actions/wallet/sendCallsSync.mdx

## Test plan
- [x] Verified the typo is fixed in both files