### PR TITLE
fix: Replace extraData decoding with l2SequenceNumber() call in getGames

### DIFF
--- a/.changeset/warm-games-prove.md
+++ b/.changeset/warm-games-prove.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaced manual `extraData` decoding with `l2SequenceNumber()` contract call in `getGames`.

--- a/src/op-stack/abis.ts
+++ b/src/op-stack/abis.ts
@@ -464,6 +464,22 @@ export const l2ToL1MessagePasserAbi = [
   { stateMutability: 'payable', type: 'receive' },
 ] as const
 
+export const disputeGameAbi = [
+  {
+    type: 'function',
+    name: 'l2SequenceNumber',
+    inputs: [],
+    outputs: [
+      {
+        name: 'l2SequenceNumber_',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
+  },
+] as const
+
 export const disputeGameFactoryAbi = [
   {
     type: 'constructor',

--- a/src/op-stack/actions/getGames.ts
+++ b/src/op-stack/actions/getGames.ts
@@ -1,3 +1,8 @@
+import type { Address } from 'abitype'
+import {
+  type MulticallErrorType,
+  multicall,
+} from '../../actions/public/multicall.js'
 import {
   type ReadContractErrorType,
   readContract,
@@ -11,8 +16,7 @@ import type {
   DeriveChain,
   GetChainParameter,
 } from '../../types/chain.js'
-import { decodeAbiParameters } from '../../utils/abi/decodeAbiParameters.js'
-import { disputeGameFactoryAbi, portal2Abi } from '../abis.js'
+import { disputeGameAbi, disputeGameFactoryAbi, portal2Abi } from '../abis.js'
 import type { GetContractAddressParameter } from '../types/contract.js'
 import type { Game } from '../types/withdrawal.js'
 
@@ -38,7 +42,10 @@ export type GetGamesParameters<
 export type GetGamesReturnType = (Game & {
   l2BlockNumber: bigint
 })[]
-export type GetGamesErrorType = ReadContractErrorType | ErrorType
+export type GetGamesErrorType =
+  | ReadContractErrorType
+  | MulticallErrorType
+  | ErrorType
 
 /**
  * Retrieves dispute games for an L2.
@@ -106,23 +113,29 @@ export async function getGames<
     }),
   ])
 
-  const games = (
-    (await readContract(client, {
-      abi: disputeGameFactoryAbi,
-      functionName: 'findLatestGames',
-      address: disputeGameFactoryAddress,
-      args: [
-        gameType,
-        BigInt(Math.max(0, Number(gameCount - 1n))),
-        BigInt(Math.min(limit, Number(gameCount))),
-      ],
-    })) as Game[]
-  )
-    .map((game) => {
-      const [blockNumber] = decodeAbiParameters(
-        [{ type: 'uint256' }],
-        game.extraData,
-      )
+  const rawGames = (await readContract(client, {
+    abi: disputeGameFactoryAbi,
+    functionName: 'findLatestGames',
+    address: disputeGameFactoryAddress,
+    args: [
+      gameType,
+      BigInt(Math.max(0, Number(gameCount - 1n))),
+      BigInt(Math.min(limit, Number(gameCount))),
+    ],
+  })) as Game[]
+
+  const l2SequenceNumbers = await multicall(client, {
+    allowFailure: false,
+    contracts: rawGames.map((game) => ({
+      abi: disputeGameAbi,
+      address: `0x${game.metadata.slice(26)}` as Address,
+      functionName: 'l2SequenceNumber' as const,
+    })),
+  })
+
+  const games = rawGames
+    .map((game, i) => {
+      const blockNumber = l2SequenceNumbers[i] as bigint
       return !l2BlockNumber || blockNumber > l2BlockNumber
         ? { ...game, l2BlockNumber: blockNumber }
         : null


### PR DESCRIPTION
Resolves https://github.com/wevm/viem/discussions/3794

**Summary**

- Replace manual decodeAbiParameters on game.extraData with an l2SequenceNumber() contract call on each game proxy
- Extract proxy addresses from the metadata (GameId) field and use multicall to batch the calls efficiently
- Add disputeGameAbi with the l2SequenceNumber function signature

**Test plan**

- Existing getGames tests pass
- Existing getGame tests pass (downstream consumer)
- TypeScript type check passes