### PR TITLE
fix: correct XLayer testnet chain ID and mainnet RPC URL

### DIFF
--- a/src/chains/definitions/xLayer.ts
+++ b/src/chains/definitions/xLayer.ts
@@ -9,7 +9,7 @@ export const xLayer = /*#__PURE__*/ defineChain({
     symbol: 'OKB',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.xlayer.tech'] },
+    default: { http: ['https://xlayerrpc.okx.com'] },
   },
   blockExplorers: {
     default: {

--- a/src/chains/definitions/xLayerTestnet.ts
+++ b/src/chains/definitions/xLayerTestnet.ts
@@ -1,7 +1,7 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const xLayerTestnet = /*#__PURE__*/ defineChain({
-  id: 195,
+  id: 1952,
   name: 'X1 Testnet',
   nativeCurrency: {
     decimals: 18,


### PR DESCRIPTION
This pull request updates the configuration for the XLayer chains, focusing on correcting the chain ID for the testnet and updating the mainnet RPC URL. These changes ensure proper connectivity and identification of the networks.

Network configuration updates:

* Changed the chain ID for `xLayerTestnet` in `src/chains/definitions/xLayerTestnet.ts` from `195` to `1952` to match the correct testnet identifier.
* Updated the default RPC URL for `xLayer` in `src/chains/definitions/xLayer.ts` from `https://rpc.xlayer.tech` to `https://xlayerrpc.okx.com` for improved reliability and accuracy.
