### PR TITLE
fix(abi): handle anonymous events in encodeEventTopics

### DIFF
--- a/src/utils/abi/encodeEventTopics.test-d.ts
+++ b/src/utils/abi/encodeEventTopics.test-d.ts
@@ -2,6 +2,7 @@ import type { Abi } from 'abitype'
 import { expectTypeOf, test } from 'vitest'
 
 import { seaportContractConfig } from '~test/abis.js'
+import type { Hex } from '../../types/misc.js'
 import {
   type EncodeEventTopicsParameters,
   encodeEventTopics,
@@ -173,4 +174,34 @@ test('abi has no errors', () => {
       },
     ],
   })
+})
+
+test('return type: anonymous event', () => {
+  const result = encodeEventTopics({
+    abi: [
+      {
+        anonymous: true,
+        inputs: [{ indexed: true, name: 'topic0', type: 'bytes32' }],
+        name: 'RawEvent',
+        type: 'event',
+      },
+    ] as const,
+  })
+
+  expectTypeOf(result).toEqualTypeOf<(Hex | Hex[] | null)[]>()
+})
+
+test('return type: non-anonymous event', () => {
+  const result = encodeEventTopics({
+    abi: [
+      {
+        anonymous: false,
+        inputs: [{ indexed: true, name: 'topic0', type: 'bytes32' }],
+        name: 'RawEvent',
+        type: 'event',
+      },
+    ] as const,
+  })
+
+  expectTypeOf(result).toEqualTypeOf<[Hex, ...(Hex | Hex[] | null)[]]>()
 })

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -312,6 +312,90 @@ test('Foo(string)', () => {
   ])
 })
 
+test('anonymous event: no args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [
+            { indexed: true, name: 'topic0', type: 'bytes32' },
+            { indexed: true, name: 'topic1', type: 'bytes32' },
+            { indexed: true, name: 'topic2', type: 'bytes32' },
+            { indexed: true, name: 'topic3', type: 'bytes32' },
+          ],
+          name: 'RawEvent',
+          type: 'event',
+        },
+      ],
+    }),
+  ).toEqual([])
+})
+
+test('anonymous event: partial args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [
+            { indexed: true, name: 'topic0', type: 'bytes32' },
+            { indexed: true, name: 'topic1', type: 'bytes32' },
+            { indexed: true, name: 'topic2', type: 'bytes32' },
+            { indexed: true, name: 'topic3', type: 'bytes32' },
+          ],
+          name: 'RawEvent',
+          type: 'event',
+        },
+      ],
+      args: {
+        topic0:
+          '0x000000000000000000000000000000000000000000000000000000000000abcd',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    null,
+    null,
+    null,
+  ])
+})
+
+test('anonymous event: all args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [
+            { indexed: true, name: 'topic0', type: 'bytes32' },
+            { indexed: true, name: 'topic1', type: 'bytes32' },
+            { indexed: true, name: 'topic2', type: 'bytes32' },
+            { indexed: true, name: 'topic3', type: 'bytes32' },
+          ],
+          name: 'RawEvent',
+          type: 'event',
+        },
+      ],
+      args: {
+        topic0:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        topic1:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        topic2:
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        topic3:
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+      },
+    }),
+  ).toEqual([
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+  ])
+})
+
 test('Foo((uint,string))', () => {
   expect(() =>
     encodeEventTopics({

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -2,6 +2,7 @@ import type {
   Abi,
   AbiParameter,
   AbiParameterToPrimitiveType,
+  ExtractAbiEvent,
   ExtractAbiEvents,
 } from 'abitype'
 
@@ -66,7 +67,26 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+type EncodeEventTopic = Hex | Hex[] | null
+type EncodeEventTopicsArray = EncodeEventTopic[]
+type NonAnonymousEncodeEventTopicsReturnType = [Hex, ...EncodeEventTopicsArray]
+
+type EncodeEventTopicsAbiEvent<
+  abi extends Abi | readonly unknown[],
+  eventName extends ContractEventName<abi> | undefined,
+> = ExtractAbiEvent<
+  abi extends Abi ? abi : Abi,
+  eventName extends ContractEventName<abi> ? eventName : ContractEventName<abi>
+>
+
+export type EncodeEventTopicsReturnType<
+  abi extends Abi | readonly unknown[] = Abi,
+  eventName extends ContractEventName<abi> | undefined = ContractEventName<abi>,
+> = EncodeEventTopicsAbiEvent<abi, eventName> extends infer abiEvent
+  ? abiEvent extends { anonymous: true }
+    ? EncodeEventTopicsArray
+    : NonAnonymousEncodeEventTopicsReturnType
+  : NonAnonymousEncodeEventTopicsReturnType
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -81,7 +101,7 @@ export function encodeEventTopics<
   eventName extends ContractEventName<abi> | undefined = undefined,
 >(
   parameters: EncodeEventTopicsParameters<abi, eventName>,
-): EncodeEventTopicsReturnType {
+): EncodeEventTopicsReturnType<abi, eventName> {
   const { abi, eventName, args } = parameters as EncodeEventTopicsParameters
 
   let abiItem = abi[0]
@@ -94,10 +114,7 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
-
-  let topics: (Hex | Hex[] | null)[] = []
+  let topics: EncodeEventTopicsArray = []
   if (args && 'inputs' in abiItem) {
     const indexedInputs = abiItem.inputs?.filter(
       (param) => 'indexed' in param && param.indexed,
@@ -121,7 +138,13 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
-  return [signature, ...topics]
+
+  if (abiItem.anonymous)
+    return topics as EncodeEventTopicsReturnType<abi, eventName>
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
+  return [signature, ...topics] as EncodeEventTopicsReturnType<abi, eventName>
 }
 
 export type EncodeArgErrorType =


### PR DESCRIPTION
## Summary

Fixes #4461

### Root cause

`encodeEventTopics` always prepends the event signature to the returned topic list. That is correct for non-anonymous events, but anonymous events do not include the signature as `topic0`, and they can legitimately return `[]` when no indexed args are provided.

The exported return type also assumed that a signature is always present, which makes anonymous events type-incorrect.

### Fix

Return the collected topics directly when `abiItem.anonymous` is `true`, and keep the existing selector path for non-anonymous events.

Infer the return type from the selected ABI event so anonymous events resolve to `(Hex | Hex[] | null)[]` while non-anonymous events keep `[Hex, ...(Hex | Hex[] | null)[]]`.

### Tests

Added runtime coverage for anonymous events with no args, partial args, and all args, plus type-level assertions for anonymous and non-anonymous return types.