### PR TITLE
fix: detect `waitForTransactionReceipt` replacements by sender and nonce

### DIFF
--- a/.changeset/neat-buckets-smile.md
+++ b/.changeset/neat-buckets-smile.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `waitForTransactionReceipt` replacement detection when the original transaction was unavailable by hash.

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -291,6 +291,7 @@ export {
   type ReplacementReturnType,
   type WaitForTransactionReceiptErrorType,
   type WaitForTransactionReceiptParameters,
+  type WaitForTransactionReceiptReplacement,
   type WaitForTransactionReceiptReturnType,
   waitForTransactionReceipt,
 } from './public/waitForTransactionReceipt.js'

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -3,7 +3,10 @@ import { anvilMainnet } from '~test/anvil.js'
 import { accounts } from '~test/constants.js'
 import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
 import { prepareTransactionRequest } from '../../actions/index.js'
-import { WaitForTransactionReceiptTimeoutError } from '../../errors/transaction.js'
+import {
+  TransactionNotFoundError,
+  WaitForTransactionReceiptTimeoutError,
+} from '../../errors/transaction.js'
 import { hexToNumber } from '../../utils/encoding/fromHex.js'
 import { keccak256 } from '../../utils/index.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
@@ -479,6 +482,79 @@ describe('replaced transactions', () => {
     expect(replacement.replacedTransaction).toBeDefined()
     expect(replacement.transaction).toBeDefined()
     expect(replacement.transactionReceipt).toBeDefined()
+  })
+
+  test('repriced (original transaction unavailable)', async () => {
+    setup()
+
+    await mine(client, { blocks: 10 })
+
+    const nonce = hexToNumber(
+      (await client.request({
+        method: 'eth_getTransactionCount',
+        params: [sourceAccount.address, 'latest'],
+      })) ?? '0x0',
+    )
+    const hash =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    const replacementHash = await sendTransaction(client, {
+      account: sourceAccount.address,
+      to: targetAccount.address,
+      value: parseEther('1'),
+      nonce,
+      maxFeePerGas: parseGwei('20'),
+    })
+    await mine(client, { blocks: 1 })
+
+    const replacementTransaction = await getTransactionModule.getTransaction(
+      client,
+      { hash: replacementHash },
+    )
+    const getTransaction_ = getTransactionModule.getTransaction
+    const getTransaction = vi
+      .spyOn(getTransactionModule, 'getTransaction')
+      .mockImplementation(async (client_, parameters) => {
+        if ('hash' in parameters && parameters.hash === hash)
+          throw new TransactionNotFoundError({ hash })
+        if (
+          'sender' in parameters &&
+          parameters.sender === sourceAccount.address &&
+          parameters.nonce === nonce
+        )
+          return replacementTransaction as never
+        return getTransaction_(client_ as never, parameters as never) as never
+      })
+
+    let replacement: any
+    try {
+      const receipt = await waitForTransactionReceipt(client, {
+        hash,
+        replacement: {
+          from: sourceAccount.address,
+          nonce,
+          to: targetAccount.address,
+          value: parseEther('1'),
+          input: '0x',
+        },
+        retryCount: 0,
+        onReplaced: (replacement_) => (replacement = replacement_),
+      })
+
+      expect(receipt.transactionHash).toBe(replacementHash)
+      expect(replacement.reason).toBe('repriced')
+      expect(replacement.replacedTransaction).toBeDefined()
+      expect(replacement.transaction.hash).toBe(replacementHash)
+      expect(replacement.transactionReceipt.transactionHash).toBe(
+        replacementHash,
+      )
+      expect(getTransaction).toHaveBeenCalledWith(client, {
+        sender: sourceAccount.address,
+        nonce,
+      })
+    } finally {
+      getTransaction.mockRestore()
+    }
   })
 
   test('checkReplacement: false', async () => {

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { BlockNotFoundError } from '../../errors/block.js'
@@ -9,7 +10,7 @@ import {
 } from '../../errors/transaction.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
-import type { Hash } from '../../types/misc.js'
+import type { Hash, Hex } from '../../types/misc.js'
 import type { Transaction } from '../../types/transaction.js'
 import { getAction } from '../../utils/getAction.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
@@ -50,6 +51,29 @@ export type WaitForTransactionReceiptReturnType<
   chain extends Chain | undefined = Chain | undefined,
 > = GetTransactionReceiptReturnType<chain>
 
+export type WaitForTransactionReceiptReplacement = {
+  /**
+   * The original transaction sender.
+   */
+  from: Address
+  /**
+   * The original transaction nonce.
+   */
+  nonce: number
+  /**
+   * The original transaction calldata.
+   */
+  input?: Hex | undefined
+  /**
+   * The original transaction recipient.
+   */
+  to?: Address | null | undefined
+  /**
+   * The original transaction value.
+   */
+  value?: bigint | undefined
+}
+
 export type WaitForTransactionReceiptParameters<
   chain extends Chain | undefined = Chain | undefined,
 > = {
@@ -67,6 +91,13 @@ export type WaitForTransactionReceiptParameters<
   hash: Hash
   /** Optional callback to emit if the transaction has been replaced. */
   onReplaced?: ((response: ReplacementReturnType<chain>) => void) | undefined
+  /**
+   * Optional transaction replacement lookup information.
+   *
+   * Used to detect replacements when the original transaction is no longer
+   * available by hash.
+   */
+  replacement?: WaitForTransactionReceiptReplacement | undefined
   /**
    * Polling frequency (in ms). Defaults to the client's pollingInterval config.
    * @default client.pollingInterval
@@ -109,6 +140,9 @@ export type WaitForTransactionReceiptErrorType =
  *     - Calls [`eth_getBlockByNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber) and extracts the transactions
  *     - Checks if one of the Transactions is a replacement
  *     - If so, calls [`eth_getTransactionReceipt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getTransactionReceipt).
+ *   - If replacement lookup information is provided and the original Transaction is unavailable:
+ *     - Calls `eth_getTransactionBySenderAndNonce` to find the replacement Transaction
+ *     - If so, calls [`eth_getTransactionReceipt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getTransactionReceipt).
  *
  * The `waitForTransactionReceipt` action additionally supports Replacement detection (e.g. sped up Transactions).
  *
@@ -147,6 +181,7 @@ export async function waitForTransactionReceipt<
     confirmations = 1,
     hash,
     onReplaced,
+    replacement,
     retryCount = 6,
     retryDelay = ({ count }) => ~~(1 << count) * 200, // exponential backoff
     timeout = 180_000,
@@ -179,6 +214,91 @@ export async function waitForTransactionReceipt<
         reject(new WaitForTransactionReceiptTimeoutError({ hash }))
       }, timeout)
     : undefined
+
+  const getReplacementReason = (
+    replacementTransaction: Transaction,
+    replacedTransaction: Partial<Transaction>,
+  ): ReplacementReason => {
+    if (
+      typeof replacedTransaction.to !== 'undefined' &&
+      typeof replacedTransaction.value !== 'undefined' &&
+      typeof replacedTransaction.input !== 'undefined' &&
+      replacementTransaction.to === replacedTransaction.to &&
+      replacementTransaction.value === replacedTransaction.value &&
+      replacementTransaction.input === replacedTransaction.input
+    )
+      return 'repriced'
+    if (
+      replacementTransaction.from === replacementTransaction.to &&
+      replacementTransaction.value === 0n
+    )
+      return 'cancelled'
+    return 'replaced'
+  }
+
+  const getReplacementTransaction = async (
+    blockNumber: bigint,
+  ): Promise<GetTransactionReturnType<chain> | undefined> => {
+    if (transaction) {
+      // Let's retrieve the transactions from the current block.
+      // We need to retry as some RPC Providers may be slow to sync
+      // up mined blocks.
+      retrying = true
+      try {
+        const block = await withRetry(
+          () =>
+            getAction(
+              client,
+              getBlock,
+              'getBlock',
+            )({
+              blockNumber,
+              includeTransactions: true,
+            }),
+          {
+            delay: retryDelay,
+            retryCount,
+            shouldRetry: ({ error }) => error instanceof BlockNotFoundError,
+          },
+        )
+
+        return (block.transactions as {} as Transaction[]).find(
+          ({ from, nonce }) =>
+            from === transaction!.from && nonce === transaction!.nonce,
+        ) as GetTransactionReturnType<chain> | undefined
+      } finally {
+        retrying = false
+      }
+    }
+
+    if (!replacement) return undefined
+
+    retrying = true
+    try {
+      const replacementTransaction = await withRetry(
+        () =>
+          getAction(
+            client,
+            getTransaction,
+            'getTransaction',
+          )({
+            sender: replacement.from,
+            nonce: replacement.nonce,
+          }),
+        {
+          delay: retryDelay,
+          retryCount,
+          shouldRetry: ({ error }) => error instanceof TransactionNotFoundError,
+        },
+      ).catch(() => undefined)
+
+      return replacementTransaction as
+        | GetTransactionReturnType<chain>
+        | undefined
+    } finally {
+      retrying = false
+    }
+  }
 
   _unobserve = observe(
     observerId,
@@ -273,53 +393,40 @@ export async function waitForTransactionReceipt<
 
             done(() => emit.resolve(receipt!))
           } catch (err) {
+            retrying = false
+
             // If the receipt is not found, the transaction will be pending.
             // We need to check if it has potentially been replaced.
             if (
               err instanceof TransactionNotFoundError ||
               err instanceof TransactionReceiptNotFoundError
             ) {
-              if (!transaction) {
-                retrying = false
+              if (!checkReplacement || (!transaction && !replacement)) {
                 return
               }
 
               try {
-                replacedTransaction = transaction
+                replacedTransaction =
+                  transaction ??
+                  ({
+                    from: replacement!.from,
+                    hash,
+                    input: replacement!.input,
+                    nonce: replacement!.nonce,
+                    to: replacement!.to,
+                    value: replacement!.value,
+                  } as GetTransactionReturnType<chain>)
 
-                // Let's retrieve the transactions from the current block.
-                // We need to retry as some RPC Providers may be slow to sync
-                // up mined blocks.
-                retrying = true
-                const block = await withRetry(
-                  () =>
-                    getAction(
-                      client,
-                      getBlock,
-                      'getBlock',
-                    )({
-                      blockNumber,
-                      includeTransactions: true,
-                    }),
-                  {
-                    delay: retryDelay,
-                    retryCount,
-                    shouldRetry: ({ error }) =>
-                      error instanceof BlockNotFoundError,
-                  },
-                )
-                retrying = false
-
-                const replacementTransaction = (
-                  block.transactions as {} as Transaction[]
-                ).find(
-                  ({ from, nonce }) =>
-                    from === replacedTransaction!.from &&
-                    nonce === replacedTransaction!.nonce,
-                )
+                const replacementTransaction =
+                  await getReplacementTransaction(blockNumber)
 
                 // If we couldn't find a replacement transaction, continue polling.
                 if (!replacementTransaction) return
+
+                if (replacementTransaction.hash === hash) {
+                  transaction = replacementTransaction
+                  return
+                }
 
                 // If we found a replacement transaction, return it's receipt.
                 receipt = await getAction(
@@ -328,7 +435,13 @@ export async function waitForTransactionReceipt<
                   'getTransactionReceipt',
                 )({
                   hash: replacementTransaction.hash,
+                }).catch((error) => {
+                  if (error instanceof TransactionReceiptNotFoundError)
+                    return undefined
+                  throw error
                 })
+
+                if (!receipt) return
 
                 // Check if we have enough confirmations. If not, continue polling.
                 if (
@@ -338,25 +451,16 @@ export async function waitForTransactionReceipt<
                 )
                   return
 
-                let reason: ReplacementReason = 'replaced'
-                if (
-                  replacementTransaction.to === replacedTransaction.to &&
-                  replacementTransaction.value === replacedTransaction.value &&
-                  replacementTransaction.input === replacedTransaction.input
-                ) {
-                  reason = 'repriced'
-                } else if (
-                  replacementTransaction.from === replacementTransaction.to &&
-                  replacementTransaction.value === 0n
-                ) {
-                  reason = 'cancelled'
-                }
+                const reason = getReplacementReason(
+                  replacementTransaction as Transaction,
+                  replacedTransaction,
+                )
 
                 done(() => {
                   emit.onReplaced?.({
                     reason,
                     replacedTransaction: replacedTransaction! as any,
-                    transaction: replacementTransaction,
+                    transaction: replacementTransaction as Transaction,
                     transactionReceipt: receipt!,
                   })
                   emit.resolve(receipt!)

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -1862,6 +1862,9 @@ export type PublicActions<
    *     - Calls [`eth_getBlockByNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber) and extracts the transactions
    *     - Checks if one of the Transactions is a replacement
    *     - If so, calls [`eth_getTransactionReceipt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getTransactionReceipt).
+   *   - If replacement lookup information is provided and the original Transaction is unavailable:
+   *     - Calls `eth_getTransactionBySenderAndNonce` to find the replacement Transaction
+   *     - If so, calls [`eth_getTransactionReceipt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getTransactionReceipt).
    *
    * @remarks
    * The `waitForTransactionReceipt` action additionally supports Replacement detection (e.g. sped up Transactions).

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,6 +308,7 @@ export type {
   ReplacementReturnType,
   WaitForTransactionReceiptErrorType,
   WaitForTransactionReceiptParameters,
+  WaitForTransactionReceiptReplacement,
   WaitForTransactionReceiptReturnType,
 } from './actions/public/waitForTransactionReceipt.js'
 export type {


### PR DESCRIPTION
`waitForTransactionReceipt` now accepts original transaction replacement lookup hints (`from`, `nonce`, plus optional `to`, `value`, and `input`). When the original hash is unavailable, viem uses those hints to call `eth_getTransactionBySenderAndNonce` before resolving the replacement receipt.

This fixes replacement detection for transactions that were dropped before `eth_getTransactionByHash` could return them, while preserving the existing block-scan path when the original transaction is available. Closes https://github.com/wevm/viem/issues/3875.

Validated with `pnpm exec biome check --write ...`, `pnpm exec tsc --project ./tsconfig.build.json --noEmit`, and `SKIP_GLOBAL_SETUP=true pnpm test src/actions/public/waitForTransactionReceipt.test.ts`.
