### PR TITLE
fix: do not reconnect on intentional socket close

### DIFF
--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -248,7 +248,40 @@ test('reconnect', async () => {
   socketClient.close()
 })
 
-test('reconnect on close', async () => {
+test('reconnect on socket-level close', async () => {
+  let status = 'idle'
+  let onCloseCallback: (() => void) | undefined
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onClose, onResponse }) {
+      status = 'open'
+      onCloseCallback = onClose
+      return {
+        close() {
+          status = 'closed'
+        },
+        request({ body }) {
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: body })
+        },
+      }
+    },
+    reconnect: {
+      delay: 100,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  // Simulate unexpected socket drop (not an intentional client close)
+  status = 'closed'
+  onCloseCallback?.()
+  await wait(200)
+  expect(status).toBe('open')
+
+  socketClient.close()
+})
+
+test('does not reconnect on intentional close', async () => {
   let status = 'idle'
 
   const socketClient = await getSocketRpcClient({
@@ -273,8 +306,8 @@ test('reconnect on close', async () => {
 
   socketClient.close()
   expect(status).toBe('closed')
-  await wait(100)
-  expect(status).toBe('open')
+  await wait(200)
+  expect(status).toBe('closed')
 })
 
 test('keepAlive enabled', async () => {

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -133,9 +133,10 @@ export async function getSocketRpcClient<socket extends {}>(
       let keepAliveTimer: ReturnType<typeof setInterval> | undefined
 
       let reconnectInProgress = false
+      let intentionallyClosed = false
       function attemptReconnect() {
         // Attempt to reconnect.
-        if (reconnect && reconnectCount < attempts) {
+        if (reconnect && !intentionallyClosed && reconnectCount < attempts) {
           if (reconnectInProgress) return
           reconnectInProgress = true
           reconnectCount++
@@ -220,6 +221,7 @@ export async function getSocketRpcClient<socket extends {}>(
       // Create a new socket instance.
       socketClient = {
         close() {
+          intentionallyClosed = true
           keepAliveTimer && clearInterval(keepAliveTimer)
           socket.close()
           socketClientCache.delete(id)

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -48,6 +48,19 @@ describe.runIf(process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket')(
       expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
     })
 
+    test('close does not reconnect', async () => {
+      const socketClient = await getWebSocketRpcClient(
+        'ws://127.0.0.1:8545/69422',
+        {
+          reconnect: { delay: 100 },
+        },
+      )
+      expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
+      socketClient.close()
+      await wait(500)
+      expect(socketClient.socket.readyState).not.toEqual(WebSocket.OPEN)
+    })
+
     test('keepalive', async () => {
       const socketClient = await getWebSocketRpcClient(
         'ws://127.0.0.1:8545/69421',


### PR DESCRIPTION
## Summary

Calling `socketClient.close()` triggers the underlying `socket.close()`, which fires the `onClose` callback, which calls `attemptReconnect()`. This causes the socket to reconnect even when the caller explicitly wanted to close it — resulting in the node process never exiting.

**Root cause:** `attemptReconnect()` had no way to distinguish between an intentional close and an unexpected socket drop.

**Fix:** Added an `intentionallyClosed` flag (closure-scoped, mirrors the existing `reconnectInProgress` pattern). Set to `true` in `socketClient.close()` before calling `socket.close()`. Checked in `attemptReconnect()` to skip reconnection.

Fixes #4378

## Test plan

- `reconnect on socket-level close` — verifies unexpected socket drops still trigger reconnect
- `does not reconnect on intentional close` — verifies `socketClient.close()` no longer reconnects
- `close does not reconnect` (webSocket integration test) — end-to-end with a real WebSocket