### PR TITLE
chore: Add Tron blockTime + multicall deployment

### DIFF
--- a/.changeset/forty-mice-do.md
+++ b/.changeset/forty-mice-do.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added Tron block time + multicall3
+Added Tron block time

--- a/.changeset/forty-mice-do.md
+++ b/.changeset/forty-mice-do.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Tron block time + multicall3

--- a/src/chains/definitions/tron.ts
+++ b/src/chains/definitions/tron.ts
@@ -17,10 +17,4 @@ export const tron = /*#__PURE__*/ defineChain({
       apiUrl: 'https://apilist.tronscanapi.com/api',
     },
   },
-  contracts: {
-    multicall3: {
-      address: '0x32a4F47A74a6810BD0bF861CABAb99656a75DE9E',
-      blockCreated: 51_067_989,
-    },
-  },
 })

--- a/src/chains/definitions/tron.ts
+++ b/src/chains/definitions/tron.ts
@@ -9,11 +9,18 @@ export const tron = /*#__PURE__*/ defineChain({
       http: ['https://api.trongrid.io/jsonrpc'],
     },
   },
+  blockTime: 3000,
   blockExplorers: {
     default: {
       name: 'Tronscan',
       url: 'https://tronscan.org',
       apiUrl: 'https://apilist.tronscanapi.com/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x32a4F47A74a6810BD0bF861CABAb99656a75DE9E',
+      blockCreated: 51_067_989,
     },
   },
 })


### PR DESCRIPTION
Tron has 3s slots, where each slot is expected to produce a block.
https://developers.tron.network/docs/concensus#definition

Multicall3 deployment from https://www.multicall3.com/deployments. The 
Multicall3 website uses Tron's base58 encoding; the address here is
base16 20 bytes (checksum + 0x41 prefix dropped).