### PR TITLE
fix: update etherscan explorer for MegaETH

### DIFF
--- a/.changeset/hot-hairs-rush.md
+++ b/.changeset/hot-hairs-rush.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Adds etherscan explorer for MegaETH

--- a/src/chains/definitions/megaeth.ts
+++ b/src/chains/definitions/megaeth.ts
@@ -17,9 +17,14 @@ export const megaeth = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'Blockscout',
-      url: 'https://megaeth.blockscout.com',
-      apiUrl: 'https://megaeth.blockscout.com/api',
+      name: 'Etherscan',
+      url: 'https://mega.etherscan.io',
+      apiUrl: 'https://api.etherscan.io/v2/api',
+    },
+    blockscout: {
+      name: 'Etherscan',
+      url: 'https://mega.etherscan.io',
+      apiUrl: 'https://api.etherscan.io/v2/api',
     },
   },
   contracts: {

--- a/src/chains/definitions/megaethTestnet.ts
+++ b/src/chains/definitions/megaethTestnet.ts
@@ -17,8 +17,9 @@ export const megaethTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'MegaETH Testnet Explorer',
-      url: 'https://www.megaexplorer.xyz/',
+      name: 'Etherscan',
+      url: 'https://testnet-mega.etherscan.io',
+      apiUrl: 'https://api.etherscan.io/v2/api',
     },
     blockscout: {
       name: 'Blockscout',


### PR DESCRIPTION
## Summary

Updates default explorer for MegaETH to etherscan.
For when MegaETH was added via this PR #4247, we did not have etherscan instance available for MegaETH then, but now that we do now imo we should update it.

