### PR TITLE
fix(chains): build explorer api requests with URL params

### DIFF
--- a/.changeset/morph-holesky-api-url.md
+++ b/.changeset/morph-holesky-api-url.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `morphHolesky` block explorer `apiUrl` (removed trailing `?`).

--- a/src/chains/definitions/morphHolesky.ts
+++ b/src/chains/definitions/morphHolesky.ts
@@ -14,7 +14,7 @@ export const morphHolesky = /*#__PURE__*/ defineChain({
     default: {
       name: 'Morph Holesky Explorer',
       url: 'https://explorer-holesky.morphl2.io',
-      apiUrl: 'https://explorer-api-holesky.morphl2.io/api?',
+      apiUrl: 'https://explorer-api-holesky.morphl2.io/api',
     },
   },
   testnet: true,

--- a/test/scripts/chains.test.ts
+++ b/test/scripts/chains.test.ts
@@ -71,16 +71,15 @@ describe.each(chains)('$name', ({ name, ...chain }) => {
     async () => {
       if (!blockExplorer?.apiUrl) return
 
-      const response = await fetch(
-        `${
-          blockExplorer.apiUrl
-        }?module=block&action=getblocknobytime&closest=before&timestamp=${Math.floor(
-          Date.now() / 1000,
-        )}`,
-        {
-          headers: { 'Content-Type': 'application/json' },
-        },
-      )
+      const apiUrl = new URL(blockExplorer.apiUrl)
+      apiUrl.searchParams.set('module', 'block')
+      apiUrl.searchParams.set('action', 'getblocknobytime')
+      apiUrl.searchParams.set('closest', 'before')
+      apiUrl.searchParams.set('timestamp', `${Math.floor(Date.now() / 1000)}`)
+
+      const response = await fetch(apiUrl, {
+        headers: { 'Content-Type': 'application/json' },
+      })
       const data = await response.json()
       expect(data).toMatchObject({
         status: '1',


### PR DESCRIPTION
## Summary

- Replace template-string concatenation in `test/scripts/chains.test.ts` (`blockExplorer.apiUrl` path) with `new URL()` + `searchParams.set()`, so values are encoded safely and pre-existing query params (e.g. Etherscan v2 `chainid=...`) are preserved.
- Drop trailing `?` from `morphHolesky.apiUrl` so the URL is well-formed.
- Add `patch` changeset for the `morphHolesky` fix.

Based on [#4602](https://github.com/wevm/viem/pull/4602) by @tn0vak — credit to them for the diagnosis and original patch.

## Test plan

- [ ] `pnpm test:chains` passes against the updated `blockExplorer.apiUrl` path.
- [ ] Morph Holesky explorer request resolves without a doubled `?`.