### PR TITLE
fix(tempo): verify allowAccessKey for secp256k1 keychain

### DIFF
--- a/.changeset/tempo-verify-secp256k1-keychain.md
+++ b/.changeset/tempo-verify-secp256k1-keychain.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed `verifyHash` for Tempo `allowAccessKey` mode to support `secp256k1` keychain access keys (whose inner envelope does not carry a `publicKey`).
+Fixed `verifyHash` for Tempo `allowAccessKey` mode with `secp256k1` keychain access keys, whose inner envelope did not carry a `publicKey`.

--- a/.changeset/tempo-verify-secp256k1-keychain.md
+++ b/.changeset/tempo-verify-secp256k1-keychain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `verifyHash` for Tempo `allowAccessKey` mode to support `secp256k1` keychain access keys (whose inner envelope does not carry a `publicKey`).

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -388,6 +388,30 @@ describe('verifyHash', () => {
     ).toBe(true)
   })
 
+  test('accessKey: secp256k1 valid signature', async () => {
+    const rootAccount = accounts.at(0)!
+    const accessKey = Account.fromSecp256k1(generatePrivateKey(), {
+      access: rootAccount,
+    })
+
+    await accessKeyActions.authorizeSync(client, {
+      accessKey,
+      expiry: Math.floor((Date.now() + 30_000) / 1000),
+    })
+
+    const hash = hashMessage('hello world')
+    const signature = await accessKey.sign({ hash })
+
+    expect(
+      await verifyHash(client, {
+        address: accessKey.address,
+        hash,
+        signature,
+        mode: 'allowAccessKey',
+      }),
+    ).toBe(true)
+  })
+
   test('accessKey: invalid signature returns false', async () => {
     const rootAccount = accounts.at(0)!
     const accessKey = Account.fromP256(generatePrivateKey(), {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -1,6 +1,7 @@
 import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as PublicKey from 'ox/PublicKey'
+import * as Secp256k1 from 'ox/Secp256k1'
 import { SignatureEnvelope, type TokenId } from 'ox/tempo'
 import { getCode } from '../actions/public/getCode.js'
 import { verifyHash } from '../actions/public/verifyHash.js'
@@ -115,9 +116,28 @@ export const chainConfig = {
       // Access key (keychain) signature verification: check the key is
       // authorized, not expired, and not revoked on the AccountKeychain.
       if (envelope?.type === 'keychain' && mode === 'allowAccessKey') {
-        const accessKeyAddress = Address.fromPublicKey(
-          PublicKey.from(envelope.inner.publicKey as PublicKey.PublicKey),
-        )
+        // For v2 keychain envelopes, the inner signature signs
+        // keccak256(0x04 || hash || userAddress).
+        const innerPayload =
+          envelope.version === 'v2'
+            ? keccak256(Hex.concat('0x04', hash, address))
+            : hash
+
+        let accessKeyAddress: Address.Address
+        try {
+          if ('publicKey' in envelope.inner && envelope.inner.publicKey)
+            accessKeyAddress = Address.fromPublicKey(
+              PublicKey.from(envelope.inner.publicKey as PublicKey.PublicKey),
+            )
+          else if (envelope.inner.type === 'secp256k1')
+            accessKeyAddress = Secp256k1.recoverAddress({
+              payload: innerPayload,
+              signature: envelope.inner.signature,
+            })
+          else return false
+        } catch {
+          return false
+        }
 
         const keyInfo = await getMetadata(client, {
           account: address,
@@ -129,13 +149,6 @@ export const chainConfig = {
         if (keyInfo.isRevoked) return false
         if (keyInfo.expiry <= BigInt(Math.floor(Date.now() / 1000)))
           return false
-
-        // For v2 keychain envelopes, the inner signature signs
-        // keccak256(0x04 || hash || userAddress).
-        const innerPayload =
-          envelope.version === 'v2'
-            ? keccak256(Hex.concat('0x04', hash, address))
-            : hash
         return SignatureEnvelope.verify(envelope.inner, {
           address: accessKeyAddress,
           payload: innerPayload,

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -1,7 +1,4 @@
-import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
-import * as PublicKey from 'ox/PublicKey'
-import * as Secp256k1 from 'ox/Secp256k1'
 import { SignatureEnvelope, type TokenId } from 'ox/tempo'
 import { getCode } from '../actions/public/getCode.js'
 import { verifyHash } from '../actions/public/verifyHash.js'
@@ -123,21 +120,17 @@ export const chainConfig = {
             ? keccak256(Hex.concat('0x04', hash, address))
             : hash
 
-        let accessKeyAddress: Address.Address
-        try {
-          if ('publicKey' in envelope.inner && envelope.inner.publicKey)
-            accessKeyAddress = Address.fromPublicKey(
-              PublicKey.from(envelope.inner.publicKey as PublicKey.PublicKey),
-            )
-          else if (envelope.inner.type === 'secp256k1')
-            accessKeyAddress = Secp256k1.recoverAddress({
+        const accessKeyAddress = (() => {
+          try {
+            return SignatureEnvelope.extractAddress({
               payload: innerPayload,
-              signature: envelope.inner.signature,
+              signature: envelope.inner,
             })
-          else return false
-        } catch {
-          return false
-        }
+          } catch {
+            return undefined
+          }
+        })()
+        if (!accessKeyAddress) return false
 
         const keyInfo = await getMetadata(client, {
           account: address,


### PR DESCRIPTION
 ## What is this PR solving?
                                                                                                                                                                                                 
  This PR fixes an incomplete `allowAccessKey` verification path in `tempo` `verifyHash`.                                                                                                        
                                                                                                                                                                                                 
  In the keychain branch, the current logic derives the access key address only from `envelope.inner.publicKey`.                                                                                 
  For `secp256k1` access keys, the inner envelope may not include `publicKey`, which can cause thrown errors or false-negative verification for otherwise valid signatures.                      
                                                                                                                                                                                                 
  This change adds a fallback path:                                                                                                                                                              
  - If `envelope.inner.publicKey` exists, keep current behavior.                                                                                                                                 
  - If it is missing and `envelope.inner.type === 'secp256k1'`, recover the access key address from the inner signature + payload.                                                               
  - If address derivation fails, return `false` instead of throwing.                                                                                                                             
                                                                                                                                                                                                 
  This preserves the existing metadata checks (authorized, not revoked, not expired) and only broadens support for valid `secp256k1` keychain envelopes.                                         
                                                                                                                                                                                                 
  ## Alternatives explored                                                                                                                                                                       
                                                                                                                                                                                                 
  - Require `publicKey` for all key types in keychain envelopes.                                                                                                                                 
    - Rejected: not compatible with existing `secp256k1` envelope shape.                                                                                                                         
  - Skip local envelope verification and always fall back to generic `verifyHash`.                                                                                                               
    - Rejected: would bypass the intended access-key metadata validation path in `allowAccessKey` mode.                                                                                          
  - Current approach: minimal fallback only for missing-`publicKey` `secp256k1` inner signatures.                                                                                                
    - Chosen for minimal surface area and behavior preservation.
                                                                                                                                                                                                 
  ## Reviewer attention                                                                                                                                                                          
                                                                                                                                                                                                 
  Please focus on:                                                                                                                                                                               
  - The new fallback in `src/tempo/chainConfig.ts` for keychain + `allowAccessKey`.                                                                                                              
  - `innerPayload` usage consistency for v1/v2 keychain envelopes.                                                                                                                               
  - Error handling behavior (`false` return instead of throw) in malformed/missing-key scenarios.                                                                                                
                                                                                                                                                                                                 
  ## Tests
                                                                                                                                                                                                 
  Added:                                                                                                                                                                                         
  - `accessKey: secp256k1 valid signature` in `src/tempo/chainConfig.test.ts`.                                                                                                                   

  The new test reproduces the previously unhandled `secp256k1` keychain path and validates the fix.                                                                                              
                                                                                                                                                                                                 
  ## Docs                                                                                                                                                                                        
                                                                                                                                                                                                 
  No public API changes. No docs update required.