### PR TITLE
fix: proper offset to increase entropy in uid generation

### DIFF
--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -10,5 +10,5 @@ export function uid(length = 11) {
       buffer += ((256 + Math.random() * 256) | 0).toString(16).substring(1)
     }
   }
-  return buffer.substring(index, index++ + length)
+  return buffer.substring(index, (index += length))
 }


### PR DESCRIPTION
Simple fix to increase entropy (avoid sharing characters) when generating UIDs -- I think this is what was originally intended.

