### PR TITLE
fix(errors): preserve original provider cause in getContractError

### DIFF
--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -176,16 +176,18 @@ export class ContractFunctionRevertedError extends BaseError {
 
   constructor({
     abi,
+    cause,
     data,
     functionName,
     message,
   }: {
     abi: Abi
+    cause?: Error | undefined
     data?: Hex | undefined
     functionName: string
     message?: string | undefined
   }) {
-    let cause: Error | undefined
+    let cause_ = cause
     let decodedData: DecodeErrorResultReturnType | undefined
     let metaMessages: string[] | undefined
     let reason: string | undefined
@@ -222,13 +224,13 @@ export class ContractFunctionRevertedError extends BaseError {
           ]
         }
       } catch (err) {
-        cause = err as Error
+        cause_ = err as Error
       }
     } else if (message) reason = message
 
     let signature: Hex | undefined
-    if (cause instanceof AbiErrorSignatureNotFoundError) {
-      signature = cause.signature
+    if (cause_ instanceof AbiErrorSignatureNotFoundError) {
+      signature = cause_.signature
       metaMessages = [
         `Unable to decode signature "${signature}" as it was not found on the provided ABI.`,
         'Make sure you are using the correct ABI and that the error exists on it.',
@@ -246,7 +248,7 @@ export class ContractFunctionRevertedError extends BaseError {
           ].join('\n')
         : `The contract function "${functionName}" reverted.`,
       {
-        cause,
+        cause: cause_,
         metaMessages,
         name: 'ContractFunctionRevertedError',
       },

--- a/src/utils/errors/getContractError.test.ts
+++ b/src/utils/errors/getContractError.test.ts
@@ -250,6 +250,28 @@ describe('getContractError', () => {
     `)
   })
 
+  test('preserves provider error as nested cause', () => {
+    const providerError = new Error('Execution error in custom provider') as Error & {
+      code: number
+      data: string
+      name: string
+    }
+    providerError.name = 'CustomProviderExecutionError'
+    providerError.code = 3
+    providerError.data =
+      '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000087265766572746564000000000000000000000000000000000000000000000000'
+
+    const error = getContractError(new BaseError('An RPC error occurred', { cause: providerError }), {
+      abi: baycContractConfig.abi,
+      functionName: 'mintApe',
+      args: [1n],
+      sender: accounts[0].address,
+    })
+
+    expect(error.cause.name).toBe('ContractFunctionRevertedError')
+    expect(error.cause.cause?.name).toBe('CustomProviderExecutionError')
+  })
+
   test('unknown function', () => {
     const error = getContractError(
       new BaseError('An RPC error occurred', {

--- a/src/utils/errors/getContractError.ts
+++ b/src/utils/errors/getContractError.ts
@@ -67,6 +67,7 @@ export function getContractError<err extends ErrorType<string>>(
     ) {
       return new ContractFunctionRevertedError({
         abi,
+        cause: error,
         data: typeof data === 'object' ? data.data : data,
         functionName,
         message:


### PR DESCRIPTION
Fixes #4387

## Summary
When a custom provider throws an execution error (e.g. `{ code: 3, data, name: 'CustomProviderExecutionError' }`), `getContractError` currently wraps it into `ContractFunctionRevertedError` but can lose the original nested cause.

This PR preserves that cause chain:
- `getContractError` now passes the discovered low-level error as `cause` into `ContractFunctionRevertedError`.
- `ContractFunctionRevertedError` now accepts an optional `cause` parameter and keeps it unless replaced by ABI decode failures.
- Added a regression test asserting `error.cause.cause?.name === 'CustomProviderExecutionError'`.

## Notes
I couldn't fully run local repo checks in this environment because `viem` currently requires Node >= 24.5 and this runner is Node 22. CI should validate on the project's standard toolchain.