### PR TITLE
refactor(tempo): align `Actions.wallet.send` params with latest wallet RPC schema

### DIFF
--- a/.changeset/wise-tempo-send.md
+++ b/.changeset/wise-tempo-send.md
@@ -1,0 +1,16 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Updated `Actions.wallet.send` parameters to match the latest wallet RPC schema: renamed `value` to `amount`, added an optional `memo` field (UTF-8, max 32 bytes; rejected for non-TIP-20 tokens), and widened `token` to also accept curated tokenlist symbols.
+
+```diff
+await Actions.wallet.send(client, {
++  amount: '1.5',
++  memo: 'thanks',
+   to: '0x...',
+-  token: '0x...',
++  token: 'pathUsd',
+-  value: '1.5',
+})
+```

--- a/src/tempo/actions/wallet.test.ts
+++ b/src/tempo/actions/wallet.test.ts
@@ -42,10 +42,11 @@ const client = (requests: unknown[]) =>
 test('send', async () => {
   const requests: unknown[] = []
   const result = await wallet.send(client(requests), {
+    amount: '1.5',
     feePayer: false,
+    memo: 'thanks',
     to: '0x0000000000000000000000000000000000000003',
     token: '0x0000000000000000000000000000000000000004',
-    value: '1.5',
   })
 
   expect({ requests, result }).toMatchInlineSnapshot(`
@@ -55,10 +56,11 @@ test('send', async () => {
           "method": "wallet_send",
           "params": [
             {
+              "amount": "1.5",
               "feePayer": false,
+              "memo": "thanks",
               "to": "0x0000000000000000000000000000000000000003",
               "token": "0x0000000000000000000000000000000000000004",
-              "value": "1.5",
             },
           ],
         },

--- a/src/tempo/actions/wallet.ts
+++ b/src/tempo/actions/wallet.ts
@@ -19,9 +19,9 @@ import type { TransactionReceipt } from '../Transaction.js'
  * })
  *
  * const { receipt } = await Actions.wallet.send(client, {
+ *   amount: '1.5',
  *   to: '0x...',
  *   token: '0x...',
- *   value: '1.5',
  * })
  * ```
  *
@@ -48,17 +48,27 @@ export async function send<chain extends Chain | undefined>(
 
 export declare namespace send {
   export type Parameters = {
+    /** Human-readable amount to pre-fill (for example, "1.5"). */
+    amount?: string | undefined
     /**
      * Fee payer override. `false` to disable the wallet's default fee payer,
      * a URL string to use a custom fee payer service.
      */
     feePayer?: boolean | string | undefined
+    /**
+     * UTF-8 memo (max 32 bytes) to attach to the transfer. Wallet rejects
+     * the request if the selected token does not support memos (non-TIP-20).
+     */
+    memo?: string | undefined
     /** Recipient address to pre-fill. */
     to?: Address | undefined
-    /** Token contract address to pre-fill. Omit to let the user choose. */
-    token?: Address | undefined
-    /** Human-readable amount to pre-fill (for example, "1.5"). */
-    value?: string | undefined
+    /**
+     * Token to pre-fill, accepted as either a contract address or a curated
+     * tokenlist symbol (case-insensitive, for example `"pathUsd"`). Symbols
+     * are resolved against the curated tokenlist on the active chain. Omit
+     * to let the user choose.
+     */
+    token?: Address | string | undefined
   }
 
   export type ReturnValue = {


### PR DESCRIPTION
Aligns `Actions.wallet.send` parameters in `viem/tempo` with the latest wallet RPC schema in `wallet-next/ref/sdk`.

Renames `value` to `amount`, adds an optional `memo` field (UTF-8, max 32 bytes; rejected by the wallet for non-TIP-20 tokens), and widens `token` to also accept curated tokenlist symbols (e.g. `"pathUsd"`).

```diff
await Actions.wallet.send(client, {
+  amount: '1.5',
+  memo: 'thanks',
   to: '0x...',
-  token: '0x...',
+  token: 'pathUsd',
-  value: '1.5',
})
```
