### PR TITLE
fix: add blockCreated to MegaETH multicall3 contracts

### DIFF
--- a/.changeset/megaeth-multicall3-block-created.md
+++ b/.changeset/megaeth-multicall3-block-created.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `blockCreated` field to MegaETH Mainnet and Testnet multicall3 contract definitions.

--- a/src/chains/definitions/megaeth.ts
+++ b/src/chains/definitions/megaeth.ts
@@ -30,6 +30,7 @@ export const megaeth = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 0,
     },
   },
 })

--- a/src/chains/definitions/megaethTestnet.ts
+++ b/src/chains/definitions/megaethTestnet.ts
@@ -30,6 +30,7 @@ export const megaethTestnet = /*#__PURE__*/ defineChain({
   contracts: {
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 0,
     },
   },
   testnet: true,


### PR DESCRIPTION
## Summary

- Add missing `blockCreated` field to MegaETH Mainnet and Testnet multicall3 contract definitions

## Details

Both MegaETH Mainnet (chain ID 4326) and Testnet (chain ID 6343) have Multicall3 pre-deployed at genesis (block 0). This was verified by querying `eth_getCode` at block 0 on both chains' RPC endpoints.

### Verification

```bash
# Mainnet - contract exists at block 0
curl -s https://mainnet.megaeth.com/rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xcA11bde05977b3631167028862bE2a173976CA11","0x0"],"id":1}'
# Returns full contract bytecode

# Testnet - contract exists at block 0
curl -s https://carrot.megaeth.com/rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xcA11bde05977b3631167028862bE2a173976CA11","0x0"],"id":1}'
# Returns full contract bytecode
```

Follow-up to #4247.