### PR TITLE
fix(zksync): reject priority type on request path

### DIFF
--- a/.changeset/zksync-reject-priority-type.md
+++ b/.changeset/zksync-reject-priority-type.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed zkSync `sendTransaction` and `signTransaction` to reject the `priority` transaction type on the request path, which is not supported as a request type.

--- a/src/zksync/actions/sendTransaction.test.ts
+++ b/src/zksync/actions/sendTransaction.test.ts
@@ -49,3 +49,21 @@ test('other', async () => {
     `"0x9afe47f3d95eccfc9210851ba5f877f76d372514a26b48bad848a07f77c33b87"`,
   )
 })
+
+test('errors: priority type unsupported', async () => {
+  await expect(() =>
+    sendTransaction(client, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      ...eip712,
+      type: 'priority' as any,
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [InvalidEip712TransactionError: Transaction is not an EIP712 transaction.
+
+    Transaction must:
+      - include \`type: "eip712"\`
+      - include one of the following: \`customSignature\`, \`paymaster\`, \`paymasterInput\`, \`gasPerPubdata\`, \`factoryDeps\`
+
+    Version: viem@x.y.z]
+  `)
+})

--- a/src/zksync/actions/sendTransaction.ts
+++ b/src/zksync/actions/sendTransaction.ts
@@ -8,6 +8,7 @@ import type {
 import { sendTransaction as core_sendTransaction } from '../../actions/wallet/sendTransaction.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
+import { InvalidEip712TransactionError } from '../errors/transaction.js'
 import type { ChainEIP712 } from '../types/chain.js'
 import { isEIP712Transaction } from '../utils/isEip712Transaction.js'
 import {
@@ -82,6 +83,9 @@ export async function sendTransaction<
   client: Client<Transport, chain, account>,
   parameters: SendTransactionParameters<chain, account, chainOverride, request>,
 ): Promise<SendTransactionReturnType> {
+  if ((parameters as { type?: string | undefined }).type === 'priority')
+    throw new InvalidEip712TransactionError()
+
   if (isEIP712Transaction(parameters))
     return sendEip712Transaction(
       client,

--- a/src/zksync/actions/signTransaction.test.ts
+++ b/src/zksync/actions/signTransaction.test.ts
@@ -42,3 +42,21 @@ test('other', async () => {
     `"0x02f84e82014480808080808080c080a0e9ff0193c0db842635d2b50dd8401c95f5fc53aa96b7170e85b5425c7ece8989a07bf8bd7e5a9ef6c8fb32cc7b5fc85f8529c71faab273eb7d00562542cc8b4dc4"`,
   )
 })
+
+test('errors: priority type unsupported', async () => {
+  await expect(() =>
+    signTransaction(client, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      ...eip712,
+      type: 'priority' as any,
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [InvalidEip712TransactionError: Transaction is not an EIP712 transaction.
+
+    Transaction must:
+      - include \`type: "eip712"\`
+      - include one of the following: \`customSignature\`, \`paymaster\`, \`paymasterInput\`, \`gasPerPubdata\`, \`factoryDeps\`
+
+    Version: viem@x.y.z]
+  `)
+})

--- a/src/zksync/actions/signTransaction.ts
+++ b/src/zksync/actions/signTransaction.ts
@@ -12,6 +12,7 @@ import type {
   GetChainParameter,
 } from '../../types/chain.js'
 import type { UnionOmit } from '../../types/utils.js'
+import { InvalidEip712TransactionError } from '../errors/transaction.js'
 import type { ChainEIP712 } from '../types/chain.js'
 import type { TransactionRequestEIP712 } from '../types/transaction.js'
 import { isEIP712Transaction } from '../utils/isEip712Transaction.js'
@@ -90,6 +91,9 @@ export async function signTransaction<
   client: Client<Transport, chain, account>,
   args: SignTransactionParameters<chain, account, chainOverride>,
 ): Promise<SignTransactionReturnType> {
+  if ((args as { type?: string | undefined }).type === 'priority')
+    throw new InvalidEip712TransactionError()
+
   if (isEIP712Transaction(args)) return signEip712Transaction(client, args)
   return await signTransaction_(client, args as any)
 }

--- a/src/zksync/formatters.test.ts
+++ b/src/zksync/formatters.test.ts
@@ -1727,15 +1727,12 @@ describe('transactionRequest', () => {
       }),
     ).toMatchInlineSnapshot(`
       {
-        "eip712Meta": {
-          "gasPerPubdata": "0xc350",
-        },
         "from": "0x0f16e9b0d03470827a95cdfd0cb8a8a3b46969b9",
         "gas": "0x32c8",
         "maxFeePerGas": "0x2",
         "maxPriorityFeePerGas": "0x1",
         "nonce": "0x4",
-        "type": "0x71",
+        "type": undefined,
         "value": "0x0",
       }
     `)

--- a/src/zksync/formatters.ts
+++ b/src/zksync/formatters.ts
@@ -106,6 +106,9 @@ export const formatters = {
       'paymasterInput',
     ],
     format(args: ZksyncTransactionRequest): ZksyncRpcTransactionRequest {
+      if ((args as { type?: string | undefined }).type === 'priority')
+        return {} as ZksyncRpcTransactionRequest
+
       if (
         args.gasPerPubdata ||
         (args.paymaster && args.paymasterInput) ||

--- a/src/zksync/types/transaction.ts
+++ b/src/zksync/types/transaction.ts
@@ -136,7 +136,7 @@ export type ZksyncTransactionRequestEIP712<
     gasPerPubdata?: bigint | undefined
     customSignature?: Hex | undefined
     factoryDeps?: Hex[] | undefined
-    type?: 'eip712' | 'priority' | undefined
+    type?: 'eip712' | undefined
   } & (
     | { paymaster: Address; paymasterInput: Hex }
     | { paymaster?: undefined; paymasterInput?: undefined }
@@ -154,7 +154,7 @@ export type ZksyncRpcTransactionRequestEIP712 = TransactionRequestBase<
 > &
   ExactPartial<FeeValuesEIP1559<Quantity>> & {
     eip712Meta: ZksyncEip712Meta
-    type: EIP712Type | PriorityType
+    type: EIP712Type
   }
 
 export type ZksyncRpcTransactionRequest =

--- a/src/zksync/utils/isEip712Transaction.test.ts
+++ b/src/zksync/utils/isEip712Transaction.test.ts
@@ -53,4 +53,16 @@ test('false', () => {
       value: 69n,
     }),
   ).toBeFalsy()
+  expect(
+    isEIP712Transaction({
+      type: 'priority',
+    }),
+  ).toBeFalsy()
+  expect(
+    isEIP712Transaction({
+      from: '0x0000000000000000000000000000000000000000',
+      gasPerPubdata: 1n,
+      type: 'priority',
+    }),
+  ).toBeFalsy()
 })

--- a/src/zksync/utils/isEip712Transaction.ts
+++ b/src/zksync/utils/isEip712Transaction.ts
@@ -9,6 +9,7 @@ export function isEIP712Transaction(
     OneOf<ZksyncTransactionRequest | ZksyncTransactionSerializable>
   >,
 ) {
+  if (transaction.type === 'priority') return false
   if (transaction.type === 'eip712') return true
   if (
     ('customSignature' in transaction && transaction.customSignature) ||


### PR DESCRIPTION
  ## What is this PR solving?
                                                                                                                                                                                                  
  `zksync` had a request-side contract mismatch for `priority` transactions:                                                                                                                      
                                                                                                                                                                                                  
  - Type definitions allowed `type: 'priority'` on request payloads.                                                                                                                              
  - Runtime routing (`isEIP712Transaction` + `sendTransaction`/`signTransaction`) and formatter behavior were effectively EIP-712-centric (`0x71`), not a stable `priority` request path.         
                                                                                                                                                                                                  
  This PR makes the contract explicit and consistent by treating `priority` as **response-side only** (RPC tx type parsing), and **not supported on request-side**.                               
                                                                                                                                                                                                  
  ### Changes                                                                                                                                                                                     
                                                                                                                                                                                                  
  - Tighten request types:                                                                                                                                                                        
    - `ZksyncTransactionRequestEIP712.type` -> `'eip712'` only                                                                                                                                    
    - `ZksyncRpcTransactionRequestEIP712.type` -> `EIP712Type` only                                                                                                                               
  - Runtime guardrails:                                                                                                                                                                           
    - `isEIP712Transaction` explicitly returns `false` for `type: 'priority'`                                                                                                                     
    - `zksync/sendTransaction` and `zksync/signTransaction` explicitly throw `InvalidEip712TransactionError` for `type: 'priority'`                                                               
  - Formatter alignment:                                                                                                                                                                          
    - `zksync` transaction request formatter no longer produces EIP-712 request metadata when `type: 'priority'` is passed                                                                        
  - Tests:                                                                                                                                                                                        
    - Added/updated tests for the above behavior.                                                                                                                                                 
                                                                                                                                                                                                  
  Fixes: N/A (no linked GitHub issue in this repo context).                                                                                                                                       
                                                                                                                                                                                                  
  ## What alternatives were explored?                                                                                                                                                             
                                                                                                                                                                                                  
  - Keep current behavior and document it: rejected, because it keeps a misleading public type contract.                                                                                          
  - Add full request-side `priority` support (`0xff`) across routing/signing/serialization: rejected for this PR due to larger scope and unclear existing semantics.                              
                                                                                                                                                                                                  
  Chosen approach: minimal contract-tightening to a single source of truth.                                                                                                                       
                                                                                                                                                                                                  
  ## Are there any parts that require more attention from reviewers?                                                                                                                              
                                                                                                                                                                                                  
  - Type-level breaking surface: callers passing `type: 'priority'` in request args now fail by design.                                                                                           
  - Ensure response-side `priority` parsing remains unchanged (`0xff` -> `priority` in transaction formatters).                                                                                   
  - Confirm explicit error behavior in:                                                                                                                                                           
    - `src/zksync/actions/sendTransaction.ts`                                                                                                                                                     
    - `src/zksync/actions/signTransaction.ts`                                                                                                                                                     
                                                                                                                                                                                                  
  ## Documentation                                                                                                                                                                                
                                                                                                                                                                                                  
  No documentation update included in this PR (behavior clarification via type/runtime alignment only).                                                                                           
                                                                                                                                                                                                  
  ## Tests                                                                                                                                                                                        
                                                                                                                                                                                                  
  Updated tests:                                                                                                                                                                                  
  - `src/zksync/utils/isEip712Transaction.test.ts`                                                                                                                                                
  - `src/zksync/actions/sendTransaction.test.ts`                                                                                                                                                  
  - `src/zksync/actions/signTransaction.test.ts`                                                                                                                                                  
  - `src/zksync/formatters.test.ts`     