### PR TITLE
Add CCIP-Read Tunneling

### DIFF
--- a/.changeset/poor-garlics-sing.md
+++ b/.changeset/poor-garlics-sing.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added CCIP-Read Tunneling.

--- a/src/constants/solidity.ts
+++ b/src/constants/solidity.ts
@@ -13,7 +13,7 @@ export const panicReasons = {
   81: 'Attempted to call a zero-initialized variable of internal function type.',
 } as const
 
-export const solidityError: AbiError = {
+export const solidityError = {
   inputs: [
     {
       name: 'message',
@@ -22,8 +22,8 @@ export const solidityError: AbiError = {
   ],
   name: 'Error',
   type: 'error',
-}
-export const solidityPanic: AbiError = {
+} as const satisfies AbiError
+export const solidityPanic = {
   inputs: [
     {
       name: 'reason',
@@ -32,4 +32,4 @@ export const solidityPanic: AbiError = {
   ],
   name: 'Panic',
   type: 'error',
-}
+} as const satisfies AbiError

--- a/src/utils/ccipTunnel.test.ts
+++ b/src/utils/ccipTunnel.test.ts
@@ -1,13 +1,3 @@
-import { describe, expect, test, beforeEach, beforeAll } from 'vitest'
-
-import { anvilMainnet } from '~test/anvil.js'
-import { createCcipReadTunnel } from './ccipTunnel.js'
-import {
-  getCode,
-  getEnsAddress,
-  getEnsResolver,
-  readContract,
-} from 'viem/actions'
 import {
   ccipRequest,
   decodeFunctionResult,
@@ -16,6 +6,10 @@ import {
   parseAbi,
   toHex,
 } from 'viem'
+import { getEnsAddress, getEnsResolver, readContract } from 'viem/actions'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { anvilMainnet } from '~test/anvil.js'
+import { createCcipReadTunnel } from './ccipTunnel.js'
 import { packetToBytes } from './ens/packetToBytes.js'
 
 const batchGateways = ['https://ccip-v3.ens.xyz']

--- a/src/utils/ccipTunnel.test.ts
+++ b/src/utils/ccipTunnel.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test, beforeEach, beforeAll } from 'vitest'
+
+import { anvilMainnet } from '~test/anvil.js'
+import { createCcipReadTunnel } from './ccipTunnel.js'
+import {
+  getCode,
+  getEnsAddress,
+  getEnsResolver,
+  readContract,
+} from 'viem/actions'
+import {
+  ccipRequest,
+  decodeFunctionResult,
+  encodeFunctionData,
+  namehash,
+  parseAbi,
+  toHex,
+} from 'viem'
+import { packetToBytes } from './ens/packetToBytes.js'
+
+const batchGateways = ['https://ccip-v3.ens.xyz']
+const requested = new Set<string>()
+const client = anvilMainnet.getClient({
+  ccipRead: createCcipReadTunnel({
+    batchGateways,
+    ccipRequest: async (args) => {
+      for (const x of args.urls) {
+        requested.add(x)
+      }
+      return ccipRequest(args)
+    },
+  }),
+})
+
+const NAME = 'raffy.base.eth'
+const ADDR = '0x51050ec063d393217B436747617aD1C2285Aeeee'
+
+describe('ccipTunnel', () => {
+  beforeEach(() => requested.clear())
+
+  test('passthrough', async () => {
+    const addr = await getEnsAddress(client, { name: NAME })
+    expect(addr).toStrictEqual(ADDR)
+    expect([...requested]).toStrictEqual(batchGateways)
+  })
+
+  test('tunnelled', async () => {
+    const abi = parseAbi(['function addr(bytes32) view returns (address)'])
+    const addr = decodeFunctionResult({
+      abi,
+      data: await readContract(client, {
+        address: await getEnsResolver(client, { name: NAME }),
+        abi: parseAbi(['function resolve(bytes, bytes) view returns (bytes)']),
+        functionName: 'resolve',
+        args: [
+          toHex(packetToBytes(NAME)),
+          encodeFunctionData({
+            abi,
+            args: [namehash(NAME)],
+          }),
+        ],
+      }),
+    })
+    expect(addr).toStrictEqual(ADDR)
+    expect([...requested]).toStrictEqual(batchGateways)
+  })
+})

--- a/src/utils/ccipTunnel.ts
+++ b/src/utils/ccipTunnel.ts
@@ -1,4 +1,5 @@
 import { batchGatewayAbi } from '../constants/abis.js'
+import { solidityError } from '../constants/solidity.js'
 import { HttpRequestError } from '../errors/request.js'
 import { decodeErrorResult } from './abi/decodeErrorResult.js'
 import { decodeFunctionResult } from './abi/decodeFunctionResult.js'
@@ -50,7 +51,18 @@ export function createCcipReadTunnel({
               status,
               url: urls.join(' | '),
             })
-          } catch {}
+          } catch {
+            let message: string | undefined
+            try {
+              ;({
+                args: [message],
+              } = decodeErrorResult({
+                abi: [solidityError],
+                data: responses[0],
+              }))
+            } catch {}
+            throw new Error(message ?? 'An unknown error occurred.')
+          }
         }
         return responses[0]
       }

--- a/src/utils/ccipTunnel.ts
+++ b/src/utils/ccipTunnel.ts
@@ -39,6 +39,7 @@ export function createCcipReadTunnel({
           }),
         })
         if (failures[0]) {
+          let error: Error | undefined
           try {
             const {
               args: [status, message],
@@ -46,23 +47,29 @@ export function createCcipReadTunnel({
               abi: batchGatewayAbi,
               data: responses[0],
             })
-            throw new HttpRequestError({
+            error = new HttpRequestError({
               body: { message },
               status,
               url: urls.join(' | '),
             })
-          } catch {
-            let message: string | undefined
+          } catch {}
+          if (!error) {
             try {
-              ;({
+              const {
                 args: [message],
               } = decodeErrorResult({
                 abi: [solidityError],
                 data: responses[0],
-              }))
+              })
+              if (message) {
+                error = new Error(message)
+              }
             } catch {}
-            throw new Error(message ?? 'An unknown error occurred.')
+            if (!error) {
+              throw new Error('An unknown error occurred.')
+            }
           }
+          throw error
         }
         return responses[0]
       }

--- a/src/utils/ccipTunnel.ts
+++ b/src/utils/ccipTunnel.ts
@@ -1,0 +1,59 @@
+import { batchGatewayAbi } from '../constants/abis.js'
+import { HttpRequestError } from '../errors/request.js'
+import { decodeErrorResult } from './abi/decodeErrorResult.js'
+import { decodeFunctionResult } from './abi/decodeFunctionResult.js'
+import { encodeFunctionData } from './abi/encodeFunctionData.js'
+import { ccipRequest as ccipRequest_ } from './ccip.js'
+import { localBatchGatewayUrl } from './ens/localBatchGatewayRequest.js'
+
+export type CcipReadTunnelParameters = {
+  batchGateways: string[]
+  ccipRequest?: typeof ccipRequest_
+}
+
+export function createCcipReadTunnel({
+  batchGateways,
+  ccipRequest = ccipRequest_,
+}: CcipReadTunnelParameters): { request: typeof ccipRequest_ } {
+  return {
+    async request({ data, sender, urls }) {
+      if (urls.includes(localBatchGatewayUrl)) {
+        return ccipRequest({
+          data,
+          sender,
+          urls: batchGateways,
+        })
+      } else {
+        const [failures, responses] = decodeFunctionResult({
+          abi: batchGatewayAbi,
+          functionName: 'query',
+          data: await ccipRequest({
+            data: encodeFunctionData({
+              abi: batchGatewayAbi,
+              functionName: 'query',
+              args: [[{ sender, data, urls }]],
+            }),
+            sender,
+            urls: batchGateways,
+          }),
+        })
+        if (failures[0]) {
+          try {
+            const {
+              args: [status, message],
+            } = decodeErrorResult({
+              abi: batchGatewayAbi,
+              data: responses[0],
+            })
+            throw new HttpRequestError({
+              body: { message },
+              status,
+              url: urls.join(' | '),
+            })
+          } catch {}
+        }
+        return responses[0]
+      }
+    },
+  }
+}

--- a/src/utils/ccipTunnel.ts
+++ b/src/utils/ccipTunnel.ts
@@ -41,35 +41,24 @@ export function createCcipReadTunnel({
         if (failures[0]) {
           let error: Error | undefined
           try {
-            const {
-              args: [status, message],
-            } = decodeErrorResult({
-              abi: batchGatewayAbi,
+            const res = decodeErrorResult({
+              abi: [...batchGatewayAbi, solidityError],
               data: responses[0],
             })
-            error = new HttpRequestError({
-              body: { message },
-              status,
-              url: urls.join(' | '),
-            })
-          } catch {}
-          if (!error) {
-            try {
-              const {
-                args: [message],
-              } = decodeErrorResult({
-                abi: [solidityError],
-                data: responses[0],
+            if (res.errorName === 'HttpError') {
+              error = new HttpRequestError({
+                body: { message: res.args[1] },
+                status: res.args[0],
+                url: urls.join(' | '),
               })
+            } else {
+              const message = res.args[0]
               if (message) {
                 error = new Error(message)
               }
-            } catch {}
-            if (!error) {
-              throw new Error('An unknown error occurred.')
             }
-          }
-          throw error
+          } catch {}
+          throw error ?? new Error('An unknown error occurred.')
         }
         return responses[0]
       }

--- a/src/utils/ccipTunnel.ts
+++ b/src/utils/ccipTunnel.ts
@@ -12,7 +12,7 @@ export type CcipReadTunnelParameters = {
   ccipRequest?: typeof ccipRequest_
 }
 
-export function createCcipReadTunnel({
+export function ccipReadTunnel({
   batchGateways,
   ccipRequest = ccipRequest_,
 }: CcipReadTunnelParameters): { request: typeof ccipRequest_ } {

--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -22,7 +22,7 @@ import { accounts, poolId } from './constants.js'
 export const anvilMainnet = defineAnvil({
   chain: mainnet,
   forkUrl: getEnv('VITE_ANVIL_FORK_URL', 'https://cloudflare-eth.com'),
-  forkBlockNumber: 22263623n,
+  forkBlockNumber: 24000000n,
   noMining: true,
   port: 8545,
 })

--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -22,7 +22,7 @@ import { accounts, poolId } from './constants.js'
 export const anvilMainnet = defineAnvil({
   chain: mainnet,
   forkUrl: getEnv('VITE_ANVIL_FORK_URL', 'https://cloudflare-eth.com'),
-  forkBlockNumber: 24000000n,
+  forkBlockNumber: 22263623n,
   noMining: true,
   port: 8545,
 })


### PR DESCRIPTION
- added `utils/ccipTunnel.ts` and tests
     * exposes `ccipReadTunnel()`
 
---

Usage:
```ts
// <meta http-equiv="Content-Security-Policy" content="connect-src 'self' <batchGateway>;">
createClient({
   ccipRead: ccipReadTunnel({ batchGateways: [<batchGateway>] })
});
```
&rarr; routes <ins>ALL</ins> CCIP-Read `OffchainLookup` requests through `<batchGateway>`.

---

Note: CCIP-Read is not ENS-specific.