### PR TITLE
Update Polygon RPC URL to new endpoint

### DIFF
--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -7,7 +7,7 @@ export const polygon = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'POL', symbol: 'POL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://polygon-rpc.com'],
+      http: ['https://polygon.drpc.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
As per the website banner on [polygon-rpc.com](https://polygon-rpc.com/):

> Action Required! This free RPC endpoint will stop working on Feb 16, 2026. Find a new RPC provider here → https://docs.polygon.technology/pos/reference/rpc-endpoints/#infrastructure-providers

Suggesting an update to `https://polygon.drpc.org` as the main endpoint referenced by [docs.polygon.technology](https://docs.polygon.technology/pos/reference/rpc-endpoints/#mainnet)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

