### PR TITLE
types: add tempo virtual address capability

### DIFF
--- a/.changeset/fifty-virtual-addresses-bow.md
+++ b/.changeset/fifty-virtual-addresses-bow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `virtualAddresses` metadata to Tempo fill transaction capabilities.

--- a/src/tempo/Capabilities.ts
+++ b/src/tempo/Capabilities.ts
@@ -64,6 +64,8 @@ export type FillTransactionCapabilities = {
       }
     | undefined
   sponsored?: boolean | undefined
+  /** Virtual-address resolutions keyed by lowercase literal virtual address. */
+  virtualAddresses?: Readonly<Record<Address, Address | null>> | undefined
 }
 
 export type BalanceDiff = {


### PR DESCRIPTION
## Summary

Adds `virtualAddresses` to Tempo `FillTransactionCapabilities` so relays can surface virtual address resolution metadata from `eth_fillTransaction`.

The shape is a map from the literal virtual address to its resolved master address, or `null` when the address matches the virtual address format but has no registered master.

## Testing

Not run in this temporary checkout; type-only change.
