### PR TITLE
fix(somnia): update the somnia chain definitions

### DIFF
--- a/src/chains/definitions/somnia.ts
+++ b/src/chains/definitions/somnia.ts
@@ -4,6 +4,7 @@ export const somnia = /*#__PURE__*/ defineChain({
   id: 5031,
   name: 'Somnia',
   nativeCurrency: { name: 'Somnia', symbol: 'SOMI', decimals: 18 },
+  blockTime: 100,
   rpcUrls: {
     default: {
       http: ['https://api.infra.mainnet.somnia.network'],
@@ -14,6 +15,12 @@ export const somnia = /*#__PURE__*/ defineChain({
       name: 'Somnia Explorer',
       url: 'https://explorer.somnia.network',
       apiUrl: 'https://explorer.somnia.network/api',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0x5e44F178E8cF9B2F5409B6f18ce936aB817C5a11',
+      blockCreated: 38516341,
     },
   },
   testnet: false,

--- a/src/chains/definitions/somniaTestnet.ts
+++ b/src/chains/definitions/somniaTestnet.ts
@@ -7,7 +7,7 @@ export const somniaTestnet = /*#__PURE__*/ defineChain({
   blockTime: 100,
   rpcUrls: {
     default: {
-      http: ['https://api.infra.testnet.somnia.network/'],
+      http: ['https://api.infra.testnet.somnia.network'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/somniaTestnet.ts
+++ b/src/chains/definitions/somniaTestnet.ts
@@ -4,15 +4,16 @@ export const somniaTestnet = /*#__PURE__*/ defineChain({
   id: 50312,
   name: 'Somnia Testnet',
   nativeCurrency: { name: 'STT', symbol: 'STT', decimals: 18 },
+  blockTime: 100,
   rpcUrls: {
     default: {
-      http: ['https://dream-rpc.somnia.network'],
+      http: ['https://api.infra.testnet.somnia.network/'],
     },
   },
   blockExplorers: {
     default: {
       name: 'Somnia Testnet Explorer',
-      url: 'https://shannon-explorer.somnia.network/',
+      url: 'https://shannon-explorer.somnia.network',
       apiUrl: 'https://shannon-explorer.somnia.network/api',
     },
   },


### PR DESCRIPTION
This PR updates the somnia mainnet and testnet chain definitions to be inline with [the docs](https://docs.somnia.network/developer/network-info)

It also adds `blockTime` to both mainnet and testnet so that polling is not based off the default `12_000`