### PR TITLE
fix: preserve nonce 0 in prepareTransactionRequest

### DIFF
--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -2294,6 +2294,25 @@ describe('behavior: attemptFill', () => {
     expect(fillTransactionSpy).toHaveBeenCalled()
   })
 
+  test('behavior: preserves nonce === 0 from fillTransaction', async () => {
+    vi.spyOn(fillTransaction, 'fillTransaction').mockResolvedValue({
+      raw: '0x',
+      transaction: {
+        gas: 21000n,
+        nonce: 0,
+      } as any,
+    })
+
+    const request = await prepareTransactionRequest(client, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      parameters: ['gas', 'nonce'],
+      to: targetAccount.address,
+      value: parseEther('1'),
+    })
+
+    expect(request.nonce).toBe(0)
+  })
+
   test('behavior: do not attempt fill when blobs and kzg are provided with blobVersionedHashes parameter', async () => {
     await setup()
 

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -473,7 +473,7 @@ export async function prepareTransactionRequest<
   request = {
     ...(fillResult as any),
     ...(account ? { from: account?.address } : {}),
-    ...(nonce ? { nonce } : {}),
+    ...(typeof nonce !== 'undefined' ? { nonce } : {}),
   }
   const { blobs, gas, kzg, type } = request
 


### PR DESCRIPTION
`prepareTransactionRequest` now preserves a filled `nonce` value of `0` when merging the `eth_fillTransaction` response back into the prepared request.

The previous merge used a truthiness check and dropped `nonce: 0`, which left first-use accounts without the filled nonce. This switches the merge to an explicit `undefined` check and adds a regression test covering `nonce === 0`.

Follow-up to #4456.