### PR TITLE
fix(http): preserve HTTP metadata on non-2xx RPC errors

### DIFF
--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -10,6 +10,7 @@ import { createBatchScheduler } from '../../utils/promise/createBatchScheduler.j
 import {
   getHttpRpcClient,
   type HttpRpcClientOptions,
+  rpcErrorHttpMetadata,
 } from '../../utils/rpc/http.js'
 
 import {
@@ -153,12 +154,25 @@ export function http<
           const [{ error, result }] = await fn(body)
 
           if (raw) return { error, result }
-          if (error)
+          if (error) {
+            const metadata = (
+              error as {
+                [rpcErrorHttpMetadata]?:
+                  | {
+                      headers: Headers
+                      status: number
+                    }
+                  | undefined
+              }
+            )[rpcErrorHttpMetadata]
             throw new RpcRequestError({
               body,
               error,
+              headers: metadata?.headers,
+              status: metadata?.status,
               url: url_,
             })
+          }
           return result
         },
         retryCount,

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -79,14 +79,20 @@ export type RpcRequestErrorType = RpcRequestError & {
 export class RpcRequestError extends BaseError {
   code: number
   data?: unknown
+  headers?: Headers | undefined
+  status?: number | undefined
   url: string
   constructor({
     body,
     error,
+    headers,
+    status,
     url,
   }: {
     body: { [x: string]: unknown } | { [y: string]: unknown }[]
     error: { code: number; data?: unknown; message: string }
+    headers?: Headers | undefined
+    status?: number | undefined
     url: string
   }) {
     super('RPC Request failed.', {
@@ -97,6 +103,8 @@ export class RpcRequestError extends BaseError {
     })
     this.code = error.code
     this.data = error.data
+    this.headers = headers
+    this.status = status
     this.url = url
   }
 }

--- a/src/errors/rpc.ts
+++ b/src/errors/rpc.ts
@@ -36,6 +36,8 @@ type RpcErrorOptions<code extends number = RpcErrorCode> = {
 export type RpcErrorType = RpcError & { name: 'RpcError' }
 export class RpcError<code_ extends number = RpcErrorCode> extends BaseError {
   code: code_ | (number & {})
+  headers?: Headers | undefined
+  status?: number | undefined
 
   constructor(
     cause: Error,
@@ -58,6 +60,10 @@ export class RpcError<code_ extends number = RpcErrorCode> extends BaseError {
     this.code = (
       cause instanceof RpcRequestError ? cause.code : (code ?? unknownErrorCode)
     ) as code_
+    if ('headers' in cause && cause.headers instanceof Headers)
+      this.headers = cause.headers
+    if ('status' in cause && typeof cause.status === 'number')
+      this.status = cause.status
   }
 }
 

--- a/src/utils/buildRequest.test.ts
+++ b/src/utils/buildRequest.test.ts
@@ -1176,6 +1176,34 @@ describe('behavior', () => {
       expect(retryCount).toBe(3)
     })
 
+    test('non-deterministic RpcError (HTTP 429 w/ Retry-After header)', async () => {
+      const start = Date.now()
+      let end = 0
+      let retryCount = -1
+      const server = await createHttpServer((_req, res) => {
+        retryCount++
+        end = Date.now() - start
+        res.writeHead(429, {
+          'Content-Type': 'application/json',
+          'Retry-After': 1,
+        })
+        res.end(
+          JSON.stringify({
+            error: { code: InvalidParamsRpcError.code, message: 'message' },
+          }),
+        )
+      })
+
+      await expect(() =>
+        buildRequest(request(server.url), { retryCount: 1, retryDelay: 1 })({
+          method: 'eth_blockNumber',
+        }),
+      ).rejects.toThrowError()
+      expect(retryCount).toBe(1)
+      expect(end).toBeGreaterThan(900)
+      await server.close()
+    })
+
     test('non-deterministic HttpRequestError (403)', async () => {
       let retryCount = -1
       const server = await createHttpServer((_req, res) => {
@@ -1444,6 +1472,32 @@ describe('shouldRetry', () => {
         new HttpRequestError({ body: {}, details: '', status: 413, url: '' }),
       ),
     ).toBe(true)
+  })
+
+  test('RpcRequestError (status 429)', () => {
+    expect(
+      shouldRetry(
+        new RpcRequestError({
+          body: {},
+          error: { code: InvalidParamsRpcError.code, message: '' },
+          status: 429,
+          url: '',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test('RpcRequestError prioritizes HTTP status over RPC code', () => {
+    expect(
+      shouldRetry(
+        new RpcRequestError({
+          body: {},
+          error: { code: InternalRpcError.code, message: '' },
+          status: 401,
+          url: '',
+        }),
+      ),
+    ).toBe(false)
   })
 
   test('InternalRpcError', () => {

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -1,10 +1,9 @@
 import { BaseError } from '../errors/base.js'
-import {
-  HttpRequestError,
-  type HttpRequestErrorType,
-  type RpcRequestErrorType,
-  type TimeoutErrorType,
-  type WebSocketRequestErrorType,
+import type {
+  HttpRequestErrorType,
+  RpcRequestErrorType,
+  TimeoutErrorType,
+  WebSocketRequestErrorType,
 } from '../errors/request.js'
 import {
   AtomicityNotSupportedError,
@@ -254,11 +253,11 @@ export function buildRequest<request extends (args: any) => Promise<any>>(
           {
             delay: ({ count, error }) => {
               // If we find a Retry-After header, let's retry after the given time.
-              if (error && error instanceof HttpRequestError) {
-                const retryAfter = error?.headers?.get('Retry-After')
-                if (retryAfter?.match(/\d/))
-                  return Number.parseInt(retryAfter, 10) * 1000
-              }
+              const retryAfter = error
+                ? getHttpErrorHeaders(error)?.get('Retry-After')
+                : undefined
+              if (retryAfter?.match(/\d/))
+                return Number.parseInt(retryAfter, 10) * 1000
 
               // Otherwise, let's retry with an exponential backoff.
               return ~~(1 << count) * retryDelay
@@ -274,6 +273,27 @@ export function buildRequest<request extends (args: any) => Promise<any>>(
 
 /** @internal */
 export function shouldRetry(error: Error) {
+  const status = getHttpErrorStatus(error)
+  if (status) {
+    // Forbidden
+    if (status === 403) return true
+    // Request Timeout
+    if (status === 408) return true
+    // Request Entity Too Large
+    if (status === 413) return true
+    // Too Many Requests
+    if (status === 429) return true
+    // Internal Server Error
+    if (status === 500) return true
+    // Bad Gateway
+    if (status === 502) return true
+    // Service Unavailable
+    if (status === 503) return true
+    // Gateway Timeout
+    if (status === 504) return true
+    return false
+  }
+
   if ('code' in error && typeof error.code === 'number') {
     if (error.code === -1) return true // Unknown error
     if (error.code === LimitExceededRpcError.code) return true
@@ -284,26 +304,21 @@ export function shouldRetry(error: Error) {
     if (error.code === 429) return true
     return false
   }
-  if (error instanceof HttpRequestError && error.status) {
-    // Forbidden
-    if (error.status === 403) return true
-    // Request Timeout
-    if (error.status === 408) return true
-    // Request Entity Too Large
-    if (error.status === 413) return true
-    // Too Many Requests
-    if (error.status === 429) return true
-    // Internal Server Error
-    if (error.status === 500) return true
-    // Bad Gateway
-    if (error.status === 502) return true
-    // Service Unavailable
-    if (error.status === 503) return true
-    // Gateway Timeout
-    if (error.status === 504) return true
-    return false
-  }
   return true
+}
+
+function getHttpErrorHeaders(error: Error): Headers | undefined {
+  if (!('headers' in error)) return
+  const { headers } = error as { headers?: unknown }
+  if (!(headers instanceof Headers)) return
+  return headers
+}
+
+function getHttpErrorStatus(error: Error): number | undefined {
+  if (!('status' in error)) return
+  const { status } = error as { status?: unknown }
+  if (typeof status !== 'number') return
+  return status
 }
 
 /** @internal cyrb53 – fast, non-cryptographic 53-bit string hash */

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -76,6 +76,14 @@ export type HttpRpcClient = {
   ): Promise<HttpRequestReturnType<body>>
 }
 
+/** @internal */
+export const rpcErrorHttpMetadata = Symbol.for('viem.rpcErrorHttpMetadata')
+
+type RpcErrorHttpMetadata = {
+  headers: Headers
+  status: number
+}
+
 export function getHttpRpcClient(
   url_: string,
   options: HttpRpcClientOptions = {},
@@ -157,11 +165,17 @@ export function getHttpRpcClient(
         if (!response.ok) {
           // If the response body contains a valid JSON-RPC error, return it
           // so it flows through the normal RPC error handling pipeline.
-          if (
-            typeof data.error?.code === 'number' &&
-            typeof data.error?.message === 'string'
-          )
+          if (hasRpcError(data.error)) {
+            Object.defineProperty(data.error, rpcErrorHttpMetadata, {
+              configurable: true,
+              enumerable: false,
+              value: {
+                headers: response.headers,
+                status: response.status,
+              } as RpcErrorHttpMetadata,
+            })
             return data
+          }
 
           throw new HttpRequestError({
             body,
@@ -211,4 +225,20 @@ export function parseUrl(url_: string) {
   } catch {
     return { url: url_ }
   }
+}
+
+function hasRpcError(error: unknown): error is {
+  code: number
+  data?: unknown
+  message: string
+  [rpcErrorHttpMetadata]?: RpcErrorHttpMetadata | undefined
+} {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof error.code === 'number' &&
+    'message' in error &&
+    typeof error.message === 'string'
+  )
 }


### PR DESCRIPTION
  ## What is this PR solving?
                                                                                                                                                                                                  
  `http` transport was dropping HTTP-layer semantics when a non-2xx response still contained a JSON-RPC error body.                                                                               
                                                                                                                                                                                                  
  In `src/utils/rpc/http.ts`, the non-2xx + valid JSON-RPC error path returned the RPC error directly, so downstream retry logic could no longer read HTTP `status`/`headers` (especially `Retry- 
  After`).                                                                                                                                                                                        
                                                                                                                                                                                                  
  This PR preserves those HTTP semantics while keeping the existing RPC error pipeline:                                                                                                           
                                                                                                                                                                                                  
  - attach HTTP metadata (`status`, `headers`) to RPC errors on non-2xx responses                                                                                                                 
  - propagate metadata through `http` transport into `RpcRequestError`                                                                                                                            
  - surface metadata on `RpcError`                                                                                                                                                                
  - update retry behavior to prioritize HTTP status when present and read `Retry-After` from propagated headers                                                                                   
                                                                                                                                                                                                  
  This keeps default behavior unchanged for normal 2xx JSON-RPC responses.                                                                                                                        
                                                                                                                                                                                                  
  Fixes: N/A (follow-up hardening after #4440 behavior).                                                                                                                                          
                                                                                                                                                                                                  
  ## What alternatives were explored?                                                                                                                                                             
                                                                                                                                                                                                  
  - Always throw `HttpRequestError` for all non-2xx responses (would bypass normal RPC error mapping path).                                                                                       
  - Only special-case RPC `code === 429` (already done in #4440, but still loses HTTP semantics for non-2xx RPC error responses).                                                                 
                                                                                                                                                                                                  
  Chosen approach: minimal targeted propagation of HTTP metadata across the existing RPC error flow.
                                                                                                                                                                                                  
  ## Are there any parts that require more attention from reviewers?                                                                                                                              
                                                                                                                                                                                                  
  - Verify metadata propagation chain:                                                                                                                                                            
    - `src/utils/rpc/http.ts`                                                                                                                                                                     
    - `src/clients/transports/http.ts`                                                                                                                                                            
    - `src/errors/request.ts`                                                                                                                                                                     
    - `src/errors/rpc.ts`                                                                                                                                                                         
  - Verify retry precedence in `src/utils/buildRequest.ts`:                                                                                                                                       
    - HTTP `status` is evaluated before RPC `code` when both exist                                                                                                                                
    - `Retry-After` is honored when headers are available on propagated RPC errors                                                                                                                
  - Confirm no regression for existing cases:                                                                                                                                                     
    - HTTP 200 + JSON-RPC `{ code: 429 }` (batch/provider-specific behavior)                                                                                                                      
    - non-HTTP transports (IPC/WebSocket) remain unaffected                                                                                                                                       
                                                                                                                                                                                                  
  ## Documentation                                                                                                                                                                                
                                                                                                                                                                                                  
  No documentation update is needed (internal error/retry behavior fix, no public API shape change).
                                                                                                                                                                                                  
  ## Tests                                                                                                                                                                                        
                                                                                                                                                                                                  
  Added targeted tests in:                                                                                                                                                                        
                                                                                                                                                                                                  
  - `src/utils/buildRequest.test.ts`                                                                                                                                                              
    - `non-deterministic RpcError (HTTP 429 w/ Retry-After header)`                                                                                                                               
    - `RpcRequestError (status 429)`
    - `RpcRequestError prioritizes HTTP status over RPC code`                                                                                                                                     
                                                                                                                                                                                                  
  Relevant existing coverage:                                                                                                                                                                     
                                                                                                                                                                                                  
  - `src/utils/buildRequest.test.ts`                                                                                                                                                              
    - existing `HttpRequestError` retry + `Retry-After` tests                                                                                                                                     
    - existing RPC code `429` retry test                                                                                                                                                          
  - `src/utils/rpc/http.test.ts`                                                                                                                                                                  
  - `src/clients/transports/http.test.ts`   