### PR TITLE
fix(chains): preserve OP predeploy contracts on Zircuit

### DIFF
--- a/.changeset/fluffy-hats-wait.md
+++ b/.changeset/fluffy-hats-wait.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added OP Stack chain config to Zircuit.

--- a/src/chains/definitions/zircuit.ts
+++ b/src/chains/definitions/zircuit.ts
@@ -24,6 +24,7 @@ export const zircuit = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
     },

--- a/src/chains/definitions/zircuitGarfieldTestnet.ts
+++ b/src/chains/definitions/zircuitGarfieldTestnet.ts
@@ -20,6 +20,7 @@ export const zircuitGarfieldTestnet = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
     },


### PR DESCRIPTION
  This PR fixes a silent config-loss bug in Zircuit OP Stack chain definitions.
                                                                                                                                                                                      
  ## What is this PR solving?                                                                                                                                                         
  `zircuit` and `zircuitGarfieldTestnet` spread `...chainConfig` at the top level, but their `contracts` objects did not spread `...chainConfig.contracts`, which overwrote OP predeploy defaults (for example `gasPriceOracle`, `l1Block`, and `l2ToL1MessagePasser`).                                                                                            
                                                                                                                                                                                      
  This change adds `...chainConfig.contracts` in:                                                                                                                                     
  - `src/chains/definitions/zircuit.ts`                                                                                                                                               
  - `src/chains/definitions/zircuitGarfieldTestnet.ts`                                                                                                                                
                                                                                                                                                                                      
  Related: #4423                                                                                                                                                                      
                                                                                                                                                                                      
  ## What alternatives were explored?                                                                                                                                                 
  - Deep-merging `contracts` inside `defineChain` was considered, but it would change merge semantics globally.                                                                       
  - Copying OP predeploy entries directly into Zircuit files was considered, but it duplicates source-of-truth and increases drift risk.                                              
  - Changing `src/op-stack/contracts.ts` was unnecessary because defaults there are already correct.                                                                                  
                                                                                                                                                                                      
  ## What should reviewers pay extra attention to?                                                                                                                                    
  - Confirm Zircuit-specific contract entries still override inherited defaults where keys overlap.                                                                                   
  - Confirm this is a minimal, scoped fix with no behavior changes outside the two Zircuit chain definitions.                                                                         
                                                                                                                                                                                      
  ## Documentation                                                                                                                                                                    
  No documentation update is needed because this is an internal chain-definition correctness fix with no public API change.                                                           
                                                                                                                                                                                      
  ## Tests                                                                                                                                                                            
  Please run:                                                                                                                                                                         
  - `pnpm test:chains`                                                                                                                                                                
  - `pnpm check:types`         