### PR TITLE
feat(tempo): expose Chain namespace

### DIFF
--- a/.changeset/quick-tempo-chains.md
+++ b/.changeset/quick-tempo-chains.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Tempo chain exports to `viem/tempo` and `viem/tempo/chains`.

--- a/site/pages/tempo/accounts/index.mdx
+++ b/site/pages/tempo/accounts/index.mdx
@@ -8,15 +8,14 @@ These accounts are fully backwards compatible with Viem APIs, meaning you can us
 
 ```ts twoslash [example.ts]
 import { createWalletClient, http } from 'viem'
-import { Account, WebAuthnP256 } from 'viem/tempo'
-import { tempoModerato } from 'viem/chains'
+import { Account, Chain, WebAuthnP256 } from 'viem/tempo'
 
 // Create a passkey account
 const credential = await WebAuthnP256.createCredential({ label: 'Example' })
 const account = Account.fromWebAuthnP256(credential)
 
 const client = createWalletClient({
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 

--- a/site/pages/tempo/actions/wallet.deposit.mdx
+++ b/site/pages/tempo/actions/wallet.deposit.mdx
@@ -21,13 +21,12 @@ const result = await Actions.wallet.deposit(client, {
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"
 import { Provider } from 'accounts'
 import { createClient, custom, publicActions, walletActions } from 'viem'
-import { tempo } from 'viem/chains'
-import { tempoActions } from 'viem/tempo'
+import { Chain, tempoActions } from 'viem/tempo'
 
 const provider = Provider.create()
 
 export const client = createClient({
-  chain: tempo,
+  chain: Chain.mainnet,
   transport: custom(provider),
 })
   .extend(publicActions)

--- a/site/pages/tempo/actions/wallet.swap.mdx
+++ b/site/pages/tempo/actions/wallet.swap.mdx
@@ -24,13 +24,12 @@ console.log('Transaction hash:', receipt.transactionHash)
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"
 import { Provider } from 'accounts'
 import { createClient, custom, publicActions, walletActions } from 'viem'
-import { tempo } from 'viem/chains'
-import { tempoActions } from 'viem/tempo'
+import { Chain, tempoActions } from 'viem/tempo'
 
 const provider = Provider.create()
 
 export const client = createClient({
-  chain: tempo,
+  chain: Chain.mainnet,
   transport: custom(provider),
 })
   .extend(publicActions)

--- a/site/pages/tempo/actions/wallet.transfer.mdx
+++ b/site/pages/tempo/actions/wallet.transfer.mdx
@@ -24,13 +24,12 @@ console.log('Transaction hash:', receipt.transactionHash)
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"
 import { Provider } from 'accounts'
 import { createClient, custom, publicActions, walletActions } from 'viem'
-import { tempo } from 'viem/chains'
-import { tempoActions } from 'viem/tempo'
+import { Chain, tempoActions } from 'viem/tempo'
 
 const provider = Provider.create()
 
 export const client = createClient({
-  chain: tempo,
+  chain: Chain.mainnet,
   transport: custom(provider),
 })
   .extend(publicActions)

--- a/site/pages/tempo/chains.mdx
+++ b/site/pages/tempo/chains.mdx
@@ -3,11 +3,32 @@
 The following Tempo chains are available:
 
 ```ts
+import { Chain } from 'viem/tempo'
+
+Chain.mainnet // [!code hl]
+Chain.testnet // [!code hl]
+Chain.devnet // [!code hl]
+Chain.localnet // [!code hl]
+Chain.moderato // [!code hl]
+```
+
+You can also import Tempo chains by name from `viem/tempo/chains`:
+
+```ts
 import {
+  tempo, // [!code hl]
+  tempoMainnet, // [!code hl]
   tempoDevnet, // [!code hl]
   tempoLocalnet, // [!code hl]
   tempoModerato, // [!code hl]
-} from 'viem/chains'
+  tempoTestnet, // [!code hl]
+} from 'viem/tempo/chains'
+```
+
+Tempo chains are still exported from `viem/chains` if you prefer to import them from the shared chains entrypoint:
+
+```ts
+import { tempo, tempoModerato } from 'viem/chains'
 ```
 
 ## Default Fee Token
@@ -17,9 +38,9 @@ It is possible to set a default fee token for a Tempo chain by adding a `feeToke
 Once set, all transactions will use this token as the default fee token, unless an override is provided at the transaction level.
 
 ```ts
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
-const chain = tempoModerato.extend({
+const chain = Chain.testnet.extend({
   feeToken: '0x20c0000000000000000000000000000000000001',
 })
 ```

--- a/site/pages/tempo/index.mdx
+++ b/site/pages/tempo/index.mdx
@@ -42,8 +42,10 @@ In the snippet below, we will set up a Tempo chain, and extend our client with `
 It is also possible to set up a default fee token by adding a `feeToken` property to the chain.
 
 ```ts
+import { Chain } from 'viem/tempo'
+
 export const client = createClient({
-  chain: tempoModerato.extend({ // [!code hl]
+  chain: Chain.testnet.extend({ // [!code hl]
     feeToken: '0x20c0000000000000000000000000000000000001', // [!code hl]
   }), // [!code hl]
   // ...

--- a/site/pages/tempo/transactions.mdx
+++ b/site/pages/tempo/transactions.mdx
@@ -7,16 +7,16 @@ Tempo Transactions are a Tempo-native EIP-2718 transaction type designed for pay
 ## Setup 
 
 In order to use Tempo Transactions, ensure that you have set up your Viem client
-with the `tempoModerato` chain.
+with `Chain.testnet`.
 
 ```ts twoslash [viem.config.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains' // [!code focus]
+import { Chain } from 'viem/tempo' // [!code focus]
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato, // [!code focus]
+  chain: Chain.testnet, // [!code focus]
   transport: http(),
 })
 ```
@@ -47,11 +47,11 @@ const receipt = await client.sendTransactionSync({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts" filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -64,11 +64,11 @@ You can also set a default `feeToken` globally by extending the chain.
 ```ts twoslash [example.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato.extend({ // [!code focus] 
+  chain: Chain.testnet.extend({ // [!code focus] 
     feeToken: '0x20c0000000000000000000000000000000000001'  // [!code focus]
   }), // [!code focus]
   transport: http(),
@@ -127,11 +127,11 @@ const receipt = await client.sendTransactionSync({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -172,11 +172,11 @@ const receipt = await client.sendTransactionSync({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -223,11 +223,11 @@ const receipt = await client.sendTransactionSync({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -268,11 +268,11 @@ const [receipt1, receipt2, receipt3] = await Promise.all([
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -302,11 +302,11 @@ const hash2 = await client.sendTransaction({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```
@@ -335,11 +335,11 @@ const receipt = await client.sendTransactionSync({
 ```tsx twoslash [viem.config.ts] filename="viem.config.ts"
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 
 export const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
 ```

--- a/site/pages/tempo/transports/withFeePayer.mdx
+++ b/site/pages/tempo/transports/withFeePayer.mdx
@@ -14,12 +14,11 @@ Creates a transport that routes transactions to a relay service when a `feePayer
 ```ts twoslash [example.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { Chain, withFeePayer } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: withFeePayer(
     http(),                               // ← Default Transport
     http('https://sponsor.example.com'),  // ← Fee Payer Transport // [!code hl]
@@ -56,12 +55,11 @@ See `server.ts` for the server-side implementation. It uses [`Handler.relay` pro
 ```ts twoslash [client.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { Chain, withFeePayer } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: withFeePayer(
     http(),
     http('http://localhost:3000'),
@@ -79,11 +77,11 @@ const hash = await client.sendTransactionSync({
 import { createServer } from 'node:http'
 import { createClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 import { Handler } from 'tempo.ts/server'
 
 const client = createClient({
-  chain: tempoModerato.extend({
+  chain: Chain.testnet.extend({
     // Note: the fee payer can specify their own fee token.
     feeToken: '0x20c0000000000000000000000000000000000001'
   }),

--- a/site/pages/tempo/transports/withRelay.mdx
+++ b/site/pages/tempo/transports/withRelay.mdx
@@ -18,12 +18,11 @@ Creates a transport that routes Tempo relay traffic between a default transport 
 ```ts twoslash [example.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
-import { withRelay } from 'viem/tempo'
+import { Chain, withRelay } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: withRelay(
     http(),                             // ← Default Transport
     http('https://relay.example.com'),  // ← Relay Transport // [!code hl]
@@ -59,12 +58,11 @@ See `server.ts` for the server-side implementation. It uses [`Handler.relay` pro
 ```ts twoslash [client.ts]
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
-import { withRelay } from 'viem/tempo'
+import { Chain, withRelay } from 'viem/tempo'
 
 const client = createWalletClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: withRelay(
     http(),
     http('http://localhost:3000'),
@@ -82,11 +80,11 @@ const hash = await client.sendTransactionSync({
 import { createServer } from 'node:http'
 import { createClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { Chain } from 'viem/tempo'
 import { Handler } from 'accounts/server'
 
 const client = createClient({
-  chain: tempoModerato.extend({
+  chain: Chain.testnet.extend({
     // Note: the relay can specify its own fee token.
     feeToken: '0x20c0000000000000000000000000000000000001',
   }),

--- a/site/snippets/tempo/viem.config.ts
+++ b/site/snippets/tempo/viem.config.ts
@@ -1,12 +1,11 @@
 // [!region setup]
 import { createClient, http, publicActions, walletActions } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
-import { tempoActions } from 'viem/tempo'
+import { Chain, tempoActions } from 'viem/tempo'
 
 export const client = createClient({
   account: privateKeyToAccount('0x...'),
-  chain: tempoModerato,
+  chain: Chain.testnet,
   transport: http(),
 })
   .extend(publicActions)

--- a/src/tempo/Chain.ts
+++ b/src/tempo/Chain.ts
@@ -1,0 +1,20 @@
+// biome-ignore lint/performance/noBarrelFile: namespace module
+export {
+  tempo,
+  tempo as mainnet,
+  tempo as tempoMainnet,
+} from '../chains/definitions/tempo.js'
+export {
+  tempoDevnet,
+  tempoDevnet as devnet,
+} from '../chains/definitions/tempoDevnet.js'
+export {
+  tempoLocalnet,
+  tempoLocalnet as localnet,
+} from '../chains/definitions/tempoLocalnet.js'
+export {
+  tempoModerato,
+  tempoModerato as moderato,
+  tempoModerato as tempoTestnet,
+  tempoModerato as testnet,
+} from '../chains/definitions/tempoModerato.js'

--- a/src/tempo/chains/index.ts
+++ b/src/tempo/chains/index.ts
@@ -1,8 +1,9 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
-export { tempo, tempo as tempoMainnet } from '../../chains/definitions/tempo.js'
-export { tempoDevnet } from '../../chains/definitions/tempoDevnet.js'
-export { tempoLocalnet } from '../../chains/definitions/tempoLocalnet.js'
 export {
+  tempo,
+  tempoDevnet,
+  tempoLocalnet,
+  tempoMainnet,
   tempoModerato,
-  tempoModerato as tempoTestnet,
-} from '../../chains/definitions/tempoModerato.js'
+  tempoTestnet,
+} from '../Chain.js'

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -24,6 +24,7 @@ export * as Account from './Account.js'
 export * as Addresses from './Addresses.js'
 export * as Actions from './actions/index.js'
 export * as Capabilities from './Capabilities.js'
+export * as Chain from './Chain.js'
 export {
   type Decorator as TempoActions,
   decorator as tempoActions,


### PR DESCRIPTION
Adds a `Chain` namespace to `viem/tempo` for Tempo chain aliases and updates Tempo docs to use it. The docs also call out that users can still import Tempo chains from `viem/chains` or use the lighter `viem/tempo/chains` entrypoint.

```ts
import { Chain } from 'viem/tempo'
import { tempoMainnet } from 'viem/tempo/chains'
import { tempoModerato } from 'viem/chains'

const mainnet = Chain.mainnet
const testnet = Chain.testnet
```