### PR TITLE
fix(tempo): pass chainId in keyAuthorization instead of wildcard

### DIFF
--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -46,7 +46,10 @@ export type RootAccount = Account_base<'root'> & {
   /** Sign key authorization. */
   signKeyAuthorization: (
     key: Pick<AccessKeyAccount, 'accessKeyAddress' | 'keyType'>,
-    parameters?: Pick<KeyAuthorization.KeyAuthorization, 'expiry' | 'limits'>,
+    parameters?: Pick<
+      KeyAuthorization.KeyAuthorization,
+      'chainId' | 'expiry' | 'limits'
+    >,
   ) => Promise<KeyAuthorization.Signed>
 }
 
@@ -374,12 +377,13 @@ export async function signKeyAuthorization(
   account: LocalAccount,
   parameters: signKeyAuthorization.Parameters,
 ): Promise<signKeyAuthorization.ReturnValue> {
-  const { key, expiry, limits } = parameters
+  const { key, chainId, expiry, limits } = parameters
   const { accessKeyAddress, keyType: type } = key
 
   const signature = await account.sign!({
     hash: KeyAuthorization.getSignPayload({
       address: accessKeyAddress,
+      chainId,
       expiry,
       limits,
       type,
@@ -387,6 +391,7 @@ export async function signKeyAuthorization(
   })
   return KeyAuthorization.from({
     address: accessKeyAddress,
+    chainId,
     expiry,
     limits,
     signature: SignatureEnvelope.from(signature),
@@ -397,7 +402,7 @@ export async function signKeyAuthorization(
 export declare namespace signKeyAuthorization {
   type Parameters = Pick<
     KeyAuthorization.KeyAuthorization,
-    'expiry' | 'limits'
+    'chainId' | 'expiry' | 'limits'
   > & {
     key: Pick<AccessKeyAccount, 'accessKeyAddress' | 'keyType'>
   }
@@ -508,12 +513,13 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
     ...account,
     source: 'root',
     async signKeyAuthorization(key, parameters = {}) {
-      const { expiry, limits } = parameters
+      const { chainId, expiry, limits } = parameters
       const { accessKeyAddress, keyType: type } = key
 
       const signature = await account.sign({
         hash: KeyAuthorization.getSignPayload({
           address: accessKeyAddress,
+          chainId,
           expiry,
           limits,
           type,
@@ -521,6 +527,7 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
       })
       const keyAuthorization = KeyAuthorization.from({
         address: accessKeyAddress,
+        chainId,
         expiry,
         limits,
         signature: SignatureEnvelope.from(signature),

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -396,7 +396,9 @@ describe('sendTransaction', () => {
       access: account,
     })
 
-    const keyAuthorization = await account.signKeyAuthorization(accessKey)
+    const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+      chainId: BigInt(chain.id),
+    })
 
     {
       const receipt = await sendTransactionSync(client, {
@@ -660,7 +662,9 @@ describe('sendTransaction', () => {
         access: account,
       })
 
-      const keyAuthorization = await account.signKeyAuthorization(accessKey)
+      const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+        chainId: BigInt(chain.id),
+      })
 
       {
         const receipt = await sendTransactionSync(client, {
@@ -689,7 +693,9 @@ describe('sendTransaction', () => {
       })
       const feePayer = accounts[0]
 
-      const keyAuthorization = await account.signKeyAuthorization(accessKey)
+      const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+        chainId: BigInt(chain.id),
+      })
 
       {
         const receipt = await sendTransactionSync(client, {
@@ -889,7 +895,9 @@ describe('sendTransaction', () => {
 
       await setupFeeToken(client, { account })
 
-      const keyAuthorization = await account.signKeyAuthorization(accessKey)
+      const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+        chainId: BigInt(chain.id),
+      })
 
       {
         const receipt = await sendTransactionSync(client, {
@@ -1161,7 +1169,9 @@ describe('sendTransaction', () => {
 
       await setupFeeToken(client, { account })
 
-      const keyAuthorization = await account.signKeyAuthorization(accessKey)
+      const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+        chainId: BigInt(chain.id),
+      })
 
       {
         const receipt = await sendTransactionSync(client, {
@@ -1748,7 +1758,9 @@ describe('relay', () => {
         },
       )
 
-      const keyAuthorization = await account.signKeyAuthorization(accessKey)
+      const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+        chainId: BigInt(chain.id),
+      })
 
       await setupFeeToken(client, { account })
 


### PR DESCRIPTION
## Summary
Pass actual `chainId` in key authorization signing instead of wildcard (`0`), which is no longer supported by Tempo nodes.

## Motivation
Tempo nodes now reject `chainId: 0` (wildcard) in key authorizations with:
```
KeyAuthorization chain_id mismatch: expected 31318, got 0
```

This broke the `sendTransaction > behavior: with access key` e2e test.

## Changes
- `Account.ts`: Add `chainId` to `signKeyAuthorization` parameters, pass through to `KeyAuthorization.getSignPayload()` and `KeyAuthorization.from()`
- `actions/accessKey.ts`: Auto-derive `chainId` from `client.chain.id` in `authorize`, throw if unavailable. Add `chainId` to `signAuthorization` params.
- `e2e.test.ts`: Pass `chainId: BigInt(chain.id)` in all `signKeyAuthorization` calls

## Testing
- `tsc --noEmit` passes cleanly
- e2e tests require a running Tempo devnet (CI validates)

Prompted by: tanishk