### PR TITLE
Fix getTimeToNextGame crash when dispute game factory has zero or one games

### DIFF
--- a/.changeset/fix-empty-dispute-games.md
+++ b/.changeset/fix-empty-dispute-games.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getTimeToNextGame` crash when dispute game factory has zero or one games.

--- a/src/op-stack/actions/getTimeToNextGame.test.ts
+++ b/src/op-stack/actions/getTimeToNextGame.test.ts
@@ -3,6 +3,7 @@ import { anvilMainnet } from '~test/anvil.js'
 import { reset } from '../../actions/index.js'
 import { optimism } from '../../op-stack/chains.js'
 import { getGames } from './getGames.js'
+import * as getGamesModule from './getGames.js'
 import { getTimeToNextGame } from './getTimeToNextGame.js'
 
 const client = anvilMainnet.getClient()
@@ -58,4 +59,35 @@ test('l2BlockNumber < latestGame.blockNumber', async () => {
   })
   expect(seconds).toBe(0)
   expect(timestamp).toBe(undefined)
+})
+
+test('zero games (fresh chain)', async () => {                                                                                                           
+  const spy = vi.spyOn(getGamesModule, 'getGames').mockResolvedValueOnce([])
+  const result = await getTimeToNextGame(client, {                                                                                                       
+    l2BlockNumber: 1000n,
+    targetChain: optimism,
+  })                                                                                                                                                     
+  expect(result).toEqual({ interval: 0, seconds: 0, timestamp: undefined })
+  spy.mockRestore()                                                                                                                                      
+})              
+
+test('single game (no interval data)', async () => {
+  const spy = vi.spyOn(getGamesModule, 'getGames').mockResolvedValueOnce([
+    {                                                                                                                                                    
+      index: 0n,
+      metadata: '0x' as `0x${string}`,                                                                                                                   
+      timestamp: BigInt(Math.floor(Date.now() / 1000) - 3600),
+      rootClaim: '0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`,                                                  
+      extraData: '0x' as `0x${string}`,
+      l2BlockNumber: 500n,                                                                                                                               
+    },          
+  ])                                                                                                                                                     
+  const result = await getTimeToNextGame(client, {
+    l2BlockNumber: 1000n,
+    targetChain: optimism,                                                                                                                               
+  })
+  expect(result.interval).toBe(0)                                                                                                                        
+  expect(result.seconds).toBe(0)
+  expect(result.timestamp).toBeUndefined()
+  spy.mockRestore()
 })

--- a/src/op-stack/actions/getTimeToNextGame.ts
+++ b/src/op-stack/actions/getTimeToNextGame.ts
@@ -129,6 +129,9 @@ export async function getTimeToNextGame<
     // then we assume that the dispute game has already been submitted.
     if (latestGame.l2BlockNumber > l2BlockNumber) return 0
 
+    // If there is only a single game, no interval data
+    if (intervalWithBuffer === 0) return 0                                                                          
+
     const elapsedBlocks = Number(l2BlockNumber - latestGame.l2BlockNumber)
 
     const elapsed = Math.ceil((now - latestGameTimestamp) / 1000)

--- a/src/op-stack/actions/getTimeToNextGame.ts
+++ b/src/op-stack/actions/getTimeToNextGame.ts
@@ -87,6 +87,10 @@ export async function getTimeToNextGame<
     limit: 10,
   })
 
+  if (games.length === 0) {                                                                                                                              
+    return { interval: 0, seconds: 0, timestamp: undefined }                                                                                             
+  }           
+
   const deltas = games
     .map(({ l2BlockNumber, timestamp }, index) => {
       return index === games.length - 1
@@ -97,18 +101,17 @@ export async function getTimeToNextGame<
           ]
     })
     .filter(Boolean)
-  const interval = Math.ceil(
-    (deltas as [bigint, bigint][]).reduce(
-      (a, [b]) => Number(a) - Number(b),
-      0,
-    ) / deltas.length,
-  )
-  const blockInterval = Math.ceil(
-    (deltas as [bigint, bigint][]).reduce(
-      (a, [_, b]) => Number(a) - Number(b),
-      0,
-    ) / deltas.length,
-  )
+
+  const interval = deltas.length > 0                  
+    ? Math.ceil(                                                                                                                                         
+        (deltas as [bigint, bigint][]).reduce((a, [b]) => Number(a) - Number(b), 0) / deltas.length,
+      )                                                                                                                                                  
+    : 0                                               
+  const blockInterval = deltas.length > 0                                                                                                                
+    ? Math.ceil(                                 
+        (deltas as [bigint, bigint][]).reduce((a, [_, b]) => Number(a) - Number(b), 0) / deltas.length,
+      )                                                                                                                                                  
+    : 0
 
   const latestGame = games[0]
   const latestGameTimestamp = Number(latestGame.timestamp) * 1000


### PR DESCRIPTION
`getTimeToNextGame` assumes the `games` array returned by `getGames` is always non-empty and has at least two entries for interval calculation. This breaks on fresh OP Stack chains where the dispute game factory has no games yet, or only one game has been submitted so far.

**Two bugs:**

1. **Zero games** — `games[0]` throws `TypeError: Cannot read properties of undefined` since the array is empty.
2. **One game** — `deltas` is empty after `.filter(Boolean)` (the single entry maps to `null`), so `reduce(...) / deltas.length` divides by zero producing `NaN` for both `interval` and `blockInterval`. This also causes `elapsed % intervalWithBuffer` → `elapsed % 0` → `NaN` to leak into the `seconds` return value.

**Fix:**

- Early-return `{ interval: 0, seconds: 0, timestamp: undefined }` when `games` is empty — no data to estimate from, caller should poll immediately.
- Guard `deltas.length > 0` before computing `interval` and `blockInterval`, falling back to `0`.
- Guard `intervalWithBuffer === 0` inside the `seconds` computation to prevent `NaN` from `x % 0`.

Returning `seconds: 0` is the correct behavior for both cases — `waitForNextGame` will start polling immediately, which is what you want on a chain where the proposer hasn't submitted games yet.

**Tests added:**

- `zero games (fresh chain)` — mocks `getGames` to return `[]`, asserts the early return.
- `single game (no interval data)` — mocks `getGames` to return one game with `l2BlockNumber` behind the target, asserts `seconds === 0` (not `NaN`).