### PR TITLE
fix: handle anonymous events in encodeEventTopics

### DIFF
--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -500,6 +500,90 @@ test("errors: event doesn't exist", () => {
   `)
 })
 
+test('anonymous event: no args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          name: 'RawEvent',
+          type: 'event',
+          anonymous: true,
+          inputs: [
+            { name: 'topic0', type: 'bytes32', indexed: true },
+            { name: 'topic1', type: 'bytes32', indexed: true },
+            { name: 'topic2', type: 'bytes32', indexed: true },
+            { name: 'topic3', type: 'bytes32', indexed: true },
+          ],
+        },
+      ] as const,
+    }),
+  ).toEqual([])
+})
+
+test('anonymous event: with args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          name: 'RawEvent',
+          type: 'event',
+          anonymous: true,
+          inputs: [
+            { name: 'topic0', type: 'bytes32', indexed: true },
+            { name: 'topic1', type: 'bytes32', indexed: true },
+            { name: 'topic2', type: 'bytes32', indexed: true },
+            { name: 'topic3', type: 'bytes32', indexed: true },
+          ],
+        },
+      ] as const,
+      args: {
+        topic0:
+          '0x000000000000000000000000000000000000000000000000000000000000abcd',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    null,
+    null,
+    null,
+  ])
+})
+
+test('anonymous event: all topics', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          name: 'RawEvent',
+          type: 'event',
+          anonymous: true,
+          inputs: [
+            { name: 'topic0', type: 'bytes32', indexed: true },
+            { name: 'topic1', type: 'bytes32', indexed: true },
+            { name: 'topic2', type: 'bytes32', indexed: true },
+            { name: 'topic3', type: 'bytes32', indexed: true },
+          ],
+        },
+      ] as const,
+      args: {
+        topic0:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        topic1:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        topic2:
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        topic3:
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+      },
+    }),
+  ).toEqual([
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+  ])
+})
+
 test('https://github.com/wevm/viem/issues/3278', () => {
   const bugAbi = [
     {

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,9 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+export type EncodeEventTopicsReturnType =
+  | [Hex, ...(Hex | Hex[] | null)[]]
+  | (Hex | Hex[] | null)[]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -94,9 +96,6 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
-
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
     const indexedInputs = abiItem.inputs?.filter(
@@ -121,6 +120,11 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+
+  if ('anonymous' in abiItem && abiItem.anonymous) return topics
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
encodeEventTopics unconditionally prepended the event signature as topic[0], which is incorrect for anonymous events. Anonymous events have no signature topic per the Solidity ABI spec, so all 4 topic slots are available for indexed parameters.

This skips the signature when `abiItem.anonymous` is true and widens the return type accordingly.

Fixes #4461