### PR TITLE
fix(tempo): export portable chain types

### DIFF
--- a/.changeset/soft-tempo-types.md
+++ b/.changeset/soft-tempo-types.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Tempo chain declarations to emit portable inferred types for exported derived chains.

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -767,6 +767,28 @@ export { zoraTestnet } from './definitions/zoraTestnet.js'
 // Required type exports to prevent TypeScript error "TS2742".
 
 export type {
+  /** @deprecated */
+  Signed as KeyAuthorizationSigned,
+} from 'ox/tempo/KeyAuthorization'
+export type {
+  /** @deprecated */
+  SignatureEnvelope,
+  /** @deprecated */
+  SignatureEnvelopeRpc,
+} from 'ox/tempo/SignatureEnvelope'
+export type {
+  /** @deprecated */
+  Address as TempoAddress,
+} from 'ox/tempo/TempoAddress'
+export type {
+  /** @deprecated */
+  TokenIdOrAddress,
+} from 'ox/tempo/TokenId'
+export type {
+  /** @deprecated */
+  Call as TxEnvelopeTempoCall,
+} from 'ox/tempo/TxEnvelopeTempo'
+export type {
   assertTransactionCIP42 as assertTransactionCIP42Celo,
   assertTransactionCIP64 as assertTransactionCIP64Celo,
   SerializeTransactionCIP64ReturnType,
@@ -823,6 +845,34 @@ export type {
   TransactionSerializableDeposit,
   TransactionSerializedDeposit,
 } from '../op-stack/types/transaction.js'
+export type {
+  /** @deprecated */
+  Transaction as z_Transaction,
+  /** @deprecated */
+  TransactionReceipt as z_TransactionReceipt,
+  /** @deprecated */
+  TransactionReceiptRpc as z_TransactionReceiptRpc,
+  /** @deprecated */
+  TransactionRequest as z_TransactionRequest,
+  /** @deprecated */
+  TransactionRequestRpc as z_TransactionRequestRpc,
+  /** @deprecated */
+  TransactionRequestTempo as z_TransactionRequestTempo,
+  /** @deprecated */
+  TransactionRpc as z_TransactionRpc,
+  /** @deprecated */
+  TransactionSerializable as z_TransactionSerializable,
+  /** @deprecated */
+  TransactionSerializableTempo as z_TransactionSerializableTempo,
+  /** @deprecated */
+  TransactionSerialized as z_TransactionSerialized,
+  /** @deprecated */
+  TransactionSerializedTempo as z_TransactionSerializedTempo,
+  /** @deprecated */
+  TransactionTempo as z_TransactionTempo,
+  /** @deprecated */
+  TransactionType as z_TransactionType,
+} from '../tempo/Transaction.js'
 export type {
   Assign,
   Omit,


### PR DESCRIPTION
Tempo chain definitions now expose the minimal Tempo-specific types TypeScript needs from `viem/chains`. The viem-local transaction types use deprecated `z_` exports for inference plumbing, while the external `ox` symbols remain direct deprecated exports because TS2742 does not accept aliased wrappers for them.

This keeps inferred exported Tempo chains portable for declaration emit without adding local wrapper types in `tempo/Transaction` or `chainConfig`.

Validated with `pnpm exec biome check --write src/chains/index.ts`, `pnpm clean && pnpm build:types`, and a packed external declaration-emitting consumer that reproduced the TS2742 failure.
