### PR TITLE
fix(chains): build explorer api requests with URL params

### DIFF
--- a/src/chains/definitions/morphHolesky.ts
+++ b/src/chains/definitions/morphHolesky.ts
@@ -14,7 +14,7 @@ export const morphHolesky = /*#__PURE__*/ defineChain({
     default: {
       name: 'Morph Holesky Explorer',
       url: 'https://explorer-holesky.morphl2.io',
-      apiUrl: 'https://explorer-api-holesky.morphl2.io/api?',
+      apiUrl: 'https://explorer-api-holesky.morphl2.io/api',
     },
   },
   testnet: true,

--- a/test/scripts/chains.test.ts
+++ b/test/scripts/chains.test.ts
@@ -71,16 +71,15 @@ describe.each(chains)('$name', ({ name, ...chain }) => {
     async () => {
       if (!blockExplorer?.apiUrl) return
 
-      const response = await fetch(
-        `${
-          blockExplorer.apiUrl
-        }?module=block&action=getblocknobytime&closest=before&timestamp=${Math.floor(
-          Date.now() / 1000,
-        )}`,
-        {
-          headers: { 'Content-Type': 'application/json' },
-        },
-      )
+      const apiUrl = new URL(blockExplorer.apiUrl)
+      apiUrl.searchParams.set('module', 'block')
+      apiUrl.searchParams.set('action', 'getblocknobytime')
+      apiUrl.searchParams.set('closest', 'before')
+      apiUrl.searchParams.set('timestamp', `${Math.floor(Date.now() / 1000)}`)
+
+      const response = await fetch(apiUrl, {
+        headers: { 'Content-Type': 'application/json' },
+      })
       const data = await response.json()
       expect(data).toMatchObject({
         status: '1',


### PR DESCRIPTION
  ## What is this PR solving?
                                                                                                                                                                                                 
  This PR fixes how `blockExplorer.apiUrl` requests are built in `test/scripts/chains.test.ts`.
                                                                                                                                                                                                 
  Previously, the test appended query params via string concatenation:                                                                                                                           
  - ``${blockExplorer.apiUrl}?module=...``                                                                                                                                                       
                                                                                                                                                                                                 
  That breaks or becomes ambiguous when `apiUrl` already contains query params (for example `?chainid=...`) or ends with `?`.                                                                    
  As a result, URL construction could be incorrect and chain metadata validation could produce false failures.                                                                                   
                                                                                                                                                                                                 
  This PR updates the request construction to use `URL` + `searchParams`, which safely merges params and preserves existing query values.
                                                                                                                                                                                                 
  Additionally, it normalizes one malformed definition:                                                                                                                                          
  - `src/chains/definitions/morphHolesky.ts`                                                                                                                                                     
  - `apiUrl` changed from `https://explorer-api-holesky.morphl2.io/api?` to `https://explorer-api-holesky.morphl2.io/api`                                                                        
                                                                                                                                                                                                 
  ## Alternatives considered                                                                                                                                                                     

  - Keep string concatenation and special-case `?` handling with manual conditionals.                                                                                                            
    - Rejected: still fragile and easy to regress.
  - Rewrite all chain `apiUrl` entries to enforce a no-query convention.
    - Rejected: unnecessary scope increase, and some URLs intentionally include required query params (e.g. `chainid` for Etherscan v2).                                                         
  - Use `URLSearchParams` over `URL`.                                                                                                                                                            
    - Chosen: robust, minimal, and standards-based.                                                                                                                                              
                                                                                                                                                                                                 
  ## Areas for reviewer attention                                                                                                                                                                
                                                                                                                                                                                                 
  Please focus on:                                                                                                                                                                               
  - The `blockExplorer.apiUrl` test path in `test/scripts/chains.test.ts`.                                                                                                                       
  - Whether preserving pre-existing query params (like `chainid`) is the expected behavior.                                                                                                      
  - The single normalization in `morphHolesky.ts` and that no unrelated chain definitions were changed.                                                                                          

  ## Tests                                                                                                                                                                                       

  - Updated path is covered by existing `test/scripts/chains.test.ts` `blockExplorer.apiUrl` checks.                                                                                             
  - No new test file added; this PR fixes the request-construction logic in the existing test path.                                                                                              
                                                                                                                                                                                                 
  ## Documentation impact                                                                                                                                                                        

  No documentation changes are required.