### PR TITLE
fix(encodeEventTopics): do not prepend signature topic for anonymous events

### DIFF
--- a/.changeset/encode-event-topics-anonymous.md
+++ b/.changeset/encode-event-topics-anonymous.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `encodeEventTopics` incorrectly prepending the event signature as a topic for anonymous events.

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -532,3 +532,89 @@ test('https://github.com/wevm/viem/issues/3278', () => {
     ]
   `)
 })
+
+test('https://github.com/wevm/viem/issues/4461', () => {
+  const anonymousAbi = [
+    {
+      name: 'RawEvent',
+      type: 'event',
+      anonymous: true,
+      inputs: [
+        { name: 'topic0', type: 'bytes32', indexed: true },
+        { name: 'topic1', type: 'bytes32', indexed: true },
+        { name: 'topic2', type: 'bytes32', indexed: true },
+        { name: 'topic3', type: 'bytes32', indexed: true },
+      ],
+    },
+  ] as const
+
+  // no args: signature topic must not be prepended
+  expect(encodeEventTopics({ abi: anonymousAbi })).toEqual([])
+
+  // leading indexed arg
+  expect(
+    encodeEventTopics({
+      abi: anonymousAbi,
+      args: {
+        topic0:
+          '0x000000000000000000000000000000000000000000000000000000000000abcd',
+      },
+    }),
+  ).toEqual([
+    '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    null,
+    null,
+    null,
+  ])
+
+  // all indexed args
+  expect(
+    encodeEventTopics({
+      abi: anonymousAbi,
+      args: {
+        topic0:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        topic1:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        topic2:
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        topic3:
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+      },
+    }),
+  ).toEqual([
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+  ])
+
+  // unnamed args
+  const anonymousAbiUnnamed = [
+    {
+      name: 'RawEvent',
+      type: 'event',
+      anonymous: true,
+      inputs: [
+        { type: 'bytes32', indexed: true },
+        { type: 'bytes32', indexed: true },
+        { type: 'bytes32', indexed: true },
+        { type: 'bytes32', indexed: true },
+      ],
+    },
+  ] as const
+
+  expect(
+    encodeEventTopics({
+      abi: anonymousAbiUnnamed,
+      args: [
+        '0x000000000000000000000000000000000000000000000000000000000000abcd',
+      ],
+    }),
+  ).toEqual([
+    '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    null,
+    null,
+    null,
+  ])
+})

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,22 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = (Hex | Hex[] | null)[]
+export type EncodeEventTopicsReturnType<
+  abi extends Abi | readonly unknown[] = Abi,
+  eventName extends ContractEventName<abi> | undefined = undefined,
+  ///
+  resolvedEvent = abi extends Abi
+    ? eventName extends string
+      ? Extract<ExtractAbiEvents<abi>, { name: eventName }>
+      : abi['length'] extends 1
+        ? abi[0]
+        : ExtractAbiEvents<abi>
+    : unknown,
+> = IsNarrowable<abi, Abi> extends true
+  ? [resolvedEvent] extends [{ anonymous: true }]
+    ? (Hex | Hex[] | null)[]
+    : [Hex, ...(Hex | Hex[] | null)[]]
+  : (Hex | Hex[] | null)[]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -81,7 +96,7 @@ export function encodeEventTopics<
   eventName extends ContractEventName<abi> | undefined = undefined,
 >(
   parameters: EncodeEventTopicsParameters<abi, eventName>,
-): EncodeEventTopicsReturnType {
+): EncodeEventTopicsReturnType<abi, eventName> {
   const { abi, eventName, args } = parameters as EncodeEventTopicsParameters
 
   let abiItem = abi[0]
@@ -120,11 +135,12 @@ export function encodeEventTopics<
   }
   // Anonymous events are not identified by a signature topic, so the event
   // selector must not be prepended.
-  if (abiItem.anonymous) return topics
+  if (abiItem.anonymous)
+    return topics as EncodeEventTopicsReturnType<abi, eventName>
 
   const definition = formatAbiItem(abiItem)
   const signature = toEventSelector(definition as EventDefinition)
-  return [signature, ...topics]
+  return [signature, ...topics] as EncodeEventTopicsReturnType<abi, eventName>
 }
 
 export type EncodeArgErrorType =

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,7 +66,7 @@ export type EncodeEventTopicsParameters<
 > &
   (hasEvents extends true ? unknown : never)
 
-export type EncodeEventTopicsReturnType = [Hex, ...(Hex | Hex[] | null)[]]
+export type EncodeEventTopicsReturnType = (Hex | Hex[] | null)[]
 
 export type EncodeEventTopicsErrorType =
   | AbiEventNotFoundErrorType
@@ -94,9 +94,6 @@ export function encodeEventTopics<
   if (abiItem.type !== 'event')
     throw new AbiEventNotFoundError(undefined, { docsPath })
 
-  const definition = formatAbiItem(abiItem)
-  const signature = toEventSelector(definition as EventDefinition)
-
   let topics: (Hex | Hex[] | null)[] = []
   if (args && 'inputs' in abiItem) {
     const indexedInputs = abiItem.inputs?.filter(
@@ -121,6 +118,12 @@ export function encodeEventTopics<
         }) ?? []
     }
   }
+  // Anonymous events are not identified by a signature topic, so the event
+  // selector must not be prepended.
+  if (abiItem.anonymous) return topics
+
+  const definition = formatAbiItem(abiItem)
+  const signature = toEventSelector(definition as EventDefinition)
   return [signature, ...topics]
 }
 


### PR DESCRIPTION
## What is this PR solving?

`encodeEventTopics` always prepended the event selector as the first topic, even for anonymous events. Anonymous events are not identified by a signature topic, so the encoded topics were incorrect and could not be used to filter logs.

This adds an `anonymous` check: for anonymous events the indexed-argument topics are returned as-is, without the leading signature topic. Non-anonymous events are unchanged.

Closes #4461

## What's changed

- `src/utils/abi/encodeEventTopics.ts`: skip prepending the event selector when `abiItem.anonymous` is true. The selector is now only computed for non-anonymous events.
- `EncodeEventTopicsReturnType` widened from `[Hex, ...(Hex | Hex[] | null)[]]` to `(Hex | Hex[] | null)[]`, since anonymous events can produce a signature-less (and possibly empty) topic list. This is a superset of the previous type; no internal callers rely on the tuple shape.

## What alternatives were explored?

Keeping the strict tuple return type and only changing runtime behavior. This was rejected because the tuple type makes a valid (signature-less) anonymous-event result fail typechecking.

## What should reviewers pay attention to?

- Non-anonymous event encoding is byte-for-byte unchanged (signature still prepended, existing tests untouched).
- The widened return type — `decodeEventLog` already models the signature-less case with `| []`, so this aligns the encode side.

## Tests

Added `src/utils/abi/encodeEventTopics.test.ts > https://github.com/wevm/viem/issues/4461` covering anonymous events with: no args, a leading indexed arg, all indexed args, and unnamed args.