### PR TITLE
fix: clear nonce cache on nonce manager reset

### DIFF
--- a/.changeset/strong-masks-reset.md
+++ b/.changeset/strong-masks-reset.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Clear cached nonces when resetting nonce managers.

--- a/src/utils/nonceManager.reset.test.ts
+++ b/src/utils/nonceManager.reset.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest'
+
+import { createNonceManager } from './nonceManager.js'
+
+const args = {
+  address: '0x0000000000000000000000000000000000000001',
+  chainId: 1,
+  client: {} as never,
+} as const
+
+test('reset clears consumed nonce cache', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+
+  expect(await nonceManager.consume(args)).toBe(1)
+
+  nonceManager.reset(args)
+
+  expect(await nonceManager.consume(args)).toBe(1)
+})
+
+test('get preserves consumed nonce cache', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+
+  expect(await nonceManager.consume(args)).toBe(1)
+  expect(await nonceManager.get(args)).toBe(2)
+  expect(await nonceManager.consume(args)).toBe(2)
+})

--- a/src/utils/nonceManager.ts
+++ b/src/utils/nonceManager.ts
@@ -50,6 +50,10 @@ export function createNonceManager(
 
   const getKey = ({ address, chainId }: FunctionParameters) =>
     `${address}.${chainId}`
+  const reset = (key: string) => {
+    deltaMap.delete(key)
+    promiseMap.delete(key)
+  }
 
   return {
     async consume({ address, chainId, client }) {
@@ -83,7 +87,7 @@ export function createNonceManager(
             nonceMap.delete(key)
             return nonce
           } finally {
-            this.reset({ address, chainId })
+            reset(key)
           }
         })()
         promiseMap.set(key, promise)
@@ -94,8 +98,8 @@ export function createNonceManager(
     },
     reset({ address, chainId }) {
       const key = getKey({ address, chainId })
-      deltaMap.delete(key)
-      promiseMap.delete(key)
+      nonceMap.delete(key)
+      reset(key)
     },
   }
 }


### PR DESCRIPTION
## Summary

- split nonce manager internal promise/delta cleanup from the public reset path
- clear the cached consumed nonce when `nonceManager.reset` is called
- add regression coverage for reusing a consumed nonce after reset while preserving the normal `get` cache behavior

Refs #4364.

## Tests

- `SKIP_GLOBAL_SETUP=true pnpm test src/utils/nonceManager.reset.test.ts`
- `pnpm exec tsc --noEmit --project src/tsconfig.json`
- `pnpm exec biome check --write --unsafe src/utils/nonceManager.ts src/utils/nonceManager.reset.test.ts .changeset/strong-masks-reset.md`

I also attempted `pnpm test src/utils/nonceManager.test.ts`; the local forked-Anvil harness failed during `beforeAll` on `anvil_setBalance` before running assertions, so I isolated the regression in a pure nonce-manager unit test.
