### PR TITLE
fix: preserve tempo transaction type in prepareTransactionRequest

### DIFF
--- a/.changeset/preserve-tempo-transaction-type.md
+++ b/.changeset/preserve-tempo-transaction-type.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `prepareTransactionRequest` return types to preserve chain-specific transaction types.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -38,15 +38,7 @@ import type {
   GetChainParameter,
 } from '../../types/chain.js'
 import type { GetTransactionRequestKzgParameter } from '../../types/kzg.js'
-import type {
-  TransactionRequest,
-  TransactionRequestEIP1559,
-  TransactionRequestEIP2930,
-  TransactionRequestEIP4844,
-  TransactionRequestEIP7702,
-  TransactionRequestLegacy,
-  TransactionSerializable,
-} from '../../types/transaction.js'
+import type { TransactionSerializable } from '../../types/transaction.js'
 import type {
   ExactPartial,
   IsNever,
@@ -106,6 +98,12 @@ type ParameterTypeToParameters<
 > = parameterType extends 'fees'
   ? 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasPrice'
   : parameterType
+type ExtractTransactionRequest<transactionRequest, transactionType> =
+  transactionRequest extends { type?: infer type | undefined }
+    ? Extract<transactionType, type> extends never
+      ? never
+      : transactionRequest
+    : never
 
 export type PrepareTransactionRequestRequest<
   chain extends Chain | undefined = Chain | undefined,
@@ -166,12 +164,10 @@ export type PrepareTransactionRequestReturnType<
     : GetTransactionType<request> extends 'legacy'
       ? unknown
       : GetTransactionType<request>,
-  _transactionRequest extends TransactionRequest =
-    | (_transactionType extends 'legacy' ? TransactionRequestLegacy : never)
-    | (_transactionType extends 'eip1559' ? TransactionRequestEIP1559 : never)
-    | (_transactionType extends 'eip2930' ? TransactionRequestEIP2930 : never)
-    | (_transactionType extends 'eip4844' ? TransactionRequestEIP4844 : never)
-    | (_transactionType extends 'eip7702' ? TransactionRequestEIP7702 : never),
+  _transactionRequest = ExtractTransactionRequest<
+    UnionOmit<FormattedTransactionRequest<_derivedChain>, 'from'>,
+    _transactionType
+  >,
 > = Prettify<
   UnionRequiredBy<
     Extract<

--- a/src/tempo/chainConfig.test-d.ts
+++ b/src/tempo/chainConfig.test-d.ts
@@ -1,0 +1,25 @@
+import { expectTypeOf, test } from 'vitest'
+import { prepareTransactionRequest } from '../actions/wallet/prepareTransactionRequest.js'
+import { tempoLocalnet } from '../chains/index.js'
+import { createWalletClient } from '../clients/createWalletClient.js'
+import { http } from '../clients/transports/http.js'
+
+test('prepareTransactionRequest preserves tempo transaction type', async () => {
+  const client = createWalletClient({
+    account: '0x',
+    chain: tempoLocalnet,
+    transport: http(),
+  })
+
+  const request_action = await prepareTransactionRequest(client, {
+    calls: [],
+    type: 'tempo',
+  })
+  const request_client = await client.prepareTransactionRequest({
+    calls: [],
+    type: 'tempo',
+  })
+
+  expectTypeOf(request_action.type).toEqualTypeOf<'tempo'>()
+  expectTypeOf(request_client.type).toEqualTypeOf<'tempo'>()
+})


### PR DESCRIPTION
## Summary
Preserves the literal Tempo transaction type in prepareTransactionRequest return types.

## Motivation
prepareTransactionRequest narrowed built-in transaction types, but fell back to the broad chain request union for type: 'tempo'.

## Changes
- Derive the narrowed return branch from FormattedTransactionRequest in src/actions/wallet/prepareTransactionRequest.ts
- Add a Tempo type regression test in src/tempo/chainConfig.test-d.ts
- Add a patch changeset

## Testing
pnpm exec biome check src/actions/wallet/prepareTransactionRequest.ts src/tempo/chainConfig.test-d.ts
pnpm exec tsc -b test/tsconfig.json
TYPES=true pnpm exec vitest -c ./test/vitest.config.ts --project type-bench src/tempo/chainConfig.bench-d.ts