### PR TITLE
feat: support anonymous events in encodeEventTopics

### DIFF
--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -500,6 +500,141 @@ test("errors: event doesn't exist", () => {
   `)
 })
 
+test('anonymous event: no args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+          anonymous: true,
+        },
+      ],
+      eventName: 'Transfer',
+    }),
+  ).toEqual([])
+})
+
+test('anonymous event: named args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+          anonymous: true,
+        },
+      ],
+      eventName: 'Transfer',
+      args: {
+        from: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        to: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    '0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b',
+  ])
+})
+
+test('anonymous event: unnamed args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: false,
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+          anonymous: true,
+        },
+      ],
+      eventName: 'Transfer',
+      args: [
+        '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
+      ],
+    }),
+  ).toEqual([
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    '0x000000000000000000000000c961145a54c96e3ae9baa048c4f4d6b04c13916b',
+  ])
+})
+
+test('non-anonymous event still includes signature topic', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+          anonymous: false,
+        },
+      ],
+      eventName: 'Transfer',
+      args: {
+        from: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      },
+    }),
+  ).toEqual([
+    '0xd4419cf35f6100c64400a46af29a62b98c54b65ce3e0009ad138010b5a1b1fba',
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  ])
+})
+
 test('https://github.com/wevm/viem/issues/3278', () => {
   const bugAbi = [
     {

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,11 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+export type EncodeEventTopicsReturnType<
+  anonymous extends boolean = false,
+> = anonymous extends true
+  ? (Hex | Hex[] | null)[]
+  : [Hex, ...(Hex | Hex[] | null)[]]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -94,8 +98,7 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
+  const isAnonymous = 'anonymous' in abiItem && abiItem.anonymous
 
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
@@ -121,6 +124,11 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+
+  if (isAnonymous) return topics as EncodeEventTopicsReturnType
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
## Summary
- `encodeEventTopics()` unconditionally prepended the event signature hash as the first topic, but anonymous Solidity events (`anonymous: true`) should have no signature topic
- **Fix:** Check `abiItem.anonymous` and skip `toEventSelector()` + signature prepend for anonymous events
- **Return type:** Made generic over `anonymous` boolean — anonymous events return `(Hex | Hex[] | null)[]`, non-anonymous keep `[Hex, ...(Hex | Hex[] | null)[]]`. Default is `false` so all existing callers are unaffected.
- Downstream callers (`getLogs`, `watchEvent`, `watchContractEvent`, `createEventFilter`) need no changes

**Files:**
- `src/utils/abi/encodeEventTopics.ts` — runtime check + return type
- `src/utils/abi/encodeEventTopics.test.ts` — 4 new test cases

Fixes #4461

## Test plan
- [ ] Anonymous event with no args → returns `[]`
- [ ] Anonymous event with indexed args → encoded topics without signature
- [ ] Non-anonymous events → unchanged behavior
- [ ] Existing test suite passes