### PR TITLE
fix: replace deprecated Polygon RPC URL

### DIFF
--- a/.changeset/fix-polygon-rpc-url.md
+++ b/.changeset/fix-polygon-rpc-url.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Polygon chain default RPC URL.

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -7,7 +7,7 @@ export const polygon = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'POL', symbol: 'POL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://polygon-rpc.com'],
+      http: ['https://polygon.drpc.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
The default Polygon RPC URL (`polygon-rpc.com`, powered by Ankr) has deprecated public access as of Feb 16, 2026 and is no longer functional.

<img width="1727" height="931" alt="image" src="https://github.com/user-attachments/assets/fbde79d0-16e9-4cf3-b110-e65b6c84db01" />

This PR replaces it with `polygon.drpc.org` ([dRPC](https://drpc.org)), which is listed as the first option in official docs - https://docs.polygon.technology/pos/reference/rpc-endpoints/#infrastructure-providers.
