### PR TITLE
fix: clear `observe` caches after unwatch

### DIFF
--- a/.changeset/clear-observe-cache.md
+++ b/.changeset/clear-observe-cache.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `observe` retaining listener and cleanup cache entries after the last listener unwatched.

--- a/src/utils/observe.test.ts
+++ b/src/utils/observe.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 
-import { observe } from './observe.js'
+import { cleanupCache, listenersCache, observe } from './observe.js'
 import { wait } from './wait.js'
 
 test('emits data to callbacks', async () => {
@@ -208,6 +208,37 @@ test('cleans up emit function when last listener unwatch', async () => {
 
   unwatch2()
 
+  expect(cleanup).toHaveBeenCalledTimes(1)
+})
+
+test('removes caches when last listener unwatches', () => {
+  const id = 'mock'
+  const cleanup = vi.fn()
+  const emitter = vi.fn(() => cleanup)
+
+  const unwatch1 = observe(id, { emit: vi.fn() }, emitter)
+  const unwatch2 = observe(id, { emit: vi.fn() }, emitter)
+
+  unwatch1()
+
+  expect(listenersCache.get(id)).toHaveLength(1)
+  expect(cleanupCache.has(id)).toBe(true)
+
+  unwatch2()
+
+  expect(cleanup).toHaveBeenCalledTimes(1)
+  expect(listenersCache.has(id)).toBe(false)
+  expect(cleanupCache.has(id)).toBe(false)
+})
+
+test('does not reuse cleanup after last listener unwatches', () => {
+  const id = 'mock'
+  const cleanup = vi.fn()
+
+  observe(id, { emit: vi.fn() }, () => cleanup)()
+  expect(cleanup).toHaveBeenCalledTimes(1)
+
+  observe(id, { emit: vi.fn() }, () => {})()
   expect(cleanup).toHaveBeenCalledTimes(1)
 })
 

--- a/src/utils/observe.ts
+++ b/src/utils/observe.ts
@@ -39,10 +39,13 @@ export function observe<callbacks extends Callbacks>(
 
   const unsubscribe = () => {
     const listeners = getListeners()
-    listenersCache.set(
-      observerId,
-      listeners.filter((cb: any) => cb.id !== callbackId),
-    )
+    const nextListeners = listeners.filter((cb: any) => cb.id !== callbackId)
+    if (nextListeners.length === 0) {
+      listenersCache.delete(observerId)
+      cleanupCache.delete(observerId)
+      return
+    }
+    listenersCache.set(observerId, nextListeners)
   }
 
   const unwatch = () => {


### PR DESCRIPTION
Clears `observe` listener and cleanup cache entries once the final listener unsubscribes. This prevents short-lived watchers from retaining empty listener arrays and stale cleanup closures after `watchBlockNumber` or similar observers are torn down.

Adds regression coverage for final unwatch cache deletion and for a later observer not reusing the previous cleanup. Validated with `SKIP_GLOBAL_SETUP=true pnpm test src/utils/observe.test.ts` and `pnpm exec biome check src/utils/observe.ts src/utils/observe.test.ts`.

Closes https://github.com/wevm/viem/issues/4390
