### PR TITLE
fix: prevent reconnect after socket client close

### DIFF
--- a/.changeset/green-buckets-listen.md
+++ b/.changeset/green-buckets-listen.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Prevent socket RPC clients from reconnecting after an intentional `close()`.

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -271,10 +271,42 @@ test('reconnect on close', async () => {
     url: anvilMainnet.rpcUrl.ws,
   })
 
-  socketClient.close()
+  socketClient.socket.close()
   expect(status).toBe('closed')
   await wait(100)
   expect(status).toBe('open')
+
+  socketClient.close()
+})
+
+test('close does not reconnect', async () => {
+  let status = 'idle'
+  let count = 0
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onClose }) {
+      count++
+      status = 'open'
+      return {
+        close() {
+          status = 'closed'
+          onClose()
+        },
+        request() {},
+      }
+    },
+    reconnect: {
+      delay: 100,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  socketClient.close()
+  expect(status).toBe('closed')
+  await wait(100)
+  expect(status).toBe('closed')
+  expect(count).toBe(1)
 })
 
 test('keepAlive enabled', async () => {

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -132,10 +132,11 @@ export async function getSocketRpcClient<socket extends {}>(
       let socket: Socket<{}>
       let keepAliveTimer: ReturnType<typeof setInterval> | undefined
 
+      let closing = false
       let reconnectInProgress = false
       function attemptReconnect() {
         // Attempt to reconnect.
-        if (reconnect && reconnectCount < attempts) {
+        if (!closing && reconnect && reconnectCount < attempts) {
           if (reconnectInProgress) return
           reconnectInProgress = true
           reconnectCount++
@@ -220,6 +221,7 @@ export async function getSocketRpcClient<socket extends {}>(
       // Create a new socket instance.
       socketClient = {
         close() {
+          closing = true
           keepAliveTimer && clearInterval(keepAliveTimer)
           socket.close()
           socketClientCache.delete(id)


### PR DESCRIPTION
Fixes #4378.

`socketClient.close()` currently runs through the same `onClose` path as an unexpected socket close, so clients configured with reconnect enabled immediately schedule a reconnect after the user explicitly closes the RPC client.

This adds an intentional-close guard so the reconnect path only runs for socket failure/remote closure. The existing reconnect behavior is preserved for direct underlying socket closes, and a new regression test covers the explicit `socketClient.close()` case.

Validation:
- `PATH=/opt/homebrew/bin:$PATH pnpm exec biome check --write src/utils/rpc/socket.ts src/utils/rpc/socket.test.ts`
- `PATH=/opt/homebrew/bin:$PATH SKIP_GLOBAL_SETUP=true pnpm test src/utils/rpc/socket.test.ts -t "close does not reconnect|reconnect on close"`

Note: the full `src/utils/rpc/socket.test.ts` file still has local snapshot mismatches around generated request ids in this checkout, unrelated to this change; the new and affected close/reconnect cases pass.
