### PR TITLE
fix: accept readonly arrays in LogTopic type

### DIFF
--- a/.changeset/readonly-log-topic.md
+++ b/.changeset/readonly-log-topic.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `LogTopic` type to accept readonly arrays.

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -215,10 +215,10 @@ test('GetEventArgs', () => {
     'Transfer'
   >
   expectTypeOf<Result['from']>().toEqualTypeOf<
-    `0x${string}` | `0x${string}`[] | null | undefined
+    `0x${string}` | readonly `0x${string}`[] | null | undefined
   >()
   expectTypeOf<Result['to']>().toEqualTypeOf<
-    `0x${string}` | `0x${string}`[] | null | undefined
+    `0x${string}` | readonly `0x${string}`[] | null | undefined
   >()
 })
 
@@ -260,7 +260,7 @@ test('GetValue', () => {
 
 test('LogTopicType', () => {
   expectTypeOf<LogTopicType<string, Hex>>().toEqualTypeOf<string>()
-  expectTypeOf<LogTopicType<string, Hex[]>>().toEqualTypeOf<string[]>()
+  expectTypeOf<LogTopicType<string, Hex[]>>().toEqualTypeOf<readonly string[]>()
   expectTypeOf<LogTopicType<string, null>>().toEqualTypeOf<null>()
 
   expectTypeOf<LogTopicType<string, Hex | null>>().toEqualTypeOf<
@@ -271,7 +271,7 @@ test('LogTopicType', () => {
 test('AbiEventParameterToPrimitiveType', () => {
   expectTypeOf<
     AbiEventParameterToPrimitiveType<{ name: 'foo'; type: 'string' }>
-  >().toEqualTypeOf<string | string[] | null>()
+  >().toEqualTypeOf<string | readonly string[] | null>()
   expectTypeOf<
     AbiEventParameterToPrimitiveType<
       { name: 'foo'; type: 'string' },
@@ -286,7 +286,7 @@ test('AbiEventTopicToPrimitiveType', () => {
   >().toEqualTypeOf<`0x${string}`>()
   expectTypeOf<
     AbiEventTopicToPrimitiveType<{ name: 'foo'; type: 'string' }, Hex[]>
-  >().toEqualTypeOf<`0x${string}`[][]>() // TODO: Is this correct?
+  >().toEqualTypeOf<readonly `0x${string}`[][]>() // TODO: Is this correct?
   expectTypeOf<
     AbiEventTopicToPrimitiveType<{ name: 'foo'; type: 'string' }, null>
   >().toEqualTypeOf<null>()
@@ -300,7 +300,7 @@ test('AbiEventTopicToPrimitiveType', () => {
   >().toEqualTypeOf<boolean>()
   expectTypeOf<
     AbiEventTopicToPrimitiveType<{ name: 'foo'; type: 'bool' }, Hex[]>
-  >().toEqualTypeOf<boolean[]>()
+  >().toEqualTypeOf<readonly boolean[]>()
 })
 
 test('AbiEventParametersToPrimitiveTypes', () => {
@@ -310,7 +310,7 @@ test('AbiEventParametersToPrimitiveTypes', () => {
       [{ name: 'foo'; type: 'string'; indexed: true }]
     >
   >().toEqualTypeOf<{
-    foo?: string | string[] | null | undefined
+    foo?: string | readonly string[] | null | undefined
   }>()
   expectTypeOf<
     AbiEventParametersToPrimitiveTypes<
@@ -321,8 +321,8 @@ test('AbiEventParametersToPrimitiveTypes', () => {
       ]
     >
   >().toEqualTypeOf<{
-    foo?: string | string[] | null | undefined
-    bar?: number | number[] | null | undefined
+    foo?: string | readonly string[] | null | undefined
+    bar?: number | readonly number[] | null | undefined
   }>()
 
   type Named_AllowNonIndexed = AbiEventParametersToPrimitiveTypes<
@@ -338,9 +338,9 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     }
   >
   expectTypeOf<Named_AllowNonIndexed>().toEqualTypeOf<{
-    foo?: string | string[] | null | undefined
-    bar?: number | number[] | null | undefined
-    baz?: `0x${string}` | `0x${string}`[] | null | undefined
+    foo?: string | readonly string[] | null | undefined
+    bar?: number | readonly number[] | null | undefined
+    baz?: `0x${string}` | readonly `0x${string}`[] | null | undefined
   }>()
   type Named_DisableUnion = AbiEventParametersToPrimitiveTypes<
     [
@@ -373,8 +373,8 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     >
   >().toEqualTypeOf<
     | readonly []
-    | readonly [string | string[] | null]
-    | readonly [string | string[] | null, number | number[] | null]
+    | readonly [string | readonly string[] | null]
+    | readonly [string | readonly string[] | null, number | readonly number[] | null]
   >()
 
   type Unnamed_AllowNonIndexed = AbiEventParametersToPrimitiveTypes<
@@ -391,12 +391,12 @@ test('AbiEventParametersToPrimitiveTypes', () => {
   >
   expectTypeOf<Unnamed_AllowNonIndexed>().toEqualTypeOf<
     | readonly []
-    | readonly [string | string[] | null]
-    | readonly [string | string[] | null, number | number[] | null]
+    | readonly [string | readonly string[] | null]
+    | readonly [string | readonly string[] | null, number | readonly number[] | null]
     | readonly [
-        string | string[] | null,
-        number | number[] | null,
-        `0x${string}` | `0x${string}`[] | null,
+        string | readonly string[] | null,
+        number | readonly number[] | null,
+        `0x${string}` | readonly `0x${string}`[] | null,
       ]
   >()
 
@@ -426,7 +426,7 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     >
   >().toEqualTypeOf<
     | readonly []
-    | readonly [string | string[] | null]
-    | readonly [string | string[] | null, number | number[] | null]
+    | readonly [string | readonly string[] | null]
+    | readonly [string | readonly string[] | null, number | readonly number[] | null]
   >()
 })

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -466,8 +466,8 @@ export type LogTopicType<
   topic extends LogTopic = LogTopic,
 > = topic extends Hex
   ? primitiveType
-  : topic extends Hex[]
-    ? primitiveType[]
+  : topic extends readonly Hex[]
+    ? readonly primitiveType[]
     : topic extends null
       ? null
       : never

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -3,7 +3,7 @@ import type { OneOf } from './utils.js'
 export type ByteArray = Uint8Array
 export type Hex = `0x${string}`
 export type Hash = `0x${string}`
-export type LogTopic = Hex | Hex[] | null
+export type LogTopic = Hex | readonly Hex[] | null
 export type SignableMessage =
   | string
   | {


### PR DESCRIPTION
## Summary

`LogTopic` is changed from `Hex | Hex[] | null` to `Hex | readonly Hex[] | null`. Since `readonly T[]` is a supertype of `T[]`, this accepts both mutable and readonly arrays.

`LogTopicType` conditional is updated correspondingly: it now matches `readonly Hex[]` (which includes `Hex[]`) and produces `readonly primitiveType[]`.

## Motivation

TypeScript's `readonly T[]` is not assignable to `T[]`. Users who define topic arrays with `as const` or receive them from functions returning readonly arrays get type errors when passing them to `getLogs`, `createEventFilter`, `watchEvent`, etc.

Log topic filters are read-only by nature — they're passed to JSON-RPC calls and never mutated — so accepting readonly arrays is both correct and expected.

This is a non-breaking change: all existing mutable-array code continues to work since `T[]` is assignable to `readonly T[]`.

## Related discussions

- #2671 — readonly values friction with viem APIs
- #1480 — readonly tuple assignability errors with hex values
- #163 — log `topics` type narrowing
- #3549 — excessive type inference hurting ecosystem

## Test plan

- [x] All 51 type test files pass (343 tests, no type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)