### PR TITLE
fix(erc7821): scope supportsExecutionMode cache per client

### DIFF
--- a/src/experimental/erc7821/actions/execute.ts
+++ b/src/experimental/erc7821/actions/execute.ts
@@ -18,7 +18,6 @@ import type {
 import type { Hex } from '../../../types/misc.js'
 import type { UnionEvaluate, UnionPick } from '../../../types/utils.js'
 import type { FormattedTransactionRequest } from '../../../utils/formatters/transactionRequest.js'
-import { withCache } from '../../../utils/promise/withCache.js'
 import { executionMode } from '../constants.js'
 import { ExecuteUnsupportedError } from '../errors.js'
 import {
@@ -147,16 +146,10 @@ export async function execute<
   const address = authorizationList?.[0]?.address ?? parameters.address
   const mode = opData ? executionMode.opData : executionMode.default
 
-  const supported = await withCache(
-    () =>
-      supportsExecutionMode(client, {
-        address,
-        mode,
-      }),
-    {
-      cacheKey: `supportsExecutionMode.${client.uid}.${address}.${mode}`,
-    },
-  )
+  const supported = await supportsExecutionMode(client, {
+    address,
+    mode,
+  })
   if (!supported) throw new ExecuteUnsupportedError()
 
   try {

--- a/src/experimental/erc7821/actions/executeBatches.ts
+++ b/src/experimental/erc7821/actions/executeBatches.ts
@@ -18,7 +18,6 @@ import type {
 import type { Hex } from '../../../types/misc.js'
 import type { UnionEvaluate, UnionPick } from '../../../types/utils.js'
 import type { FormattedTransactionRequest } from '../../../utils/formatters/transactionRequest.js'
-import { withCache } from '../../../utils/promise/withCache.js'
 import { ExecuteUnsupportedError } from '../errors.js'
 import {
   type EncodeExecuteBatchesDataErrorType,
@@ -169,16 +168,10 @@ export async function executeBatches<
 
   const address = authorizationList?.[0]?.address ?? parameters.address
 
-  const supported = await withCache(
-    () =>
-      supportsExecutionMode(client, {
-        address,
-        mode: 'batchOfBatches',
-      }),
-    {
-      cacheKey: `supportsExecutionMode.${client.uid}.${address}.batchOfBatches`,
-    },
-  )
+  const supported = await supportsExecutionMode(client, {
+    address,
+    mode: 'batchOfBatches',
+  })
   if (!supported) throw new ExecuteUnsupportedError()
 
   try {

--- a/src/experimental/erc7821/actions/supportsExecutionMode.cache.test.ts
+++ b/src/experimental/erc7821/actions/supportsExecutionMode.cache.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import * as readContract from '../../../actions/public/readContract.js'
+import { createClient } from '../../../clients/createClient.js'
+import { http } from '../../../clients/transports/http.js'
+import {
+  promiseCache,
+  responseCache,
+} from '../../../utils/promise/withCache.js'
+import { supportsExecutionMode } from './supportsExecutionMode.js'
+
+beforeEach(() => {
+  promiseCache.clear()
+  responseCache.clear()
+  vi.restoreAllMocks()
+})
+
+test('behavior: cache key is isolated per client', async () => {
+  const address = '0x0000000000000000000000000000000000000001'
+  const client_1 = createClient({
+    transport: http('https://mock-1.example.com'),
+  })
+  const client_2 = createClient({
+    transport: http('https://mock-2.example.com'),
+  })
+
+  const readContractSpy = vi
+    .spyOn(readContract, 'readContract')
+    .mockResolvedValueOnce(true as never)
+    .mockResolvedValueOnce(false as never)
+
+  expect(
+    await supportsExecutionMode(client_1, {
+      address,
+    }),
+  ).toBe(true)
+  expect(
+    await supportsExecutionMode(client_2, {
+      address,
+    }),
+  ).toBe(false)
+  expect(readContractSpy).toHaveBeenCalledTimes(2)
+})

--- a/src/experimental/erc7821/actions/supportsExecutionMode.ts
+++ b/src/experimental/erc7821/actions/supportsExecutionMode.ts
@@ -64,7 +64,7 @@ export async function supportsExecutionMode<
           args: [mode],
         }),
       {
-        cacheKey: `supportsExecutionMode.${address}.${mode}`,
+        cacheKey: `supportsExecutionMode.${client.uid}.${address}.${mode}`,
       },
     )
   } catch {


### PR DESCRIPTION
## What is this PR solving?

`supportsExecutionMode` was caching by `address` and `mode` only, so different clients could reuse the same result.

This scopes the cache key by `client.uid`, removes the redundant outer cache in `execute` and `executeBatches`, and adds a regression test for per-client cache isolation.