### PR TITLE
fix: cache `supportsFillTransaction` for InvalidRequestRpcError (-32600)

### DIFF
--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -417,6 +417,7 @@ export async function prepareTransactionRequest<
           const unsupported = error.walk?.((e) => {
             const error = e as BaseError
             return (
+              error.name === 'InvalidRequestRpcError' ||
               error.name === 'MethodNotFoundRpcError' ||
               error.name === 'MethodNotSupportedRpcError'
             )


### PR DESCRIPTION
Alchemy returns -32600 (InvalidRequest) instead of -32601 (MethodNotFound) or -32004 (MethodNotSupported) when `eth_fillTransaction` is unsupported.

Without recognizing this error code, viem never caches the failure, causing every write call to re-attempt `eth_fillTransaction` and return unfilled requests.