### PR TITLE
Update outdated GitHub links from wagmi-dev to wevm

### DIFF
--- a/examples/op-stack_deposit/README.md
+++ b/examples/op-stack_deposit/README.md
@@ -1,3 +1,3 @@
 # OP Stack – Deposit Example
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/wagmi-dev/viem/tree/main/examples/op-stack_deposit)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/wevm/viem/tree/main/examples/op-stack_deposit)

--- a/site/pages/docs/chains/introduction.md
+++ b/site/pages/docs/chains/introduction.md
@@ -16,9 +16,9 @@ const client = createPublicClient({
 })
 ```
 
-[See here for a list of supported chains](https://github.com/wagmi-dev/viem/tree/main/src/chains/index.ts).
+[See here for a list of supported chains](https://github.com/wevm/viem/tree/main/src/chains/index.ts).
 
-> Want to add a chain that's not listed in viem? Read the [Contributing Guide](https://github.com/wagmi-dev/viem/blob/main/.github/CONTRIBUTING.md#chains), and then open a Pull Request with your chain.
+> Want to add a chain that's not listed in viem? Read the [Contributing Guide](https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md#chains), and then open a Pull Request with your chain.
 
 ## Custom Chains
 

--- a/site/pages/docs/clients/custom.md
+++ b/site/pages/docs/clients/custom.md
@@ -67,7 +67,7 @@ const response = await debugClient.traceCall({
 // { failed: false, gas: 69420, returnValue: '...', structLogs: [] }
 ```
 
-For a more succinct implementation of using `.extend`, check out viem's [Public Client implementation](https://github.com/wagmi-dev/viem/blob/29c053f5069a5b44e3791972c221368a2c71a254/src/clients/createPublicClient.ts#L48-L68) extended with [Public Actions](https://github.com/wagmi-dev/viem/blob/29c053f5069a5b44e3791972c221368a2c71a254/src/clients/decorators/public.ts#L1377-L1425).
+For a more succinct implementation of using `.extend`, check out viem's [Public Client implementation](https://github.com/wevm/viem/blob/29c053f5069a5b44e3791972c221368a2c71a254/src/clients/createPublicClient.ts#L48-L68) extended with [Public Actions](https://github.com/wevm/viem/blob/29c053f5069a5b44e3791972c221368a2c71a254/src/clients/decorators/public.ts#L1377-L1425).
 
 ### Tree-shaking
 

--- a/site/pages/docs/clients/public.md
+++ b/site/pages/docs/clients/public.md
@@ -417,6 +417,6 @@ const publicClient = createPublicClient({
 
 ## Live Example
 
-Check out the usage of `createPublicClient` in the live [Public Client Example](https://stackblitz.com/github/wagmi-dev/viem/tree/main/examples/clients_public-client) below.
+Check out the usage of `createPublicClient` in the live [Public Client Example](https://stackblitz.com/github/wevm/viem/tree/main/examples/clients_public-client) below.
 
-<iframe frameBorder="0" width="100%" height="500px" src="https://stackblitz.com/github/wagmi-dev/viem/tree/main/examples/clients_public-client?embed=1&file=index.ts&hideNavigation=1&hideDevTools=true&terminalHeight=0&ctl=1"></iframe>
+<iframe frameBorder="0" width="100%" height="500px" src="https://stackblitz.com/github/wevm/viem/tree/main/examples/clients_public-client?embed=1&file=index.ts&hideNavigation=1&hideDevTools=true&terminalHeight=0&ctl=1"></iframe>

--- a/site/pages/docs/ethers-migration.mdx
+++ b/site/pages/docs/ethers-migration.mdx
@@ -1,6 +1,6 @@
 # Ethers v5 → viem Migration Guide [Migrate from Ethers v5 to viem]
 
-This is a long document. Feel free to use the search bar above (⌘ K) or the Table of Contents to the side. If there is an API you need which is missing or cannot find, create a [Parity Request here](https://github.com/wagmi-dev/viem/discussions/new?category=feature-request&title=Parity%20Request:).
+This is a long document. Feel free to use the search bar above (⌘ K) or the Table of Contents to the side. If there is an API you need which is missing or cannot find, create a [Parity Request here](https://github.com/wevm/viem/discussions/new?category=feature-request&title=Parity%20Request:).
 
 You may notice some of the APIs in viem are a little more verbose than Ethers. We prefer boring code and we want to strongly embrace [clarity & composability](/docs/introduction#developer-experience). We believe that [verbose APIs are more flexible](https://www.youtube.com/watch?v=4anAwXYqLG8&t=789s) to move, change and remove compared to code that is prematurely abstracted and hard to change.
 

--- a/site/pages/docs/typescript.mdx
+++ b/site/pages/docs/typescript.mdx
@@ -210,7 +210,7 @@ For advanced use-cases, you may want to configure viem's internal types. Most of
 
 ## `window` Polyfill
 
-By importing the `viem/window` Polyfill, the global `window.ethereum` will typed as an [`EIP1193Provider`](https://github.com/wagmi-dev/viem/blob/4bdbf15be0d61b52a195e11c97201e707fb616cc/src/types/eip1193.ts#L24-L26) (including a fully-typed `request` function & typed events).
+By importing the `viem/window` Polyfill, the global `window.ethereum` will typed as an [`EIP1193Provider`](https://github.com/wevm/viem/blob/4bdbf15be0d61b52a195e11c97201e707fb616cc/src/types/eip1193.ts#L24-L26) (including a fully-typed `request` function & typed events).
 
 ```ts twoslash
 // @noErrors

--- a/site/pages/op-stack/guides/deposits.md
+++ b/site/pages/op-stack/guides/deposits.md
@@ -580,4 +580,4 @@ export const publicClientL2 = createPublicClient({
 
 ## Example
 
-<iframe frameBorder="0" width="100%" height="500px" src="https://stackblitz.com/github/wagmi-dev/viem/tree/main/examples/op-stack_deposit?embed=1&file=index.ts&hideNavigation=1&hideDevTools=true&terminalHeight=0&ctl=1"></iframe>
+<iframe frameBorder="0" width="100%" height="500px" src="https://stackblitz.com/github/wevm/viem/tree/main/examples/op-stack_deposit?embed=1&file=index.ts&hideNavigation=1&hideDevTools=true&terminalHeight=0&ctl=1"></iframe>


### PR DESCRIPTION
## Summary
- Updated outdated GitHub links from `wagmi-dev/viem` to `wevm/viem` across documentation and example files
- The repository was moved from wagmi-dev to wevm organization, and these links needed updating

Files updated:
- examples/op-stack_deposit/README.md
- site/pages/op-stack/guides/deposits.md
- site/pages/docs/chains/introduction.md
- site/pages/docs/ethers-migration.mdx
- site/pages/docs/clients/public.md
- site/pages/docs/clients/custom.md
- site/pages/docs/typescript.mdx

## Test plan
- [x] Verified all GitHub links are updated to the correct wevm/viem organization