### PR TITLE
feat(chains): update seismic testnet RPC url for chain ID 5124

### DIFF
--- a/src/chains/definitions/seismicDevnet.ts
+++ b/src/chains/definitions/seismicDevnet.ts
@@ -1,19 +1,22 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
-export const seismicDevnet = /*#__PURE__*/ defineChain({
+export const seismicTestnet = /*#__PURE__*/ defineChain({
   id: 5124,
-  name: 'Seismic Devnet',
+  name: 'Seismic Testnet',
   nativeCurrency: { name: 'Seismic Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://node-2.seismicdev.net/rpc'],
+      http: ['https://gcp-2.seismictest.net/rpc'],
+      webSocket: ['wss://gcp-2.seismictest.net/ws']
     },
   },
   blockExplorers: {
     default: {
-      name: 'Seismic Devnet Explorer',
-      url: 'https://explorer-2.seismicdev.net',
+      name: 'Seismic Testnet Explorer',
+      url: 'https://seismic-testnet.socialscan.io',
     },
   },
   testnet: true,
 })
+
+export const seismicDevnet = seismicTestnet


### PR DESCRIPTION
We launched our testnet. In light of this, we deprecated Seismic devnet 2 (node-2.seismicdev.net)

This commit adds the `seismicTestnet` network. To avoid breaking people's imports, we aliased `seismicDevnet` to this new Seismic testnet

The chain ID is the same (5124) as before, and the RPC paths are the same: /rpc (https) and /ws (wss)