### PR TITLE
fix: resolve flaky CI test failures caused by transient anvil 400 errors

### DIFF
--- a/src/actions/wallet/sendTransactionSync.test.ts
+++ b/src/actions/wallet/sendTransactionSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { getSmartAccounts_07 } from '~test/account-abstraction.js'
 import { anvilMainnet } from '~test/anvil.js'
 import { accounts } from '~test/constants.js'
@@ -1528,8 +1528,12 @@ describe('local account', () => {
   })
 })
 
-describe('smart account', async () => {
-  const [account] = await getSmartAccounts_07()
+describe('smart account', () => {
+  let account: Awaited<ReturnType<typeof getSmartAccounts_07>>[0]
+
+  beforeAll(async () => {
+    ;[account] = await getSmartAccounts_07()
+  })
 
   test('default', async () => {
     await expect(() =>

--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -253,7 +253,21 @@ function defineAnvil<const chain extends Chain>(
               address: accounts[1].address,
             } as any
 
-          return request({ method, params }, opts)
+          // Retry on transient HTTP 400 errors from prool/anvil proxy
+          // during instance startup.
+          for (let i = 0; ; i++) {
+            try {
+              return await request({ method, params }, opts)
+            } catch (err) {
+              const isRetryable =
+                i < 3 &&
+                err instanceof Error &&
+                'status' in err &&
+                (err as any).status === 400
+              if (!isRetryable) throw err
+              await new Promise((resolve) => setTimeout(resolve, 1000))
+            }
+          }
         },
         value,
       }


### PR DESCRIPTION
## Problem

Multiple test files fail intermittently on CI with `HttpRequestError: Bad Request` (HTTP 400) from the prool/anvil proxy when anvil fork instances aren't fully ready during startup.

Affected tests include `sendTransactionSync.test.ts`, `parseEventLogs.test.ts`, `sendTransaction.test.ts`, `watchContractEvent.test.ts`, `buildRequest.test.ts`, and others — any test that makes RPC calls during file setup or `beforeAll`/`beforeEach` hooks.

## Root Cause

The prool proxy returns HTTP 400 when the underlying anvil fork instance hasn't finished starting. viem's built-in `shouldRetry` in `buildRequest.ts` does not retry on status 400, so these errors propagate immediately. Additionally, test files using top-level `await` in async `describe` blocks (e.g. `await getSmartAccounts_07()`) crash the entire suite during file evaluation, bypassing vitest's test-level retry mechanism.

## Fix

1. **Transport-level retry in `test/src/anvil.ts`**: Added retry logic (3 attempts, 1s delay) for HTTP 400 errors directly in the test transport's `request` function. This covers all test files globally without requiring per-file changes.

2. **`sendTransactionSync.test.ts`**: Moved `getSmartAccounts_07()` from the async `describe` block body into a `beforeAll` hook, converting an unrecoverable suite-level crash into a retriable hook failure.