### PR TITLE
chore: drop duplicate fast-uri override

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
       "estree-util-value-to-estree@<3.3.3": "3.3.3",
       "express-rate-limit@>=8.2.0 <8.2.2": ">=8.2.2",
-      "fast-uri@<=3.1.1": "3.1.2",
       "fastify": ">=5.8.5",
       "follow-redirects@<1.16.0": "1.16.0",
       "uuid@<14.0.0": "14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,6 @@ overrides:
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   estree-util-value-to-estree@<3.3.3: 3.3.3
   express-rate-limit@>=8.2.0 <8.2.2: '>=8.2.2'
-  fast-uri@<=3.1.1: 3.1.2
   fastify: '>=5.8.5'
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0


### PR DESCRIPTION
The \`fast-uri@<=3.1.1: 3.1.2\` override was already present in \`package.json\` and \`pnpm-lock.yaml\` before [#4590](https://github.com/wevm/viem/pull/4590) was merged. The squash merge of #4590 re-added it as a duplicate. This drops the duplicate to keep the overrides section tidy.

See [a9bfd944 diff](https://github.com/wevm/viem/commit/a9bfd944aea8f7822b8fc3fcf92c583f4144f672#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) — the \`+\` line is a duplicate of an entry that already existed lower in the same overrides block.