### PR TITLE
fix(site): resolve twoslash `viem` imports from source

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -95,6 +95,14 @@ export default defineConfig({
   twoslash: {
     throws: false,
     twoslashOptions: {
+      vfsRoot: '..',
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          viem: ['../src/index.ts'],
+          'viem/*': ['../src/*/index.ts', '../src/*.ts'],
+        },
+      },
       handbookOptions: {
         // FIXME: fix all twoslash errors.
         noErrors: true,


### PR DESCRIPTION
Configures the site Twoslash compiler to overlay the repo root and resolve `viem` package imports to the workspace source files. This keeps docs hovers using the symlinked workspace package instead of requiring generated `src/_types` declarations before Vocs renders snippets.

Validated by deleting `src/_types` and `site/.cache/twoslash`, then checking a Twoslash query for `createPublicClient` resolves to a structured client type instead of `any`. Also ran `pnpm exec biome check site/vocs.config.ts site/package.json`.

Closes https://github.com/wevm/viem/issues/4427
