### PR TITLE
docs(tempo): add validator fee action docs

### DIFF
--- a/site/pages/tempo/actions/fee.getValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.getValidatorToken.mdx
@@ -1,0 +1,51 @@
+import ReadAccountParameters from '../../../snippets/tempo/read-parameters.mdx'
+
+# `fee.getValidatorToken`
+
+Gets the validator's default fee token preference. [Learn more about fees](https://docs.tempo.xyz/protocol/fees)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.fee.getValidatorToken({
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+console.log('Fee token address:', result?.address)
+// @log: Fee token address: 0x20c0000000000000000000000000000000000000
+console.log('Fee token ID:', result?.id)
+// @log: Fee token ID: 0n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Address of the fee token */
+  address: Address
+  /** ID of the fee token */
+  id: bigint
+} | null
+```
+
+Returns `null` if the validator has not set a preferred fee token.
+
+## Parameters
+
+### validator
+
+- **Type:** `Address`
+
+Validator address.
+
+<ReadAccountParameters />

--- a/site/pages/tempo/actions/fee.setValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.setValidatorToken.mdx
@@ -1,0 +1,75 @@
+import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
+
+# `fee.setValidatorToken`
+
+Sets the validator's default fee token preference. [Learn more about fees](https://docs.tempo.xyz/protocol/fees)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { validator, token, receipt } = await client.fee.setValidatorTokenSync({
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log('Validator:', validator)
+// @log: Validator: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+console.log('Fee token:', token)
+// @log: Fee token: 0x20c0000000000000000000000000000000000001
+console.log('Transaction hash:', receipt.transactionHash)
+// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `fee.setValidatorToken` action and wait for inclusion manually:
+
+```ts twoslash
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const hash = await client.fee.setValidatorToken({
+  token: '0x20c0000000000000000000000000000000000001',
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+
+const { args } = Actions.fee.setValidatorToken.extractEvent(receipt.logs)
+const { validator, token } = args
+
+console.log('Validator:', validator)
+console.log('Fee token:', token)
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Address of the validator */
+  validator: Address
+  /** Address of the token set */
+  token: Address
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+}
+```
+
+## Parameters
+
+### token
+
+- **Type:** `Address | bigint`
+
+Address or ID of the TIP-20 token to use for validator fees.
+
+<WriteParameters />

--- a/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
@@ -1,0 +1,97 @@
+# `fee.watchSetValidatorToken`
+
+Watches for validator token set events on the Fee Manager.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const unwatch = client.fee.watchSetValidatorToken({
+  onValidatorTokenSet: (args, log) => {
+    console.log('Validator:', args.validator)
+    console.log('New fee token:', args.token)
+  },
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onValidatorTokenSet
+
+- **Type:** `function`
+
+```ts
+declare function onValidatorTokenSet(args: Args, log: Log): void
+
+type Args = {
+  /** Address of the validator */
+  validator: Address
+  /** Address of the new fee token */
+  token: Address
+}
+```
+
+Callback to invoke when a validator token is set.
+
+### args (optional)
+
+- **Type:** `object`
+
+```ts
+type Args = {
+  /** Address of the validator to filter by */
+  validator?: Address | Address[] | null
+  /** Address of the token to filter by */
+  token?: Address | Address[] | null
+}
+```
+
+Optional filters for the event.
+
+### fromBlock (optional)
+
+- **Type:** `bigint`
+
+Block to start listening from.
+
+### onError (optional)
+
+- **Type:** `function`
+
+```ts
+declare function onError(error: Error): void
+```
+
+The callback to call when an error occurred when trying to fetch a new block.
+
+### poll (optional)
+
+- **Type:** `true`
+
+Whether to use polling.
+
+### pollingInterval (optional)
+
+- **Type:** `number`
+
+Polling frequency (in ms). Defaults to Client's pollingInterval config.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1937,6 +1937,18 @@ export const sidebar = {
                 text: 'watchSetUserToken',
                 link: '/tempo/actions/fee.watchSetUserToken',
               },
+              {
+                text: 'getValidatorToken',
+                link: '/tempo/actions/fee.getValidatorToken',
+              },
+              {
+                text: 'setValidatorToken',
+                link: '/tempo/actions/fee.setValidatorToken',
+              },
+              {
+                text: 'watchSetValidatorToken',
+                link: '/tempo/actions/fee.watchSetValidatorToken',
+              },
             ],
           },
           {


### PR DESCRIPTION
## Description

Adds missing Tempo docs for validator fee actions:
- `fee.getValidatorToken`
- `fee.setValidatorToken`
- `fee.watchSetValidatorToken`

Also updates the Tempo docs sidebar to surface the new pages.
