### PR TITLE
feat: add Tempo fee token validation

### DIFF
--- a/.changeset/friendly-fee-tokens.md
+++ b/.changeset/friendly-fee-tokens.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Tempo fee token validation with typed errors.

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
       "estree-util-value-to-estree@<3.3.3": "3.3.3",
       "express-rate-limit@>=8.2.0 <8.2.2": ">=8.2.2",
+      "fast-uri@<=3.1.1": "3.1.2",
       "fastify": ">=5.8.5",
       "follow-redirects@<1.16.0": "1.16.0",
       "uuid@<14.0.0": "14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   estree-util-value-to-estree@<3.3.3: 3.3.3
   express-rate-limit@>=8.2.0 <8.2.2: '>=8.2.2'
+  fast-uri@<=3.1.1: 3.1.2
   fastify: '>=5.8.5'
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0
@@ -3856,8 +3857,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
@@ -7188,7 +7189,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1
-      fast-uri: 3.0.3
+      fast-uri: 3.1.2
 
   '@fastify/error@4.2.0': {}
 
@@ -8965,7 +8966,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9862,7 +9863,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1
-      fast-uri: 3.0.3
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -9874,7 +9875,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.0.3: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@4.5.1: {}
 

--- a/site/pages/tempo/actions/fee.validateToken.mdx
+++ b/site/pages/tempo/actions/fee.validateToken.mdx
@@ -1,0 +1,63 @@
+import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
+
+# `fee.validateToken`
+
+Validates that a token can be used as a Tempo fee token. Fee tokens must be unpaused USD-denominated TIP-20 tokens.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.fee.validateToken({
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log('Fee token address:', result.address)
+// @log: Fee token address: 0x20c0000000000000000000000000000000000001
+console.log('Fee token currency:', result.metadata.currency)
+// @log: Fee token currency: USD
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Address of the fee token */
+  address: Address
+  /** ID of the fee token */
+  id: bigint
+  /** TIP-20 token metadata */
+  metadata: {
+    currency: string
+    decimals: number
+    name: string
+    paused?: boolean
+    quoteToken?: Address
+    supplyCap?: bigint
+    symbol: string
+    totalSupply: bigint
+    transferPolicyId?: bigint
+  }
+}
+```
+
+Throws `FeeTokenNotTip20Error`, `FeeTokenNotUsdError`, or `FeeTokenPausedError` when the token cannot be used for fees.
+
+## Parameters
+
+### token
+
+- **Type:** `Address | bigint`
+
+Fee token address or ID to validate.
+
+<ReadParameters />

--- a/site/pages/tempo/actions/index.mdx
+++ b/site/pages/tempo/actions/index.mdx
@@ -21,6 +21,7 @@
 | **Faucet Actions** | |
 | [`faucet.fund`](/tempo/actions/faucet.fund) | Funds an account with testnet tokens |
 | **Fee Actions** | |
+| [`fee.validateToken`](/tempo/actions/fee.validateToken) | Validates that a token can be used as a fee token |
 | [`fee.getUserToken`](/tempo/actions/fee.getUserToken) | Gets the user's default fee token preference |
 | [`fee.setUserToken`](/tempo/actions/fee.setUserToken) | Sets the user's default fee token preference |
 | [`fee.watchSetUserToken`](/tempo/actions/fee.watchSetUserToken) | Watches for user token set events |

--- a/site/pages/tempo/transactions.mdx
+++ b/site/pages/tempo/transactions.mdx
@@ -80,6 +80,31 @@ export const client = createWalletClient({
 See a full guide on [paying fees in any stablecoin](https://docs.tempo.xyz/guide/payments/pay-fees-in-any-stablecoin).
 :::
 
+You can validate a fee token before submitting a transaction or saving it as a fee preference.
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+import { Actions } from 'viem/tempo'
+
+const feeToken = '0x20c0000000000000000000000000000000000001'
+
+await Actions.fee.validateToken(client, {
+  token: feeToken,
+})
+```
+
+#### Common Errors
+
+`invalid fee token` means the token cannot be used to pay fees. Fee tokens must be unpaused USD-denominated TIP-20 tokens.
+
+`FeeTokenNotTip20Error` means the token is not registered as a TIP-20 token. TIP-20 token addresses use the `0x20c0...` address prefix.
+
+`FeeTokenNotUsdError` means the token is a TIP-20 token, but its currency is not `USD`.
+
+`FeeTokenPausedError` means the token is currently paused and cannot be used for fees.
+
+If validation passes but submission fails, check that the account has enough fee token balance and that the Fee AMM has liquidity for the selected token.
+
 ### Fee Sponsorship
 
 A fee payer can cover gas fees for the sender via the `feePayer` field. You can use a local account or a remote relay service.

--- a/site/snippets/tempo/write-parameters.mdx
+++ b/site/snippets/tempo/write-parameters.mdx
@@ -10,7 +10,7 @@ Account that will be used to send the transaction.
 
 Fee token for the transaction. 
 
-Can be a TIP-20 token address or ID.
+Can be an unpaused USD-denominated TIP-20 token address or ID. Use `client.fee.validateToken({ token })` to validate a token before submitting a transaction or setting it as a fee preference.
 
 ### feePayer (optional)
 

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -1390,6 +1390,31 @@ export type Decorator<
   }
   fee: {
     /**
+     * Validates that a token can be used as a Tempo fee token.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     *
+     * const client = createClient({
+     *   chain: tempo
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const { address } = await client.fee.validateToken({
+     *   token: '0x20c0000000000000000000000000000000000001',
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns The fee token address, ID, and metadata.
+     */
+    validateToken: (
+      parameters: feeActions.validateToken.Parameters,
+    ) => Promise<feeActions.validateToken.ReturnValue>
+    /**
      * Gets the user's default fee token.
      *
      * @example
@@ -4321,6 +4346,8 @@ export function decorator() {
           nonceActions.watchNonceIncremented(client, parameters),
       },
       fee: {
+        validateToken: (parameters) =>
+          feeActions.validateToken(client, parameters),
         // @ts-expect-error
         getUserToken: (parameters) =>
           // @ts-expect-error

--- a/src/tempo/actions/fee.test.ts
+++ b/src/tempo/actions/fee.test.ts
@@ -7,6 +7,11 @@ import {
   setupFeeToken,
 } from '~test/tempo/config.js'
 import * as Prool from '~test/tempo/prool.js'
+import {
+  FeeTokenNotTip20Error,
+  FeeTokenNotUsdError,
+  FeeTokenPausedError,
+} from '../errors.js'
 import * as actions from './index.js'
 
 const account = accounts[0]
@@ -20,6 +25,96 @@ const client = getClient({
 
 afterEach(async () => {
   await Prool.restart(client)
+})
+
+describe('validateToken', () => {
+  test('default', async () => {
+    await expect(
+      actions.fee.validateToken(client, {
+        token: feeToken,
+      }),
+    ).resolves.toMatchInlineSnapshot(`
+      {
+        "address": "0x20c0000000000000000000000000000000000000",
+        "id": 0n,
+        "metadata": {
+          "currency": "USD",
+          "decimals": 6,
+          "name": "pathUSD",
+          "symbol": "pathUSD",
+          "totalSupply": 184467440737095516150n,
+        },
+      }
+    `)
+  })
+
+  test('behavior: validates token IDs', async () => {
+    await expect(
+      actions.fee.validateToken(client, {
+        token: 1n,
+      }),
+    ).resolves.toMatchObject({
+      address: '0x20c0000000000000000000000000000000000001',
+      id: 1n,
+      metadata: {
+        currency: 'USD',
+        paused: false,
+      },
+    })
+  })
+
+  test('behavior: rejects non TIP20-prefixed addresses', async () => {
+    await expect(
+      actions.fee.validateToken(client, {
+        token: '0x0000000000000000000000000000000000000000',
+      }),
+    ).rejects.toThrow(FeeTokenNotTip20Error)
+  })
+
+  test('behavior: rejects unregistered TIP20-prefixed addresses', async () => {
+    await expect(
+      actions.fee.validateToken(client, {
+        token: '0x20c000000000000000000000000000000000dead',
+      }),
+    ).rejects.toThrow(FeeTokenNotTip20Error)
+  })
+
+  test('behavior: rejects non-USD tokens', async () => {
+    const { token } = await actions.token.createSync(client, {
+      currency: 'EUR',
+      name: 'Euro Token',
+      symbol: 'EURT',
+    })
+
+    await expect(
+      actions.fee.validateToken(client, {
+        token,
+      }),
+    ).rejects.toThrow(FeeTokenNotUsdError)
+  })
+
+  test('behavior: rejects paused tokens', async () => {
+    const { token } = await actions.token.createSync(client, {
+      currency: 'USD',
+      name: 'Paused Fee Token',
+      symbol: 'PFT',
+    })
+
+    await actions.token.grantRolesSync(client, {
+      roles: ['pause'],
+      to: client.account.address,
+      token,
+    })
+    await actions.token.pauseSync(client, {
+      token,
+    })
+
+    await expect(
+      actions.fee.validateToken(client, {
+        token,
+      }),
+    ).rejects.toThrow(FeeTokenPausedError)
+  })
 })
 
 describe('getUserToken', () => {
@@ -115,6 +210,41 @@ describe('setUserToken', () => {
       }
     `,
     )
+  })
+
+  test('behavior: validates token before setting user preference', async () => {
+    const userToken = await actions.fee.getUserToken(client)
+
+    await expect(
+      actions.fee.setUserTokenSync(client, {
+        token: '0x0000000000000000000000000000000000000000',
+      }),
+    ).rejects.toThrow(FeeTokenNotTip20Error)
+
+    expect(await actions.fee.getUserToken(client)).toStrictEqual(userToken)
+  })
+
+  test('behavior: rejects paused token before setting user preference', async () => {
+    const { token } = await actions.token.createSync(client, {
+      currency: 'USD',
+      name: 'Paused User Fee Token',
+      symbol: 'PUFT',
+    })
+
+    await actions.token.grantRolesSync(client, {
+      roles: ['pause'],
+      to: client.account.address,
+      token,
+    })
+    await actions.token.pauseSync(client, {
+      token,
+    })
+
+    await expect(
+      actions.fee.setUserTokenSync(client, {
+        token,
+      }),
+    ).rejects.toThrow(FeeTokenPausedError)
   })
 })
 
@@ -332,6 +462,14 @@ describe('setValidatorToken', () => {
         "id": 2n,
       }
     `)
+  })
+
+  test('behavior: validates token before setting validator preference', async () => {
+    await expect(
+      actions.fee.setValidatorTokenSync(getClient({ account: validator }), {
+        token: '0x0000000000000000000000000000000000000000',
+      }),
+    ).rejects.toThrow(FeeTokenNotTip20Error)
   })
 })
 

--- a/src/tempo/actions/fee.test.ts
+++ b/src/tempo/actions/fee.test.ts
@@ -211,41 +211,6 @@ describe('setUserToken', () => {
     `,
     )
   })
-
-  test('behavior: validates token before setting user preference', async () => {
-    const userToken = await actions.fee.getUserToken(client)
-
-    await expect(
-      actions.fee.setUserTokenSync(client, {
-        token: '0x0000000000000000000000000000000000000000',
-      }),
-    ).rejects.toThrow(FeeTokenNotTip20Error)
-
-    expect(await actions.fee.getUserToken(client)).toStrictEqual(userToken)
-  })
-
-  test('behavior: rejects paused token before setting user preference', async () => {
-    const { token } = await actions.token.createSync(client, {
-      currency: 'USD',
-      name: 'Paused User Fee Token',
-      symbol: 'PUFT',
-    })
-
-    await actions.token.grantRolesSync(client, {
-      roles: ['pause'],
-      to: client.account.address,
-      token,
-    })
-    await actions.token.pauseSync(client, {
-      token,
-    })
-
-    await expect(
-      actions.fee.setUserTokenSync(client, {
-        token,
-      }),
-    ).rejects.toThrow(FeeTokenPausedError)
-  })
 })
 
 describe('watchSetUserToken', async () => {
@@ -462,14 +427,6 @@ describe('setValidatorToken', () => {
         "id": 2n,
       }
     `)
-  })
-
-  test('behavior: validates token before setting validator preference', async () => {
-    await expect(
-      actions.fee.setValidatorTokenSync(getClient({ account: validator }), {
-        token: '0x0000000000000000000000000000000000000000',
-      }),
-    ).rejects.toThrow(FeeTokenNotTip20Error)
   })
 })
 

--- a/src/tempo/actions/fee.ts
+++ b/src/tempo/actions/fee.ts
@@ -11,7 +11,7 @@ import { writeContractSync } from '../../actions/wallet/writeContractSync.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { zeroAddress } from '../../constants/address.js'
-import type { BaseErrorType } from '../../errors/base.js'
+import type { BaseError, BaseErrorType } from '../../errors/base.js'
 import type { Chain } from '../../types/chain.js'
 import type { ExtractAbiItem, GetEventArgs } from '../../types/contract.js'
 import type { Log, Log as viem_Log } from '../../types/log.js'
@@ -19,6 +19,12 @@ import type { Compute, UnionOmit } from '../../types/utils.js'
 import { parseEventLogs } from '../../utils/abi/parseEventLogs.js'
 import * as Abis from '../Abis.js'
 import * as Addresses from '../Addresses.js'
+import {
+  FeeTokenNotTip20Error,
+  FeeTokenNotUsdError,
+  FeeTokenPausedError,
+  InvalidFeeTokenError,
+} from '../errors.js'
 import type {
   GetAccountParameter,
   ReadParameters,
@@ -26,6 +32,116 @@ import type {
 } from '../internal/types.js'
 import { defineCall } from '../internal/utils.js'
 import type { TransactionReceipt } from '../Transaction.js'
+import * as tokenActions from './token.js'
+
+const tip20AddressPrefix = '0x20c0'
+
+/**
+ * Validates that a token can be used as a Tempo fee token.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempo,
+ *   transport: http(),
+ * })
+ *
+ * const { address, metadata } = await Actions.fee.validateToken(client, {
+ *   token: '0x20c0000000000000000000000000000000000001',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The fee token address, ID, and metadata.
+ */
+export async function validateToken<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  parameters: validateToken.Parameters,
+): Promise<validateToken.ReturnValue> {
+  const { token, ...rest } = parameters
+  const token_ = String(token)
+  const address = (() => {
+    try {
+      return TokenId.toAddress(token)
+    } catch (cause) {
+      throw new InvalidFeeTokenError({
+        cause: cause as BaseError | Error,
+        token: token_,
+      })
+    }
+  })()
+
+  if (!address.toLowerCase().startsWith(tip20AddressPrefix))
+    throw new FeeTokenNotTip20Error({ token: address })
+
+  const isPathUsd = address.toLowerCase() === Addresses.pathUsd.toLowerCase()
+  if (!isPathUsd) {
+    const isTip20 = await readContract(client, {
+      ...rest,
+      address: Addresses.tip20Factory,
+      abi: Abis.tip20Factory,
+      functionName: 'isTIP20',
+      args: [address],
+    }).catch((cause) => {
+      throw new InvalidFeeTokenError({
+        cause: cause as BaseError | Error,
+        token: address,
+      })
+    })
+    if (!isTip20) throw new FeeTokenNotTip20Error({ token: address })
+  }
+
+  const metadata = await tokenActions
+    .getMetadata(client, {
+      ...rest,
+      token: address,
+    })
+    .catch((cause) => {
+      throw new InvalidFeeTokenError({
+        cause: cause as BaseError | Error,
+        token: address,
+      })
+    })
+
+  if (metadata.currency !== 'USD')
+    throw new FeeTokenNotUsdError({
+      currency: metadata.currency,
+      token: address,
+    })
+  if (metadata.paused === true)
+    throw new FeeTokenPausedError({ token: address })
+
+  return {
+    address,
+    id: TokenId.fromAddress(address),
+    metadata,
+  }
+}
+
+export declare namespace validateToken {
+  export type Parameters = ReadParameters & {
+    /** Address or ID of the TIP20 token. */
+    token: TokenId.TokenIdOrAddress
+  }
+
+  export type ReturnValue = Compute<{
+    address: Address
+    id: bigint
+    metadata: tokenActions.getMetadata.ReturnValue
+  }>
+
+  export type ErrorType =
+    | FeeTokenNotTip20Error
+    | FeeTokenNotUsdError
+    | FeeTokenPausedError
+    | InvalidFeeTokenError
+    | BaseErrorType
+}
 
 /**
  * Gets the user's default fee token.
@@ -167,6 +283,7 @@ export namespace setUserToken {
     parameters: setUserToken.Parameters<chain, account>,
   ): Promise<ReturnType<action>> {
     const { token, ...rest } = parameters
+    await validateToken(client, { token })
     const call = setUserToken.call({ token })
     return (await action(client, {
       ...rest,
@@ -499,6 +616,7 @@ export namespace setValidatorToken {
     parameters: setValidatorToken.Parameters<chain, account>,
   ): Promise<ReturnType<action>> {
     const { token, ...rest } = parameters
+    await validateToken(client, { token })
     const call = setValidatorToken.call({ token })
     return (await action(client, {
       ...rest,

--- a/src/tempo/actions/fee.ts
+++ b/src/tempo/actions/fee.ts
@@ -283,7 +283,6 @@ export namespace setUserToken {
     parameters: setUserToken.Parameters<chain, account>,
   ): Promise<ReturnType<action>> {
     const { token, ...rest } = parameters
-    await validateToken(client, { token })
     const call = setUserToken.call({ token })
     return (await action(client, {
       ...rest,
@@ -616,7 +615,6 @@ export namespace setValidatorToken {
     parameters: setValidatorToken.Parameters<chain, account>,
   ): Promise<ReturnType<action>> {
     const { token, ...rest } = parameters
-    await validateToken(client, { token })
     const call = setValidatorToken.call({ token })
     return (await action(client, {
       ...rest,

--- a/src/tempo/errors.ts
+++ b/src/tempo/errors.ts
@@ -1,0 +1,78 @@
+import { BaseError } from '../errors/base.js'
+
+export type InvalidFeeTokenErrorType = InvalidFeeTokenError & {
+  name: 'InvalidFeeTokenError'
+}
+export class InvalidFeeTokenError extends BaseError {
+  constructor({
+    cause,
+    token,
+  }: {
+    cause?: BaseError | Error | undefined
+    token: string
+  }) {
+    super(`Fee token "${token}" is invalid.`, {
+      cause,
+      docsPath: '/tempo/transactions',
+      docsSlug: 'pay-fees-with-stablecoins',
+      metaMessages: [
+        'Fee tokens must be unpaused USD-denominated TIP-20 tokens.',
+        'Use `client.fee.validateToken({ token })` before sending transactions or setting fee preferences.',
+      ],
+      name: 'InvalidFeeTokenError',
+    })
+  }
+}
+
+export type FeeTokenNotTip20ErrorType = FeeTokenNotTip20Error & {
+  name: 'FeeTokenNotTip20Error'
+}
+export class FeeTokenNotTip20Error extends BaseError {
+  constructor({ token }: { token: string }) {
+    super(`Fee token "${token}" is not a TIP-20 token.`, {
+      docsPath: '/tempo/transactions',
+      docsSlug: 'pay-fees-with-stablecoins',
+      metaMessages: [
+        'Fee tokens must be TIP-20 token addresses or token IDs.',
+        'TIP-20 token addresses use the `0x20c0...` address prefix.',
+      ],
+      name: 'FeeTokenNotTip20Error',
+    })
+  }
+}
+
+export type FeeTokenNotUsdErrorType = FeeTokenNotUsdError & {
+  name: 'FeeTokenNotUsdError'
+}
+export class FeeTokenNotUsdError extends BaseError {
+  constructor({
+    currency,
+    token,
+  }: {
+    currency: string
+    token: string
+  }) {
+    super(`Fee token "${token}" is denominated in "${currency}", not "USD".`, {
+      docsPath: '/tempo/transactions',
+      docsSlug: 'pay-fees-with-stablecoins',
+      metaMessages: [
+        'Only USD-denominated TIP-20 tokens can be used as fee tokens.',
+      ],
+      name: 'FeeTokenNotUsdError',
+    })
+  }
+}
+
+export type FeeTokenPausedErrorType = FeeTokenPausedError & {
+  name: 'FeeTokenPausedError'
+}
+export class FeeTokenPausedError extends BaseError {
+  constructor({ token }: { token: string }) {
+    super(`Fee token "${token}" is paused.`, {
+      docsPath: '/tempo/transactions',
+      docsSlug: 'pay-fees-with-stablecoins',
+      metaMessages: ['Paused TIP-20 tokens cannot be used as fee tokens.'],
+      name: 'FeeTokenPausedError',
+    })
+  }
+}

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -29,6 +29,7 @@ export {
   decorator as tempoActions,
 } from './Decorator.js'
 export * as Expiry from './Expiry.js'
+export * from './errors.js'
 export * as Formatters from './Formatters.js'
 export * as Hardfork from './Hardfork.js'
 export * as P256 from './P256.js'


### PR DESCRIPTION
## Summary

Add Tempo fee token validation with typed errors, wire validation into fee token preference setters, document common fee token errors, and patch the transitive fast-uri audit advisory.