### PR TITLE
fix(wallet): preserve account context in local signTransaction

### DIFF
--- a/src/actions/wallet/signTransaction.test.ts
+++ b/src/actions/wallet/signTransaction.test.ts
@@ -130,6 +130,24 @@ describe('eip1559', () => {
     )
   })
 
+  test('default: local includes account context in sign request', async () => {
+    const account = privateKeyToAccount(sourceAccount.privateKey)
+    const signTransaction_ = account.signTransaction
+    let request: unknown
+
+    account.signTransaction = async (transaction, options) => {
+      request = transaction
+      return signTransaction_(transaction, options)
+    }
+
+    await signTransaction(client, {
+      account,
+      ...baseEip1559,
+    })
+
+    expect((request as { account?: unknown } | undefined)?.account).toBe(account)
+  })
+
   test('w/ prepareTransactionRequest', async () => {
     await mine(client, { blocks: 1 })
 

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -162,6 +162,7 @@ export async function signTransaction<
     return account.signTransaction(
       {
         ...transaction,
+        account,
         chainId,
       } as TransactionSerializable,
       { serializer: client.chain?.serializers?.transaction },


### PR DESCRIPTION
## What is this PR solving?
                                                                                                                                                                                         
  `wallet/signTransaction` local-account flow was dropping `account` context before calling `account.signTransaction`.                                                                   
  Tempo transaction detection (`src/tempo/Transaction.ts#getType`) relies on `transaction.account.source` / `transaction.account.keyType`, so secp256k1 access-key accounts could be misdetected and routed to the wrong serialization path.                                                                                                                                
                                                                                                                                                                                         
  This PR:
  - Passes parsed `account` into the local `signTransaction` payload in `src/actions/wallet/signTransaction.ts`.                                                                         
  - Adds a regression test in `src/actions/wallet/signTransaction.test.ts` to assert account context is preserved in local sign requests.                                                
                                                                                                                                                                                         
  Related: #4448                                                                                                                                                                         
                                                                                                                                                                                         
  ## What alternatives were explored?                                                                                                                                                    
                                                                                                                                                                                         
  - Extending Tempo detection with more field heuristics only: rejected because it is brittle for secp256k1 access-key accounts.                                                         
  - Forcing callers to explicitly set transaction type: rejected because it pushes internal routing responsibility to users.                                                             
                                                                                                                                                                                         
  ## What should reviewers pay extra attention to?                                                                                                                                       
                                                                                                                                                                                         
  - The added `account` field in local signing payload should not affect non-Tempo serializers (extra field should be ignored).                                                          
  - Regression coverage in `signTransaction` tests for local signing path.                                                                                                               
                                                                                                                                                                                         
  ## Checklist                                                                                                                                                                           
                                                                                                                                                                                         
  - [x] Read the Contributing Guidelines.                                                                                                                                                
  - [ ] Checked for duplicate PRs solving the same issue (please confirm in GitHub UI).                                                                                                  
  - [x] Documentation update not required for this internal routing fix.
  - [x] Added relevant test for the affected path (`src/actions/wallet/signTransaction.test.ts`).   