### PR TITLE
fix: incorrect documentation for `sendTransactionSync` return type

### DIFF
--- a/site/pages/docs/actions/wallet/sendTransactionSync.md
+++ b/site/pages/docs/actions/wallet/sendTransactionSync.md
@@ -83,9 +83,9 @@ export const walletClient = createWalletClient({
 
 ## Returns
 
-[`Hash`](/docs/glossary/types#hash)
+[`TransactionReceipt`](/docs/glossary/types#transaction-receipt)
 
-The [Transaction](/docs/glossary/terms#transaction) hash.
+The [Transaction receipt](/docs/glossary/terms#transaction-receipt).
 
 ## Parameters
 


### PR DESCRIPTION
This updates the documentation for the return type of  [`sendTransactionSync`](https://viem.sh/docs/actions/wallet/sendTransactionSync#returns). It should be `TransactionReceipt`.

