### PR TITLE
fix(observe): clear cache keys on final unwatch

### DIFF
--- a/src/utils/observe.test.ts
+++ b/src/utils/observe.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 
-import { observe } from './observe.js'
+import { cleanupCache, listenersCache, observe } from './observe.js'
 import { wait } from './wait.js'
 
 test('emits data to callbacks', async () => {
@@ -263,4 +263,19 @@ test('handles async cleanup errors', async () => {
   // Give the async cleanup time to execute and fail
   await wait(10)
   expect(cleanup).toHaveBeenCalledTimes(1)
+})
+
+test('deletes cache keys when the last listener unwatches', () => {
+  const id = 'mock'
+  const callback = vi.fn()
+  const emitter = vi.fn(() => () => undefined)
+
+  const unwatch = observe(id, { emit: callback }, emitter)
+  expect(listenersCache.has(id)).toBe(true)
+  expect(cleanupCache.has(id)).toBe(true)
+
+  unwatch()
+
+  expect(listenersCache.has(id)).toBe(false)
+  expect(cleanupCache.has(id)).toBe(false)
 })

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -39,21 +39,24 @@ export function observe<callbacks extends Callbacks>(
 
   const unsubscribe = () => {
     const listeners = getListeners()
-    listenersCache.set(
-      observerId,
-      listeners.filter((cb: any) => cb.id !== callbackId),
+    const filteredListeners = listeners.filter(
+      (cb: any) => cb.id !== callbackId,
     )
+    if (filteredListeners.length === 0) listenersCache.delete(observerId)
+    else listenersCache.set(observerId, filteredListeners)
   }
 
   const unwatch = () => {
     const listeners = getListeners()
     if (!listeners.some((cb: any) => cb.id === callbackId)) return
+    const isLastListener = listeners.length === 1
     const cleanup = cleanupCache.get(observerId)
-    if (listeners.length === 1 && cleanup) {
+    if (isLastListener && cleanup) {
       const p = cleanup()
       if (p instanceof Promise) p.catch(() => {})
     }
     unsubscribe()
+    if (isLastListener) cleanupCache.delete(observerId)
   }
 
   const listeners = getListeners()


### PR DESCRIPTION
  ## What is this PR solving?
                                                                                                                                                                                                 
  This PR fixes a lifecycle gap in `observe`: when the last listener unsubscribes, `listenersCache` and `cleanupCache` kept stale keys instead of removing them.                                 
                                                                                                                                                                                                 
  In high-cardinality observer flows (for example `waitForTransactionReceipt(hash)`), this can accumulate many dead keys over time.                                                              
  The change makes final unwatch fully release cache entries.                                                                                                                                    
                                                                                                                                                                                                 
  ## What alternatives were explored?                                                                                                                                                            
                                                                                                                                                                                                 
  - Keeping empty entries and relying on periodic/global cache clears.                                                                                                                           
  - Adding a background/periodic sweep.                                                                                                                                                          
                                                                                                                                                                                                 
  I chose immediate deletion on final unwatch because it is the smallest, deterministic fix with no extra runtime overhead.                                                                      
                                                                                                                                                                                                 
  ## What should reviewers pay attention to?                                                                                                                                                     
                                                                                                                                                                                                 
  - Final-unwatch behavior now removes both cache keys.                                                                                                                                          
  - Cleanup invocation semantics are unchanged (including async cleanup handling).                                                                                                               
  - Multi-listener sharing behavior and idempotent repeated `unwatch()` calls remain intact.                                                                                                     
                                                                                                                                                                                                 
  ## Tests                                                                                                                                                                                       
                                                                                                                                                                                                 
  - Added a targeted test in `src/utils/observe.test.ts`:                                                                                                                                        
    - `deletes cache keys when the last listener unwatches`                                                                                                                                      
  - Verified with:                                                                                                                                                                               
    - `pnpm vitest src/utils/observe.test.ts`                                                                                                                                                    
    - `pnpm biome check src/utils/observe.ts src/utils/observe.test.ts`                                                                                                                          
                                                                                                                                                                                                 
  ## Docs                                                                                                                                                                                        
                                                                                                                                                                                                 
  No documentation update needed (internal utility behavior fix).  