### PR TITLE
fix: clean up empty listener cache entries in observe

### DIFF
--- a/src/utils/observe.test.ts
+++ b/src/utils/observe.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 
-import { observe } from './observe.js'
+import { cleanupCache, listenersCache, observe } from './observe.js'
 import { wait } from './wait.js'
 
 test('emits data to callbacks', async () => {
@@ -263,4 +263,25 @@ test('handles async cleanup errors', async () => {
   // Give the async cleanup time to execute and fail
   await wait(10)
   expect(cleanup).toHaveBeenCalledTimes(1)
+})
+
+test('removes cache entries when all listeners unsubscribe', async () => {
+  const id = 'observe-leak-test'
+
+  const emitter = vi.fn(({ emit }) => {
+    setTimeout(() => emit({ foo: 'bar' }), 100)
+    return () => {}
+  })
+
+  const unwatch1 = observe(id, { emit: vi.fn() }, emitter)
+  const unwatch2 = observe(id, { emit: vi.fn() }, emitter)
+
+  expect(listenersCache.has(id)).toBe(true)
+
+  unwatch1()
+  expect(listenersCache.has(id)).toBe(true)
+
+  unwatch2()
+  expect(listenersCache.has(id)).toBe(false)
+  expect(cleanupCache.has(id)).toBe(false)
 })

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -39,10 +39,13 @@ export function observe<callbacks extends Callbacks>(
 
   const unsubscribe = () => {
     const listeners = getListeners()
-    listenersCache.set(
-      observerId,
-      listeners.filter((cb: any) => cb.id !== callbackId),
-    )
+    const remaining = listeners.filter((cb: any) => cb.id !== callbackId)
+    if (remaining.length === 0) {
+      listenersCache.delete(observerId)
+      cleanupCache.delete(observerId)
+    } else {
+      listenersCache.set(observerId, remaining)
+    }
   }
 
   const unwatch = () => {


### PR DESCRIPTION
When all listeners for an observerId call unwatch(), the unsubscribe function filters out callbacks but never deletes the Map entry from listenersCache or cleanupCache. This leaves stale empty arrays that accumulate over time, causing a memory leak in long-running processes.

This patch deletes the entries entirely when the remaining listeners array is empty instead of persisting an empty array.

Fixes #4390