### PR TITLE
feat: add multicall3 contract to hyperEvm chain

### DIFF
--- a/.changeset/add-multicall3-hyperevm.md
+++ b/.changeset/add-multicall3-hyperevm.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `multicall3` contract address to `hyperEvm` chain definition. Multicall3 is deployed at the canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` on HyperEVM (verified on hyperevmscan.io), enabling wagmi's automatic read batching for HyperEVM users.

--- a/src/chains/definitions/hyperEvm.ts
+++ b/src/chains/definitions/hyperEvm.ts
@@ -15,5 +15,10 @@ export const hyperEvm = /*#__PURE__*/ defineChain({
       http: ['https://rpc.hyperliquid.xyz/evm'],
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    },
+  },
   testnet: false,
 })


### PR DESCRIPTION
Multicall3 is deployed at the canonical address \`0xcA11bde05977b3631167028862bE2a173976CA11\` on HyperEVM ([verified on hyperevmscan](https://hyperevmscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11#code)). Without this entry, wagmi's automatic multicall batching silently no-ops for all HyperEVM users, causing N separate \`eth_call\` RPCs instead of one \`aggregate3\`.