### PR TITLE
feat(chains): add multicall3 to hyperEvm

### DIFF
--- a/.changeset/hyperevm-multicall3.md
+++ b/.changeset/hyperevm-multicall3.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `multicall3` contract address to `hyperEvm` chain definition. Multicall3 is deployed at the canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` on HyperEVM (verified on [hyperevmscan.io](https://hyperevmscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)), enabling automatic `eth_call` batching via `multicall` and wagmi's read batching.

--- a/.changeset/hyperevm-multicall3.md
+++ b/.changeset/hyperevm-multicall3.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added `multicall3` contract address to `hyperEvm` chain definition. Multicall3 is deployed at the canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` on HyperEVM (verified on [hyperevmscan.io](https://hyperevmscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)), enabling automatic `eth_call` batching via `multicall` and wagmi's read batching.
+Added `multicall3` contract address to `hyperEvm` chain definition. 

--- a/src/chains/definitions/hyperEvm.ts
+++ b/src/chains/definitions/hyperEvm.ts
@@ -10,6 +10,12 @@ export const hyperEvm = /*#__PURE__*/ defineChain({
       url: 'https://hyperevmscan.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 13051,
+    },
+  },
   rpcUrls: {
     default: {
       http: ['https://rpc.hyperliquid.xyz/evm'],


### PR DESCRIPTION
Multicall3 is deployed at the canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` on HyperEVM ([verified on hyperevmscan.io](https://hyperevmscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11#code)) at block `13051`.

Without this entry, automatic `eth_call` batching via `multicall` (and wagmi's read batching) silently no-ops for HyperEVM users, causing N separate `eth_call` RPCs instead of one `aggregate3`.

Verified bytecode is present at that address on HyperEVM mainnet:

```
$ cast code 0xcA11bde05977b3631167028862bE2a173976CA11 --rpc-url https://rpc.hyperliquid.xyz/evm
0x608060405260043610...
```

Supersedes #4476 (closed without explanation; this PR additionally provides `blockCreated` for `getContractEvents`/log-scanning use cases).