### PR TITLE
fix: retry `fallback` local transactions per transport

### DIFF
--- a/.changeset/calm-keys-smile.md
+++ b/.changeset/calm-keys-smile.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed fallback local transaction retries using one RPC transport for each transaction attempt.

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -52,6 +52,10 @@ import {
   type AssertRequestParameters,
   assertRequest,
 } from '../../utils/transaction/assertRequest.js'
+import {
+  getFallbackRetry,
+  withRetryingTransport,
+} from '../../utils/withRetryingTransport.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 import {
   defaultParameters,
@@ -310,56 +314,80 @@ export async function sendTransaction<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
+      const send = async (
+        client_: Client<Transport, chain, account>,
+      ): Promise<SendTransactionReturnType> => {
+        nonceManagerParameters = undefined
+        if (account.nonceManager && typeof nonce === 'undefined') {
+          const requestChainId = (rest as unknown as { chainId?: number })
+            .chainId
+          const chainId = await (async () => {
+            if (typeof requestChainId === 'number') return requestChainId
+            if (chain) return chain.id
+            return getAction(client_, getChainId, 'getChainId')({})
+          })()
+          nonceManagerParameters = { address: account.address, chainId }
+        }
+
+        // Prepare the request for signing (assign appropriate fees, etc.)
+        const request = await getAction(
+          client_,
+          prepareTransactionRequest,
+          'prepareTransactionRequest',
+        )({
+          account,
+          accessList,
+          authorizationList,
+          blobs,
+          chain,
+          data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
+          gas,
+          gasPrice,
+          maxFeePerBlobGas,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          nonce,
+          nonceManager: account.nonceManager,
+          parameters: [...defaultParameters, 'sidecars'],
+          type,
+          value,
+          ...rest,
+          to,
+        } as any)
+
+        const serializer = chain?.serializers?.transaction
+        const serializedTransaction = (await account.signTransaction(
+          request as never,
+          {
+            serializer,
+          },
+        )) as Hash
+        return await getAction(
+          client_,
+          sendRawTransaction,
+          'sendRawTransaction',
+        )({
+          serializedTransaction,
+        })
       }
 
-      // Prepare the request for signing (assign appropriate fees, etc.)
-      const request = await getAction(
-        client,
-        prepareTransactionRequest,
-        'prepareTransactionRequest',
-      )({
-        account,
-        accessList,
-        authorizationList,
-        blobs,
-        chain,
-        data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
-        gas,
-        gasPrice,
-        maxFeePerBlobGas,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce,
-        nonceManager: account.nonceManager,
-        parameters: [...defaultParameters, 'sidecars'],
-        type,
-        value,
-        ...rest,
-        to,
-      } as any)
+      const retry = getFallbackRetry(client)
+      if (retry)
+        return await retry(async ({ index, transport }) => {
+          try {
+            return await send(
+              withRetryingTransport(client, { index, transport }) as never,
+            )
+          } catch (err) {
+            if (nonceManagerParameters) {
+              account.nonceManager?.reset(nonceManagerParameters)
+              nonceManagerParameters = undefined
+            }
+            throw err
+          }
+        })
 
-      const serializer = chain?.serializers?.transaction
-      const serializedTransaction = (await account.signTransaction(
-        request as never,
-        {
-          serializer,
-        },
-      )) as Hash
-      return await getAction(
-        client,
-        sendRawTransaction,
-        'sendRawTransaction',
-      )({
-        serializedTransaction,
-      })
+      return await send(client)
     }
 
     if (account?.type === 'smart')

--- a/src/actions/wallet/sendTransactionSync.ts
+++ b/src/actions/wallet/sendTransactionSync.ts
@@ -56,6 +56,10 @@ import {
   type AssertRequestParameters,
   assertRequest,
 } from '../../utils/transaction/assertRequest.js'
+import {
+  getFallbackRetry,
+  withRetryingTransport,
+} from '../../utils/withRetryingTransport.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 import {
   type WaitForTransactionReceiptErrorType,
@@ -349,58 +353,85 @@ export async function sendTransactionSync<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
+      const send = async (
+        client_: Client<Transport, chain, account>,
+      ): Promise<SendTransactionSyncReturnType<chain>> => {
+        nonceManagerParameters = undefined
+        if (account.nonceManager && typeof nonce === 'undefined') {
+          const requestChainId = (rest as unknown as { chainId?: number })
+            .chainId
+          const chainId = await (async () => {
+            if (typeof requestChainId === 'number') return requestChainId
+            if (chain) return chain.id
+            return getAction(client_, getChainId, 'getChainId')({})
+          })()
+          nonceManagerParameters = { address: account.address, chainId }
+        }
+
+        // Prepare the request for signing (assign appropriate fees, etc.)
+        const request = await getAction(
+          client_,
+          prepareTransactionRequest,
+          'prepareTransactionRequest',
+        )({
+          account,
+          accessList,
+          authorizationList,
+          blobs,
+          chain,
+          data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
+          gas,
+          gasPrice,
+          maxFeePerBlobGas,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          nonce,
+          nonceManager: account.nonceManager,
+          parameters: [...defaultParameters, 'sidecars'],
+          type,
+          value,
+          ...rest,
+          to,
+        } as any)
+
+        const serializer = chain?.serializers?.transaction
+        const serializedTransaction = (await account.signTransaction(
+          request as never,
+          {
+            serializer,
+          },
+        )) as Hash
+        return (await getAction(
+          client_,
+          sendRawTransactionSync,
+          'sendRawTransactionSync',
+        )({
+          serializedTransaction,
+          throwOnReceiptRevert,
+          timeout: parameters.timeout,
+        })) as never
       }
 
-      // Prepare the request for signing (assign appropriate fees, etc.)
-      const request = await getAction(
-        client,
-        prepareTransactionRequest,
-        'prepareTransactionRequest',
-      )({
-        account,
-        accessList,
-        authorizationList,
-        blobs,
-        chain,
-        data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
-        gas,
-        gasPrice,
-        maxFeePerBlobGas,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce,
-        nonceManager: account.nonceManager,
-        parameters: [...defaultParameters, 'sidecars'],
-        type,
-        value,
-        ...rest,
-        to,
-      } as any)
+      const retry = getFallbackRetry(client)
+      if (retry)
+        return await retry(async ({ index, transport }) => {
+          try {
+            return await send(
+              withRetryingTransport(client, { index, transport }) as never,
+            )
+          } catch (err) {
+            if (
+              nonceManagerParameters &&
+              !(err instanceof TransactionReceiptRevertedError)
+            ) {
+              account.nonceManager?.reset(nonceManagerParameters)
+              nonceManagerParameters = undefined
+            }
+            throw err
+          }
+        })
 
-      const serializer = chain?.serializers?.transaction
-      const serializedTransaction = (await account.signTransaction(
-        request as never,
-        {
-          serializer,
-        },
-      )) as Hash
-      return (await getAction(
-        client,
-        sendRawTransactionSync,
-        'sendRawTransactionSync',
-      )({
-        serializedTransaction,
-        throwOnReceiptRevert,
-        timeout: parameters.timeout,
-      })) as never
+      return await send(client)
     }
 
     if (account?.type === 'smart')

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -1,8 +1,10 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { createHttpServer } from '~test/utils.js'
+import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
 import { getBlockNumber } from '../../actions/public/getBlockNumber.js'
-import { localhost } from '../../chains/index.js'
+import { sendTransaction } from '../../actions/wallet/sendTransaction.js'
+import { localhost, mainnet } from '../../chains/index.js'
 import {
   InternalRpcError,
   MethodNotSupportedRpcError,
@@ -12,7 +14,9 @@ import {
 import { wait } from '../../utils/wait.js'
 import { createClient } from '../createClient.js'
 import { createPublicClient } from '../createPublicClient.js'
+import { createWalletClient } from '../createWalletClient.js'
 import type { Transport } from './createTransport.js'
+import { custom } from './custom.js'
 import {
   type FallbackTransport,
   fallback,
@@ -810,6 +814,61 @@ describe('client', () => {
 
     expect(await getBlockNumber(client)).toBe(1n)
     expect(count).toBe(2)
+  })
+
+  test('sendTransaction retries the operation on a single transport', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const calls: string[] = []
+    const hash =
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        custom({
+          async request({ method }) {
+            calls.push(`a:${method}`)
+            if (method === 'eth_getTransactionCount') return '0x0'
+            if (method === 'eth_sendRawTransaction')
+              throw { code: -32000, message: 'nonce too low' }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method }) {
+            calls.push(`b:${method}`)
+            if (method === 'eth_getTransactionCount') return '0x1'
+            if (method === 'eth_sendRawTransaction') return hash
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    expect(
+      await sendTransaction(client, {
+        chainId: mainnet.id,
+        gas: 21_000n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        to: account.address,
+        type: 'eip1559',
+        value: 1n,
+      }),
+    ).toBe(hash)
+    expect(calls).toMatchInlineSnapshot(`
+      [
+        "a:eth_fillTransaction",
+        "a:eth_getTransactionCount",
+        "a:eth_sendRawTransaction",
+        "b:eth_fillTransaction",
+        "b:eth_getTransactionCount",
+        "b:eth_sendRawTransaction",
+      ]
+    `)
   })
 
   test('all error (non deterministic)', async () => {

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -34,6 +34,18 @@ export type OnResponseFn = (
   ),
 ) => void
 
+export type FallbackTransportRetryFn = <returnType>(
+  fn: (parameters: {
+    index: number
+    transport: ReturnType<Transport>
+  }) => Promise<returnType>,
+) => Promise<returnType>
+
+const retryByRequest = new WeakMap<
+  ReturnType<Transport>['request'],
+  FallbackTransportRetryFn
+>()
+
 type RankOptions = {
   /**
    * The polling interval (in ms) at which the ranker should ping the RPC URL.
@@ -121,6 +133,62 @@ export function fallback<const transports extends readonly Transport[]>(
 
     let onResponse: OnResponseFn = () => {}
 
+    const getTransport = (i: number) => {
+      const transport = transports[i]({
+        ...rest,
+        chain,
+        retryCount: 0,
+        timeout,
+      })
+      return {
+        ...transport,
+        async request({ method, params }, options) {
+          try {
+            const response = await transport.request(
+              {
+                method,
+                params,
+              } as any,
+              options,
+            )
+
+            onResponse({
+              method,
+              params: params as unknown[],
+              response,
+              transport,
+              status: 'success',
+            })
+
+            return response
+          } catch (err) {
+            onResponse({
+              error: err as Error,
+              method,
+              params: params as unknown[],
+              transport,
+              status: 'error',
+            })
+
+            throw err
+          }
+        },
+      } as ReturnType<Transport>
+    }
+
+    const retry: FallbackTransportRetryFn = async (fn) => {
+      const fetch = async (i = 0): Promise<any> => {
+        try {
+          return await fn({ index: i, transport: getTransport(i) })
+        } catch (err) {
+          if (shouldThrow_(err as Error)) throw err
+          if (i === transports.length - 1) throw err
+          return fetch(i + 1)
+        }
+      }
+      return fetch()
+    }
+
     const transport = createTransport(
       {
         key,
@@ -129,36 +197,15 @@ export function fallback<const transports extends readonly Transport[]>(
           let includes: boolean | undefined
 
           const fetch = async (i = 0): Promise<any> => {
-            const transport = transports[i]({
-              ...rest,
-              chain,
-              retryCount: 0,
-              timeout,
-            })
+            const transport = getTransport(i)
             try {
               const response = await transport.request({
                 method,
                 params,
               } as any)
 
-              onResponse({
-                method,
-                params: params as unknown[],
-                response,
-                transport,
-                status: 'success',
-              })
-
               return response
             } catch (err) {
-              onResponse({
-                error: err as Error,
-                method,
-                params: params as unknown[],
-                transport,
-                status: 'error',
-              })
-
               if (shouldThrow_(err as Error)) throw err
 
               // If we've reached the end of the fallbacks, throw the error.
@@ -186,9 +233,12 @@ export function fallback<const transports extends readonly Transport[]>(
       },
       {
         onResponse: (fn: OnResponseFn) => (onResponse = fn),
-        transports: transports.map((fn) => fn({ chain, retryCount: 0 })),
+        transports: transports.map((_, i) => getTransport(i)) as {
+          [key in keyof transports]: ReturnType<transports[key]>
+        },
       },
     )
+    retryByRequest.set(transport.request, retry)
 
     if (rank) {
       const rankOptions = (typeof rank === 'object' ? rank : {}) as RankOptions
@@ -208,6 +258,7 @@ export function fallback<const transports extends readonly Transport[]>(
 }
 
 export function shouldThrow(error: Error) {
+  if (error.name === 'TransactionReceiptRevertedError') return true
   if ('code' in error && typeof error.code === 'number') {
     if (
       error.code === TransactionRejectedRpcError.code ||
@@ -219,6 +270,11 @@ export function shouldThrow(error: Error) {
       return true
   }
   return false
+}
+
+/** @internal */
+export function getFallbackRetry(request: ReturnType<Transport>['request']) {
+  return retryByRequest.get(request)
 }
 
 /** @internal */

--- a/src/utils/withRetryingTransport.ts
+++ b/src/utils/withRetryingTransport.ts
@@ -1,0 +1,49 @@
+import type { Client } from '../clients/createClient.js'
+import type { Transport } from '../clients/transports/createTransport.js'
+import { getFallbackRetry as getFallbackTransportRetry } from '../clients/transports/fallback.js'
+
+export function getFallbackRetry(client: Client<Transport>) {
+  return getFallbackTransportRetry(client.request)
+}
+
+export function withRetryingTransport<client extends Client<Transport>>(
+  client: client,
+  {
+    index,
+    transport,
+  }: {
+    index: number
+    transport: ReturnType<Transport>
+  },
+): client {
+  const {
+    account,
+    batch,
+    cacheTime,
+    ccipRead,
+    chain,
+    dataSuffix,
+    experimental_blockTag,
+    key,
+    name,
+    pollingInterval,
+    type,
+  } = client
+
+  return {
+    account,
+    batch,
+    cacheTime,
+    ccipRead,
+    chain,
+    dataSuffix,
+    experimental_blockTag,
+    key,
+    name,
+    pollingInterval,
+    request: transport.request,
+    transport: { ...transport.config, ...transport.value },
+    type,
+    uid: `${client.uid}.${index}`,
+  } as client
+}


### PR DESCRIPTION
Fallback local-account transaction sends now run the full prepare/sign/send attempt against one child transport. When a retryable RPC error occurs, viem moves to the next fallback transport and rebuilds the request before signing again.

This prevents nonce, gas, or `eth_fillTransaction` state from one RPC being mixed with `eth_sendRawTransaction` on another. Nonce-manager state is reset between failed fallback attempts. Closes https://github.com/wevm/viem/issues/4509.

Validated with `pnpm exec tsc --project ./tsconfig.build.json --noEmit`, `SKIP_GLOBAL_SETUP=true pnpm test src/clients/transports/fallback.test.ts`, `pnpm exec biome check --write ...`, and `git diff --check`.
