### PR TITLE
fix(chains): correct Sova block explorer default URL

### DIFF
--- a/.changeset/quiet-moons-drive.md
+++ b/.changeset/quiet-moons-drive.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix(chains): correct Sova block explorer default URL

--- a/src/chains/definitions/sova.ts
+++ b/src/chains/definitions/sova.ts
@@ -16,7 +16,7 @@ export const sova = /*#__PURE__*/ defineChain({
   blockExplorers: {
     default: {
       name: 'Sova Block Explorer',
-      url: 'hhttps://explorer.sova.io',
+      url: 'https://explorer.sova.io',
     },
   },
   testnet: false,


### PR DESCRIPTION
  ## What is this PR solving?
                                                                                                                                                                                                 
  This PR fixes a typo in the Sova chain definition:                                                                                                                                             
                                                                                                                                                                                                 
  - `src/chains/definitions/sova.ts`
  - `blockExplorers.default.url` was `hhttps://explorer.sova.io`                                                                                                                                 
  - corrected to `https://explorer.sova.io`                                                                                                                                                      
                                                                                                                                                                                                 
  This is a real correctness issue (not a design change).                                                                                                                                        
  The invalid scheme can break URL parsing and cause explorer-link checks/usages to fail.                                                                                                        
                                                                                                                                                                                                 
  ## Alternatives considered                                                                                                                                                                     
                                                                                                                                                                                                 
  - Keep the current value and rely on consumers to handle malformed URLs.                                                                                                                       
    - Rejected: pushes a bad config downstream.                                                                                                                                                  
  - Add runtime normalization/fallback for malformed explorer URLs.                                                                                                                              
    - Rejected: unnecessary complexity for a single source typo.                                                                                                                                 
  - Apply a minimal source fix in the chain definition.                                                                                                                                          
    - Chosen: smallest, safest, and most maintainable change.                                                                                                                                    
                                                                                                                                                                                                 
  ## Reviewer attention                                                                                                                                                                          
                                                                                                                                                                                                 
  Please focus on:                                                                                                                                                                               
  - The one-line change in `src/chains/definitions/sova.ts`.                                                                                                                                     
  - Confirming no unrelated chain definitions were modified.                                                                                                                                     
                                                                                                                                                                                                 
  ## Documentation impact                                                                                                                                                                        
                                                                                                                                                                                                 
  No documentation changes are required (no API or behavior contract changes beyond correcting bad data).                                                                                        
                                                                                                                                                                                                 
  ## Tests                                                                                                                                                                                       
                                                                                                                                                                                                 
  No new tests were added because existing coverage already validates explorer URLs in `test/scripts/chains.test.ts` (`blockExplorer.url` check).                                                
  This change is intended to make Sova pass that existing path with a valid URL scheme. 