### PR TITLE
feat: add EIP712Domain type definition to user operation and transaction types

### DIFF
--- a/src/account-abstraction/utils/userOperation/getUserOperationTypedData.test.ts
+++ b/src/account-abstraction/utils/userOperation/getUserOperationTypedData.test.ts
@@ -41,6 +41,24 @@ describe('entryPoint: 0.8', () => {
         },
         "primaryType": "PackedUserOperation",
         "types": {
+          "EIP712Domain": [
+            {
+              "name": "name",
+              "type": "string",
+            },
+            {
+              "name": "version",
+              "type": "string",
+            },
+            {
+              "name": "chainId",
+              "type": "uint256",
+            },
+            {
+              "name": "verifyingContract",
+              "type": "address",
+            },
+          ],
           "PackedUserOperation": [
             {
               "name": "sender",
@@ -134,6 +152,24 @@ describe('entryPoint: 0.8', () => {
         },
         "primaryType": "PackedUserOperation",
         "types": {
+          "EIP712Domain": [
+            {
+              "name": "name",
+              "type": "string",
+            },
+            {
+              "name": "version",
+              "type": "string",
+            },
+            {
+              "name": "chainId",
+              "type": "uint256",
+            },
+            {
+              "name": "verifyingContract",
+              "type": "address",
+            },
+          ],
           "PackedUserOperation": [
             {
               "name": "sender",
@@ -224,6 +260,24 @@ describe('entryPoint: 0.8', () => {
         },
         "primaryType": "PackedUserOperation",
         "types": {
+          "EIP712Domain": [
+            {
+              "name": "name",
+              "type": "string",
+            },
+            {
+              "name": "version",
+              "type": "string",
+            },
+            {
+              "name": "chainId",
+              "type": "uint256",
+            },
+            {
+              "name": "verifyingContract",
+              "type": "address",
+            },
+          ],
           "PackedUserOperation": [
             {
               "name": "sender",

--- a/src/account-abstraction/utils/userOperation/getUserOperationTypedData.ts
+++ b/src/account-abstraction/utils/userOperation/getUserOperationTypedData.ts
@@ -16,6 +16,12 @@ export type GetUserOperationTypedDataReturnType = TypedDataDefinition<
 >
 
 const types = {
+  EIP712Domain: [
+    { type: 'string', name: 'name' },
+    { type: 'string', name: 'version' },
+    { type: 'uint256', name: 'chainId' },
+    { type: 'address', name: 'verifyingContract' },
+  ],
   PackedUserOperation: [
     { type: 'address', name: 'sender' },
     { type: 'uint256', name: 'nonce' },

--- a/src/zksync/utils/getEip712Domain.test.ts
+++ b/src/zksync/utils/getEip712Domain.test.ts
@@ -59,6 +59,24 @@ test('default', () => {
       },
       "primaryType": "Transaction",
       "types": {
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string",
+          },
+          {
+            "name": "version",
+            "type": "string",
+          },
+          {
+            "name": "chainId",
+            "type": "uint256",
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address",
+          },
+        ],
         "Transaction": [
           {
             "name": "txType",

--- a/src/zksync/utils/getEip712Domain.ts
+++ b/src/zksync/utils/getEip712Domain.ts
@@ -26,6 +26,12 @@ export const getEip712Domain: EIP712DomainFn<
       chainId: transaction.chainId,
     },
     types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
       Transaction: [
         { name: 'txType', type: 'uint256' },
         { name: 'from', type: 'uint256' },


### PR DESCRIPTION
Adds the missing EIP712Domain type to EIP-712 typed data definitions to ensure spec compliance and correct domain separator hashing.
https://eips.ethereum.org/EIPS/eip-712