### PR TITLE
fix(tempo): bump gas for self-paid local signers

### DIFF
--- a/.changeset/soft-gifts-allow.md
+++ b/.changeset/soft-gifts-allow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Tempo transaction preparation to add the intrinsic gas bump for self-paid local WebAuthn and access-key transactions while preserving the existing fee-payer WebAuthn bump behavior.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -14,6 +14,7 @@ import { createClient, http } from '../index.js'
 import { defineChain } from '../utils/chain/defineChain.js'
 import { hashMessage } from '../utils/index.js'
 import * as accessKeyActions from './actions/accessKey.js'
+import { chainConfig } from './chainConfig.js'
 import { Account, P256, WebCryptoP256 } from './index.js'
 
 const client = getClient({
@@ -22,7 +23,87 @@ const client = getClient({
 
 const maxUint256 = 2n ** 256n - 1n
 
+async function prepareAfterFillParameters(request: Record<string, unknown>) {
+  const [prepare] = chainConfig.prepareTransactionRequest
+  return await prepare(
+    request as never,
+    { phase: 'afterFillParameters' } as never,
+  )
+}
+
 describe('prepareTransactionRequest', () => {
+  test('behavior: self-paid local webAuthn transactions add the intrinsic gas bump', async () => {
+    const request = await prepareAfterFillParameters({
+      account: Account.fromHeadlessWebAuthn(generatePrivateKey(), {
+        origin: 'http://localhost',
+        rpId: 'localhost',
+      }),
+      gas: 50_000n,
+    })
+
+    expect(request.gas).toBe(70_000n)
+  })
+
+  test('behavior: self-paid local access key transactions add the intrinsic gas bump', async () => {
+    const request = await prepareAfterFillParameters({
+      account: Account.fromP256(generatePrivateKey(), {
+        access: accounts.at(0)!,
+      }),
+      gas: 50_000n,
+    })
+
+    expect(request.gas).toBe(60_000n)
+  })
+
+  test('behavior: self-paid local webAuthn access key transactions keep the smaller intrinsic gas bump', async () => {
+    const request = await prepareAfterFillParameters({
+      account: Account.fromHeadlessWebAuthn(generatePrivateKey(), {
+        access: accounts.at(0)!,
+        origin: 'http://localhost',
+        rpId: 'localhost',
+      }),
+      gas: 50_000n,
+    })
+
+    expect(request.gas).toBe(60_000n)
+  })
+
+  test('behavior: feePayer webAuthn transactions keep the intrinsic gas bump', async () => {
+    const request = await prepareAfterFillParameters({
+      feePayer: true,
+      gas: 50_000n,
+      keyAuthorization: {
+        signature: { type: 'webAuthn' },
+      },
+    })
+
+    expect(request.gas).toBe(70_000n)
+  })
+
+  test('behavior: feePayer webAuthn key authorizations keep the larger bump for access key accounts', async () => {
+    const request = await prepareAfterFillParameters({
+      account: Account.fromP256(generatePrivateKey(), {
+        access: accounts.at(0)!,
+      }),
+      feePayer: true,
+      gas: 50_000n,
+      keyAuthorization: {
+        signature: { type: 'webAuthn' },
+      },
+    })
+
+    expect(request.gas).toBe(70_000n)
+  })
+
+  test('behavior: self-paid local p256 root transactions do not add the intrinsic gas bump', async () => {
+    const request = await prepareAfterFillParameters({
+      account: Account.fromP256(generatePrivateKey()),
+      gas: 50_000n,
+    })
+
+    expect(request.gas).toBe(50_000n)
+  })
+
   test('behavior: expiring nonces for feePayer transactions', async () => {
     const now = Math.floor(Date.now() / 1000)
     const requests = await Promise.all([

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -50,14 +50,24 @@ export const chainConfig = {
       }
 
       // FIXME: node estimates gas with secp256k1 dummy sig + null feePayerSignature.
-      // Actual tx has larger keychain/webAuthn sigs + real fee payer sig, costing more intrinsic gas.
+      // Actual tx can carry larger keychain/webAuthn signatures and/or a real fee payer signature,
+      // costing more intrinsic gas.
       if (phase === 'afterFillParameters') {
-        if (request.feePayer) {
-          if (request.keyAuthorization?.signature.type === 'webAuthn')
-            request.gas = (request.gas ?? 0n) + 20_000n
-          else if (request.account?.source === 'accessKey')
-            request.gas = (request.gas ?? 0n) + 10_000n
-        }
+        if (
+          request.feePayer &&
+          request.keyAuthorization?.signature.type === 'webAuthn'
+        )
+          request.gas = (request.gas ?? 0n) + 20_000n
+        else if (
+          request.account?.type === 'local' &&
+          request.account.source === 'accessKey'
+        )
+          request.gas = (request.gas ?? 0n) + 10_000n
+        else if (
+          request.account?.type === 'local' &&
+          request.account.keyType === 'webAuthn'
+        )
+          request.gas = (request.gas ?? 0n) + 20_000n
         return request as unknown as typeof r
       }
 


### PR DESCRIPTION
Adds the intrinsic gas bump during Tempo transaction preparation for self-paid local WebAuthn and access-key transactions, while preserving the existing sponsored WebAuthn behavior.

The test coverage now locks in the branch ordering so self-paid WebAuthn access keys keep the smaller access-key bump instead of being treated like root WebAuthn signers.

Validation:
- `pnpm exec vitest -c ./test/vitest.config.ts src/tempo/chainConfig.test.ts`
- `pnpm exec biome check src/tempo/chainConfig.ts src/tempo/chainConfig.test.ts .changeset/soft-gifts-allow.md`