### PR TITLE
fix(tempo): update `wallet.deposit` params

### DIFF
--- a/.changeset/wallet-deposit-amount.md
+++ b/.changeset/wallet-deposit-amount.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Updated `wallet.deposit` to use `amount` and supported token symbols for `wallet_deposit` requests.

--- a/site/pages/tempo/actions/wallet.deposit.mdx
+++ b/site/pages/tempo/actions/wallet.deposit.mdx
@@ -13,8 +13,8 @@ import { Actions } from 'viem/tempo'
 import { client } from './viem.config'
 
 const result = await Actions.wallet.deposit(client, {
-  token: '0x20c0000000000000000000000000000000000001',
-  value: '1.5',
+  amount: '1.5',
+  token: 'pathUsd',
 })
 ```
 
@@ -57,13 +57,7 @@ The wallet may return `undefined` (or an object with no `receipts`) if the depos
 
 Deposit address to pre-fill.
 
-### token (optional)
-
-- **Type:** `Address`
-
-Token contract address to pre-fill. Omit to let the user choose.
-
-### value (optional)
+### amount (optional)
 
 - **Type:** `string`
 
@@ -80,3 +74,9 @@ Source chain ID to pre-fill.
 - **Type:** `string`
 
 Human-readable account display name.
+
+### token (optional)
+
+- **Type:** `Address | string`
+
+Token contract address or supported deposit token symbol to pre-fill. Omit to let the user choose.

--- a/src/tempo/actions/wallet.test.ts
+++ b/src/tempo/actions/wallet.test.ts
@@ -141,10 +141,10 @@ test('deposit', async () => {
   const requests: unknown[] = []
   const result = await wallet.deposit(client(requests), {
     address: '0x0000000000000000000000000000000000000003',
+    amount: '3.5',
     chainId: 1,
     displayName: 'Account',
-    token: '0x0000000000000000000000000000000000000004',
-    value: '3.5',
+    token: 'pathUsd',
   })
 
   expect({ requests, result }).toMatchInlineSnapshot(`
@@ -155,10 +155,10 @@ test('deposit', async () => {
           "params": [
             {
               "address": "0x0000000000000000000000000000000000000003",
+              "amount": "3.5",
               "chainId": 1,
               "displayName": "Account",
-              "token": "0x0000000000000000000000000000000000000004",
-              "value": "3.5",
+              "token": "pathUsd",
             },
           ],
         },

--- a/src/tempo/actions/wallet.ts
+++ b/src/tempo/actions/wallet.ts
@@ -213,8 +213,8 @@ export declare namespace swap {
  * })
  *
  * const result = await Actions.wallet.deposit(client, {
- *   token: '0x...',
- *   value: '1.5',
+ *   amount: '1.5',
+ *   token: 'pathUsd',
  * })
  * ```
  *
@@ -243,14 +243,17 @@ export declare namespace deposit {
   export type Parameters = {
     /** Deposit address to pre-fill. */
     address?: Address | undefined
+    /** Human-readable amount to pre-fill (for example, "1.5"). */
+    amount?: string | undefined
     /** Source chain ID to pre-fill. */
     chainId?: number | undefined
     /** Human-readable account display name. */
     displayName?: string | undefined
-    /** Token contract address to pre-fill. Omit to let the user choose. */
-    token?: Address | undefined
-    /** Human-readable amount to pre-fill (for example, "1.5"). */
-    value?: string | undefined
+    /**
+     * Token to pre-fill, accepted as either a contract address or a supported
+     * deposit token symbol. Omit to let the user choose.
+     */
+    token?: Address | string | undefined
   }
 
   export type ReturnValue =


### PR DESCRIPTION
Updates `viem/tempo`'s `wallet.deposit` helper and docs to match the current `wallet_deposit` params: `amount` for the prefilled amount and `token` as either an address or supported symbol.

This keeps the helper aligned with wallet implementations that accept token symbols such as `pathUsd`. Validated with `pnpm test src/tempo/actions/wallet.test.ts`, `pnpm check:types`, and focused Biome checks.
