### PR TITLE
feat(tempo/zones): override Zone A/B name and RPC for moderato 6/7

### DIFF
--- a/.changeset/tempo-zone-overrides.md
+++ b/.changeset/tempo-zone-overrides.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added override for `zoneModerato(6)` (`Zone A`) and `zoneModerato(7)` (`Zone B`) names and RPC URLs.

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -25,6 +25,24 @@ export function getPortalAddress(
   return address
 }
 
+type Override = {
+  name: string
+  rpcUrl: string
+}
+
+const overrides = {
+  [tempoModerato.id]: {
+    6: {
+      name: 'Zone A',
+      rpcUrl: 'https://rpc-zone-a.testnet.tempo.xyz',
+    },
+    7: {
+      name: 'Zone B',
+      rpcUrl: 'https://rpc-zone-b.testnet.tempo.xyz',
+    },
+  },
+} as const satisfies Record<number, Record<number, Override>>
+
 export const zone = /*#__PURE__*/ from({
   sourceId: tempo.id,
   rpcHost: 'tempo.xyz',
@@ -41,10 +59,14 @@ export function from(options: from.Options) {
     const chainId = ZoneId.toChainId(id)
     const paddedId = String(id).padStart(3, '0')
 
+    const override = (
+      overrides as Record<number, Record<number, Override>>
+    )[options.sourceId]?.[id]
+
     return defineChain({
       ...chainConfig,
       id: chainId,
-      name: `Tempo Zone ${paddedId}`,
+      name: override?.name ?? `Tempo Zone ${paddedId}`,
       nativeCurrency: {
         name: 'USD',
         symbol: 'USD',
@@ -52,7 +74,10 @@ export function from(options: from.Options) {
       },
       rpcUrls: {
         default: {
-          http: [`https://rpc-zone-${paddedId}.${options.rpcHost}`],
+          http: [
+            override?.rpcUrl ??
+              `https://rpc-zone-${paddedId}.${options.rpcHost}`,
+          ],
         },
       },
       sourceId: options.sourceId,

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -31,17 +31,15 @@ type Override = {
 }
 
 const overrides = {
-  [tempoModerato.id]: {
-    6: {
-      name: 'Zone A',
-      rpcUrl: 'https://rpc-zone-a.testnet.tempo.xyz',
-    },
-    7: {
-      name: 'Zone B',
-      rpcUrl: 'https://rpc-zone-b.testnet.tempo.xyz',
-    },
+  6: {
+    name: 'Zone A',
+    rpcUrl: 'https://rpc-zone-a.testnet.tempo.xyz',
   },
-} as const satisfies Record<number, Record<number, Override>>
+  7: {
+    name: 'Zone B',
+    rpcUrl: 'https://rpc-zone-b.testnet.tempo.xyz',
+  },
+} as const satisfies Record<number, Override>
 
 export const zone = /*#__PURE__*/ from({
   sourceId: tempo.id,
@@ -59,9 +57,7 @@ export function from(options: from.Options) {
     const chainId = ZoneId.toChainId(id)
     const paddedId = String(id).padStart(3, '0')
 
-    const override = (
-      overrides as Record<number, Record<number, Override>>
-    )[options.sourceId]?.[id]
+    const override = (overrides as Record<number, Override>)[id]
 
     return defineChain({
       ...chainConfig,


### PR DESCRIPTION
Adds an override for `zoneModerato(6)` and `zoneModerato(7)`:

- `zoneModerato(6)` → name `Zone A`, RPC `https://rpc-zone-a.testnet.tempo.xyz`
- `zoneModerato(7)` → name `Zone B`, RPC `https://rpc-zone-b.testnet.tempo.xyz`

All other zones still fall back to the default `Tempo Zone NNN` / `rpc-zone-NNN.<rpcHost>` pattern.