### PR TITLE
feat(tempo): add withRelay and deprecate withFeePayer

### DIFF
--- a/.changeset/clean-icons-turn.md
+++ b/.changeset/clean-icons-turn.md
@@ -1,0 +1,16 @@
+---
+"viem": minor
+---
+
+Added `withRelay` to `viem/tempo` as the primary relay transport, and deprecated `withFeePayer` in favor of it.
+
+**Relay transport**
+
+- Added `withRelay(defaultTransport, relayTransport, parameters?)` to `viem/tempo`.
+- `eth_fillTransaction` requests sent through `withRelay` are now forwarded to the relay transport.
+- The `feePayer` value on `eth_fillTransaction` requests is preserved as provided, including `true`, explicit addresses, and omitted or nullish values.
+
+**Compatibility**
+
+- Deprecated `withFeePayer` in favor of `withRelay`.
+- Existing `feePayer: true` sponsored transaction flows continue to work when sending Tempo transactions through the relay.

--- a/.changeset/clean-icons-turn.md
+++ b/.changeset/clean-icons-turn.md
@@ -1,16 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
 Added `withRelay` to `viem/tempo` as the primary relay transport, and deprecated `withFeePayer` in favor of it.
-
-**Relay transport**
-
-- Added `withRelay(defaultTransport, relayTransport, parameters?)` to `viem/tempo`.
-- `eth_fillTransaction` requests sent through `withRelay` are now forwarded to the relay transport.
-- The `feePayer` value on `eth_fillTransaction` requests is preserved as provided, including `true`, explicit addresses, and omitted or nullish values.
-
-**Compatibility**
-
-- Deprecated `withFeePayer` in favor of `withRelay`.
-- Existing `feePayer: true` sponsored transaction flows continue to work when sending Tempo transactions through the relay.

--- a/site/pages/tempo/transactions.mdx
+++ b/site/pages/tempo/transactions.mdx
@@ -325,4 +325,4 @@ export const client = createWalletClient({
 
 - Tempo protocol docs: [Tempo Transactions](https://docs.tempo.xyz/protocol/transactions#tempo-transactions)
 - Tempo Viem setup: [Getting Started](https://docs.tempo.xyz/tempo)
-- Tempo transports: [`withFeePayer`](https://docs.tempo.xyz/tempo/transports/withFeePayer)
+- Tempo transports: [`withRelay`](https://docs.tempo.xyz/tempo/transports/withRelay)

--- a/site/pages/tempo/transports/withRelay.mdx
+++ b/site/pages/tempo/transports/withRelay.mdx
@@ -1,11 +1,15 @@
-# `withFeePayer`
+# `withRelay`
 
-Deprecated alias for [`withRelay`](https://docs.tempo.xyz/tempo/transports/withRelay).
-
-Creates a transport that routes transactions to a relay service when a `feePayer` is requested on an action.
+Creates a transport that routes Tempo relay traffic between a default transport and a relay service.
 
 - [View Guide](https://docs.tempo.xyz/guide/payments/sponsor-user-fees)
 - [View Specification](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction)
+
+`withRelay` forwards every `eth_fillTransaction` request to the relay and preserves the request's `feePayer` value so the relay can decide whether to sponsor the transaction.
+
+- `feePayer: true` asks the relay to sponsor the transaction.
+- If `feePayer` is omitted, `undefined`, or `null`, that value is forwarded as-is.
+- An explicit `feePayer` address is preserved.
 
 ## Usage
 
@@ -15,14 +19,14 @@ Creates a transport that routes transactions to a relay service when a `feePayer
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { tempoModerato } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
   chain: tempoModerato,
-  transport: withFeePayer(
-    http(),                               // ← Default Transport
-    http('https://sponsor.example.com'),  // ← Fee Payer Transport // [!code hl]
+  transport: withRelay(
+    http(),                             // ← Default Transport
+    http('https://relay.example.com'),  // ← Relay Transport // [!code hl]
   ),
 })
 
@@ -33,10 +37,9 @@ const receipt1 = await client.sendTransactionSync({
 
 // Sponsored transaction // [!code hl]
 const receipt2 = await client.sendTransactionSync({ // [!code hl]
-  // [!code hl]
   feePayer: true, // [!code hl]
   to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code hl]
-}) // [!code hl]
+})
 ```
 
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"
@@ -45,9 +48,9 @@ const receipt2 = await client.sendTransactionSync({ // [!code hl]
 
 :::
 
-### Example Fee Payer Service
+### Example Relay Service
 
-Below is an end-to-end example of a client/server fee payer setup.
+Below is an end-to-end example of a client/server relay setup.
 
 See `server.ts` for the server-side implementation. It uses [`Handler.relay` provided by `tempo.ts/server`](https://docs.tempo.xyz/sdk/typescript/server/handler.relay) to handle relay requests.
 
@@ -57,12 +60,12 @@ See `server.ts` for the server-side implementation. It uses [`Handler.relay` pro
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { tempoModerato } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
   chain: tempoModerato,
-  transport: withFeePayer(
+  transport: withRelay(
     http(),
     http('http://localhost:3000'),
   ),
@@ -84,8 +87,8 @@ import { Handler } from 'tempo.ts/server'
 
 const client = createClient({
   chain: tempoModerato.extend({
-    // Note: the fee payer can specify their own fee token.
-    feeToken: '0x20c0000000000000000000000000000000000001'
+    // Note: the relay can specify its own fee token.
+    feeToken: '0x20c0000000000000000000000000000000000001',
   }),
   transport: http(),
 })
@@ -104,7 +107,7 @@ server.listen(3000)
 ## Return Type
 
 ```ts
-type ReturnType = Transport<'feePayer'>
+type ReturnType = Transport<'relay'>
 ```
 
 ## Parameters
@@ -113,27 +116,27 @@ type ReturnType = Transport<'feePayer'>
 
 - **Type:** `Transport`
 
-The default transport to use for regular (non-sponsored) transactions.
+The default transport to use for regular relay traffic and for broadcasting transactions when `policy` is `'sign-only'`.
 
 ### relayTransport
 
 - **Type:** `Transport`
 
-The relay transport to use for sponsored transactions. This should point to a fee payer service that will sign and submit the transaction with a fee payer signature.
+The relay transport to use for `eth_fillTransaction` and sponsored transaction handling.
 
 ### Parameters (optional)
 
-- **Type:** `withFeePayer.Parameters`
+- **Type:** `withRelay.Parameters`
 
-Options for `withFeePayer` usage.
+Options for `withRelay` usage.
 
 #### `policy` (optional)
 
 - **Type:** `'sign-only' | 'sign-and-broadcast'`
 - **Default:** `'sign-only'`
 
-Controls how the fee payer handles sponsored transactions:
+Controls how the relay handles sponsored transactions:
 
-- **`'sign-only'`**: Fee payer co-signs the transaction and returns it to the client transport, which then broadcasts it via the default transport.
+- **`'sign-only'`**: The relay co-signs the transaction and returns it to the client transport, which then broadcasts it via the default transport.
 
-- **`'sign-and-broadcast'`**: Fee payer co-signs and broadcasts the transaction directly. The fee payer service handles both signing and submission to the blockchain.
+- **`'sign-and-broadcast'`**: The relay co-signs and broadcasts the transaction directly. The relay service handles both signing and submission to the blockchain.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -2297,8 +2297,8 @@ export const sidebar = {
         text: 'Transports',
         items: [
           {
-            text: 'withFeePayer',
-            link: '/tempo/transports/withFeePayer',
+            text: 'withRelay',
+            link: '/tempo/transports/withRelay',
           },
         ],
       },

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -12,11 +12,11 @@ import {
 import { Transaction } from 'viem/tempo'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { accounts, chain, getClient, http } from '~test/tempo/config.js'
-import { walletNamespaceCompat, withFeePayer } from './Transport.js'
+import { walletNamespaceCompat, withFeePayer, withRelay } from './Transport.js'
 
-describe('withFeePayer', () => {
+describe('withRelay', () => {
   let server: Http.Server
-  let feePayerRequests: Array<{
+  let relayRequests: Array<{
     method: string
     params: readonly unknown[] | undefined
   }> = []
@@ -32,7 +32,7 @@ describe('withFeePayer', () => {
           await r.json(),
         ) as RpcRequest.RpcRequest<any>
 
-        feePayerRequests.push({
+        relayRequests.push({
           method: request.method,
           params: request.params,
         })
@@ -101,12 +101,12 @@ describe('withFeePayer', () => {
   })
 
   beforeEach(() => {
-    feePayerRequests = []
+    relayRequests = []
   })
 
   describe('policy: sign-only (default)', () => {
     const client = getClient({
-      transport: withFeePayer(http(), http('http://localhost:3051')),
+      transport: withRelay(http(), http('http://localhost:3051')),
     })
 
     test('behavior: sendTransaction with feePayer: true', async () => {
@@ -122,8 +122,8 @@ describe('withFeePayer', () => {
 
       expect(receipt.status).toBe('success')
       expect(receipt.feePayer).toBe(accounts[0].address.toLowerCase())
-      expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContainEqual({
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
         method: 'eth_signRawTransaction',
         params: expect.any(Array),
       })
@@ -140,12 +140,75 @@ describe('withFeePayer', () => {
         ],
       })
 
-      expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContainEqual({
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
         method: 'eth_fillTransaction',
         params: [
           {
             feePayer: true,
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+    })
+
+    test('behavior: eth_fillTransaction without feePayer preserves omission', async () => {
+      await client.request({
+        method: 'eth_fillTransaction',
+        params: [{ to: '0x0000000000000000000000000000000000000000' }],
+      })
+
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+    })
+
+    test('behavior: eth_fillTransaction preserves explicit feePayer: null', async () => {
+      await client.request({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: null,
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: null,
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+    })
+
+    test('behavior: eth_fillTransaction preserves explicit feePayer', async () => {
+      await client.request({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: accounts[0].address,
+            to: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      })
+
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: [
+          {
+            feePayer: accounts[0].address,
             to: '0x0000000000000000000000000000000000000000',
           },
         ],
@@ -164,8 +227,8 @@ describe('withFeePayer', () => {
       })
 
       expect(receipt.status).toBe('success')
-      expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContainEqual({
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
         method: 'eth_signRawTransaction',
         params: expect.any(Array),
       })
@@ -178,13 +241,13 @@ describe('withFeePayer', () => {
       })
 
       expect(receipt.status).toBe('success')
-      expect(feePayerRequests).toHaveLength(0)
+      expect(relayRequests).toHaveLength(0)
     })
   })
 
   describe('policy: sign-and-broadcast', () => {
     const client = getClient({
-      transport: withFeePayer(http(), http('http://localhost:3051'), {
+      transport: withRelay(http(), http('http://localhost:3051'), {
         policy: 'sign-and-broadcast',
       }),
     })
@@ -200,8 +263,8 @@ describe('withFeePayer', () => {
         to: '0x0000000000000000000000000000000000000000',
       })
 
-      expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContainEqual({
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
         method: 'eth_sendRawTransaction',
         params: expect.any(Array),
       })
@@ -219,9 +282,34 @@ describe('withFeePayer', () => {
       })
 
       expect(receipt.status).toBe('success')
-      expect(feePayerRequests).toHaveLength(1)
-      expect(feePayerRequests).toContainEqual({
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
         method: 'eth_sendRawTransactionSync',
+        params: expect.any(Array),
+      })
+    })
+  })
+
+  describe('withFeePayer', () => {
+    const client = getClient({
+      transport: withFeePayer(http(), http('http://localhost:3051')),
+    })
+
+    test('behavior: backwards compatible alias', async () => {
+      const account = privateKeyToAccount(
+        '0xecc3fe55647412647e5c6b657c496803b08ef956f927b7a821da298cfbdd9666',
+      )
+
+      const receipt = await sendTransactionSync(client, {
+        account,
+        feePayer: true,
+        to: '0x0000000000000000000000000000000000000003',
+      })
+
+      expect(receipt.status).toBe('success')
+      expect(relayRequests).toHaveLength(1)
+      expect(relayRequests).toContainEqual({
+        method: 'eth_signRawTransaction',
         params: expect.any(Array),
       })
     })

--- a/src/tempo/Transport.ts
+++ b/src/tempo/Transport.ts
@@ -16,27 +16,35 @@ import type { Chain } from '../types/chain.js'
 import type { ChainConfig } from './chainConfig.js'
 import * as Transaction from './Transaction.js'
 
+type RelayProxyParameters = {
+  /** Policy for how the relay should handle sponsored transactions. Defaults to `'sign-only'`. */
+  policy?: 'sign-only' | 'sign-and-broadcast' | undefined
+}
+
 export type FeePayer = Transport<typeof withFeePayer.type>
+export type Relay = Transport<typeof withRelay.type>
 
 /**
- * Creates a fee payer transport that routes requests between
- * the default transport or the fee payer transport.
+ * Creates a relay transport that routes requests between
+ * the default transport or the relay transport.
  *
- * The policy parameter controls how the fee payer handles transactions:
- * - `eth_fillTransaction` requests are forwarded to the fee payer transport when `feePayer: true`
- * - `'sign-only'`: Fee payer co-signs the transaction and returns it to the client transport, which then broadcasts it via the default transport
- * - `'sign-and-broadcast'`: Fee payer co-signs and broadcasts the transaction directly
+ * All `eth_fillTransaction` requests are sent to the relay with the request's
+ * `feePayer` value preserved so the relay can decide whether to sponsor the transaction.
+ *
+ * The policy parameter controls how the relay handles sponsored transactions:
+ * - `'sign-only'`: Relay co-signs the transaction and returns it to the client transport, which then broadcasts it via the default transport
+ * - `'sign-and-broadcast'`: Relay co-signs and broadcasts the transaction directly
  *
  * @param defaultTransport - The default transport to use.
- * @param feePayerTransport - The fee payer transport to use.
+ * @param relayTransport - The relay transport to use.
  * @param parameters - Configuration parameters.
  * @returns A relay transport.
  */
-export function withFeePayer(
+export function withRelay(
   defaultTransport: Transport,
   relayTransport: Transport,
-  parameters?: withFeePayer.Parameters,
-): withFeePayer.ReturnValue {
+  parameters?: withRelay.Parameters,
+): withRelay.ReturnValue {
   const { policy = 'sign-only' } = parameters ?? {}
 
   return (config) => {
@@ -44,19 +52,12 @@ export function withFeePayer(
     const transport_relay = relayTransport(config)
 
     return createTransport({
-      key: withFeePayer.type,
+      key: withRelay.type,
       name: 'Relay Proxy',
       async request({ method, params }, options) {
-        if (method === 'eth_fillTransaction') {
-          const request = (params as readonly unknown[] | undefined)?.[0]
-          if (
-            request &&
-            typeof request === 'object' &&
-            'feePayer' in request &&
-            request.feePayer === true
-          )
-            return transport_relay.request({ method, params }, options) as never
-        }
+        if (method === 'eth_fillTransaction')
+          return transport_relay.request({ method, params }, options) as never
+
         if (
           method === 'eth_sendRawTransactionSync' ||
           method === 'eth_sendRawTransaction'
@@ -93,23 +94,42 @@ export function withFeePayer(
             }
           }
         }
+
         return (await transport_default.request(
           { method, params },
           options,
         )) as never
       },
-      type: withFeePayer.type,
+      type: withRelay.type,
     })
   }
+}
+
+export declare namespace withRelay {
+  export const type = 'relay'
+
+  export type Parameters = RelayProxyParameters
+
+  export type ReturnValue = Relay
+}
+
+/** @deprecated Use `withRelay` instead. */
+export function withFeePayer(
+  defaultTransport: Transport,
+  relayTransport: Transport,
+  parameters?: withFeePayer.Parameters,
+): withFeePayer.ReturnValue {
+  return withRelay(
+    defaultTransport,
+    relayTransport,
+    parameters,
+  ) as unknown as withFeePayer.ReturnValue
 }
 
 export declare namespace withFeePayer {
   export const type = 'feePayer'
 
-  export type Parameters = {
-    /** Policy for how the fee payer should handle transactions. Defaults to `'sign-only'`. */
-    policy?: 'sign-only' | 'sign-and-broadcast' | undefined
-  }
+  export type Parameters = RelayProxyParameters
 
   export type ReturnValue = FeePayer
 }

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -1402,6 +1402,17 @@ describe('relay', () => {
 
         const request = RpcRequest.from(await r.json())
 
+        // Proxy `eth_fillTransaction` to the Tempo node.
+        if (request.method === 'eth_fillTransaction') {
+          const result = await client.request({
+            method: request.method,
+            params: request.params,
+          } as never)
+          return Response.json(
+            RpcResponse.from({ result }, { request }),
+          )
+        }
+
         // Validate method
         if (
           (request as any).method !== 'eth_signRawTransaction' &&
@@ -1413,7 +1424,7 @@ describe('relay', () => {
               {
                 error: new RpcResponse.InvalidParamsError({
                   message:
-                    'service only supports `eth_signTransaction`, `eth_sendRawTransaction`, and `eth_sendRawTransactionSync`',
+                    'service only supports `eth_fillTransaction`, `eth_signTransaction`, `eth_sendRawTransaction`, and `eth_sendRawTransactionSync`',
                 }),
               },
               { request },

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -57,6 +57,6 @@ export type {
 } from './Transaction.js'
 export * as Transaction from './Transaction.js'
 export * as Transport from './Transport.js'
-export { walletNamespaceCompat, withFeePayer } from './Transport.js'
+export { walletNamespaceCompat, withFeePayer, withRelay } from './Transport.js'
 export * as WebAuthnP256 from './WebAuthnP256.js'
 export * as WebCryptoP256 from './WebCryptoP256.js'


### PR DESCRIPTION
## Summary
- add `withRelay` as the primary Tempo relay transport
- deprecate `withFeePayer` as a backwards-compatible wrapper around `withRelay`
- route `eth_fillTransaction` through the relay transport and preserve the provided `feePayer` value
- update Tempo docs/sidebar links and add a changeset for the new API

## Verification
- `pnpm check:types`
- `pnpm exec biome check src/tempo/Transport.ts src/tempo/index.ts src/tempo/Transport.test.ts site/sidebar.ts`
- `git diff --check`

## Notes
- did not run the test suite in this PR