### PR TITLE
fix(tempo): preserve feeToken on broadcast envelope once fee payer has signed

### DIFF
--- a/.changeset/plenty-walls-search.md
+++ b/.changeset/plenty-walls-search.md
@@ -1,0 +1,9 @@
+---
+"viem": patch
+---
+
+**Tempo**: Preserve `feeToken` in the broadcast envelope once the fee
+payer has signed. Previously `feeToken` was unconditionally stripped
+whenever `feePayer === true`, which removed it from the post-signed
+envelope and caused the chain to fall back to the sender's default
+account token. The strip is now gated on `!feePayerSignature`.

--- a/.changeset/plenty-walls-search.md
+++ b/.changeset/plenty-walls-search.md
@@ -2,8 +2,4 @@
 "viem": patch
 ---
 
-**Tempo**: Preserve `feeToken` in the broadcast envelope once the fee
-payer has signed. Previously `feeToken` was unconditionally stripped
-whenever `feePayer === true`, which removed it from the post-signed
-envelope and caused the chain to fall back to the sender's default
-account token. The strip is now gated on `!feePayerSignature`.
+`viem/tempo`: Preserved `feeToken` on broadcast envelope when `feePayerSignature` is present. Previously stripped unconditionally when `feePayer === true`, breaking fee payer signature verification on-chain.

--- a/src/tempo/Formatters.test.ts
+++ b/src/tempo/Formatters.test.ts
@@ -140,7 +140,7 @@ describe('formatTransactionRequest', () => {
     expect(rpc.calls?.[0]?.to).toBe(undefined)
   })
 
-  test('behavior: feePayer: true deletes feeToken', () => {
+  test('behavior: feePayer: true deletes feeToken (no fee payer signature)', () => {
     const rpc = Formatters.formatTransactionRequest({
       chainId: 1,
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
@@ -148,6 +148,22 @@ describe('formatTransactionRequest', () => {
       feeToken,
     } as never)
     expect((rpc as Record<string, unknown>).feeToken).toBeUndefined()
+    expect((rpc as Record<string, unknown>).feePayer).toBe(true)
+  })
+
+  test('behavior: feePayer: true preserves feeToken once feePayerSignature is set', () => {
+    const rpc = Formatters.formatTransactionRequest({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      feePayer: true,
+      feeToken,
+      feePayerSignature: {
+        r: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        s: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        yParity: 0,
+      },
+    } as never)
+    expect((rpc as Record<string, unknown>).feeToken).toBe(feeToken)
     expect((rpc as Record<string, unknown>).feePayer).toBe(true)
   })
 

--- a/src/tempo/Formatters.ts
+++ b/src/tempo/Formatters.ts
@@ -72,6 +72,10 @@ export function formatTransactionRequest(
 ): TransactionRequestRpc {
   const request = r as TransactionRequest & {
     account?: viem_Account | Address | undefined
+    feePayerSignature?:
+      | { r: Hex.Hex; s: Hex.Hex; yParity: number; v?: number | undefined }
+      | null
+      | undefined
     keyData?: Hex.Hex | undefined
     keyId?: Address | undefined
     keyType?: 'p256' | 'secp256k1' | 'webAuthn' | undefined
@@ -100,10 +104,17 @@ export function formatTransactionRequest(
       },
     ]
 
-  // If we have marked the transaction as intended to be paid
-  // by a fee payer (feePayer: true), we will not use the fee token
-  // as the fee payer will choose their fee token.
-  if (request.feePayer === true) delete request.feeToken
+  // If we have marked the transaction as intended to be paid by a fee
+  // payer (feePayer: true), we strip the fee token from the sender's
+  // sign payload — per TIP-76 the sender does not commit to it; the fee
+  // payer chooses and commits to the token via its own signature.
+  //
+  // Once the fee payer has signed (`feePayerSignature` is populated),
+  // the relay has chosen a token and signed over it. The broadcast
+  // envelope must therefore include `feeToken` so the chain can verify
+  // the fee payer's signature and identify which token to charge.
+  if (request.feePayer === true && !request.feePayerSignature)
+    delete request.feeToken
 
   const rpc = ox_TransactionRequest.toRpc({
     ...request,

--- a/src/tempo/Transaction.test.ts
+++ b/src/tempo/Transaction.test.ts
@@ -216,6 +216,38 @@ describe('serialize', () => {
     expect(serialized.startsWith('0x78')).toBe(true)
   })
 
+  test('behavior: feePayer: true preserves feeToken once feePayerSignature is set', async () => {
+    // Sender-side serialization (no feePayerSignature yet) — feeToken
+    // must be stripped per TIP-76; sender does not commit to a token.
+    const unsigned = await Transaction.serialize({
+      chainId: 1,
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      feePayer: true,
+      feeToken,
+    })
+    const unsignedParsed = Transaction.deserialize(unsigned as `0x76${string}`)
+    expect(unsignedParsed.feeToken).toBeUndefined()
+
+    // Final broadcast envelope (fee payer has signed) — feeToken must
+    // remain so the chain can verify the fee payer's signature and
+    // identify which token to charge.
+    const signed = await Transaction.serialize(
+      {
+        chainId: 1,
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        feePayer: true,
+        feeToken,
+        from: accounts.at(0)!.address,
+        feePayerSignature: { r: '0x1', s: '0x1', yParity: 0 } as never,
+      },
+      { type: 'secp256k1', signature: { r: 1n, s: 1n, yParity: 0 } },
+    )
+    const signedParsed = Transaction.deserialize(signed as `0x78${string}`)
+    expect((signedParsed.feeToken as string)?.toLowerCase()).toBe(
+      feeToken.toLowerCase(),
+    )
+  })
+
   test('behavior: serializes with feePayer as object (co-signed)', async () => {
     const serialized = await Transaction.serialize(
       {

--- a/src/tempo/Transaction.ts
+++ b/src/tempo/Transaction.ts
@@ -325,10 +325,16 @@ async function serializeTempo(
     ...(nonce ? { nonce: BigInt(nonce) } : {}),
   } satisfies TxTempo.TxEnvelopeTempo
 
-  // If we have marked the transaction as intended to be paid
-  // by a fee payer (feePayer: true), we will not use the fee token
-  // as the fee payer will choose their fee token.
-  if (feePayer === true) delete transaction_ox.feeToken
+  // If we have marked the transaction as intended to be paid by a fee
+  // payer (feePayer: true), we strip the fee token from the sender's
+  // sign payload — per TIP-76 the sender does not commit to it; the fee
+  // payer chooses and commits to the token via its own signature.
+  //
+  // Once the fee payer has signed (`feePayerSignature` is populated),
+  // the relay has chosen a token and signed over it. The broadcast
+  // envelope must therefore include `feeToken` so the chain can verify
+  // the fee payer's signature and identify which token to charge.
+  if (feePayer === true && !feePayerSignature) delete transaction_ox.feeToken
 
   if (signature && typeof transaction.feePayer === 'object') {
     const tx = TxTempo.from(transaction_ox, {
@@ -372,8 +378,12 @@ async function serializeTempo(
 
   return TxTempo.serialize(
     // If we have specified a fee payer, the user will not be signing over the fee token.
-    // Defer the fee token signing to the fee payer.
-    { ...transaction_ox, ...(feePayer ? { feeToken: undefined } : {}) },
+    // Defer the fee token signing to the fee payer. Once the fee payer has signed,
+    // keep `feeToken` so the broadcast envelope carries the token the chain must charge.
+    {
+      ...transaction_ox,
+      ...(feePayer && !feePayerSignature ? { feeToken: undefined } : {}),
+    },
     {
       feePayerSignature: undefined,
       signature,


### PR DESCRIPTION
## Summary

A Tempo `feePayer: true` transaction is signed twice: by the sender
(who per TIP-76 does not commit to a `feeToken`) and by a fee payer
(who chooses a token and signs over it). The broadcast envelope must
include the `feeToken` so the chain can verify the fee payer's
signature.

`formatTransactionRequest` and `serializeTransaction` currently strip
`feeToken` whenever `feePayer === true`. That's correct for the
sender's sign payload but also strips it from the post-signed
broadcast envelope, causing the chain to fall back to the sender's
default account token and revert with `insufficient liquidity in
FeeAMM pool to swap fee tokens`.

## Changes

- `src/tempo/Formatters.ts`, `src/tempo/Transaction.ts`: gate the
  `delete feeToken` on `!feePayerSignature` (3 sites total).
- New unit tests asserting the round-trip in both files.

## Testing

- `pnpm check`, `pnpm check:types`: clean.
- New tests pass against the local Tempo testcontainer.
- Verified end-to-end against a live Tempo network with a fee-sponsor
  relay.
