### PR TITLE
Handle transaction block timestamps

### DIFF
--- a/.changeset/tempo-block-timestamp.md
+++ b/.changeset/tempo-block-timestamp.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `blockTimestamp` formatting for transaction responses.

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -27,6 +27,10 @@ export function formatTransaction(
 ): Transaction<bigint, number, boolean> {
   if (!isTempo(transaction)) return viem_formatTransaction(transaction as never)
 
+  const blockTimestamp =
+    transaction.blockTimestamp == null
+      ? undefined
+      : BigInt(transaction.blockTimestamp)
   const {
     feePayerSignature,
     gasPrice: _,
@@ -37,6 +41,7 @@ export function formatTransaction(
   return {
     ...tx,
     accessList: tx.accessList!,
+    ...(typeof blockTimestamp !== 'undefined' && { blockTimestamp }),
     feePayerSignature: feePayerSignature
       ? {
           r: Hex.fromNumber(feePayerSignature.r, { size: 32 }),

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -27,6 +27,7 @@ export function formatTransaction(
 ): Transaction<bigint, number, boolean> {
   if (!isTempo(transaction)) return viem_formatTransaction(transaction as never)
 
+  // TODO: upstream `blockTimestamp` formatting into `ox`.
   const blockTimestamp =
     transaction.blockTimestamp == null
       ? undefined

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -153,6 +153,7 @@ describe('formatters', () => {
       hash: receipt.transactionHash,
     })
     expect(transaction.hash).toBe(receipt.transactionHash)
+    expect(transaction.blockTimestamp).toBeTypeOf('bigint')
     expect(transaction.type).toBe('tempo')
     expect(transaction.calls).toBeDefined()
     expect(transaction.signature).toBeDefined()

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -30,6 +30,15 @@ import { withFeePayer } from './Transport.js'
 
 const client = getClient()
 
+function withoutVolatileTransactionFields<
+  transaction extends { blockTimestamp?: bigint | undefined },
+>(transaction: transaction) {
+  const { blockTimestamp, ...transaction_ } = transaction
+  expect(blockTimestamp).toBeTypeOf('bigint')
+  expect(blockTimestamp).toBeGreaterThan(0n)
+  return transaction_
+}
+
 /** Spending limits covering both fee tokens (pathUsd + alphaUsd). */
 function feeTokenLimits(limit: bigint, period?: number) {
   return [
@@ -84,7 +93,9 @@ describe('sendTransaction', () => {
     expect(v).toBeDefined()
     expect(yParity).toBeDefined()
     expect(transactionIndex).toBeDefined()
-    expect(transaction).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction),
+    ).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "input": "0xdeadbeef",
@@ -142,7 +153,9 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(transaction).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction),
+    ).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -216,7 +229,9 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(transaction).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction),
+    ).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -293,7 +308,9 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(transaction).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction),
+    ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -358,7 +375,9 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeTypeOf('number')
-    expect(transaction).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction),
+    ).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -492,7 +511,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -576,7 +597,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -644,7 +667,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -781,7 +806,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -986,7 +1013,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1074,7 +1103,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore2).toBeNull()
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1146,7 +1177,9 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1358,7 +1391,9 @@ describe('signTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeTypeOf('number')
-    expect(transaction2).toMatchInlineSnapshot(`
+    expect(
+      withoutVolatileTransactionFields(transaction2),
+    ).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -1533,7 +1568,9 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1655,7 +1692,9 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1750,7 +1789,9 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(transaction).toMatchInlineSnapshot(`
+      expect(
+        withoutVolatileTransactionFields(transaction),
+      ).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -30,15 +30,6 @@ import { withFeePayer } from './Transport.js'
 
 const client = getClient()
 
-function withoutVolatileTransactionFields<
-  transaction extends { blockTimestamp?: bigint | undefined },
->(transaction: transaction) {
-  const { blockTimestamp, ...transaction_ } = transaction
-  expect(blockTimestamp).toBeTypeOf('bigint')
-  expect(blockTimestamp).toBeGreaterThan(0n)
-  return transaction_
-}
-
 /** Spending limits covering both fee tokens (pathUsd + alphaUsd). */
 function feeTokenLimits(limit: bigint, period?: number) {
   return [
@@ -61,6 +52,7 @@ describe('sendTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       chainId,
       from,
       gas,
@@ -80,6 +72,8 @@ describe('sendTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(chainId).toBeDefined()
     expect(from).toBe(account.address.toLowerCase())
     expect(gas).toBeDefined()
@@ -93,9 +87,7 @@ describe('sendTransaction', () => {
     expect(v).toBeDefined()
     expect(yParity).toBeDefined()
     expect(transactionIndex).toBeDefined()
-    expect(
-      withoutVolatileTransactionFields(transaction),
-    ).toMatchInlineSnapshot(`
+    expect(transaction).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "input": "0xdeadbeef",
@@ -121,6 +113,7 @@ describe('sendTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       chainId,
       feeToken: feeToken_,
       from,
@@ -140,6 +133,8 @@ describe('sendTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(chainId).toBeDefined()
     expect(feeToken_).toBe(feeToken)
     expect(from).toBe(account.address.toLowerCase())
@@ -153,9 +148,7 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(
-      withoutVolatileTransactionFields(transaction),
-    ).toMatchInlineSnapshot(`
+    expect(transaction).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -197,6 +190,7 @@ describe('sendTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       chainId,
       feeToken: feeToken_,
       from,
@@ -216,6 +210,8 @@ describe('sendTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(chainId).toBeDefined()
     expect(feeToken_).toBe(feeToken)
     expect(from).toBe(accounts[0].address.toLowerCase())
@@ -229,9 +225,7 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(
-      withoutVolatileTransactionFields(transaction),
-    ).toMatchInlineSnapshot(`
+    expect(transaction).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -275,6 +269,7 @@ describe('sendTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       calls,
       chainId,
       feeToken: ___,
@@ -295,6 +290,8 @@ describe('sendTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(calls?.length).toBe(1)
     expect(chainId).toBeDefined()
     expect(from).toBe(account.address.toLowerCase())
@@ -308,9 +305,7 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeNull()
-    expect(
-      withoutVolatileTransactionFields(transaction),
-    ).toMatchInlineSnapshot(`
+    expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -342,6 +337,7 @@ describe('sendTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       chainId,
       feePayerSignature,
       feeToken: ___,
@@ -362,6 +358,8 @@ describe('sendTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(chainId).toBeDefined()
     expect(feePayerSignature).toBeDefined()
     expect(from).toBe(account.address.toLowerCase())
@@ -375,9 +373,7 @@ describe('sendTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeTypeOf('number')
-    expect(
-      withoutVolatileTransactionFields(transaction),
-    ).toMatchInlineSnapshot(`
+    expect(transaction).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -478,6 +474,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         chainId,
         feeToken: ___,
         from,
@@ -499,6 +496,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(chainId).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
       expect(gas).toBeDefined()
@@ -511,9 +510,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -562,6 +559,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         calls,
         chainId,
         feeToken: ___,
@@ -584,6 +582,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(calls?.length).toBe(1)
       expect(chainId).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
@@ -597,9 +597,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -634,6 +632,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         chainId,
         feePayerSignature,
         feeToken: ___,
@@ -654,6 +653,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(chainId).toBeDefined()
       expect(feePayerSignature).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
@@ -667,9 +668,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -773,6 +772,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         chainId,
         feeToken: ___,
         from,
@@ -794,6 +794,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(chainId).toBeDefined()
       expect(from).toBeDefined()
       expect(gas).toBeDefined()
@@ -806,9 +808,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -980,6 +980,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         chainId,
         feeToken: ___,
         from,
@@ -1001,6 +1002,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(chainId).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
       expect(gas).toBeDefined()
@@ -1013,9 +1016,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeNull()
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1068,6 +1069,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         calls,
         chainId,
         feeToken: ___,
@@ -1090,6 +1092,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(calls?.length).toBe(1)
       expect(chainId).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
@@ -1103,9 +1107,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore2).toBeNull()
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1144,6 +1146,7 @@ describe('sendTransaction', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         chainId,
         feePayerSignature,
         feeToken: ___,
@@ -1164,6 +1167,8 @@ describe('sendTransaction', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(chainId).toBeDefined()
       expect(feePayerSignature).toBeDefined()
       expect(from).toBe(account.address.toLowerCase())
@@ -1177,9 +1182,7 @@ describe('sendTransaction', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1358,6 +1361,7 @@ describe('signTransaction', () => {
     const {
       blockHash,
       blockNumber,
+      blockTimestamp,
       chainId,
       feePayerSignature,
       feeToken: ___,
@@ -1378,6 +1382,8 @@ describe('signTransaction', () => {
 
     expect(blockHash).toBeDefined()
     expect(blockNumber).toBeDefined()
+    expect(blockTimestamp).toBeTypeOf('bigint')
+    expect(blockTimestamp).toBeGreaterThan(0n)
     expect(chainId).toBeDefined()
     expect(feePayerSignature).toBeDefined()
     expect(from).toBe(account.address.toLowerCase())
@@ -1391,9 +1397,7 @@ describe('signTransaction', () => {
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
     expect(validBefore).toBeTypeOf('number')
-    expect(
-      withoutVolatileTransactionFields(transaction2),
-    ).toMatchInlineSnapshot(`
+    expect(transaction2).toMatchInlineSnapshot(`
       {
         "accessList": [],
         "authorizationList": [],
@@ -1533,6 +1537,7 @@ describe('relay', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         calls,
         chainId,
         feePayerSignature,
@@ -1554,6 +1559,8 @@ describe('relay', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(calls?.length).toBe(1)
       expect(chainId).toBeDefined()
       expect(feePayerSignature).toBeDefined()
@@ -1568,9 +1575,7 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1657,6 +1662,7 @@ describe('relay', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         calls,
         chainId,
         feePayerSignature,
@@ -1678,6 +1684,8 @@ describe('relay', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(calls?.length).toBe(1)
       expect(chainId).toBeDefined()
       expect(feePayerSignature).toBeDefined()
@@ -1692,9 +1700,7 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],
@@ -1754,6 +1760,7 @@ describe('relay', () => {
       const {
         blockHash,
         blockNumber,
+        blockTimestamp,
         calls,
         chainId,
         feePayerSignature,
@@ -1775,6 +1782,8 @@ describe('relay', () => {
 
       expect(blockHash).toBeDefined()
       expect(blockNumber).toBeDefined()
+      expect(blockTimestamp).toBeTypeOf('bigint')
+      expect(blockTimestamp).toBeGreaterThan(0n)
       expect(calls?.length).toBe(1)
       expect(chainId).toBeDefined()
       expect(feePayerSignature).toBeDefined()
@@ -1789,9 +1798,7 @@ describe('relay', () => {
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
       expect(validBefore).toBeTypeOf('number')
-      expect(
-        withoutVolatileTransactionFields(transaction),
-      ).toMatchInlineSnapshot(`
+      expect(transaction).toMatchInlineSnapshot(`
         {
           "accessList": [],
           "authorizationList": [],

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -88,6 +88,8 @@ export type TransactionBase<
   blockHash: isPending extends true ? null : Hash
   /** Number of block containing this transaction or `null` if pending */
   blockNumber: isPending extends true ? null : quantity
+  /** Unix timestamp of when this block was collated */
+  blockTimestamp?: quantity | undefined
   /** Transaction sender */
   from: Address
   /** Gas provided for transaction execution */

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -49,7 +49,7 @@ export type TransactionReceipt<
   blockHash: Hash
   /** Number of block containing this transaction */
   blockNumber: quantity
-  /** Unix timestamp of when this block was collated */
+  /** Unix timestamp of when this block was included */
   blockTimestamp?: quantity | undefined
   /** Address of new contract or `null` if no contract was created */
   contractAddress: Address | null | undefined
@@ -88,7 +88,7 @@ export type TransactionBase<
   blockHash: isPending extends true ? null : Hash
   /** Number of block containing this transaction or `null` if pending */
   blockNumber: isPending extends true ? null : quantity
-  /** Unix timestamp of when this block was collated */
+  /** Unix timestamp of when this block was included */
   blockTimestamp?: quantity | undefined
   /** Transaction sender */
   from: Address

--- a/src/utils/formatters/transaction.test.ts
+++ b/src/utils/formatters/transaction.test.ts
@@ -8,6 +8,7 @@ test('legacy transaction', () => {
       accessList: undefined,
       blockHash: '0x1',
       blockNumber: '0x10f2c',
+      blockTimestamp: '0x10f2c',
       from: '0x1',
       gas: '0x4234584',
       gasPrice: '0x45',
@@ -26,6 +27,7 @@ test('legacy transaction', () => {
     {
       "blockHash": "0x1",
       "blockNumber": 69420n,
+      "blockTimestamp": 69420n,
       "chainId": undefined,
       "from": "0x1",
       "gas": 69420420n,

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -55,6 +55,9 @@ export function formatTransaction(
     blockNumber: transaction.blockNumber
       ? BigInt(transaction.blockNumber)
       : null,
+    ...(transaction.blockTimestamp != null && {
+      blockTimestamp: BigInt(transaction.blockTimestamp),
+    }),
     chainId: transaction.chainId ? hexToNumber(transaction.chainId) : undefined,
     gas: transaction.gas ? BigInt(transaction.gas) : undefined,
     gasPrice: transaction.gasPrice ? BigInt(transaction.gasPrice) : undefined,


### PR DESCRIPTION
## Summary
- format transaction `blockTimestamp` values as `bigint` when RPC responses include them
- assert Tempo e2e transaction `blockTimestamp` separately from inline snapshots so snapshots stay stable
- add a formatter unit test and patch changeset

## Test plan
- `pnpm check:types`
- `SKIP_GLOBAL_SETUP=true pnpm exec vitest -c ./test/vitest.config.ts --project core --run src/utils/formatters/transaction.test.ts`
- `pnpm exec vitest -c ./test/vitest.config.ts --bail=1 --project tempo e2e` *(local setup did not reach tests; Tempo setup timed out while minting liquidity via local Prool/Testcontainers RPC)*