### PR TITLE
fix(abi): handle anonymous events in encodeEventTopics

### DIFF
--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -532,3 +532,46 @@ test('https://github.com/wevm/viem/issues/3278', () => {
     ]
   `)
 })
+
+test('anonymous event: no args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          name: 'RawEvent',
+          type: 'event',
+          anonymous: true,
+          inputs: [
+            { name: 'topic0', type: 'bytes32', indexed: true },
+            { name: 'topic1', type: 'bytes32', indexed: true },
+          ],
+        },
+      ] as const,
+    }),
+  ).toEqual([])
+})
+
+test('anonymous event: with args', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          name: 'RawEvent',
+          type: 'event',
+          anonymous: true,
+          inputs: [
+            { name: 'topic0', type: 'bytes32', indexed: true },
+            { name: 'topic1', type: 'bytes32', indexed: true },
+          ],
+        },
+      ] as const,
+      args: {
+        topic0:
+          '0x000000000000000000000000000000000000000000000000000000000000abcd',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    null,
+  ])
+})

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -94,9 +94,6 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
-
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
     const indexedInputs = abiItem.inputs?.filter(
@@ -121,6 +118,12 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+
+  if ('anonymous' in abiItem && abiItem.anonymous)
+    return topics as (Hex | Hex[] | null)[] as EncodeEventTopicsReturnType
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
encodeEventTopics unconditionally prepends the event signature as topic[0], which is incorrect for anonymous events. Anonymous events do not emit a signature topic and can use all 4 topic slots for indexed parameters.

This moves the signature computation after the argument encoding and skips it when the event has `anonymous: true`.

Fixes #4461