### PR TITLE
fix(tempo): forward feePayer: false in transaction request formatter

### DIFF
--- a/.changeset/forward-feepayer-false.md
+++ b/.changeset/forward-feepayer-false.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed Tempo formatter to forward `feePayer: false` in transaction requests.

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -133,7 +133,7 @@ export function formatTransactionRequest(
     ...(keyData ? { keyData } : {}),
     ...(keyId ? { keyId } : {}),
     ...(keyType ? { keyType } : {}),
-    ...(request.feePayer
+    ...(typeof request.feePayer !== 'undefined'
       ? {
           feePayer:
             typeof request.feePayer === 'object'


### PR DESCRIPTION
The Tempo transaction request formatter was only forwarding `feePayer` when truthy. This meant `feePayer: false` (explicit opt-out of sponsorship) was silently dropped, so the relay never saw it.

Changed the condition from `request.feePayer` to `typeof request.feePayer !== 'undefined'` so `false` is forwarded.