### PR TITLE
docs(tempo): align getRemainingLimit return type docs

### DIFF
--- a/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
+++ b/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
@@ -11,14 +11,16 @@ Gets the remaining spending limit for a key-token pair.
 ```ts twoslash [example.ts]
 import { client } from './viem.config'
 
-const remaining = await client.accessKey.getRemainingLimit({
+const { remaining, periodEnd } = await client.accessKey.getRemainingLimit({
   account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
   accessKey: '0x1234567890abcdef1234567890abcdef12345678',
   token: '0x20c0000000000000000000000000000000000000',
 })
 
 console.log('Remaining limit:', remaining)
+console.log('Period end:', periodEnd)
 // @log: Remaining limit: 1000000n
+// @log: Period end: 1712345678n
 ```
 
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"
@@ -30,10 +32,15 @@ console.log('Remaining limit:', remaining)
 ## Return Type
 
 ```ts
-type ReturnType = bigint
+type ReturnType = {
+  remaining: bigint
+  periodEnd: bigint | undefined
+}
 ```
 
-The remaining spending amount.
+The remaining spending amount and period end timestamp.
+
+`periodEnd` is `undefined` on pre-T3 chains.
 
 ## Parameters
 

--- a/src/tempo/actions/accessKey.ts
+++ b/src/tempo/actions/accessKey.ts
@@ -723,16 +723,18 @@ export namespace getMetadata {
  *   transport: http(),
  * })
  *
- * const remaining = await Actions.accessKey.getRemainingLimit(client, {
+ * const { remaining, periodEnd } = await Actions.accessKey.getRemainingLimit(client, {
  *   account: '0x...',
  *   accessKey: '0x...',
  *   token: '0x...',
  * })
+ *
+ * console.log(remaining, periodEnd)
  * ```
  *
  * @param client - Client.
  * @param parameters - Parameters.
- * @returns The remaining spending amount.
+ * @returns The remaining spending amount and period end timestamp.
  */
 export async function getRemainingLimit<
   chain extends Chain | undefined,


### PR DESCRIPTION
 ## What is this PR solving?
                                                                                                                                                                                      
  accessKey.getRemainingLimit currently returns an object ({ remaining, periodEnd }) in implementation and types, but the source JSDoc example and site docs still describe it as bigint. This mismatch can mislead users and cause incorrect integrations.                                                                                                           
                                                                                                                                                                                      
  This PR aligns docs with the real API behavior by:                                                                                                                                  
                                                                                                                                                                                      
  - updating usage examples to destructure { remaining, periodEnd }                                                                                                                   
  - updating the documented return type to:                                                                                                                                           
      - remaining: bigint                                                                                                                                                             
      - periodEnd: bigint | undefined                                                                                                                                                 
  - clarifying that periodEnd is undefined on pre-T3 chains                                                                                                                           
                                                                                                                                                                                      
  No runtime behavior is changed.                                                                                                                                                     
                                                                                                                                                                                      
  ## What alternatives have you explored?                                                                                                                                             
                                                                                                                                                                                      
  1. Revert implementation to bigint to match docs.                                                                                                                                   
     Rejected because current implementation/types/tests already use object semantics.                                                                                                
  2. Keep docs as-is and add a note only.                                                                                                                                             
     Rejected because the docs are currently incorrect, not just incomplete.                                                                                                          
  3. Add broader API/type refactor for hardfork-specific return typing.                                                                                                               
     Rejected for this PR to keep scope minimal and fix the immediate mismatch.                                                                                                       
                                                                                                                                                                                      
  ## Are there any parts that require more reviewer attention?                                                                                                                        
                                                                                                                                                                                      
  1. Wording accuracy for periodEnd behavior on pre-T3 chains (undefined).                                                                                                            
  2. Consistency between source JSDoc and site docs for the same action.                                                                                                              
  3. Example output readability and correctness in rendered docs.                                                                                                                     
                                                                                                                                                                                      
  ## Checklist                                                                                                                                                                        
                                                                                                                                                                                      
  - [x] Read the Contributing Guidelines                                                                                                                                              
  - [ ] Checked for duplicate PRs                                                                                                                                                     
  - [x] Updated corresponding documentation                                                                                                                                           
  - [x] Included relevant tests or rationale                                                                                                                                          
      - This is a docs/JSDoc alignment change only (no runtime change).                                                                                                               
      - Existing behavior is already covered by src/tempo/actions/accessKey.test.ts (getRemainingLimit cases).    