### PR TITLE
fix: fee payer fill routing in viem/tempo

### DIFF
--- a/.changeset/lucky-lizards-cheer.md
+++ b/.changeset/lucky-lizards-cheer.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Updated `withFeePayer` transports to forward `eth_fillTransaction` requests to the fee payer transport only when `feePayer: true` is requested.
+Updated `withFeePayer` transports to forward `eth_fillTransaction` requests only when `feePayer: true` is requested, and to relay raw Tempo transactions only after the sender signature is present.

--- a/.changeset/lucky-lizards-cheer.md
+++ b/.changeset/lucky-lizards-cheer.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Updated `withFeePayer` transports to forward  `eth_fillTransaction` requests to the fee payer transport

--- a/.changeset/lucky-lizards-cheer.md
+++ b/.changeset/lucky-lizards-cheer.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Updated `withFeePayer` transports to forward `eth_fillTransaction` requests only when `feePayer: true` is requested, and to relay raw Tempo transactions only after the sender signature is present.
+Updated `withFeePayer` transports to forward `eth_fillTransaction` requests to the fee payer transport only when `feePayer: true` is requested.

--- a/.changeset/lucky-lizards-cheer.md
+++ b/.changeset/lucky-lizards-cheer.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Updated `withFeePayer` transports to forward  `eth_fillTransaction` requests to the fee payer transport
+Updated `withFeePayer` transports to forward `eth_fillTransaction` requests to the fee payer transport only when `feePayer: true` is requested.

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -171,23 +171,6 @@ describe('withFeePayer', () => {
       })
     })
 
-    test('behavior: unsigned sponsored raw transaction uses default transport', async () => {
-      const serialized = await Transaction.serialize({
-        chainId: chain.id,
-        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
-        feePayer: true,
-      })
-
-      await expect(
-        client.request({
-          method: 'eth_sendRawTransaction',
-          params: [serialized],
-        }),
-      ).rejects.toThrow()
-
-      expect(feePayerRequests).toHaveLength(0)
-    })
-
     test('behavior: non-sponsored transaction uses default transport', async () => {
       const receipt = await sendTransactionSync(client, {
         account: accounts[0],

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -171,6 +171,23 @@ describe('withFeePayer', () => {
       })
     })
 
+    test('behavior: unsigned sponsored raw transaction uses default transport', async () => {
+      const serialized = await Transaction.serialize({
+        chainId: chain.id,
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        feePayer: true,
+      })
+
+      await expect(
+        client.request({
+          method: 'eth_sendRawTransaction',
+          params: [serialized],
+        }),
+      ).rejects.toThrow()
+
+      expect(feePayerRequests).toHaveLength(0)
+    })
+
     test('behavior: non-sponsored transaction uses default transport', async () => {
       const receipt = await sendTransactionSync(client, {
         account: accounts[0],

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -134,7 +134,7 @@ describe('withFeePayer', () => {
         method: 'eth_fillTransaction',
         params: [
           {
-            feePayer: accounts[0].address,
+            feePayer: true,
             to: '0x0000000000000000000000000000000000000000',
           },
         ],
@@ -147,7 +147,6 @@ describe('withFeePayer', () => {
           {
             feePayer: true,
             to: '0x0000000000000000000000000000000000000000',
-            chainId: Hex.fromNumber(chain.id),
           },
         ],
       })

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -16,7 +16,10 @@ import { walletNamespaceCompat, withFeePayer } from './Transport.js'
 
 describe('withFeePayer', () => {
   let server: Http.Server
-  let feePayerRequests: string[] = []
+  let feePayerRequests: Array<{
+    method: string
+    params: readonly unknown[] | undefined
+  }> = []
 
   beforeAll(async () => {
     server = Http.createServer(
@@ -25,9 +28,24 @@ describe('withFeePayer', () => {
           account: accounts[0],
         })
 
-        const request = RpcRequest.from(await r.json())
+        const request = RpcRequest.from(
+          await r.json(),
+        ) as RpcRequest.RpcRequest<any>
 
-        feePayerRequests.push(request.method)
+        feePayerRequests.push({
+          method: request.method,
+          params: request.params,
+        })
+
+        if (request.method === 'eth_fillTransaction') {
+          return Response.json(
+            RpcResponse.from({
+              id: request.id,
+              jsonrpc: request.jsonrpc,
+              result: request.params?.[0],
+            }),
+          )
+        }
 
         if (
           (request as any).method !== 'eth_signRawTransaction' &&
@@ -35,14 +53,13 @@ describe('withFeePayer', () => {
           request.method !== 'eth_sendRawTransactionSync'
         )
           return Response.json(
-            RpcResponse.from(
-              {
-                error: new RpcResponse.InvalidParamsError({
-                  message: 'unsupported method',
-                }),
-              },
-              { request },
-            ),
+            RpcResponse.from({
+              error: new RpcResponse.InvalidParamsError({
+                message: 'unsupported method',
+              }),
+              id: request.id,
+              jsonrpc: request.jsonrpc,
+            }),
           )
 
         const serialized = request.params?.[0] as `0x76${string}`
@@ -55,7 +72,11 @@ describe('withFeePayer', () => {
 
         if ((request as any).method === 'eth_signRawTransaction') {
           return Response.json(
-            RpcResponse.from({ result: serializedTransaction }, { request }),
+            RpcResponse.from({
+              id: request.id,
+              jsonrpc: request.jsonrpc,
+              result: serializedTransaction,
+            }),
           )
         }
 
@@ -64,7 +85,13 @@ describe('withFeePayer', () => {
           params: [serializedTransaction],
         } as never)
 
-        return Response.json(RpcResponse.from({ result }, { request }))
+        return Response.json(
+          RpcResponse.from({
+            id: request.id,
+            jsonrpc: request.jsonrpc,
+            result,
+          }),
+        )
       }),
     ).listen(3051)
   })
@@ -96,7 +123,34 @@ describe('withFeePayer', () => {
       expect(receipt.status).toBe('success')
       expect(receipt.feePayer).toBe(accounts[0].address.toLowerCase())
       expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContain('eth_signRawTransaction')
+      expect(feePayerRequests).toContainEqual({
+        method: 'eth_signRawTransaction',
+        params: expect.any(Array),
+      })
+    })
+
+    test('behavior: eth_fillTransaction with feePayer: true', async () => {
+      await client.request({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: accounts[0].address,
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+
+      expect(feePayerRequests).toHaveLength(1)
+      expect(feePayerRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: true,
+            to: '0x0000000000000000000000000000000000000000',
+            chainId: Hex.fromNumber(chain.id),
+          },
+        ],
+      })
     })
 
     test('behavior: sendTransactionSync with feePayer: true', async () => {
@@ -112,7 +166,10 @@ describe('withFeePayer', () => {
 
       expect(receipt.status).toBe('success')
       expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContain('eth_signRawTransaction')
+      expect(feePayerRequests).toContainEqual({
+        method: 'eth_signRawTransaction',
+        params: expect.any(Array),
+      })
     })
 
     test('behavior: non-sponsored transaction uses default transport', async () => {
@@ -145,7 +202,10 @@ describe('withFeePayer', () => {
       })
 
       expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContain('eth_sendRawTransaction')
+      expect(feePayerRequests).toContainEqual({
+        method: 'eth_sendRawTransaction',
+        params: expect.any(Array),
+      })
     })
 
     test('behavior: sendTransactionSync with feePayer: true', async () => {
@@ -161,7 +221,10 @@ describe('withFeePayer', () => {
 
       expect(receipt.status).toBe('success')
       expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContain('eth_sendRawTransactionSync')
+      expect(feePayerRequests).toContainEqual({
+        method: 'eth_sendRawTransactionSync',
+        params: expect.any(Array),
+      })
     })
   })
 })

--- a/src/tempo/Transport.ts
+++ b/src/tempo/Transport.ts
@@ -64,10 +64,9 @@ export function withFeePayer(
           const serialized = (params as any)[0] as `0x76${string}`
           const transaction = Transaction.deserialize(serialized)
 
-          // Serialized Tempo envelopes do not retain the original `feePayer` field.
-          // The closest equivalent is a sender-signed envelope that is still missing
-          // the fee payer co-signature.
-          if (transaction.feePayerSignature === null && transaction.signature) {
+          // Serialized Tempo envelopes encode `feePayer: true` as a missing fee payer
+          // signature until the relay co-signs the transaction.
+          if (transaction.feePayerSignature === null) {
             // For 'sign-and-broadcast', relay signs and broadcasts
             if (policy === 'sign-and-broadcast')
               return transport_relay.request(

--- a/src/tempo/Transport.ts
+++ b/src/tempo/Transport.ts
@@ -46,6 +46,31 @@ export function withFeePayer(
       key: withFeePayer.type,
       name: 'Relay Proxy',
       async request({ method, params }, options) {
+        if (method === 'eth_fillTransaction') {
+          const request = (params as readonly unknown[] | undefined)?.[0]
+          if (
+            request &&
+            typeof request === 'object' &&
+            'feePayer' in request &&
+            (request.feePayer === true || typeof request.feePayer === 'string')
+          ) {
+            return transport_relay.request(
+              {
+                method,
+                params: [
+                  {
+                    ...request,
+                    feePayer: true,
+                    chainId: config.chain?.id
+                      ? `0x${config.chain.id.toString(16)}`
+                      : undefined,
+                  },
+                ],
+              },
+              options,
+            ) as never
+          }
+        }
         if (
           method === 'eth_sendRawTransactionSync' ||
           method === 'eth_sendRawTransaction'

--- a/src/tempo/Transport.ts
+++ b/src/tempo/Transport.ts
@@ -64,9 +64,10 @@ export function withFeePayer(
           const serialized = (params as any)[0] as `0x76${string}`
           const transaction = Transaction.deserialize(serialized)
 
-          // Serialized Tempo envelopes encode `feePayer: true` as a missing fee payer
-          // signature until the relay co-signs the transaction.
-          if (transaction.feePayerSignature === null) {
+          // Serialized Tempo envelopes do not retain the original `feePayer` field.
+          // The closest equivalent is a sender-signed envelope that is still missing
+          // the fee payer co-signature.
+          if (transaction.feePayerSignature === null && transaction.signature) {
             // For 'sign-and-broadcast', relay signs and broadcasts
             if (policy === 'sign-and-broadcast')
               return transport_relay.request(

--- a/src/tempo/Transport.ts
+++ b/src/tempo/Transport.ts
@@ -23,6 +23,7 @@ export type FeePayer = Transport<typeof withFeePayer.type>
  * the default transport or the fee payer transport.
  *
  * The policy parameter controls how the fee payer handles transactions:
+ * - `eth_fillTransaction` requests are forwarded to the fee payer transport when `feePayer: true`
  * - `'sign-only'`: Fee payer co-signs the transaction and returns it to the client transport, which then broadcasts it via the default transport
  * - `'sign-and-broadcast'`: Fee payer co-signs and broadcasts the transaction directly
  *
@@ -52,24 +53,9 @@ export function withFeePayer(
             request &&
             typeof request === 'object' &&
             'feePayer' in request &&
-            (request.feePayer === true || typeof request.feePayer === 'string')
-          ) {
-            return transport_relay.request(
-              {
-                method,
-                params: [
-                  {
-                    ...request,
-                    feePayer: true,
-                    chainId: config.chain?.id
-                      ? `0x${config.chain.id.toString(16)}`
-                      : undefined,
-                  },
-                ],
-              },
-              options,
-            ) as never
-          }
+            request.feePayer === true
+          )
+            return transport_relay.request({ method, params }, options) as never
         }
         if (
           method === 'eth_sendRawTransactionSync' ||
@@ -78,7 +64,8 @@ export function withFeePayer(
           const serialized = (params as any)[0] as `0x76${string}`
           const transaction = Transaction.deserialize(serialized)
 
-          // If the transaction is intended to be sponsored, forward it to the relay.
+          // Serialized Tempo envelopes encode `feePayer: true` as a missing fee payer
+          // signature until the relay co-signs the transaction.
           if (transaction.feePayerSignature === null) {
             // For 'sign-and-broadcast', relay signs and broadcasts
             if (policy === 'sign-and-broadcast')


### PR DESCRIPTION
Fixes sponsored `eth_fillTransaction` routing in `withFeePayer` so relay-backed fills go through the fee payer transport with `feePayer: true` and the active `chainId`.