### PR TITLE
feat(tempo): export TempoAddress

### DIFF
--- a/.changeset/smooth-rooms-laugh.md
+++ b/.changeset/smooth-rooms-laugh.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**`viem/tempo`:** Exported `TempoAddress` from `ox/tempo`.

--- a/site/pages/tempo/utilities/TempoAddress.format.mdx
+++ b/site/pages/tempo/utilities/TempoAddress.format.mdx
@@ -1,0 +1,44 @@
+# `TempoAddress.format`
+
+Formats a raw Ethereum address (and optional zone ID) into a Tempo address string.
+
+## Usage
+
+```ts twoslash
+import { TempoAddress } from 'viem/tempo'
+
+const address = TempoAddress.format('0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28')
+// @log: 'tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0'
+```
+
+### Zone Address
+
+```ts twoslash
+import { TempoAddress } from 'viem/tempo'
+
+const address = TempoAddress.format(
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
+  { zoneId: 1 },
+)
+// @log: 'tempoz1qqqhgtf4e3nrfszn9yj68wzyhj08t90jh55q74d9uj'
+```
+
+## Parameters
+
+### address
+
+- **Type:** `Address`
+
+The raw 20-byte Ethereum address.
+
+### options.zoneId (optional)
+
+- **Type:** `number | bigint`
+
+Zone ID for zone addresses.
+
+## Return Type
+
+`TempoAddress`
+
+The encoded Tempo address string.

--- a/site/pages/tempo/utilities/TempoAddress.parse.mdx
+++ b/site/pages/tempo/utilities/TempoAddress.parse.mdx
@@ -1,0 +1,44 @@
+# `TempoAddress.parse`
+
+Parses a Tempo address string into a raw Ethereum address and optional zone ID.
+
+## Usage
+
+### Mainnet Address
+
+```ts twoslash
+import { TempoAddress } from 'viem/tempo'
+
+const result = TempoAddress.parse(
+  'tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0',
+)
+// @log: { address: '0x742d35CC6634c0532925a3B844bc9e7595F2Bd28', zoneId: undefined }
+```
+
+### Zone Address
+
+```ts twoslash
+import { TempoAddress } from 'viem/tempo'
+
+const result = TempoAddress.parse(
+  'tempoz1qqqhgtf4e3nrfszn9yj68wzyhj08t90jh55q74d9uj',
+)
+// @log: { address: '0x742d35CC6634c0532925a3B844bc9e7595F2Bd28', zoneId: 1 }
+```
+
+## Parameters
+
+### tempoAddress
+
+- **Type:** `string`
+
+The Tempo address string to parse.
+
+## Return Type
+
+```ts
+{
+  address: Address
+  zoneId: number | bigint | undefined
+}
+```

--- a/site/pages/tempo/utilities/TempoAddress.validate.mdx
+++ b/site/pages/tempo/utilities/TempoAddress.validate.mdx
@@ -1,0 +1,28 @@
+# `TempoAddress.validate`
+
+Validates a Tempo address string.
+
+## Usage
+
+```ts twoslash
+import { TempoAddress } from 'viem/tempo'
+
+const valid = TempoAddress.validate(
+  'tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0',
+)
+// @log: true
+```
+
+## Parameters
+
+### tempoAddress
+
+- **Type:** `string`
+
+The Tempo address string to validate.
+
+## Return Type
+
+`boolean`
+
+Whether the address is valid.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -2288,6 +2288,29 @@ export const sidebar = {
           },
         ],
       },
+      {
+        text: 'Utilities',
+        items: [
+          {
+            text: 'TempoAddress',
+            collapsed: true,
+            items: [
+              {
+                text: 'format',
+                link: '/tempo/utilities/TempoAddress.format',
+              },
+              {
+                text: 'parse',
+                link: '/tempo/utilities/TempoAddress.parse',
+              },
+              {
+                text: 'validate',
+                link: '/tempo/utilities/TempoAddress.validate',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   '/zksync': {

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -10,7 +10,7 @@ export type {
   TxEnvelopeTempo as z_TxEnvelopeTempo,
 } from 'ox/tempo'
 // biome-ignore lint/performance/noBarrelFile: _
-export { Tick, TokenId } from 'ox/tempo'
+export { TempoAddress, Tick, TokenId } from 'ox/tempo'
 export * as Abis from './Abis.js'
 export * as Account from './Account.js'
 export * as Addresses from './Addresses.js'


### PR DESCRIPTION
Exports `TempoAddress` from `ox/tempo` in `viem/tempo` and adds docs for its utilities (`format`, `parse`, `validate`).