### PR TITLE
feat(tempo): add capabilities to TransactionRequestTempo

### DIFF
--- a/.changeset/tempo-fill-transaction-request-capabilities.md
+++ b/.changeset/tempo-fill-transaction-request-capabilities.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Added `capabilities` to `TransactionRequestTempo` and forwarded it through `formatTransactionRequest`.

--- a/src/tempo/Capabilities.ts
+++ b/src/tempo/Capabilities.ts
@@ -7,11 +7,17 @@ import type { TransactionRequestTempo } from './Transaction.js'
 
 export type Schema = Omit<DefaultCapabilitiesSchema, 'sendCalls'> & {
   fillTransaction: {
+    Request: FillTransactionRequestCapabilities
     ReturnType: FillTransactionCapabilities
   }
   sendCalls: {
     Request: ExactPartial<TransactionRequestTempo>
   }
+}
+
+export type FillTransactionRequestCapabilities = {
+  /** Whether to include `balanceDiffs` in the response. */
+  balanceDiffs?: boolean | undefined
 }
 
 export type FillTransactionCapabilities = {

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -139,6 +139,7 @@ export function formatTransactionRequest(
 
   return {
     ...rpc,
+    ...(request.capabilities ? { capabilities: request.capabilities } : {}),
     ...(keyData ? { keyData } : {}),
     ...(keyId ? { keyId } : {}),
     ...(keyType ? { keyType } : {}),

--- a/src/tempo/Transaction.ts
+++ b/src/tempo/Transaction.ts
@@ -13,6 +13,7 @@ import {
   TxEnvelopeTempo as TxTempo,
 } from 'ox/tempo'
 import type { Account } from '../accounts/types.js'
+import type { ExtractCapabilities } from '../types/capabilities.js'
 import type { FeeValuesEIP1559 } from '../types/fee.js'
 import type { Signature as viem_Signature } from '../types/misc.js'
 import type {
@@ -118,10 +119,11 @@ export type TransactionRequestTempo<
 > = TransactionRequestBase<quantity, index, type> &
   ExactPartial<FeeValuesEIP1559<quantity>> & {
     accessList?: AccessList | undefined
-    keyAuthorization?: KeyAuthorization.Signed<quantity, index> | undefined
     calls?: readonly TxTempo.Call<quantity, TempoAddress.Address>[] | undefined
+    capabilities?: ExtractCapabilities<'fillTransaction', 'Request'> | undefined
     feePayer?: Account | true | undefined
     feeToken?: TempoAddress.Address | bigint | undefined
+    keyAuthorization?: KeyAuthorization.Signed<quantity, index> | undefined
     nonceKey?: 'expiring' | quantity | undefined
     validBefore?: index | undefined
     validAfter?: index | undefined


### PR DESCRIPTION
Forwards a typed `capabilities` field on `TransactionRequestTempo` through `formatTransactionRequest` to `eth_fillTransaction`.

- `tempo/Transaction.ts` — added `capabilities?: ExtractCapabilities<'fillTransaction', 'Request'>` to `TransactionRequestTempo`
- `tempo/Capabilities.ts` — added `Request: FillTransactionRequestCapabilities` to `Schema['fillTransaction']` and exported `FillTransactionRequestCapabilities` (`balanceDiffs`)
- `tempo/Formatters.ts` — passed `request.capabilities` through `formatTransactionRequest`