### PR TITLE
fix: clean up listenersCache and cleanupCache when last observer unsubscribes

### DIFF
--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -48,12 +48,17 @@ export function observe<callbacks extends Callbacks>(
   const unwatch = () => {
     const listeners = getListeners()
     if (!listeners.some((cb: any) => cb.id === callbackId)) return
-    const cleanup = cleanupCache.get(observerId)
-    if (listeners.length === 1 && cleanup) {
-      const p = cleanup()
-      if (p instanceof Promise) p.catch(() => {})
+    if (listeners.length === 1) {
+      const cleanup = cleanupCache.get(observerId)
+      if (cleanup) {
+        const p = cleanup()
+        if (p instanceof Promise) p.catch(() => {})
+      }
+      listenersCache.delete(observerId)
+      cleanupCache.delete(observerId)
+    } else {
+      unsubscribe()
     }
-    unsubscribe()
   }
 
   const listeners = getListeners()


### PR DESCRIPTION
## Summary
- When the last listener for an `observerId` calls `unwatch()`, delete the Map entries from `listenersCache` and `cleanupCache` instead of leaving empty arrays behind
- Prevents unbounded memory growth in long-running Node.js servers that create many viem clients over time

**Before:** `unsubscribe()` uses `filter()` to remove the callback, leaving `[]` in the Map. The entry is never deleted.

**After:** When `listeners.length === 1` (last listener), `listenersCache.delete(observerId)` and `cleanupCache.delete(observerId)` are called. When other listeners remain, the existing `unsubscribe()` behavior is preserved.

**File:** `src/utils/observe.ts`

Fixes #4390

## Test plan
- [ ] Create a public client, subscribe to block numbers, unsubscribe — verify `listenersCache` has no stale entries
- [ ] Multiple listeners on the same observer — verify partial unsubscribe still works
- [ ] Existing test suite passes