### PR TITLE
fix(ci): repair ccipTunnel test fork block and zksync type guard

### DIFF
--- a/src/utils/ccipTunnel.test.ts
+++ b/src/utils/ccipTunnel.test.ts
@@ -7,8 +7,9 @@ import {
   toHex,
 } from 'viem'
 import { getEnsAddress, getEnsResolver, readContract } from 'viem/actions'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { anvilMainnet } from '~test/anvil.js'
+import { reset } from '../actions/test/reset.js'
 import { ccipReadTunnel } from './ccipTunnel.js'
 import { packetToBytes } from './ens/packetToBytes.js'
 
@@ -30,6 +31,13 @@ const NAME = 'raffy.base.eth'
 const ADDR = '0x51050ec063d393217B436747617aD1C2285Aeeee'
 
 describe('ccipTunnel', () => {
+  beforeAll(async () => {
+    await reset(client, {
+      blockNumber: 23_085_558n,
+      jsonRpcUrl: anvilMainnet.forkUrl,
+    })
+  })
+
   beforeEach(() => requested.clear())
 
   test('passthrough', async () => {

--- a/src/zksync/utils/isEip712Transaction.ts
+++ b/src/zksync/utils/isEip712Transaction.ts
@@ -9,7 +9,7 @@ export function isEIP712Transaction(
     OneOf<ZksyncTransactionRequest | ZksyncTransactionSerializable>
   >,
 ) {
-  if (transaction.type === 'priority') return false
+  if ((transaction.type as string) === 'priority') return false
   if (transaction.type === 'eip712') return true
   if (
     ('customSignature' in transaction && transaction.customSignature) ||


### PR DESCRIPTION
Fixes two CI failures on `main` (https://github.com/wevm/viem/actions/runs/25988340934).

- `src/utils/ccipTunnel.test.ts`: reset the fork to block `23_085_558` in `beforeAll` so the V3 UniversalResolver at `0xeeeeeeee14d718c2b47d9923deab1335e144eeee` is deployed. The default `anvilMainnet` fork (`22263623`) predates it, causing `resolveWithGateways` to return `0x`.
- `src/zksync/utils/isEip712Transaction.ts`: cast `transaction.type` to `string` so the defensive `'priority'` runtime guard still type-checks after #4591 dropped `'priority'` from the request type union.