### PR TITLE
fix: format tempo keyData shim

### DIFF
--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -167,9 +167,7 @@ export function formatTransactionRequest(
  * 1, 2, or 4-byte key_data as a size hint; anything else silently falls
  * back to the 800-byte default.
  */
-function shimKeyData(
-  data: Hex.Hex | undefined,
-): Hex.Hex | undefined {
+function shimKeyData(data: Hex.Hex | undefined): Hex.Hex | undefined {
   if (!data) return data
   const byteLength = (data.length - 2) / 2 // subtract "0x" prefix
   if (byteLength <= 4) return data


### PR DESCRIPTION
Fixes the failing `Verify / Check` job from https://github.com/wevm/viem/actions/runs/25879817061/job/76056518857.\n\nThe failure was caused by Biome expecting the `shimKeyData` function signature to be formatted on one line.\n\nVerified locally:\n- `pnpm biome check`\n- `pnpm audit`\n- `pnpm check:repo`