### PR TITLE
fix: do not reconnect on intentional socket close

### DIFF
--- a/.changeset/fix-websocket-intentional-close.md
+++ b/.changeset/fix-websocket-intentional-close.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed WebSocket transport not reconnecting after intentional socket close followed by reconnect attempt.
+Fixed `socketClient.close()` triggering an unwanted reconnect loop that prevented the Node.js process from exiting.

--- a/.changeset/fix-websocket-intentional-close.md
+++ b/.changeset/fix-websocket-intentional-close.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed WebSocket transport not reconnecting after intentional socket close followed by reconnect attempt.

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -248,7 +248,40 @@ test('reconnect', async () => {
   socketClient.close()
 })
 
-test('reconnect on close', async () => {
+test('reconnect on socket-level close', async () => {
+  let status = 'idle'
+  let onCloseCallback: (() => void) | undefined
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onClose, onResponse }) {
+      status = 'open'
+      onCloseCallback = onClose
+      return {
+        close() {
+          status = 'closed'
+        },
+        request({ body }) {
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: body })
+        },
+      }
+    },
+    reconnect: {
+      delay: 100,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  // Simulate unexpected socket drop (not an intentional client close)
+  status = 'closed'
+  onCloseCallback?.()
+  await wait(200)
+  expect(status).toBe('open')
+
+  socketClient.close()
+})
+
+test('does not reconnect on intentional close', async () => {
   let status = 'idle'
 
   const socketClient = await getSocketRpcClient({
@@ -273,8 +306,8 @@ test('reconnect on close', async () => {
 
   socketClient.close()
   expect(status).toBe('closed')
-  await wait(100)
-  expect(status).toBe('open')
+  await wait(200)
+  expect(status).toBe('closed')
 })
 
 test('keepAlive enabled', async () => {

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -310,6 +310,48 @@ test('does not reconnect on intentional close', async () => {
   expect(status).toBe('closed')
 })
 
+test('does not reconnect when close is called during reconnect delay', async () => {
+  let status = 'idle'
+  let getSocketCount = 0
+  let onCloseCallback: (() => void) | undefined
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onClose, onResponse }) {
+      getSocketCount++
+      status = 'open'
+      onCloseCallback = onClose
+      return {
+        close() {
+          status = 'closed'
+        },
+        request({ body }) {
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: body })
+        },
+      }
+    },
+    reconnect: {
+      delay: 200,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  expect(getSocketCount).toBe(1)
+
+  // Simulate unexpected socket drop — schedules a reconnect after `delay`.
+  status = 'closed'
+  onCloseCallback?.()
+
+  // Close the client during the reconnect delay window.
+  await wait(50)
+  socketClient.close()
+
+  // Wait past the reconnect delay — setup() must not run.
+  await wait(300)
+  expect(status).toBe('closed')
+  expect(getSocketCount).toBe(1)
+})
+
 test('keepAlive enabled', async () => {
   const socketClient = await getSocketRpcClient({
     key: 'test-socket',

--- a/src/utils/rpc/socket.test.ts
+++ b/src/utils/rpc/socket.test.ts
@@ -352,6 +352,54 @@ test('does not reconnect when close is called during reconnect delay', async () 
   expect(getSocketCount).toBe(1)
 })
 
+test('does not keep reconnect socket when close is called during reconnect setup', async () => {
+  let getSocketCount = 0
+  let onCloseCallback: (() => void) | undefined
+  let resolveReconnect: (() => void) | undefined
+  const closedSockets = new Set<number>()
+
+  const socketClient = await getSocketRpcClient({
+    key: 'test-socket',
+    async getSocket({ onClose, onResponse }) {
+      getSocketCount++
+      const socketId = getSocketCount
+      onCloseCallback = onClose
+
+      if (socketId === 2)
+        await new Promise<void>((resolve) => {
+          resolveReconnect = resolve
+        })
+
+      return {
+        id: socketId,
+        close() {
+          closedSockets.add(socketId)
+        },
+        request({ body }) {
+          onResponse({ id: body.id ?? 0, jsonrpc: '2.0', result: body })
+        },
+      }
+    },
+    reconnect: {
+      delay: 50,
+    },
+    url: anvilMainnet.rpcUrl.ws,
+  })
+
+  expect(getSocketCount).toBe(1)
+
+  onCloseCallback?.()
+  await wait(100)
+  expect(getSocketCount).toBe(2)
+
+  socketClient.close()
+  resolveReconnect?.()
+  await wait(50)
+
+  expect(closedSockets).toEqual(new Set([1, 2]))
+  expect(socketClient.socket.id).toBe(1)
+})
+
 test('keepAlive enabled', async () => {
   const socketClient = await getSocketRpcClient({
     key: 'test-socket',

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -133,9 +133,10 @@ export async function getSocketRpcClient<socket extends {}>(
       let keepAliveTimer: ReturnType<typeof setInterval> | undefined
 
       let reconnectInProgress = false
+      let intentionallyClosed = false
       function attemptReconnect() {
         // Attempt to reconnect.
-        if (reconnect && reconnectCount < attempts) {
+        if (reconnect && !intentionallyClosed && reconnectCount < attempts) {
           if (reconnectInProgress) return
           reconnectInProgress = true
           reconnectCount++
@@ -220,6 +221,7 @@ export async function getSocketRpcClient<socket extends {}>(
       // Create a new socket instance.
       socketClient = {
         close() {
+          intentionallyClosed = true
           keepAliveTimer && clearInterval(keepAliveTimer)
           socket.close()
           socketClientCache.delete(id)

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -131,6 +131,7 @@ export async function getSocketRpcClient<socket extends {}>(
       let error: Error | Event | undefined
       let socket: Socket<{}>
       let keepAliveTimer: ReturnType<typeof setInterval> | undefined
+      let reconnectTimer: ReturnType<typeof setTimeout> | undefined
 
       let reconnectInProgress = false
       let intentionallyClosed = false
@@ -144,7 +145,13 @@ export async function getSocketRpcClient<socket extends {}>(
           // Make sure the previous socket is definitely closed.
           socket?.close()
 
-          setTimeout(async () => {
+          reconnectTimer = setTimeout(async () => {
+            reconnectTimer = undefined
+            // Bail if the client was intentionally closed during the delay.
+            if (intentionallyClosed) {
+              reconnectInProgress = false
+              return
+            }
             // biome-ignore lint/suspicious/noConsole: _
             await setup().catch(console.error)
             reconnectInProgress = false
@@ -223,6 +230,11 @@ export async function getSocketRpcClient<socket extends {}>(
         close() {
           intentionallyClosed = true
           keepAliveTimer && clearInterval(keepAliveTimer)
+          if (reconnectTimer) {
+            clearTimeout(reconnectTimer)
+            reconnectTimer = undefined
+            reconnectInProgress = false
+          }
           socket.close()
           socketClientCache.delete(id)
         },

--- a/src/utils/rpc/socket.ts
+++ b/src/utils/rpc/socket.ts
@@ -200,6 +200,11 @@ export async function getSocketRpcClient<socket extends {}>(
           },
         })
 
+        if (intentionallyClosed) {
+          result.close()
+          return result
+        }
+
         socket = result
 
         if (keepAlive) {

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -48,6 +48,19 @@ describe.runIf(process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket')(
       expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
     })
 
+    test('close does not reconnect', async () => {
+      const socketClient = await getWebSocketRpcClient(
+        'ws://127.0.0.1:8545/69422',
+        {
+          reconnect: { delay: 100 },
+        },
+      )
+      expect(socketClient.socket.readyState).toEqual(WebSocket.OPEN)
+      socketClient.close()
+      await wait(500)
+      expect(socketClient.socket.readyState).not.toEqual(WebSocket.OPEN)
+    })
+
     test('keepalive', async () => {
       const socketClient = await getWebSocketRpcClient(
         'ws://127.0.0.1:8545/69421',


### PR DESCRIPTION
## Summary

Calling `socketClient.close()` triggers the underlying `socket.close()`, which fires the `onClose` callback, which calls `attemptReconnect()`. This causes the socket to reconnect even when the caller explicitly wanted to close it — resulting in the node process never exiting.

**Root cause:** `attemptReconnect()` had no way to distinguish between an intentional close and an unexpected socket drop.

**Fix:** Added an `intentionallyClosed` flag (closure-scoped, mirrors the existing `reconnectInProgress` pattern). Set to `true` in `socketClient.close()` before calling `socket.close()`. Checked in `attemptReconnect()` to skip reconnection.

Fixes #4378

## Test plan

- `reconnect on socket-level close` — verifies unexpected socket drops still trigger reconnect
- `does not reconnect on intentional close` — verifies `socketClient.close()` no longer reconnects
- `close does not reconnect` (webSocket integration test) — end-to-end with a real WebSocket