### PR TITLE
chore: Deprecate Status Network Sepolia

### DIFF
--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -592,10 +592,10 @@ export { sovaSepolia } from './definitions/sovaSepolia.js'
 export { spicy } from './definitions/spicy.js'
 export { stable } from './definitions/stable.js'
 export { stableTestnet } from './definitions/stableTestnet.js'
-export {
-  statusSepolia,
-  statusSepolia as statusNetworkSepolia,
-} from './definitions/statusNetworkSepolia.js'
+/** @deprecated */
+export { statusSepolia } from './definitions/statusNetworkSepolia.js'
+/** @deprecated */
+export { statusSepolia as statusNetworkSepolia } from './definitions/statusNetworkSepolia.js'
 export { step } from './definitions/step.js'
 export { story } from './definitions/story.js'
 export { storyAeneid } from './definitions/storyAeneid.js'


### PR DESCRIPTION
Hello team!

I'm Filip, from the Status Network core team.
We are deprecating the Status Network Sepolia Testnet.

I've changed the export into separate lines so that @deprecated symbol can be more easily recognized by all Typescript compiler versions.

Hope all is good and thank you for the review,
Filip Pajic

**Checkups I've done:**
[x] Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
[x] Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
[x] Update the corresponding documentation if needed.
[x] Include relevant tests that fail without this PR, but pass with it.=

