### PR TITLE
fix: remove stale cache entries when last observer unsubscribes

### DIFF
--- a/src/utils/observe.test.ts
+++ b/src/utils/observe.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 
-import { observe } from './observe.js'
+import { cleanupCache, listenersCache, observe } from './observe.js'
 import { wait } from './wait.js'
 
 test('emits data to callbacks', async () => {
@@ -237,6 +237,36 @@ test('handles async cleanup functions', async () => {
 
   // Give the async cleanup time to execute
   await wait(10)
+  expect(cleanup).toHaveBeenCalledTimes(1)
+})
+
+test('cleans up listenersCache and cleanupCache when last listener unsubscribes', async () => {
+  const id = 'mock'
+  const callback1 = vi.fn()
+  const callback2 = vi.fn()
+  const cleanup = vi.fn()
+  const emitter = vi.fn(({ emit }) => {
+    setTimeout(() => emit({ foo: 'bar' }), 100)
+    return () => {
+      cleanup()
+    }
+  })
+
+  const unwatch1 = observe(id, { emit: callback1 }, emitter)
+  const unwatch2 = observe(id, { emit: callback2 }, emitter)
+
+  expect(listenersCache.has(id)).toBe(true)
+  expect(cleanupCache.has(id)).toBe(true)
+
+  unwatch1()
+
+  expect(listenersCache.has(id)).toBe(true)
+  expect(cleanupCache.has(id)).toBe(true)
+
+  unwatch2()
+
+  expect(listenersCache.has(id)).toBe(false)
+  expect(cleanupCache.has(id)).toBe(false)
   expect(cleanup).toHaveBeenCalledTimes(1)
 })
 

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -39,10 +39,13 @@ export function observe<callbacks extends Callbacks>(
 
   const unsubscribe = () => {
     const listeners = getListeners()
-    listenersCache.set(
-      observerId,
-      listeners.filter((cb: any) => cb.id !== callbackId),
-    )
+    const remaining = listeners.filter((cb: any) => cb.id !== callbackId)
+    if (remaining.length === 0) {
+      listenersCache.delete(observerId)
+      cleanupCache.delete(observerId)
+    } else {
+      listenersCache.set(observerId, remaining)
+    }
   }
 
   const unwatch = () => {


### PR DESCRIPTION
Fixes #4390

When all listeners for an `observerId` call `unwatch()`, the `unsubscribe` function previously filtered them out but left an empty array behind in `listenersCache` (and a stale entry in `cleanupCache`). In long-running servers creating many short-lived clients, these empty entries accumulate indefinitely.

The fix deletes both cache entries when the last listener unsubscribes, instead of storing an empty array.

I also added a test that explicitly verifies cache cleanup — it checks that both `listenersCache` and `cleanupCache` still have entries while listeners remain, and are fully deleted after the last `unwatch()` call.