### PR TITLE
fix(encodeEventTopics): handle anonymous events correctly

### DIFF
--- a/.changeset/rare-bats-wait.md
+++ b/.changeset/rare-bats-wait.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix(encodeEventTopics): handle anonymous events correctly

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -121,6 +121,11 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+
+  // only prepend signature for non-anonymous events
+  if (abiItem.anonymous)
+    return topics
+
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
Fixes #4461

Anonymous events should not have the signature prepended as topic0. This fix adds an early return for anonymous events, returning only the encoded topic values.

## Changes

In `src/utils/abi/encodeEventTopics.ts`, added a check for `abiItem.anonymous` before returning. For anonymous events, the function now returns only the encoded indexed arguments (empty array if no args), rather than prepending the event signature as topic0.

## Test cases (per issue #4461)

`anonymous event: no args` → `[]`
`anonymous event: topic0` → `[0x...abcd, null, null, null]`
`anonymous event: all topics` → `[topic0, topic1, topic2, topic3]`

---

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof