### PR TITLE
fix: decode offchain dns `addr` coin type records

### DIFF
--- a/.changeset/short-buckets-relax.md
+++ b/.changeset/short-buckets-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getEnsAddress` decoding offchain DNS address records when `coinType` was specified.

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -3,12 +3,28 @@ import { anvilMainnet } from '~test/anvil.js'
 import { createHttpServer, setVitalikResolver } from '~test/utils.js'
 import { linea, mainnet, optimism } from '../../chains/index.js'
 import { createClient } from '../../clients/createClient.js'
+import { custom } from '../../clients/transports/custom.js'
 import { http } from '../../clients/transports/http.js'
+import { universalResolverResolveAbi } from '../../constants/abis.js'
 import { toCoinType } from '../../ens/index.js'
+import { encodeFunctionResult } from '../../utils/abi/encodeFunctionResult.js'
 import { reset } from '../test/reset.js'
 import { getEnsAddress } from './getEnsAddress.js'
 
 const client = anvilMainnet.getClient()
+
+const addressResolverAbi = [
+  {
+    name: 'addr',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'name', type: 'bytes32' },
+      { name: 'coinType', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'address' }],
+  },
+] as const
 
 beforeAll(async () => {
   await reset(client, {
@@ -133,6 +149,39 @@ test('offchain: gets address for name', async () => {
   ).resolves.toMatchInlineSnapshot(
     `"0x41563129cDbbD0c5D3e1c86cf9563926b243834d"`,
   )
+})
+
+test('offchain: decodes address-encoded coinType response', async () => {
+  const address = '0x534631Bcf33BDb069fB20A93d2fdb9e4D4dD42CF'
+  const resolverAddress = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+  const data = encodeFunctionResult({
+    abi: universalResolverResolveAbi,
+    functionName: 'resolveWithGateways',
+    result: [
+      encodeFunctionResult({
+        abi: addressResolverAbi,
+        functionName: 'addr',
+        result: address,
+      }),
+      resolverAddress,
+    ],
+  })
+  const client = createClient({
+    transport: custom({
+      async request({ method }) {
+        if (method === 'eth_call') return data
+        return null
+      },
+    }),
+  })
+
+  await expect(
+    getEnsAddress(client, {
+      name: 'pokersback.com',
+      coinType: 60n,
+      universalResolverAddress: resolverAddress,
+    }),
+  ).resolves.toBe(address)
 })
 
 test('offchain: name without address', async () => {

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -18,9 +18,14 @@ import {
   encodeFunctionData,
 } from '../../utils/abi/encodeFunctionData.js'
 import {
+  type GetAddressErrorType,
+  getAddress,
+} from '../../utils/address/getAddress.js'
+import {
   type GetChainContractAddressErrorType,
   getChainContractAddress,
 } from '../../utils/chain/getChainContractAddress.js'
+import { type SizeErrorType, size } from '../../utils/data/size.js'
 import { type TrimErrorType, trim } from '../../utils/data/trim.js'
 import { type ToHexErrorType, toHex } from '../../utils/encoding/toHex.js'
 import { isNullUniversalResolverError } from '../../utils/ens/errors.js'
@@ -75,11 +80,13 @@ export type GetEnsAddressReturnType = Address | null
 
 export type GetEnsAddressErrorType =
   | GetChainContractAddressErrorType
+  | GetAddressErrorType
   | EncodeFunctionDataErrorType
   | NamehashErrorType
   | ToHexErrorType
   | PacketToBytesErrorType
   | DecodeFunctionResultErrorType
+  | SizeErrorType
   | TrimErrorType
   | ErrorType
 
@@ -167,12 +174,7 @@ export async function getEnsAddress<chain extends Chain | undefined>(
 
     if (res[0] === '0x') return null
 
-    const address = decodeFunctionResult({
-      abi: addressResolverAbi,
-      args,
-      functionName: 'addr',
-      data: res[0],
-    })
+    const address = decodeAddress({ coinType, data: res[0], args })
 
     if (address === '0x') return null
     if (trim(address) === '0x00') return null
@@ -180,6 +182,32 @@ export async function getEnsAddress<chain extends Chain | undefined>(
   } catch (err) {
     if (strict) throw err
     if (isNullUniversalResolverError(err)) return null
+    throw err
+  }
+}
+
+function decodeAddress({
+  coinType,
+  data,
+  args,
+}: {
+  coinType: bigint | undefined
+  data: `0x${string}`
+  args: readonly [`0x${string}`] | readonly [`0x${string}`, bigint]
+}) {
+  try {
+    return decodeFunctionResult({
+      abi: addressResolverAbi,
+      args,
+      functionName: 'addr',
+      data,
+    })
+  } catch (err) {
+    if (coinType == null) throw err
+
+    const address = trim(data)
+    if (size(address) === 20) return getAddress(address)
+
     throw err
   }
 }


### PR DESCRIPTION
`getEnsAddress` now handles resolver results that encode `addr(bytes32,uint256)` as an ABI address instead of dynamic `bytes`. This covers offchain DNS records like `pokersback.com` when `coinType` is specified while preserving the existing `bytes` decoding path.

The fallback only applies when `coinType` is present and the resolver payload trims to a 20-byte EVM address. Closes https://github.com/wevm/viem/issues/4467.

Validated with `pnpm exec biome check --write src/actions/ens/getEnsAddress.ts src/actions/ens/getEnsAddress.test.ts .changeset/short-buckets-relax.md`, `pnpm exec tsc --project ./tsconfig.build.json --noEmit`, and a live mainnet check for `pokersback.com` with `coinType: 60n`.
