### PR TITLE
feat(op-stack): Add support for super root games

### DIFF
--- a/.changeset/super-root-games.md
+++ b/.changeset/super-root-games.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+`viem/op-stack`: Added OP Stack super-root dispute game support for withdrawal prove flows.

--- a/examples/op-stack_super-withdrawal/README.md
+++ b/examples/op-stack_super-withdrawal/README.md
@@ -1,0 +1,67 @@
+# OP Stack Super Withdrawal Example
+
+Manual end-to-end withdrawal verification for OP Stack devnets. The same script
+can run against:
+
+- A pre-super-roots devnet where the respected Portal game type uses legacy L2
+  block-number anchors.
+- A post-super-roots devnet where the respected Portal game type uses L2
+  timestamp anchors.
+
+This example is intentionally not wired into CI. It requires external devnets,
+funded accounts, and devnet finalization timings short enough for manual runs.
+
+## Run
+
+```sh
+pnpm --filter example-op-stack-super-withdrawal dev
+```
+
+## Environment
+
+Required for both legacy and super-root devnets:
+
+```sh
+export L1_RPC_URL=http://127.0.0.1:8545
+export L2_RPC_URL=http://127.0.0.1:9545
+export L1_CHAIN_ID=900
+export L2_CHAIN_ID=901
+export PRIVATE_KEY=0x...
+export PORTAL_ADDRESS=0x...
+export DISPUTE_GAME_FACTORY_ADDRESS=0x...
+```
+
+Required only for legacy Portal/L2OutputOracle devnets:
+
+```sh
+export L2_OUTPUT_ORACLE_ADDRESS=0x...
+```
+
+Optional:
+
+```sh
+export WITHDRAWAL_AMOUNT_WEI=1000
+```
+
+## What It Does
+
+The script:
+
+1. Builds initiate-withdrawal parameters.
+2. Initiates the withdrawal on L2.
+3. Waits for the L2 transaction receipt.
+4. Reads the Portal version and respected game type to determine whether the
+   devnet uses super roots.
+5. Reads the L2 receipt block timestamp and passes it as `l2Timestamp` to
+   `waitToProve` only for super-root devnets.
+6. Builds prove-withdrawal parameters from the returned dispute game.
+7. Proves the withdrawal on L1.
+8. Waits for the L1 prove transaction receipt.
+9. Waits until the withdrawal can be finalized.
+10. Finalizes the withdrawal on L1.
+11. Waits for the L1 finalize transaction receipt and logs the L1 balance delta.
+
+For non-super devnets, the script keeps using the receipt L2 block number for
+prove readiness. For post-super-roots devnets, `l2Timestamp` becomes the L1-side
+anchor used to find the correct dispute game, and `buildProveWithdrawal`
+resolves that timestamp back to an L2 block number for the proof RPC calls.

--- a/examples/op-stack_super-withdrawal/index.ts
+++ b/examples/op-stack_super-withdrawal/index.ts
@@ -1,0 +1,316 @@
+import {
+  type Address,
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  type Hash,
+  type Hex,
+  http,
+  isAddress,
+  isAddressEqual,
+  type TransactionReceipt,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import {
+  buildInitiateWithdrawal,
+  buildProveWithdrawal,
+  finalizeWithdrawal,
+  getPortalVersion,
+  initiateWithdrawal,
+  isSuperGameType,
+  proveWithdrawal,
+  waitToFinalize,
+  waitToProve,
+} from 'viem/op-stack'
+
+const portalConfigAbi = [
+  {
+    inputs: [],
+    name: 'disputeGameFactory',
+    outputs: [
+      {
+        internalType: 'contract IDisputeGameFactory',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'respectedGameType',
+    outputs: [{ internalType: 'GameType', name: '', type: 'uint32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'systemConfig',
+    outputs: [
+      { internalType: 'contract ISystemConfig', name: '', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+const systemConfigAbi = [
+  {
+    inputs: [],
+    name: 'l2ChainId',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+function requireEnv(name: string) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env var: ${name}`)
+  return value
+}
+
+function requireAddress(name: string) {
+  const value = requireEnv(name)
+  if (!isAddress(value)) throw new Error(`${name} is not a valid address.`)
+  return value
+}
+
+function optionalAddress(name: string) {
+  const value = process.env[name]
+  if (!value) return undefined
+  if (!isAddress(value)) throw new Error(`${name} is not a valid address.`)
+  return value
+}
+
+function requireChainId(name: string) {
+  const value = Number(requireEnv(name))
+  if (!Number.isInteger(value)) throw new Error(`${name} must be an integer.`)
+  return value
+}
+
+function optionalBigInt(name: string) {
+  const value = process.env[name]
+  if (!value) return undefined
+  return BigInt(value)
+}
+
+function devnetChain({
+  id,
+  multicall3Address,
+  name,
+  rpcUrl,
+}: {
+  id: number
+  multicall3Address?: Address | undefined
+  name: string
+  rpcUrl: string
+}) {
+  return defineChain({
+    contracts: multicall3Address
+      ? {
+          multicall3: {
+            address: multicall3Address,
+            blockCreated: 0,
+          },
+        }
+      : undefined,
+    id,
+    name,
+    nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+    rpcUrls: {
+      default: { http: [rpcUrl] },
+    },
+  })
+}
+
+function assertSuccess(receipt: TransactionReceipt, label: string) {
+  if (receipt.status !== 'success')
+    throw new Error(`${label} transaction reverted.`)
+}
+
+function logHash(label: string, hash: Hash) {
+  console.log(`${label}: ${hash}`)
+}
+
+const l1RpcUrl = requireEnv('L1_RPC_URL')
+const l2RpcUrl = requireEnv('L2_RPC_URL')
+const privateKey = requireEnv('PRIVATE_KEY') as Hex
+const portalAddress = requireAddress('PORTAL_ADDRESS')
+const multicall3Address =
+  optionalAddress('MULTICALL3_ADDRESS') ??
+  '0xcA11bde05977b3631167028862bE2a173976CA11'
+const disputeGameFactoryAddress = requireAddress('DISPUTE_GAME_FACTORY_ADDRESS')
+const l2OutputOracleAddress = optionalAddress('L2_OUTPUT_ORACLE_ADDRESS')
+const withdrawalAmount = BigInt(process.env.WITHDRAWAL_AMOUNT_WEI ?? '1000')
+const initiateWithdrawalTransactionGas =
+  optionalBigInt('INITIATE_WITHDRAWAL_TRANSACTION_GAS') ?? 200_000n
+
+const account = privateKeyToAccount(privateKey)
+const l1Chain = devnetChain({
+  id: requireChainId('L1_CHAIN_ID'),
+  multicall3Address,
+  name: 'L1 Devnet',
+  rpcUrl: l1RpcUrl,
+})
+const l2Chain = devnetChain({
+  id: requireChainId('L2_CHAIN_ID'),
+  name: 'L2 Devnet',
+  rpcUrl: l2RpcUrl,
+})
+
+const publicClientL1 = createPublicClient({
+  chain: l1Chain,
+  transport: http(l1RpcUrl),
+})
+const walletClientL1 = createWalletClient({
+  account,
+  chain: l1Chain,
+  transport: http(l1RpcUrl),
+})
+const publicClientL2 = createPublicClient({
+  chain: l2Chain,
+  transport: http(l2RpcUrl),
+})
+const walletClientL2 = createWalletClient({
+  account,
+  chain: l2Chain,
+  transport: http(l2RpcUrl),
+})
+
+const contractOverrides = {
+  disputeGameFactoryAddress,
+  l2OutputOracleAddress,
+  portalAddress,
+} as const
+
+const portalVersion = await getPortalVersion(publicClientL1, { portalAddress })
+if (portalVersion.major < 3 && !l2OutputOracleAddress)
+  throw new Error('L2_OUTPUT_ORACLE_ADDRESS is required for legacy Portal.')
+if (portalVersion.major >= 3) {
+  const [portalDisputeGameFactoryAddress, systemConfigAddress] =
+    await Promise.all([
+      publicClientL1.readContract({
+        abi: portalConfigAbi,
+        address: portalAddress,
+        functionName: 'disputeGameFactory',
+      }),
+      publicClientL1.readContract({
+        abi: portalConfigAbi,
+        address: portalAddress,
+        functionName: 'systemConfig',
+      }),
+    ])
+  const portalL2ChainId = await publicClientL1.readContract({
+    abi: systemConfigAbi,
+    address: systemConfigAddress,
+    functionName: 'l2ChainId',
+  })
+
+  if (
+    !isAddressEqual(portalDisputeGameFactoryAddress, disputeGameFactoryAddress)
+  )
+    throw new Error(
+      `DISPUTE_GAME_FACTORY_ADDRESS ${disputeGameFactoryAddress} does not match Portal disputeGameFactory ${portalDisputeGameFactoryAddress}.`,
+    )
+  if (portalL2ChainId !== BigInt(l2Chain.id))
+    throw new Error(
+      `PORTAL_ADDRESS is configured for L2 chain ${portalL2ChainId}, but L2_CHAIN_ID is ${l2Chain.id}.`,
+    )
+}
+const usesSuperRoots =
+  portalVersion.major >= 3 &&
+  isSuperGameType(
+    Number(
+      await publicClientL1.readContract({
+        abi: portalConfigAbi,
+        address: portalAddress,
+        functionName: 'respectedGameType',
+      }),
+    ),
+  )
+
+console.log(`Withdrawing ${withdrawalAmount} wei from L2 to L1.`)
+console.log(`Account: ${account.address}`)
+console.log(
+  `Portal version: ${portalVersion.major}.${portalVersion.minor}.${portalVersion.patch}`,
+)
+console.log(`Uses super roots: ${usesSuperRoots}`)
+
+const startingBalance = await publicClientL1.getBalance({
+  address: account.address,
+})
+
+const initiateArgs = await buildInitiateWithdrawal(publicClientL1, {
+  account,
+  to: account.address,
+  value: withdrawalAmount,
+})
+const initiateHash = await initiateWithdrawal(walletClientL2, {
+  ...initiateArgs,
+  gas: initiateWithdrawalTransactionGas,
+})
+logHash('Initiated withdrawal on L2', initiateHash)
+
+const l2Receipt = await publicClientL2.waitForTransactionReceipt({
+  hash: initiateHash,
+})
+assertSuccess(l2Receipt, 'Initiate withdrawal')
+const l2Block = await publicClientL2.getBlock({
+  blockNumber: l2Receipt.blockNumber,
+})
+if (l2Block.timestamp === undefined)
+  throw new Error('L2 withdrawal block timestamp is unavailable.')
+console.log(`L2 withdrawal block: ${l2Receipt.blockNumber}`)
+console.log(`L2 withdrawal timestamp: ${l2Block.timestamp}`)
+
+const { game, withdrawal } = await waitToProve(publicClientL1, {
+  ...contractOverrides,
+  ...(usesSuperRoots ? { l2Timestamp: l2Block.timestamp } : {}),
+  receipt: l2Receipt,
+} as never)
+console.log(`Dispute game/output index: ${game.index}`)
+
+const proveArgs = await buildProveWithdrawal(publicClientL2, {
+  account,
+  game,
+  withdrawal,
+})
+const { targetChain: _targetChain, ...proveRequest } = proveArgs
+void _targetChain
+const proveHash = await proveWithdrawal(walletClientL1, {
+  ...proveRequest,
+  portalAddress,
+} as never)
+logHash('Proved withdrawal on L1', proveHash)
+
+const proveReceipt = await publicClientL1.waitForTransactionReceipt({
+  hash: proveHash,
+})
+assertSuccess(proveReceipt, 'Prove withdrawal')
+
+await waitToFinalize(publicClientL1, {
+  ...contractOverrides,
+  withdrawalHash: withdrawal.withdrawalHash,
+} as never)
+
+const finalizeHash = await finalizeWithdrawal(walletClientL1, {
+  account,
+  portalAddress,
+  withdrawal,
+} as never)
+logHash('Finalized withdrawal on L1', finalizeHash)
+
+const finalizeReceipt = await publicClientL1.waitForTransactionReceipt({
+  hash: finalizeHash,
+})
+assertSuccess(finalizeReceipt, 'Finalize withdrawal')
+
+const endingBalance = await publicClientL1.getBalance({
+  address: account.address,
+})
+
+console.log(`Starting L1 balance: ${startingBalance}`)
+console.log(`Ending L1 balance: ${endingBalance}`)
+console.log(`L1 balance delta: ${endingBalance - startingBalance}`)

--- a/examples/op-stack_super-withdrawal/package.json
+++ b/examples/op-stack_super-withdrawal/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-op-stack-super-withdrawal",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx --tsconfig tsconfig.json index.ts"
+  },
+  "dependencies": {
+    "viem": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/op-stack_super-withdrawal/tsconfig.json
+++ b/examples/op-stack_super-withdrawal/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "baseUrl": ".",
+    "paths": {
+      "viem": ["../../src/index.ts"],
+      "viem/accounts": ["../../src/accounts/index.ts"],
+      "viem/op-stack": ["../../src/op-stack/index.ts"]
+    },
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,22 @@ importers:
         specifier: 7.3.2
         version: 7.3.2(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/op-stack_super-withdrawal:
+    dependencies:
+      viem:
+        specifier: workspace:*
+        version: link:../../src
+    devDependencies:
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.5.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/signing_typed-data:
     dependencies:
       react:

--- a/site/pages/op-stack/guides/withdrawals.md
+++ b/site/pages/op-stack/guides/withdrawals.md
@@ -335,6 +335,19 @@ After the initiate withdrawal transaction has been processed on a block on the L
 
 Before a withdrawal transaction can be proved, the transaction needs to be included in an L2 Output proposal. Until then, we will need to wait for the withdrawal transaction to be ready to be proved (1). This usually takes a maximum of **one hour**. 
 
+The same flow works for OP Stack chains that use super-root dispute games. For those chains, the dispute game anchor is an L2 timestamp instead of an L2 block number, so pass the initiating withdrawal block timestamp as `l2Timestamp` to L1-side prove readiness checks like `waitToProve`, `getTimeToProve`, and `getWithdrawalStatus`.
+
+```ts
+const receipt = await publicClientL2.getTransactionReceipt({ hash })
+const block = await publicClientL2.getBlock({ blockNumber: receipt.blockNumber })
+
+await publicClientL1.waitToProve({
+  receipt,
+  l2Timestamp: block.timestamp,
+  targetChain: walletClientL2.chain
+})
+```
+
 Once the L2 output has been proposed, we will need to build the parameters for the prove withdrawal transaction on the L2 (2), and then execute the transaction on the L1 (3). We also want to wait for the L1 transaction to be processed on a block (4) before we continue.
 
 :::code-group

--- a/src/op-stack/actions/buildProveWithdrawal.test.ts
+++ b/src/op-stack/actions/buildProveWithdrawal.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, test } from 'vitest'
 import { anvilMainnet, anvilOptimism } from '~test/anvil.js'
 import { accounts } from '~test/constants.js'
 import { getTransactionReceipt, reset } from '../../actions/index.js'
+import { createClient } from '../../clients/createClient.js'
+import { custom } from '../../clients/transports/custom.js'
+import type { RpcBlock, RpcProof } from '../../types/rpc.js'
+import { numberToHex } from '../../utils/encoding/toHex.js'
 
 import { getL2Output, getWithdrawals, proveWithdrawal } from '../index.js'
 import {
@@ -13,6 +17,123 @@ import { getGame } from './getGame.js'
 
 const client = anvilMainnet.getClient()
 const optimismClient = anvilOptimism.getClient()
+
+const blockHash =
+  '0x000000000000000000000000000000000000000000000000000000000000000b'
+const stateRoot =
+  '0x000000000000000000000000000000000000000000000000000000000000000c'
+const storageHash =
+  '0x000000000000000000000000000000000000000000000000000000000000000d'
+const withdrawalHash =
+  '0x000000000000000000000000000000000000000000000000000000000000000e'
+
+function block(number: bigint, timestamp: bigint) {
+  return {
+    hash: blockHash,
+    number: numberToHex(number),
+    stateRoot,
+    timestamp: numberToHex(timestamp),
+    transactions: [],
+  } as unknown as RpcBlock
+}
+
+function proof() {
+  return {
+    accountProof: [],
+    address: '0x4200000000000000000000000000000000000016',
+    balance: '0x0',
+    codeHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    nonce: '0x0',
+    storageHash,
+    storageProof: [
+      {
+        key: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        proof: ['0xc0'],
+        value: '0x0',
+      },
+    ],
+  } as RpcProof
+}
+
+function superGameClient({ targetTimestamp = 180n } = {}) {
+  const blockNumbers: (string | undefined)[] = []
+  const proofBlockNumbers: (string | undefined)[] = []
+
+  const client = createClient({
+    transport: custom({
+      async request({ method, params }) {
+        if (method === 'eth_getBlockByNumber') {
+          blockNumbers.push(params[0])
+          if (params[0] === 'latest') return block(100n, 200n)
+          if (params[0] === numberToHex(99n)) return block(99n, 198n)
+          if (params[0] === numberToHex(90n)) return block(90n, targetTimestamp)
+        }
+        if (method === 'eth_getProof') {
+          proofBlockNumbers.push(params[2])
+          return proof()
+        }
+        return null
+      },
+    }),
+  })
+
+  return { blockNumbers, client, proofBlockNumbers }
+}
+
+const withdrawal = {
+  data: '0x',
+  gasLimit: 0n,
+  nonce: 0n,
+  sender: '0x0000000000000000000000000000000000000001',
+  target: '0x0000000000000000000000000000000000000002',
+  value: 0n,
+  withdrawalHash,
+} as const
+
+const game = {
+  extraData: '0x',
+  index: 1n,
+  l2BlockNumber: 180n,
+  metadata: '0x',
+  rootClaim:
+    '0x000000000000000000000000000000000000000000000000000000000000000f',
+  timestamp: 0n,
+  usesSuperRoots: true,
+} as const
+
+test('args: super game', async () => {
+  const { blockNumbers, client, proofBlockNumbers } = superGameClient()
+  const request = await buildProveWithdrawal(client, {
+    account: accounts[0].address,
+    game,
+    withdrawal,
+  })
+
+  expect(blockNumbers).toEqual(['latest', '0x63', '0x5a'])
+  expect(proofBlockNumbers).toEqual(['0x5a'])
+  expect(request.l2OutputIndex).toBe(1n)
+  expect(request.outputRootProof).toEqual({
+    latestBlockhash: blockHash,
+    messagePasserStorageRoot: storageHash,
+    stateRoot,
+    version:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+  })
+})
+
+test('args: super game timestamp mismatch', async () => {
+  const { client } = superGameClient({ targetTimestamp: 182n })
+  await expect(
+    buildProveWithdrawal(client, {
+      account: accounts[0].address,
+      game,
+      withdrawal,
+    }),
+  ).rejects.toThrow(
+    'L2 block timestamp 182 does not match dispute game timestamp 180.',
+  )
+})
 
 test.skip('default', async () => {
   await reset(optimismClient, {

--- a/src/op-stack/actions/buildProveWithdrawal.ts
+++ b/src/op-stack/actions/buildProveWithdrawal.ts
@@ -28,6 +28,10 @@ import { keccak256 } from '../../utils/hash/keccak256.js'
 import { contracts } from '../contracts.js'
 import type { Withdrawal } from '../types/withdrawal.js'
 import {
+  type GetL2BlockNumberAtTimestampErrorType,
+  getL2BlockNumberAtTimestamp,
+} from '../utils/getL2BlockNumberAtTimestamp.js'
+import {
   type GetWithdrawalHashStorageSlotErrorType,
   getWithdrawalHashStorageSlot,
 } from '../utils/getWithdrawalHashStorageSlot.js'
@@ -73,6 +77,7 @@ export type BuildProveWithdrawalReturnType<
 export type BuildProveWithdrawalErrorType =
   | GetBlockErrorType
   | GetProofErrorType
+  | GetL2BlockNumberAtTimestampErrorType
   | GetWithdrawalHashStorageSlotErrorType
   | ErrorType
 
@@ -120,18 +125,28 @@ export async function buildProveWithdrawal<
 
   const { withdrawalHash } = withdrawal
   const { l2BlockNumber } = game ?? output
+  const blockNumber = game?.usesSuperRoots
+    ? await getL2BlockNumberAtTimestamp(client, {
+        timestamp: game.l2BlockNumber,
+      })
+    : l2BlockNumber
 
   const slot = getWithdrawalHashStorageSlot({ withdrawalHash })
   const [proof, block] = await Promise.all([
     getProof(client, {
       address: contracts.l2ToL1MessagePasser.address,
       storageKeys: [slot],
-      blockNumber: l2BlockNumber,
+      blockNumber,
     }),
     getBlock(client, {
-      blockNumber: l2BlockNumber,
+      blockNumber,
     }),
   ])
+
+  if (game?.usesSuperRoots && block.timestamp !== game.l2BlockNumber)
+    throw new Error(
+      `L2 block timestamp ${block.timestamp} does not match dispute game timestamp ${game.l2BlockNumber}.`,
+    )
 
   return {
     account,

--- a/src/op-stack/actions/getGame.test.ts
+++ b/src/op-stack/actions/getGame.test.ts
@@ -24,6 +24,7 @@ test('default', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })
 
 test('args: strategy', async () => {
@@ -39,6 +40,7 @@ test('args: strategy', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })
 
 test('args: address', async () => {
@@ -54,4 +56,5 @@ test('args: address', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })

--- a/src/op-stack/actions/getGame.ts
+++ b/src/op-stack/actions/getGame.ts
@@ -42,7 +42,13 @@ export type GetGameParameters<
     strategy?: 'latest' | 'random'
   }
 export type GetGameReturnType = Game & {
+  /**
+   * L2 block number anchored by the dispute game. For super-root games, this
+   * value is the L2 timestamp instead. Check `usesSuperRoots` to distinguish
+   * the unit.
+   */
   l2BlockNumber: bigint
+  /** Whether the dispute game anchors on super roots. */
   usesSuperRoots: boolean
 }
 

--- a/src/op-stack/actions/getGame.ts
+++ b/src/op-stack/actions/getGame.ts
@@ -43,6 +43,7 @@ export type GetGameParameters<
   }
 export type GetGameReturnType = Game & {
   l2BlockNumber: bigint
+  usesSuperRoots: boolean
 }
 
 export type GetGameErrorType =

--- a/src/op-stack/actions/getGames.test.ts
+++ b/src/op-stack/actions/getGames.test.ts
@@ -26,6 +26,7 @@ test('default', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })
 
 test('args: l2BlockNumber', async () => {
@@ -43,6 +44,7 @@ test('args: l2BlockNumber', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })
 
 test('args: l2BlockNumber (high)', async () => {
@@ -70,4 +72,5 @@ test('args: address', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 })

--- a/src/op-stack/actions/getGames.ts
+++ b/src/op-stack/actions/getGames.ts
@@ -41,7 +41,13 @@ export type GetGamesParameters<
     limit?: number | undefined
   }
 export type GetGamesReturnType = (Game & {
+  /**
+   * L2 block number anchored by the dispute game. For super-root games, this
+   * value is the L2 timestamp instead. Check `usesSuperRoots` to distinguish
+   * the unit.
+   */
   l2BlockNumber: bigint
+  /** Whether the dispute game anchors on super roots. */
   usesSuperRoots: boolean
 })[]
 export type GetGamesErrorType =

--- a/src/op-stack/actions/getGames.ts
+++ b/src/op-stack/actions/getGames.ts
@@ -17,6 +17,7 @@ import type {
   GetChainParameter,
 } from '../../types/chain.js'
 import { disputeGameAbi, disputeGameFactoryAbi, portal2Abi } from '../abis.js'
+import { isSuperGameType } from '../gameTypes.js'
 import type { GetContractAddressParameter } from '../types/contract.js'
 import type { Game } from '../types/withdrawal.js'
 
@@ -41,6 +42,7 @@ export type GetGamesParameters<
   }
 export type GetGamesReturnType = (Game & {
   l2BlockNumber: bigint
+  usesSuperRoots: boolean
 })[]
 export type GetGamesErrorType =
   | ReadContractErrorType
@@ -133,11 +135,12 @@ export async function getGames<
     })),
   })
 
+  const usesSuperRoots = isSuperGameType(gameType)
   const games = rawGames
     .map((game, i) => {
       const blockNumber = l2SequenceNumbers[i] as bigint
       return !l2BlockNumber || blockNumber > l2BlockNumber
-        ? { ...game, l2BlockNumber: blockNumber }
+        ? { ...game, l2BlockNumber: blockNumber, usesSuperRoots }
         : null
     })
     .filter(Boolean) as GetGamesReturnType

--- a/src/op-stack/actions/getTimeToNextGame.test.ts
+++ b/src/op-stack/actions/getTimeToNextGame.test.ts
@@ -81,6 +81,7 @@ test('single game (no interval data)', async () => {
         '0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`,
       extraData: '0x' as `0x${string}`,
       l2BlockNumber: 500n,
+      usesSuperRoots: false,
     },
   ])
   const result = await getTimeToNextGame(client, {

--- a/src/op-stack/actions/getTimeToProve.test.ts
+++ b/src/op-stack/actions/getTimeToProve.test.ts
@@ -1,11 +1,70 @@
-import { expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { anvilMainnet, anvilOptimism } from '~test/anvil.js'
 import { getTransactionReceipt, reset } from '../../actions/index.js'
 
+import * as getPortalVersionModule from './getPortalVersion.js'
+import * as getTimeToNextGameModule from './getTimeToNextGame.js'
+import * as getTimeToNextL2OutputModule from './getTimeToNextL2Output.js'
 import { getTimeToProve } from './getTimeToProve.js'
 
 const client = anvilMainnet.getClient()
 const optimismClient = anvilOptimism.getClient()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('args: l2Timestamp', async () => {
+  vi.spyOn(getPortalVersionModule, 'getPortalVersion').mockResolvedValueOnce({
+    major: 3,
+    minor: 0,
+    patch: 0,
+  })
+  const spy = vi
+    .spyOn(getTimeToNextGameModule, 'getTimeToNextGame')
+    .mockResolvedValueOnce({
+      interval: 0,
+      seconds: 0,
+    })
+
+  await getTimeToProve(client, {
+    disputeGameFactoryAddress: '0x0000000000000000000000000000000000000001',
+    l2Timestamp: 20n,
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    receipt: { blockNumber: 10n } as never,
+  })
+
+  expect(spy).toHaveBeenCalledWith(
+    client,
+    expect.objectContaining({ l2BlockNumber: 20n }),
+  )
+})
+
+test('args: l2Timestamp (legacy)', async () => {
+  vi.spyOn(getPortalVersionModule, 'getPortalVersion').mockResolvedValueOnce({
+    major: 2,
+    minor: 0,
+    patch: 0,
+  })
+  const spy = vi
+    .spyOn(getTimeToNextL2OutputModule, 'getTimeToNextL2Output')
+    .mockResolvedValueOnce({
+      interval: 0,
+      seconds: 0,
+    })
+
+  await getTimeToProve(client, {
+    l2OutputOracleAddress: '0x0000000000000000000000000000000000000001',
+    l2Timestamp: 20n,
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    receipt: { blockNumber: 10n } as never,
+  })
+
+  expect(spy).toHaveBeenCalledWith(
+    client,
+    expect.objectContaining({ l2BlockNumber: 20n }),
+  )
+})
 
 test('default', async () => {
   await reset(optimismClient, {

--- a/src/op-stack/actions/getTimeToProve.ts
+++ b/src/op-stack/actions/getTimeToProve.ts
@@ -47,6 +47,10 @@ export type GetTimeToProveParameters<
     intervalBuffer?:
       | GetTimeToNextL2OutputParameters['intervalBuffer']
       | undefined
+    /**
+     * L2 timestamp of the withdrawal. Required for super-root dispute games.
+     */
+    l2Timestamp?: bigint | undefined
     receipt: TransactionReceipt
   }
 
@@ -98,7 +102,7 @@ export async function getTimeToProve<
   client: Client<Transport, chain, account>,
   parameters: GetTimeToProveParameters<chain, chainOverride>,
 ): Promise<GetTimeToProveReturnType> {
-  const { receipt } = parameters
+  const { l2Timestamp, receipt } = parameters
 
   const portalVersion = await getPortalVersion(
     client,
@@ -109,11 +113,11 @@ export async function getTimeToProve<
   if (portalVersion.major < 3)
     return getTimeToNextL2Output(client, {
       ...parameters,
-      l2BlockNumber: receipt.blockNumber,
+      l2BlockNumber: l2Timestamp ?? receipt.blockNumber,
     } as GetTimeToNextL2OutputParameters)
 
   return getTimeToNextGame(client, {
     ...parameters,
-    l2BlockNumber: receipt.blockNumber,
+    l2BlockNumber: l2Timestamp ?? receipt.blockNumber,
   } as GetTimeToNextGameParameters)
 }

--- a/src/op-stack/actions/getWithdrawalStatus.test.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.test.ts
@@ -1,11 +1,65 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
 import { anvilMainnet, anvilOptimism } from '~test/anvil.js'
 import { getTransactionReceipt, reset } from '../../actions/index.js'
+import * as readContractModule from '../../actions/public/readContract.js'
 
+import { GameNotFoundError } from '../errors/withdrawal.js'
+import * as getGameModule from './getGame.js'
+import * as getPortalVersionModule from './getPortalVersion.js'
 import { getWithdrawalStatus } from './getWithdrawalStatus.js'
 
 const client = anvilMainnet.getClient()
 const optimismClient = anvilOptimism.getClient()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('args: l2Timestamp', async () => {
+  vi.spyOn(getPortalVersionModule, 'getPortalVersion').mockResolvedValueOnce({
+    major: 3,
+    minor: 0,
+    patch: 0,
+  })
+  const getGame = vi
+    .spyOn(getGameModule, 'getGame')
+    .mockRejectedValueOnce(new GameNotFoundError())
+  vi.spyOn(readContractModule, 'readContract').mockImplementation(
+    (_, parameters) => {
+      if (parameters.functionName === 'numProofSubmitters')
+        return Promise.resolve(1n)
+      if (parameters.functionName === 'proofSubmitters')
+        return Promise.resolve('0x0000000000000000000000000000000000000001')
+      if (parameters.functionName === 'provenWithdrawals')
+        return Promise.resolve([
+          '0x0000000000000000000000000000000000000000',
+          0n,
+          0n,
+        ])
+      if (parameters.functionName === 'checkWithdrawal')
+        return Promise.resolve()
+      if (parameters.functionName === 'finalizedWithdrawals')
+        return Promise.resolve(false)
+      return Promise.reject(new Error('unexpected readContract call'))
+    },
+  )
+
+  const status = await getWithdrawalStatus(client, {
+    disputeGameFactoryAddress: '0x0000000000000000000000000000000000000001',
+    l2BlockNumber: 10n,
+    l2Timestamp: 20n,
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    sender: '0x0000000000000000000000000000000000000001',
+    withdrawalHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000003',
+  })
+
+  expect(status).toBe('waiting-to-prove')
+  expect(getGame).toHaveBeenCalledWith(
+    client,
+    expect.objectContaining({ l2BlockNumber: 20n }),
+  )
+})
 
 test('waiting-to-prove', async () => {
   await reset(client, {

--- a/src/op-stack/actions/getWithdrawalStatus.ts
+++ b/src/op-stack/actions/getWithdrawalStatus.ts
@@ -64,6 +64,10 @@ export type GetWithdrawalStatusParameters<
      * @default 100
      */
     gameLimit?: number
+    /**
+     * L2 timestamp of the withdrawal. Required for super-root dispute games.
+     */
+    l2Timestamp?: bigint | undefined
   } & OneOf<
     | {
         /**
@@ -160,7 +164,8 @@ export async function getWithdrawalStatus<
     return Object.values(targetChain.contracts.portal)[0].address
   })()
 
-  const l2BlockNumber = receipt?.blockNumber ?? parameters.l2BlockNumber
+  const l2BlockNumber =
+    parameters.l2Timestamp ?? receipt?.blockNumber ?? parameters.l2BlockNumber
 
   const withdrawal = (() => {
     if (receipt) {

--- a/src/op-stack/actions/waitForNextGame.test.ts
+++ b/src/op-stack/actions/waitForNextGame.test.ts
@@ -30,4 +30,5 @@ test('default', async () => {
   expect(game).toHaveProperty('timestamp')
   expect(game).toHaveProperty('rootClaim')
   expect(game).toHaveProperty('extraData')
+  expect(game).toHaveProperty('usesSuperRoots', false)
 }, 20_000)

--- a/src/op-stack/actions/waitToProve.test.ts
+++ b/src/op-stack/actions/waitToProve.test.ts
@@ -54,6 +54,7 @@ test('legacy (portal v2)', async () => {
         "metadata": "0x",
         "rootClaim": "0xdc3b54fd33b5d8a60f275ca83c74b625e3942be5b70b2f7f0b9cadd869eb7b1a",
         "timestamp": 1702377887n,
+        "usesSuperRoots": false,
       },
       "output": {
         "l2BlockNumber": 113389063n,

--- a/src/op-stack/actions/waitToProve.test.ts
+++ b/src/op-stack/actions/waitToProve.test.ts
@@ -1,11 +1,97 @@
-import { expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { anvilMainnet, anvilOptimism } from '~test/anvil.js'
 import { getTransactionReceipt, reset } from '../../actions/index.js'
 
+import * as getWithdrawalsModule from '../utils/getWithdrawals.js'
+import * as getPortalVersionModule from './getPortalVersion.js'
+import * as waitForNextGameModule from './waitForNextGame.js'
+import * as waitForNextL2OutputModule from './waitForNextL2Output.js'
 import { waitToProve } from './waitToProve.js'
 
 const client = anvilMainnet.getClient()
 const optimismClient = anvilOptimism.getClient()
+
+const withdrawal = {
+  data: '0x',
+  gasLimit: 0n,
+  nonce: 0n,
+  sender: '0x0000000000000000000000000000000000000001',
+  target: '0x0000000000000000000000000000000000000002',
+  value: 0n,
+  withdrawalHash:
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+} as const
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('args: l2Timestamp', async () => {
+  vi.spyOn(getWithdrawalsModule, 'getWithdrawals').mockReturnValueOnce([
+    withdrawal,
+  ])
+  vi.spyOn(getPortalVersionModule, 'getPortalVersion').mockResolvedValueOnce({
+    major: 3,
+    minor: 0,
+    patch: 0,
+  })
+  const spy = vi
+    .spyOn(waitForNextGameModule, 'waitForNextGame')
+    .mockResolvedValueOnce({
+      extraData: '0x',
+      index: 1n,
+      l2BlockNumber: 20n,
+      metadata: '0x',
+      rootClaim:
+        '0x0000000000000000000000000000000000000000000000000000000000000004',
+      timestamp: 0n,
+      usesSuperRoots: true,
+    })
+
+  await waitToProve(client, {
+    disputeGameFactoryAddress: '0x0000000000000000000000000000000000000001',
+    l2Timestamp: 20n,
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    receipt: { blockNumber: 10n } as never,
+  })
+
+  expect(spy).toHaveBeenCalledWith(
+    client,
+    expect.objectContaining({ l2BlockNumber: 20n }),
+  )
+})
+
+test('args: l2Timestamp (legacy)', async () => {
+  vi.spyOn(getWithdrawalsModule, 'getWithdrawals').mockReturnValueOnce([
+    withdrawal,
+  ])
+  vi.spyOn(getPortalVersionModule, 'getPortalVersion').mockResolvedValueOnce({
+    major: 2,
+    minor: 0,
+    patch: 0,
+  })
+  const spy = vi
+    .spyOn(waitForNextL2OutputModule, 'waitForNextL2Output')
+    .mockResolvedValueOnce({
+      l2BlockNumber: 20n,
+      outputIndex: 1n,
+      outputRoot:
+        '0x0000000000000000000000000000000000000000000000000000000000000004',
+      timestamp: 0n,
+    })
+
+  await waitToProve(client, {
+    l2OutputOracleAddress: '0x0000000000000000000000000000000000000001',
+    l2Timestamp: 20n,
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    receipt: { blockNumber: 10n } as never,
+  })
+
+  expect(spy).toHaveBeenCalledWith(
+    client,
+    expect.objectContaining({ l2BlockNumber: 20n }),
+  )
+})
 
 test('default', async () => {
   await reset(optimismClient, {

--- a/src/op-stack/actions/waitToProve.ts
+++ b/src/op-stack/actions/waitToProve.ts
@@ -133,6 +133,7 @@ export async function waitToProve<
         metadata: '0x',
         rootClaim: output.outputRoot,
         timestamp: output.timestamp,
+        usesSuperRoots: false,
       },
       output,
       withdrawal,

--- a/src/op-stack/actions/waitToProve.ts
+++ b/src/op-stack/actions/waitToProve.ts
@@ -49,6 +49,10 @@ export type WaitToProveParameters<
      * @default 100
      */
     gameLimit?: number | undefined
+    /**
+     * L2 timestamp of the withdrawal. Required for super-root dispute games.
+     */
+    l2Timestamp?: bigint | undefined
     receipt: TransactionReceipt
     /**
      * Polling frequency (in ms). Defaults to Client's pollingInterval config.
@@ -105,7 +109,7 @@ export async function waitToProve<
   client: Client<Transport, chain, account>,
   parameters: WaitToProveParameters<chain, chainOverride>,
 ): Promise<WaitToProveReturnType> {
-  const { gameLimit, receipt } = parameters
+  const { gameLimit, l2Timestamp, receipt } = parameters
 
   const [withdrawal] = getWithdrawals(receipt)
 
@@ -123,7 +127,7 @@ export async function waitToProve<
   if (portalVersion.major < 3) {
     const output = await waitForNextL2Output(client, {
       ...parameters,
-      l2BlockNumber: receipt.blockNumber,
+      l2BlockNumber: l2Timestamp ?? receipt.blockNumber,
     } as WaitForNextL2OutputParameters)
     return {
       game: {
@@ -143,7 +147,7 @@ export async function waitToProve<
   const game = await waitForNextGame(client, {
     ...parameters,
     limit: gameLimit,
-    l2BlockNumber: receipt.blockNumber,
+    l2BlockNumber: l2Timestamp ?? receipt.blockNumber,
   } as WaitForNextGameParameters)
   return {
     game,

--- a/src/op-stack/gameTypes.test.ts
+++ b/src/op-stack/gameTypes.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+
+import { isSuperGameType, superGameTypes } from './gameTypes.js'
+
+test('superGameTypes', () => {
+  expect([...superGameTypes]).toEqual([4, 5, 7, 9])
+})
+
+test('isSuperGameType', () => {
+  expect(isSuperGameType(4)).toBe(true)
+  expect(isSuperGameType(5)).toBe(true)
+  expect(isSuperGameType(7)).toBe(true)
+  expect(isSuperGameType(9)).toBe(true)
+
+  expect(isSuperGameType(0)).toBe(false)
+  expect(isSuperGameType(1)).toBe(false)
+  expect(isSuperGameType(6)).toBe(false)
+  expect(isSuperGameType(10)).toBe(false)
+})

--- a/src/op-stack/gameTypes.ts
+++ b/src/op-stack/gameTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * Super dispute game type IDs from the OP Stack contracts
+ * (`contracts-bedrock/src/dispute/lib/Types.sol:99-103`).
+ */
+export const superGameTypes = new Set([4, 5, 7, 9]) as ReadonlySet<number>
+
+export function isSuperGameType(gameType: number): boolean {
+  return superGameTypes.has(gameType)
+}

--- a/src/op-stack/index.ts
+++ b/src/op-stack/index.ts
@@ -208,6 +208,8 @@ export { chainConfig } from './chainConfig.js'
 
 export * from './chains.js'
 
+export { isSuperGameType, superGameTypes } from './gameTypes.js'
+
 export {
   type PublicActionsL1,
   publicActionsL1,

--- a/src/op-stack/index.ts
+++ b/src/op-stack/index.ts
@@ -207,9 +207,6 @@ export {
 export { chainConfig } from './chainConfig.js'
 
 export * from './chains.js'
-
-export { isSuperGameType, superGameTypes } from './gameTypes.js'
-
 export {
   type PublicActionsL1,
   publicActionsL1,
@@ -226,6 +223,7 @@ export {
   type WalletActionsL2,
   walletActionsL2,
 } from './decorators/walletL2.js'
+export { isSuperGameType, superGameTypes } from './gameTypes.js'
 
 export {
   type ParseTransactionErrorType,
@@ -268,6 +266,12 @@ export {
   type ExtractWithdrawalMessageLogsReturnType,
   extractWithdrawalMessageLogs,
 } from './utils/extractWithdrawalMessageLogs.js'
+export {
+  type GetL2BlockNumberAtTimestampErrorType,
+  type GetL2BlockNumberAtTimestampParameters,
+  type GetL2BlockNumberAtTimestampReturnType,
+  getL2BlockNumberAtTimestamp,
+} from './utils/getL2BlockNumberAtTimestamp.js'
 export {
   type GetL2TransactionHashErrorType,
   type GetL2TransactionHashParameters,

--- a/src/op-stack/utils/getL2BlockNumberAtTimestamp.test.ts
+++ b/src/op-stack/utils/getL2BlockNumberAtTimestamp.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest'
+import { createClient } from '../../clients/createClient.js'
+import { custom } from '../../clients/transports/custom.js'
+import type { RpcBlock } from '../../types/rpc.js'
+import { numberToHex } from '../../utils/encoding/toHex.js'
+import { getL2BlockNumberAtTimestamp } from './getL2BlockNumberAtTimestamp.js'
+
+function block(number: bigint, timestamp: bigint) {
+  return {
+    number: numberToHex(number),
+    timestamp: numberToHex(timestamp),
+    transactions: [],
+  } as unknown as RpcBlock
+}
+
+function client({
+  latest = block(100n, 200n),
+  parent = block(99n, 198n),
+}: {
+  latest?: RpcBlock
+  parent?: RpcBlock
+} = {}) {
+  return createClient({
+    transport: custom({
+      async request({ method, params }) {
+        if (method !== 'eth_getBlockByNumber') return null
+        if (params[0] === 'latest') return latest
+        if (params[0] === numberToHex(99n)) return parent
+        return null
+      },
+    }),
+  })
+}
+
+test('default', async () => {
+  await expect(
+    getL2BlockNumberAtTimestamp(client(), {
+      timestamp: 180n,
+    }),
+  ).resolves.toBe(90n)
+})
+
+test('behavior: future timestamp', async () => {
+  await expect(
+    getL2BlockNumberAtTimestamp(client(), {
+      timestamp: 202n,
+    }),
+  ).rejects.toThrow('Timestamp is in the future relative to L2 head.')
+})
+
+test('behavior: zero block time', async () => {
+  await expect(
+    getL2BlockNumberAtTimestamp(
+      client({
+        parent: block(99n, 200n),
+      }),
+      {
+        timestamp: 198n,
+      },
+    ),
+  ).rejects.toThrow('L2 block time is zero.')
+})
+
+test('behavior: unaligned timestamp', async () => {
+  await expect(
+    getL2BlockNumberAtTimestamp(client(), {
+      timestamp: 199n,
+    }),
+  ).rejects.toThrow('Timestamp does not align with the L2 block time.')
+})
+
+test('behavior: predates genesis', async () => {
+  await expect(
+    getL2BlockNumberAtTimestamp(client(), {
+      timestamp: -2n,
+    }),
+  ).rejects.toThrow('Timestamp predates L2 genesis.')
+})

--- a/src/op-stack/utils/getL2BlockNumberAtTimestamp.ts
+++ b/src/op-stack/utils/getL2BlockNumberAtTimestamp.ts
@@ -1,0 +1,57 @@
+import {
+  type GetBlockErrorType,
+  getBlock,
+} from '../../actions/public/getBlock.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { Account } from '../../types/account.js'
+import type { Chain } from '../../types/chain.js'
+
+export type GetL2BlockNumberAtTimestampParameters = {
+  /** L2 block timestamp. */
+  timestamp: bigint
+}
+
+export type GetL2BlockNumberAtTimestampReturnType = bigint
+
+export type GetL2BlockNumberAtTimestampErrorType = GetBlockErrorType | ErrorType
+
+/**
+ * Gets the L2 block number for a timestamp using the latest L2 block and its parent.
+ *
+ * @param client - Client to use.
+ * @param parameters - {@link GetL2BlockNumberAtTimestampParameters}
+ * @returns L2 block number.
+ */
+export async function getL2BlockNumberAtTimestamp(
+  client: Client<Transport, Chain | undefined, Account | undefined>,
+  parameters: GetL2BlockNumberAtTimestampParameters,
+): Promise<GetL2BlockNumberAtTimestampReturnType> {
+  const latest = await getBlock(client)
+  if (latest.number === null)
+    throw new Error('Latest L2 block number is unavailable.')
+  if (latest.timestamp === undefined)
+    throw new Error('Latest L2 block timestamp is unavailable.')
+  if (latest.number === 0n)
+    throw new Error('Cannot derive L2 block time from genesis block.')
+
+  const parent = await getBlock(client, { blockNumber: latest.number - 1n })
+  if (parent.timestamp === undefined)
+    throw new Error('Parent L2 block timestamp is unavailable.')
+
+  const blockTime = latest.timestamp - parent.timestamp
+  if (blockTime === 0n) throw new Error('L2 block time is zero.')
+
+  const timeDiff = latest.timestamp - parameters.timestamp
+  if (timeDiff < 0n)
+    throw new Error('Timestamp is in the future relative to L2 head.')
+  if (timeDiff % blockTime !== 0n)
+    throw new Error('Timestamp does not align with the L2 block time.')
+
+  const blocksToLookBack = timeDiff / blockTime
+  if (blocksToLookBack > latest.number)
+    throw new Error('Timestamp predates L2 genesis.')
+
+  return latest.number - blocksToLookBack
+}


### PR DESCRIPTION
This PR makes a set of changes to support the upcoming interop optimism upgrade, which will migrate chains to use [super roots](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/superroot.md) instead of plain output roots. Note that even chains that don't make use of interop will migrate to the super root on-chain dispute games that use the new structure supported by this PR.

Currently, the `l2SequenceNumber` corresponds one-to-one with the old `l2BlockNumber`, but after the super root migration, the `l2SequenceNumber` will refer instead to the block's timestamp instead of its number.

This PR modifies the `op-stack` library with minimal changes to support the new game types. It adds:

1) Helper function `getL2BlockNumberAtTimestamp` to map a timestamp back to a L2 block number (needed to fetch the corresponding block's info via RPC)
2) Helper function `isSuperGameType` (uses simple hard coded constants)
3) Optional `l2Timestamp` parameter to `GetTimeToProveParameters` (enables the new code path without breaking existing callers)
4) An example script illustrating a withdrawal using op-stack
5) Simple tests for the new code

Then, based on the game type being used in the proof, the function will transparently use either the old L2 block number as-is or the new timestamp instead. To minimize breaking changes, I didn't rename any of the existing `l2BlockNumber` variables. In particular, `GetGameReturnType` now may return a `l2BlockNumber` that is a timestamp instead of a block number, indicated by the `usesSuperRoots` flag.

Note that the proofs are still done as-is and still reference the chain's output root (instead of the super root itself). This is intentional, and so withdrawals work mostly as-is, the only change needed is to replace the `l2BlockNumber` (`l2SequenceNumber`) value by a `l2Timestamp` instead.

It's possible the new example or tests don't follow existing repo convention; let me know if you'd need me to make any changes to them.

I've tested these changes manually against a local devnet, and it works fine with both the new super games and the old legacy game types as well.