### PR TITLE
fix: reset `nonceManager` after failed sends

### DIFF
--- a/.changeset/smooth-singers-doubt.md
+++ b/.changeset/smooth-singers-doubt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `nonceManager` resetting stale nonces after failed transaction submissions.

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -190,6 +190,7 @@ export async function sendTransaction<
       docsPath: '/docs/actions/wallet/sendTransaction',
     })
   const account = account_ ? parseAccount(account_) : null
+  let nonceManagerParameters: { address: Address; chainId: number } | undefined
 
   try {
     assertRequest(parameters as AssertRequestParameters)
@@ -309,6 +310,16 @@ export async function sendTransaction<
     }
 
     if (account?.type === 'local') {
+      if (account.nonceManager && typeof nonce === 'undefined') {
+        const requestChainId = (rest as unknown as { chainId?: number }).chainId
+        const chainId = await (async () => {
+          if (typeof requestChainId === 'number') return requestChainId
+          if (chain) return chain.id
+          return getAction(client, getChainId, 'getChainId')({})
+        })()
+        nonceManagerParameters = { address: account.address, chainId }
+      }
+
       // Prepare the request for signing (assign appropriate fees, etc.)
       const request = await getAction(
         client,
@@ -366,6 +377,8 @@ export async function sendTransaction<
     })
   } catch (err) {
     if (err instanceof AccountTypeNotSupportedError) throw err
+    if (nonceManagerParameters)
+      account?.nonceManager?.reset(nonceManagerParameters)
     throw getTransactionError(err as BaseError, {
       ...parameters,
       account,

--- a/src/actions/wallet/sendTransactionSync.ts
+++ b/src/actions/wallet/sendTransactionSync.ts
@@ -213,6 +213,7 @@ export async function sendTransactionSync<
       docsPath: '/docs/actions/wallet/sendTransactionSync',
     })
   const account = account_ ? parseAccount(account_) : null
+  let nonceManagerParameters: { address: Address; chainId: number } | undefined
 
   try {
     assertRequest(parameters as AssertRequestParameters)
@@ -348,6 +349,16 @@ export async function sendTransactionSync<
     }
 
     if (account?.type === 'local') {
+      if (account.nonceManager && typeof nonce === 'undefined') {
+        const requestChainId = (rest as unknown as { chainId?: number }).chainId
+        const chainId = await (async () => {
+          if (typeof requestChainId === 'number') return requestChainId
+          if (chain) return chain.id
+          return getAction(client, getChainId, 'getChainId')({})
+        })()
+        nonceManagerParameters = { address: account.address, chainId }
+      }
+
       // Prepare the request for signing (assign appropriate fees, etc.)
       const request = await getAction(
         client,
@@ -407,6 +418,11 @@ export async function sendTransactionSync<
     })
   } catch (err) {
     if (err instanceof AccountTypeNotSupportedError) throw err
+    if (
+      nonceManagerParameters &&
+      !(err instanceof TransactionReceiptRevertedError)
+    )
+      account?.nonceManager?.reset(nonceManagerParameters)
     throw getTransactionError(err as BaseError, {
       ...parameters,
       account,

--- a/src/utils/nonceManager.test.ts
+++ b/src/utils/nonceManager.test.ts
@@ -6,8 +6,12 @@ import {
   dropTransaction,
   getTransaction,
   sendTransaction,
+  sendTransactionSync,
   setBalance,
 } from '../actions/index.js'
+import { mainnet } from '../chains/index.js'
+import { createWalletClient } from '../clients/createWalletClient.js'
+import { custom } from '../clients/transports/custom.js'
 import { createNonceManager, jsonRpc, nonceManager } from './nonceManager.js'
 import { parseEther } from './unit/parseEther.js'
 
@@ -178,6 +182,108 @@ test('nonceManager export', async () => {
       13,
     ]
   `)
+})
+
+test('reset clears consumed nonce cache', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+
+  expect(await nonceManager.consume(mainnetArgs)).toBe(1)
+
+  nonceManager.reset(mainnetArgs)
+
+  expect(await nonceManager.consume(mainnetArgs)).toBe(1)
+})
+
+test('get preserves consumed nonce cache', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+
+  expect(await nonceManager.consume(mainnetArgs)).toBe(1)
+  expect(await nonceManager.get(mainnetArgs)).toBe(2)
+  expect(await nonceManager.consume(mainnetArgs)).toBe(2)
+})
+
+test('failed sendTransaction resets consumed nonce', async () => {
+  const nonceManager = createNonceManager({
+    source: jsonRpc(),
+  })
+  const account = privateKeyToAccount(privateKey, { nonceManager })
+  const client = createWalletClient({
+    chain: mainnet,
+    transport: custom({
+      async request({ method }) {
+        if (method === 'eth_getTransactionCount') return '0x1'
+        if (method === 'eth_sendRawTransaction')
+          throw new Error('rate limit exceeded')
+        return '0x0'
+      },
+    }),
+  })
+
+  await expect(
+    sendTransaction(client, {
+      account,
+      gas: 21_000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      to: account.address,
+      value: 1n,
+    }),
+  ).rejects.toThrow()
+
+  expect(
+    await nonceManager.consume({
+      address: account.address,
+      chainId: mainnet.id,
+      client,
+    }),
+  ).toBe(1)
+})
+
+test('failed sendTransactionSync resets consumed nonce', async () => {
+  const nonceManager = createNonceManager({
+    source: jsonRpc(),
+  })
+  const account = privateKeyToAccount(privateKey, { nonceManager })
+  const client = createWalletClient({
+    chain: mainnet,
+    transport: custom({
+      async request({ method }) {
+        if (method === 'eth_getTransactionCount') return '0x1'
+        if (method === 'eth_sendRawTransactionSync')
+          throw new Error('rate limit exceeded')
+        return '0x0'
+      },
+    }),
+  })
+
+  await expect(
+    sendTransactionSync(client, {
+      account,
+      gas: 21_000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      to: account.address,
+      value: 1n,
+    }),
+  ).rejects.toThrow()
+
+  expect(
+    await nonceManager.consume({
+      address: account.address,
+      chainId: mainnet.id,
+      client,
+    }),
+  ).toBe(1)
 })
 
 test('dropped tx', async () => {

--- a/src/utils/nonceManager.ts
+++ b/src/utils/nonceManager.ts
@@ -50,6 +50,10 @@ export function createNonceManager(
 
   const getKey = ({ address, chainId }: FunctionParameters) =>
     `${address}.${chainId}`
+  const resetCache = (key: string) => {
+    deltaMap.delete(key)
+    promiseMap.delete(key)
+  }
 
   return {
     async consume({ address, chainId, client }) {
@@ -83,7 +87,7 @@ export function createNonceManager(
             nonceMap.delete(key)
             return nonce
           } finally {
-            this.reset({ address, chainId })
+            resetCache(key)
           }
         })()
         promiseMap.set(key, promise)
@@ -94,8 +98,8 @@ export function createNonceManager(
     },
     reset({ address, chainId }) {
       const key = getKey({ address, chainId })
-      deltaMap.delete(key)
-      promiseMap.delete(key)
+      nonceMap.delete(key)
+      resetCache(key)
     },
   }
 }


### PR DESCRIPTION
`nonceManager.reset()` now clears the consumed nonce cache while preserving the internal cleanup path used by `get()`. Failed local-account `sendTransaction` and `sendTransactionSync` calls reset nonce manager state after submission errors before acceptance, so the next transaction re-reads the pending nonce instead of skipping ahead.

`sendTransactionSync` keeps the consumed nonce for reverted receipts, since those transactions were accepted and mined. Closes https://github.com/wevm/viem/issues/4364.

Validated with `pnpm exec tsc --project ./tsconfig.build.json --noEmit`, `pnpm exec biome check --write ...`, `git diff --check`, and mocked `sendTransaction`/`sendTransactionSync` failure repros. `pnpm test src/utils/nonceManager.test.ts` is blocked locally by Anvil returning 400 on `anvil_setBalance` during suite setup.
