### PR TITLE
fix: handle anonymous event topics

### DIFF
--- a/.changeset/gentle-events-appear.md
+++ b/.changeset/gentle-events-appear.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed anonymous event topic encoding for `encodeEventTopics` and event filter actions.

--- a/src/actions/public/createEventFilter.anonymous.test.ts
+++ b/src/actions/public/createEventFilter.anonymous.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest'
+
+import { createPublicClient } from '../../clients/createPublicClient.js'
+import { custom } from '../../clients/transports/custom.js'
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
+import { createEventFilter } from './createEventFilter.js'
+
+test('creates filters for anonymous events without a signature topic', async () => {
+  const requests: Parameters<EIP1193RequestFn>[0][] = []
+  const client = createPublicClient({
+    transport: custom({
+      request: async (request) => {
+        requests.push(request)
+        return '0x1'
+      },
+    }),
+  })
+
+  const event = {
+    anonymous: true,
+    inputs: [
+      {
+        indexed: true,
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'AnonymousTransfer',
+    type: 'event',
+  } as const
+
+  const filter = await createEventFilter(client, {
+    event,
+    args: {
+      sender: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    },
+  })
+
+  expect(filter.id).toBe('0x1')
+  expect(requests).toEqual([
+    {
+      method: 'eth_newFilter',
+      params: [
+        {
+          topics: [
+            '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+          ],
+        },
+      ],
+    },
+  ])
+})

--- a/src/utils/abi/encodeEventTopics.test-d.ts
+++ b/src/utils/abi/encodeEventTopics.test-d.ts
@@ -2,6 +2,7 @@ import type { Abi } from 'abitype'
 import { expectTypeOf, test } from 'vitest'
 
 import { seaportContractConfig } from '~test/abis.js'
+import type { Hex } from '../../types/misc.js'
 import {
   type EncodeEventTopicsParameters,
   encodeEventTopics,
@@ -18,7 +19,7 @@ test('default', () => {
 })
 
 test('defined inline', () => {
-  encodeEventTopics({
+  const topics = encodeEventTopics({
     abi: [
       {
         anonymous: false,
@@ -45,6 +46,39 @@ test('defined inline', () => {
       offerer: '0x',
     },
   })
+  expectTypeOf(topics).toEqualTypeOf<[Hex, ...(Hex | Hex[] | null)[]]>()
+})
+
+test('defined inline: anonymous event', () => {
+  const abi = [
+    {
+      anonymous: true,
+      inputs: [
+        {
+          indexed: true,
+          name: 'offerer',
+          type: 'address',
+        },
+      ],
+      name: 'CounterIncremented',
+      type: 'event',
+    },
+  ] as const
+  const topics = encodeEventTopics({
+    abi,
+    eventName: 'CounterIncremented',
+    args: {
+      offerer: '0x',
+    },
+  })
+  const inferredTopics = encodeEventTopics({
+    abi,
+    args: {
+      offerer: '0x',
+    },
+  })
+  expectTypeOf(topics).toEqualTypeOf<(Hex | Hex[] | null)[]>()
+  expectTypeOf(inferredTopics).toEqualTypeOf<(Hex | Hex[] | null)[]>()
 })
 
 test('declared as Abi', () => {
@@ -69,11 +103,12 @@ test('declared as Abi', () => {
       type: 'event',
     },
   ] as Abi
-  encodeEventTopics({
+  const topics = encodeEventTopics({
     abi,
     eventName: 'SoldOutError',
     args: ['0x'],
   })
+  expectTypeOf(topics).toEqualTypeOf<[Hex, ...(Hex | Hex[] | null)[]]>()
 
   encodeEventTopics({
     abi,
@@ -103,11 +138,12 @@ test('no const assertion', () => {
       type: 'event',
     },
   ]
-  encodeEventTopics({
+  const topics = encodeEventTopics({
     abi,
     eventName: 'SoldOutError',
     args: ['0x'],
   })
+  expectTypeOf(topics).toEqualTypeOf<[Hex, ...(Hex | Hex[] | null)[]]>()
 
   encodeEventTopics({
     abi,

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -312,6 +312,61 @@ test('Foo(string)', () => {
   ])
 })
 
+test('anonymous: Foo(address,string)', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [
+            {
+              indexed: true,
+              name: 'sender',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'message',
+              type: 'string',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Foo',
+          type: 'event',
+        },
+      ],
+      eventName: 'Foo',
+      args: {
+        sender: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+        message: 'hello',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    '0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8',
+  ])
+})
+
+test('anonymous: Foo() returns no topics', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [],
+          name: 'Foo',
+          type: 'event',
+        },
+      ],
+      eventName: 'Foo',
+    }),
+  ).toEqual([])
+})
+
 test('Foo((uint,string))', () => {
   expect(() =>
     encodeEventTopics({

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,21 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+export type EncodeEventTopicsReturnType<
+  abi extends Abi | readonly unknown[] = Abi,
+  eventName extends ContractEventName<abi> | undefined = ContractEventName<abi>,
+  abiEvent = abi extends Abi
+    ? eventName extends ContractEventName<abi>
+      ? Extract<ExtractAbiEvents<abi>, { name: eventName }>
+      : ExtractAbiEvents<abi>
+    : never,
+> = IsNarrowable<abi, Abi> extends true
+  ? abi extends Abi
+    ? abiEvent extends { anonymous: true }
+      ? (Hex | Hex[] | null)[]
+      : [Hex, ...(Hex | Hex[] | null)[]]
+    : [Hex, ...(Hex | Hex[] | null)[]]
+  : [Hex, ...(Hex | Hex[] | null)[]]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -81,7 +95,7 @@ export function encodeEventTopics<
   eventName extends ContractEventName<abi> | undefined = undefined,
 >(
   parameters: EncodeEventTopicsParameters<abi, eventName>,
-): EncodeEventTopicsReturnType {
+): EncodeEventTopicsReturnType<abi, eventName> {
   const { abi, eventName, args } = parameters as EncodeEventTopicsParameters
 
   let abiItem = abi[0]
@@ -93,9 +107,6 @@ export function encodeEventTopics<
 
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
-
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
 
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
@@ -121,7 +132,13 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
-  return [signature, ...topics]
+
+  if (abiItem.anonymous)
+    return topics as EncodeEventTopicsReturnType<abi, eventName>
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
+  return [signature, ...topics] as EncodeEventTopicsReturnType<abi, eventName>
 }
 
 export type EncodeArgErrorType =


### PR DESCRIPTION
## Summary
- skip prepending the event selector when `encodeEventTopics` resolves an `anonymous: true` event
- infer the return type from the ABI event so non-anonymous events keep the existing tuple shape while anonymous events can return zero or more indexed topics
- add runtime/type coverage plus an action-level filter test showing `eth_newFilter` receives the anonymous indexed topic directly
- add a patch changeset

Fixes #4461.

## Validation
- `PATH=/Users/joeyroth/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH SKIP_GLOBAL_SETUP=true pnpm exec vitest -c ./test/vitest.config.ts src/utils/abi/encodeEventTopics.test.ts src/actions/public/createEventFilter.anonymous.test.ts`
- `PATH=/Users/joeyroth/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec biome check src/utils/abi/encodeEventTopics.ts src/utils/abi/encodeEventTopics.test.ts src/utils/abi/encodeEventTopics.test-d.ts src/actions/public/createEventFilter.anonymous.test.ts .changeset/gentle-events-appear.md`
- `PATH=/Users/joeyroth/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec tsc -p src/tsconfig.json --pretty false`

Full `pnpm check:types` was also run after installing with `--ignore-scripts`; it is blocked in this local checkout because `contracts/generated.js` is absent after skipping the repo postinstall/contract generation step.
