### PR TITLE
test(tempo): update export snapshot

### DIFF
--- a/src/tempo/index.test.ts
+++ b/src/tempo/index.test.ts
@@ -19,6 +19,7 @@ test('exports tempo', () => {
       "Addresses",
       "Actions",
       "Capabilities",
+      "Chain",
       "tempoActions",
       "Expiry",
       "Formatters",


### PR DESCRIPTION
Updates the `viem/tempo` export snapshot after `Chain` was added to the public module surface.

This fixes the failing `src/tempo/index.test.ts > exports tempo` check from the Changesets workflow. Validated with `pnpm test src/tempo/index.test.ts` and focused Biome.
