### PR TITLE
fix(erc7821): bound supportsExecutionMode cache

### DIFF
--- a/src/experimental/erc7821/actions/execute.ts
+++ b/src/experimental/erc7821/actions/execute.ts
@@ -18,7 +18,6 @@ import type {
 import type { Hex } from '../../../types/misc.js'
 import type { UnionEvaluate, UnionPick } from '../../../types/utils.js'
 import type { FormattedTransactionRequest } from '../../../utils/formatters/transactionRequest.js'
-import { withCache } from '../../../utils/promise/withCache.js'
 import { executionMode } from '../constants.js'
 import { ExecuteUnsupportedError } from '../errors.js'
 import {
@@ -147,16 +146,10 @@ export async function execute<
   const address = authorizationList?.[0]?.address ?? parameters.address
   const mode = opData ? executionMode.opData : executionMode.default
 
-  const supported = await withCache(
-    () =>
-      supportsExecutionMode(client, {
-        address,
-        mode,
-      }),
-    {
-      cacheKey: `supportsExecutionMode.${client.uid}.${address}.${mode}`,
-    },
-  )
+  const supported = await supportsExecutionMode(client, {
+    address,
+    mode,
+  })
   if (!supported) throw new ExecuteUnsupportedError()
 
   try {

--- a/src/experimental/erc7821/actions/executeBatches.ts
+++ b/src/experimental/erc7821/actions/executeBatches.ts
@@ -18,7 +18,6 @@ import type {
 import type { Hex } from '../../../types/misc.js'
 import type { UnionEvaluate, UnionPick } from '../../../types/utils.js'
 import type { FormattedTransactionRequest } from '../../../utils/formatters/transactionRequest.js'
-import { withCache } from '../../../utils/promise/withCache.js'
 import { ExecuteUnsupportedError } from '../errors.js'
 import {
   type EncodeExecuteBatchesDataErrorType,
@@ -169,16 +168,10 @@ export async function executeBatches<
 
   const address = authorizationList?.[0]?.address ?? parameters.address
 
-  const supported = await withCache(
-    () =>
-      supportsExecutionMode(client, {
-        address,
-        mode: 'batchOfBatches',
-      }),
-    {
-      cacheKey: `supportsExecutionMode.${client.uid}.${address}.batchOfBatches`,
-    },
-  )
+  const supported = await supportsExecutionMode(client, {
+    address,
+    mode: 'batchOfBatches',
+  })
   if (!supported) throw new ExecuteUnsupportedError()
 
   try {

--- a/src/experimental/erc7821/actions/supportsExecutionMode.cache.test.ts
+++ b/src/experimental/erc7821/actions/supportsExecutionMode.cache.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, vi } from 'vitest'
+
+import type { Address } from '../../../accounts/index.js'
+import * as readContract from '../../../actions/public/readContract.js'
+
+import { supportsExecutionMode } from './supportsExecutionMode.js'
+
+const toAddress = (value: number) =>
+  `0x${value.toString(16).padStart(40, '0')}` as Address
+
+test('behavior: caches per client uid', async () => {
+  const spy = vi
+    .spyOn(readContract, 'readContract')
+    .mockResolvedValue(true as any)
+  const address = toAddress(1)
+
+  await supportsExecutionMode({ uid: 'client-a' } as any, { address })
+  await supportsExecutionMode({ uid: 'client-a' } as any, { address })
+  await supportsExecutionMode({ uid: 'client-b' } as any, { address })
+
+  expect(spy).toHaveBeenCalledTimes(2)
+})
+
+test('behavior: evicts old responses for high-cardinality keys', async () => {
+  const spy = vi
+    .spyOn(readContract, 'readContract')
+    .mockResolvedValue(true as any)
+  const client = { uid: 'lru-client' } as any
+  const firstAddress = toAddress(100_000)
+
+  for (let i = 0; i < 8_193; i++) {
+    await supportsExecutionMode(client, { address: toAddress(100_000 + i) })
+  }
+
+  await supportsExecutionMode(client, { address: firstAddress })
+
+  expect(spy).toHaveBeenCalledTimes(8_194)
+})

--- a/src/experimental/erc7821/actions/supportsExecutionMode.ts
+++ b/src/experimental/erc7821/actions/supportsExecutionMode.ts
@@ -5,6 +5,7 @@ import type { Transport } from '../../../clients/transports/createTransport.js'
 import type { ErrorType } from '../../../errors/utils.js'
 import type { Chain } from '../../../types/chain.js'
 import type { Hex } from '../../../types/misc.js'
+import { LruMap } from '../../../utils/lru.js'
 import { withCache } from '../../../utils/promise/withCache.js'
 import { abi, executionMode } from '../constants.js'
 
@@ -16,6 +17,11 @@ export type SupportsExecutionModeParameters = {
 export type SupportsExecutionModeReturnType = boolean
 
 export type SupportsExecutionModeErrorType = ErrorType
+
+const responseCache = /*#__PURE__*/ new LruMap<{
+  created: Date
+  data: SupportsExecutionModeReturnType
+}>(8192)
 
 const toSerializedMode = {
   default: executionMode.default,
@@ -64,7 +70,8 @@ export async function supportsExecutionMode<
           args: [mode],
         }),
       {
-        cacheKey: `supportsExecutionMode.${address}.${mode}`,
+        cacheKey: `supportsExecutionMode.${client.uid}.${address}.${mode}`,
+        responseCache,
       },
     )
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1710,7 +1710,11 @@ export {
   type NonceManagerSource,
   nonceManager,
 } from './utils/nonceManager.js'
-export { withCache } from './utils/promise/withCache.js'
+export {
+  type WithCacheParameters,
+  type WithCacheStore,
+  withCache,
+} from './utils/promise/withCache.js'
 export {
   type WithRetryErrorType,
   withRetry,

--- a/src/utils/promise/withCache.test.ts
+++ b/src/utils/promise/withCache.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { LruMap } from '../lru.js'
 import { wait } from '../wait.js'
 
-import { getCache, withCache } from './withCache.js'
+import {
+  getCache,
+  promiseCache,
+  responseCache,
+  withCache,
+} from './withCache.js'
 
-beforeEach(() => getCache('foo').clear())
+beforeEach(() => {
+  promiseCache.clear()
+  responseCache.clear()
+})
 
 test('caches responses', async () => {
   const fn = vi.fn().mockResolvedValue('bar')
@@ -94,4 +103,31 @@ test('behavior: programmatic removal', async () => {
   expect(data).toBe('bar')
 
   expect(fn).toBeCalledTimes(2)
+})
+
+test('behavior: clears expired responses before refreshing', async () => {
+  const error = new Error('boom')
+
+  await withCache(() => Promise.resolve('bar'), { cacheKey: 'foo' })
+  await wait(150)
+
+  await expect(
+    withCache(() => Promise.reject(error), {
+      cacheKey: 'foo',
+      cacheTime: 100,
+    }),
+  ).rejects.toThrow(error)
+
+  expect(getCache('foo').response.get()).toBeUndefined()
+})
+
+test('behavior: uses custom cache stores', async () => {
+  const fn = vi.fn().mockResolvedValue('bar')
+  const responseCache = new LruMap<{ created: Date; data: string }>(1)
+
+  await withCache(fn, { cacheKey: 'foo', responseCache })
+  await withCache(fn, { cacheKey: 'bar', responseCache })
+  await withCache(fn, { cacheKey: 'foo', responseCache })
+
+  expect(fn).toBeCalledTimes(3)
 })

--- a/src/utils/promise/withCache.ts
+++ b/src/utils/promise/withCache.ts
@@ -7,17 +7,38 @@ export const responseCache = /*#__PURE__*/ new Map()
 
 export type GetCacheErrorType = ErrorType
 
-export function getCache<data>(cacheKey: string) {
-  const buildCache = <data>(cacheKey: string, cache: Map<string, data>) => ({
+export type WithCacheStore<data> = Pick<
+  Map<string, data>,
+  'delete' | 'get' | 'set'
+>
+
+type GetCacheParameters<data> = {
+  promiseCache?: WithCacheStore<Promise<data>> | undefined
+  responseCache?:
+    | WithCacheStore<{
+        created: Date
+        data: data
+      }>
+    | undefined
+}
+
+export function getCache<data>(
+  cacheKey: string,
+  {
+    promiseCache: promiseCache_ = promiseCache,
+    responseCache: responseCache_ = responseCache,
+  }: GetCacheParameters<data> = {},
+) {
+  const buildCache = <data>(cacheKey: string, cache: WithCacheStore<data>) => ({
     clear: () => cache.delete(cacheKey),
     get: () => cache.get(cacheKey),
     set: (data: data) => cache.set(cacheKey, data),
   })
 
-  const promise = buildCache<Promise<data>>(cacheKey, promiseCache)
+  const promise = buildCache<Promise<data>>(cacheKey, promiseCache_)
   const response = buildCache<{ created: Date; data: data }>(
     cacheKey,
-    responseCache,
+    responseCache_,
   )
 
   return {
@@ -30,7 +51,7 @@ export function getCache<data>(cacheKey: string) {
   }
 }
 
-type WithCacheParameters = {
+export type WithCacheParameters<data = unknown> = GetCacheParameters<data> & {
   /** The key to cache the data against. */
   cacheKey: string
   /** The time that cached data will remain in memory. Default: Infinity (no expiry) */
@@ -43,17 +64,29 @@ type WithCacheParameters = {
  */
 export async function withCache<data>(
   fn: () => Promise<data>,
-  { cacheKey, cacheTime = Number.POSITIVE_INFINITY }: WithCacheParameters,
+  {
+    cacheKey,
+    cacheTime = Number.POSITIVE_INFINITY,
+    promiseCache,
+    responseCache,
+  }: WithCacheParameters<data>,
 ) {
-  const cache = getCache<data>(cacheKey)
+  const cache = getCache<data>(cacheKey, {
+    promiseCache,
+    responseCache,
+  })
 
   // If a response exists in the cache, and it's not expired, return it
   // and do not invoke the promise.
   // If the max age is 0, the cache is disabled.
   const response = cache.response.get()
-  if (response && cacheTime > 0) {
-    const age = Date.now() - response.created.getTime()
-    if (age < cacheTime) return response.data
+  if (response) {
+    if (cacheTime > 0) {
+      const age = Date.now() - response.created.getTime()
+      if (age < cacheTime) return response.data
+    }
+
+    cache.response.clear()
   }
 
   let promise = cache.promise.get()


### PR DESCRIPTION
This bounds the `supportsExecutionMode` cache used by the ERC-7821 helpers so long-lived processes do not accumulate unbounded response entries for distinct client/address/mode combinations.

It adds optional cache store overrides to `withCache`, clears expired responses before refresh, switches `supportsExecutionMode` to a bounded `LruMap`, removes the redundant outer cache layers in `execute` and `executeBatches`, and adds focused regression coverage for per-client keys and eviction behavior.