### PR TITLE
fix: update Tempo RPC URLs (remove .presto)

### DIFF
--- a/.changeset/updated-tempo-rpc-urls.md
+++ b/.changeset/updated-tempo-rpc-urls.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Tempo RPC URLs.

--- a/src/chains/definitions/tempo.ts
+++ b/src/chains/definitions/tempo.ts
@@ -18,8 +18,8 @@ export const tempo = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.presto.tempo.xyz'],
-      webSocket: ['wss://rpc.presto.tempo.xyz'],
+      http: ['https://rpc.tempo.xyz'],
+      webSocket: ['wss://rpc.tempo.xyz'],
     },
   },
 })


### PR DESCRIPTION
The Tempo chain definition has outdated RPC URLs. `rpc.presto.tempo.xyz` is no longer the canonical endpoint — `rpc.tempo.xyz` is.

```diff
-      http: ['https://rpc.presto.tempo.xyz'],
-      webSocket: ['wss://rpc.presto.tempo.xyz'],
+      http: ['https://rpc.tempo.xyz'],
+      webSocket: ['wss://rpc.tempo.xyz'],
```

Prompted by: Georgios