### PR TITLE
fix: handle anonymous events in encodeEventTopics

### DIFF
--- a/.changeset/fix-anonymous-event-topics.md
+++ b/.changeset/fix-anonymous-event-topics.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix: handle anonymous events in encodeEventTopics

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -532,3 +532,46 @@ test('https://github.com/wevm/viem/issues/3278', () => {
     ]
   `)
 })
+
+test('https://github.com/wevm/viem/issues/4461 anonymous events omit signature topic', () => {
+  const inputs = [
+    { indexed: true, name: 'from', type: 'address' },
+    { indexed: false, name: 'amount', type: 'uint256' },
+  ] as const
+  const addr = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: true,
+          inputs: [...inputs],
+          name: 'Deposit',
+          type: 'event',
+        },
+      ],
+      eventName: 'Deposit',
+      args: { from: addr },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  ])
+
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          anonymous: false,
+          inputs: [...inputs],
+          name: 'Deposit',
+          type: 'event',
+        },
+      ],
+      eventName: 'Deposit',
+      args: { from: addr },
+    }),
+  ).toEqual([
+    '0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c',
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  ])
+})

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,9 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+export type EncodeEventTopicsReturnType =
+  | [Hex, ...(Hex | Hex[] | null)[]]
+  | (Hex | Hex[] | null)[]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -94,8 +96,9 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
+  const anonymous = Boolean(
+    'anonymous' in abiItem && abiItem.anonymous === true,
+  )
 
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
@@ -121,6 +124,11 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+
+  if (anonymous) return topics
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
## Root cause

`encodeEventTopics` always prefixed the topic list with `toEventSelector(...)`. That matches non-anonymous events, where topic0 is the keccak256 of the signature string. For **anonymous** events, the execution-layer rule is different: logs do **not** carry that signature topic—indexed arguments occupy topics starting at topic0.

Because of this mismatch, filters built via `encodeEventTopics` (and callers such as `watchContractEvent` / `createContractEventFilter`) sent an incorrect topic layout for anonymous events.

## Fix

If the ABI event item has `anonymous: true`, return only the encoded indexed-parameter topics. Otherwise, keep the existing behavior `[signature, ...indexedTopics]`.

The public return type is widened accordingly (`signature-led tuple | indexed-only topics array`).

## Testing

- Added regression coverage for https://github.com/wevm/viem/issues/4461: anonymous vs non-anonymous `Deposit(address,uint256)` with the same indexed argument shows anonymous topics without the signature hash and non-anonymous topics with signature first.
- Ran: `SKIP_GLOBAL_SETUP=1 pnpm exec vitest run src/utils/abi/encodeEventTopics.test.ts -c ./test/vitest.config.ts`

Fixes https://github.com/wevm/viem/issues/4461
