### PR TITLE
feat: export formatted transaction request extractor

### DIFF
--- a/.changeset/calm-bugs-beg.md
+++ b/.changeset/calm-bugs-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported formatted tx helper.

--- a/.changeset/calm-bugs-beg.md
+++ b/.changeset/calm-bugs-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `ExtractFormattedTransactionRequest`.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -50,7 +50,10 @@ import { blobsToCommitments } from '../../utils/blob/blobsToCommitments.js'
 import { blobsToProofs } from '../../utils/blob/blobsToProofs.js'
 import { commitmentsToVersionedHashes } from '../../utils/blob/commitmentsToVersionedHashes.js'
 import { toBlobSidecars } from '../../utils/blob/toBlobSidecars.js'
-import type { FormattedTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import type {
+  ExtractFormattedTransactionRequest,
+  FormattedTransactionRequest,
+} from '../../utils/formatters/transactionRequest.js'
 import { getAction } from '../../utils/getAction.js'
 import { LruMap } from '../../utils/lru.js'
 import type { NonceManager } from '../../utils/nonceManager.js'
@@ -98,12 +101,6 @@ type ParameterTypeToParameters<
 > = parameterType extends 'fees'
   ? 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasPrice'
   : parameterType
-type ExtractTransactionRequest<transactionRequest, transactionType> =
-  transactionRequest extends { type?: infer type | undefined }
-    ? Extract<transactionType, type> extends never
-      ? never
-      : transactionRequest
-    : never
 
 export type PrepareTransactionRequestRequest<
   chain extends Chain | undefined = Chain | undefined,
@@ -164,9 +161,9 @@ export type PrepareTransactionRequestReturnType<
     : GetTransactionType<request> extends 'legacy'
       ? unknown
       : GetTransactionType<request>,
-  _transactionRequest = ExtractTransactionRequest<
-    UnionOmit<FormattedTransactionRequest<_derivedChain>, 'from'>,
-    _transactionType
+  _transactionRequest = ExtractFormattedTransactionRequest<
+    _derivedChain,
+    { type?: _transactionType extends string ? _transactionType : undefined }
   >,
 > = Prettify<
   UnionRequiredBy<

--- a/src/index.ts
+++ b/src/index.ts
@@ -1635,6 +1635,7 @@ export {
 export {
   type DefineTransactionRequestErrorType,
   defineTransactionRequest,
+  type ExtractFormattedTransactionRequest,
   type FormatTransactionRequestErrorType,
   type FormattedTransactionRequest,
   formatTransactionRequest,

--- a/src/utils/formatters/transactionRequest.ts
+++ b/src/utils/formatters/transactionRequest.ts
@@ -11,7 +11,7 @@ import type {
   RpcTransactionRequest,
 } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
-import type { ExactPartial } from '../../types/utils.js'
+import type { ExactPartial, UnionOmit } from '../../types/utils.js'
 import { bytesToHex, numberToHex } from '../encoding/toHex.js'
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
 
@@ -22,6 +22,18 @@ export type FormattedTransactionRequest<
   'transactionRequest',
   TransactionRequest
 >
+
+export type ExtractFormattedTransactionRequest<
+  chain extends Chain | undefined,
+  request extends { type?: string | undefined },
+  ///
+  _transactionRequest = UnionOmit<FormattedTransactionRequest<chain>, 'from'>,
+  _transactionType = request['type'],
+> = _transactionRequest extends { type?: infer type | undefined }
+  ? Extract<_transactionType, type> extends never
+    ? never
+    : _transactionRequest
+  : never
 
 export const rpcTransactionType = {
   legacy: '0x0',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -341,6 +341,7 @@ export {
 export {
   type DefineTransactionRequestErrorType,
   defineTransactionRequest,
+  type ExtractFormattedTransactionRequest,
   type FormatTransactionRequestErrorType,
   type FormattedTransactionRequest,
   formatTransactionRequest,


### PR DESCRIPTION
## Summary
Export a reusable formatted transaction request extractor type.

## Motivation
Libraries building on viem need to preserve chain-specific transaction request narrowing without copying viem's internal formatted request extraction logic. Exposing this helper gives downstream libraries a stable type for deriving the formatted request branch that matches a literal transaction type.

## Changes
- Added `ExtractFormattedTransactionRequest` next to `FormattedTransactionRequest`.
- Replaced `prepareTransactionRequest`'s local extractor with the exported helper.
- Exported the helper from `viem` and `viem/utils`.
- Added a patch changeset: `Exported ExtractFormattedTransactionRequest.`

## Testing
- `pnpm exec biome check --write src/actions/wallet/prepareTransactionRequest.ts src/index.ts src/utils/formatters/transactionRequest.ts src/utils/index.ts .changeset/calm-bugs-beg.md`
- `pnpm test:typecheck src/tempo/chainConfig.test.ts` fails in this local checkout before typechecking due to the installed `ox/tempo` package not exporting `ZoneRpcAuthentication`.
