### PR TITLE
fix(tempo): use 2-byte length hint for WebAuthn keyData instead of 1400-byte blob

### DIFF
--- a/.changeset/tempo-webauthn-keydata-length-hint.md
+++ b/.changeset/tempo-webauthn-keydata-length-hint.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Encoded WebAuthn `keyData` as a 2-byte length hint instead of a raw blob, and auto-shimmed user-provided values longer than 4 bytes.

--- a/src/tempo/Formatters.test.ts
+++ b/src/tempo/Formatters.test.ts
@@ -151,6 +151,27 @@ describe('formatTransactionRequest', () => {
     expect((rpc as Record<string, unknown>).feePayer).toBe(true)
   })
 
+  test('behavior: keyData >4 bytes is shimmed to length hint', () => {
+    const rpc = Formatters.formatTransactionRequest({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      keyType: 'webAuthn',
+      keyData: `0x${'ff'.repeat(1400)}`,
+    } as never)
+    // 1400 = 0x0578 → 2-byte BE length hint
+    expect((rpc as Record<string, unknown>).keyData).toBe('0x0578')
+  })
+
+  test('behavior: keyData ≤4 bytes passes through unchanged', () => {
+    const rpc = Formatters.formatTransactionRequest({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      keyType: 'webAuthn',
+      keyData: '0x0578',
+    } as never)
+    expect((rpc as Record<string, unknown>).keyData).toBe('0x0578')
+  })
+
   test('behavior: feePayer as object is parsed', () => {
     const rpc = Formatters.formatTransactionRequest({
       chainId: 1,

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -122,7 +122,7 @@ export function formatTransactionRequest(
   const [keyType, keyData] = (() => {
     const type =
       account && 'keyType' in account ? account.keyType : account?.source
-    if (!type) return [request.keyType, request.keyData]
+    if (!type) return [request.keyType, shimKeyData(request.keyData)]
     if (type === 'webAuthn')
       // Send a 2-byte big-endian length hint (1400 = 0x0578) instead of a
       // 1400-byte dummy blob.  The node's gas estimator expects key_data to
@@ -130,7 +130,7 @@ export function formatTransactionRequest(
       // anything else falls back to the 800-byte default.
       return ['webAuthn', '0x0578']
     if (['p256', 'secp256k1'].includes(type)) return [type, undefined]
-    return [request.keyType, request.keyData]
+    return [request.keyType, shimKeyData(request.keyData)]
   })()
 
   const keyId =
@@ -159,4 +159,19 @@ export function formatTransactionRequest(
       ? { feePayerSignature: request.feePayerSignature }
       : {}),
   } as never
+}
+
+/**
+ * Auto-shim user-provided keyData that is longer than 4 bytes into a
+ * 2-byte big-endian length hint.  The node gas estimator only accepts
+ * 1, 2, or 4-byte key_data as a size hint; anything else silently falls
+ * back to the 800-byte default.
+ */
+function shimKeyData(
+  data: Hex.Hex | undefined,
+): Hex.Hex | undefined {
+  if (!data) return data
+  const byteLength = (data.length - 2) / 2 // subtract "0x" prefix
+  if (byteLength <= 4) return data
+  return Hex.fromNumber(byteLength, { size: 2 })
 }

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -124,8 +124,11 @@ export function formatTransactionRequest(
       account && 'keyType' in account ? account.keyType : account?.source
     if (!type) return [request.keyType, request.keyData]
     if (type === 'webAuthn')
-      // TODO: derive correct bytes size of key data based on webauthn create metadata.
-      return ['webAuthn', `0x${'ff'.repeat(1400)}`]
+      // Send a 2-byte big-endian length hint (1400 = 0x0578) instead of a
+      // 1400-byte dummy blob.  The node's gas estimator expects key_data to
+      // be 1, 2, or 4 bytes encoding the desired WebAuthn signature size;
+      // anything else falls back to the 800-byte default.
+      return ['webAuthn', '0x0578']
     if (['p256', 'secp256k1'].includes(type)) return [type, undefined]
     return [request.keyType, request.keyData]
   })()


### PR DESCRIPTION
## Problem

The Tempo node gas estimator (`reth_compat.rs`) parses `key_data` as a 1, 2, or 4-byte big-endian size hint to determine how many bytes of mock WebAuthn data to allocate during gas estimation. Any other `key_data` length falls back to the 800-byte default.

viem currently sends a 1400-byte `0xff` blob (`'ff'.repeat(1400)`), which hits the fallback branch (`_ => DEFAULT_WEBAUTHN_SIZE`), causing gas estimates to use 800 bytes instead of the intended 1400 — under-estimating gas for WebAuthn signatures.

## Fix

Replace the 1400-byte dummy blob with `0x0578` — a 2-byte big-endian encoding of 1400 — so the node correctly interprets the length hint and allocates 1400 bytes of mock WebAuthn signature data.

## Node reference

```rust
// crates/alloy/src/rpc/reth_compat.rs
let size = if let Some(data) = key_data.as_ref() {
    match data.len() {
        1 => data[0] as usize,
        2 => u16::from_be_bytes([data[0], data[1]]) as usize,
        4 => u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize,
        _ => DEFAULT_WEBAUTHN_SIZE, // Fallback default (800)
    }
};
```