### PR TITLE
fix(tempo): use configured zone rpc

### DIFF
--- a/test/src/tempo/zones.ts
+++ b/test/src/tempo/zones.ts
@@ -13,24 +13,13 @@ import {
 import { zoneModerato } from '../../../src/tempo/zones/zone.js'
 import { debugOptions } from './config.js'
 
-const credentials = import.meta.env.VITE_TEMPO_CREDENTIALS
-
 export const zone = zoneModerato(7)
 
-export const rpcUrl = 'https://rpc-zone-006-private.tempoxyz.dev'
+export const rpcUrl = zone.rpcUrls.default.http[0]!
 
 export const http = (url = rpcUrl, config: ZoneHttpConfig = {}) =>
   zoneHttp(url, {
     ...debugOptions({ rpcUrl: url }),
-    ...(credentials
-      ? {
-          fetchOptions: {
-            headers: {
-              Authorization: `Basic ${btoa(credentials)}`,
-            },
-          },
-        }
-      : {}),
     ...config,
   })
 


### PR DESCRIPTION
Updates the Tempo zone test fixture to source its RPC URL from `zoneModerato(7)` instead of the retired private `rpc-zone-006-private.tempoxyz.dev` endpoint.

The public Zone B endpoint is the canonical RPC for zone 7 and accepts the signed zone token header, so the fixture no longer adds `VITE_TEMPO_CREDENTIALS` Basic auth for zone requests.

Validated with `pnpm exec biome check test/src/tempo/zones.ts` and `pnpm exec vitest -c ./test/vitest.config.ts src/tempo/actions/zone.test.ts --run`.
