### PR TITLE
docs: remove incorrect import from toWebAuthnAccount rpId example

### DIFF
--- a/site/pages/account-abstraction/accounts/webauthn/toWebAuthnAccount.md
+++ b/site/pages/account-abstraction/accounts/webauthn/toWebAuthnAccount.md
@@ -93,8 +93,6 @@ Relying Party ID.
 // @noErrors
 import { createWebAuthnCredential, toWebAuthnAccount } from 'viem/account-abstraction'
 // ---cut---
-import * as passkey from 'react-native-passkeys' // [!code focus]
-
 const credential = await createWebAuthnCredential({
   name: 'Example',
 })


### PR DESCRIPTION
The `rpId` parameter example in `toWebAuthnAccount` includes an unused `import * as passkey from 'react-native-passkeys'` line that was copy-pasted from the `getFn` example above it. The `passkey` import is not referenced anywhere in the `rpId` example and the `[!code focus]` highlight draws attention to it incorrectly.

This PR removes the stray import line.