### PR TITLE
Good day, fix: handle anonymous events in encodeEventTopics()

### DIFF
--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -94,9 +94,6 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
-
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
     const indexedInputs = abiItem.inputs?.filter(
@@ -121,7 +118,13 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
-  return [signature, ...topics]
+  if (!abiItem.anonymous) {
+    const definition = formatAbiItem(abiItem)
+    const signature = toEventSelector(definition as EventDefinition)
+    topics.unshift(signature)
+  }
+
+  return topics
 }
 
 export type EncodeArgErrorType =


### PR DESCRIPTION
Good day,

This PR fixes issue #4461 — `encodeEventTopics()` incorrectly prepending the event signature as topic0 for anonymous events.

## Problem

For anonymous events (declared with `anonymous: true`), the first indexed topic should be `topic0`, not the event signature. However, the previous code unconditionally prepended the signature:

```ts
const definition = formatAbiItem(abiItem)
const signature = toEventSelector(definition as EventDefinition)
...
return [signature, ...topics]
```

## Fix

Only prepend the signature for non-anonymous events:

```diff
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
   let topics: (Hex | Hex[] | null)[] = []
   ...
-  return [signature, ...topics]
+  if (!abiItem.anonymous) {
+    const definition = formatAbiItem(abiItem)
+    const signature = toEventSelector(definition as EventDefinition)
+    topics.unshift(signature)
+  }
+  return topics
```

## Tests

The issue already includes a test case demonstrating the expected behavior. All existing tests continue to pass for non-anonymous events.

Thank you for your work on this project. Happy to iterate on this if any adjustments are needed.

Warmly,
RoomWithOutRoof