### PR TITLE
feat(tempo): manage access key authorization lifecycle

### DIFF
--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -329,6 +329,7 @@ export async function prepareTransactionRequest<
     request = await prepareTransactionRequest.fn(
       { ...request, chain },
       {
+        client,
         phase: 'beforeFillTransaction',
       },
     )
@@ -480,6 +481,7 @@ export async function prepareTransactionRequest<
     request = await prepareTransactionRequest.fn(
       { ...request, chain },
       {
+        client,
         phase: 'beforeFillParameters',
       },
     )
@@ -630,6 +632,7 @@ export async function prepareTransactionRequest<
     request = await prepareTransactionRequest.fn(
       { ...request, chain },
       {
+        client,
         phase: 'afterFillParameters',
       },
     )

--- a/src/actions/wallet/sendCalls.test.ts
+++ b/src/actions/wallet/sendCalls.test.ts
@@ -207,6 +207,36 @@ test('default', async () => {
   `)
 })
 
+test('behavior: invokes onTransactionSubmitted chain hook', async () => {
+  const submitted: unknown[] = []
+  const chain = {
+    ...mainnet,
+    onTransactionSubmitted(parameters: unknown) {
+      submitted.push(parameters)
+    },
+  }
+
+  const client = getClient({
+    chain,
+    onRequest() {},
+  })
+
+  const response = await sendCalls(client, {
+    account: accounts[0].address,
+    calls: [{ to: accounts[1].address }],
+  })
+
+  expect(submitted).toHaveLength(1)
+  expect(submitted[0]).toMatchObject({
+    account: { address: accounts[0].address },
+    id: response.id,
+    request: {
+      account: accounts[0].address,
+      calls: [{ to: accounts[1].address }],
+    },
+  })
+})
+
 test('behavior: chain on client', async () => {
   const requests: unknown[] = []
 

--- a/src/actions/wallet/sendCalls.ts
+++ b/src/actions/wallet/sendCalls.ts
@@ -11,7 +11,11 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Account, GetAccountParameter } from '../../types/account.js'
 import type { Call, Calls } from '../../types/calls.js'
 import type { ExtractCapabilities } from '../../types/capabilities.js'
-import type { Chain, DeriveChain } from '../../types/chain.js'
+import type {
+  Chain,
+  ChainTransactionRequest,
+  DeriveChain,
+} from '../../types/chain.js'
 import type { WalletSendCallsParameters } from '../../types/eip1193.js'
 import type { Hex } from '../../types/misc.js'
 import type { Prettify } from '../../types/utils.js'
@@ -161,8 +165,14 @@ export async function sendCalls<
       },
       { retryCount: 0 },
     )
-    if (typeof response === 'string') return { id: response }
-    return response as never
+    const result = typeof response === 'string' ? { id: response } : response
+    await chain?.onTransactionSubmitted?.({
+      account: account ?? undefined,
+      client,
+      id: result.id,
+      request: parameters as ChainTransactionRequest,
+    })
+    return result as never
   } catch (err) {
     const error = err as BaseError
 

--- a/src/actions/wallet/sendCallsSync.test.ts
+++ b/src/actions/wallet/sendCallsSync.test.ts
@@ -176,3 +176,30 @@ test('default', async () => {
 
   expect(response.receipts).toHaveLength(5)
 })
+
+test('behavior: invokes onTransactionConfirmed chain hook', async () => {
+  const confirmed: unknown[] = []
+  const chain = {
+    ...mainnet,
+    onTransactionConfirmed(parameters: unknown) {
+      confirmed.push(parameters)
+    },
+  }
+
+  const response = await sendCallsSync(client, {
+    account: accounts[0].address,
+    chain,
+    calls: [{ to: accounts[1].address }],
+  })
+
+  expect(response.receipts).toHaveLength(1)
+  expect(confirmed).toHaveLength(1)
+  expect(confirmed[0]).toMatchObject({
+    account: { address: accounts[0].address },
+    id: expect.any(String),
+    request: {
+      account: accounts[0].address,
+      calls: [{ to: accounts[1].address }],
+    },
+  })
+})

--- a/src/actions/wallet/sendCallsSync.ts
+++ b/src/actions/wallet/sendCallsSync.ts
@@ -1,7 +1,8 @@
+import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import type { Account } from '../../types/account.js'
-import type { Chain } from '../../types/chain.js'
+import type { Chain, ChainTransactionRequest } from '../../types/chain.js'
 import { getAction } from '../../utils/getAction.js'
 import type { GetCallsStatusReturnType } from './getCallsStatus.js'
 import {
@@ -73,7 +74,9 @@ export async function sendCallsSync<
   client: Client<Transport, chain, account>,
   parameters: SendCallsSyncParameters<chain, account, chainOverride, calls>,
 ): Promise<SendCallsSyncReturnType> {
-  const { chain = client.chain } = parameters
+  const { account: account_ = client.account, chain = client.chain } =
+    parameters
+  const account = account_ ? parseAccount(account_) : undefined
   const timeout =
     parameters.timeout ?? Math.max((chain?.blockTime ?? 0) * 3, 5_000)
   const result = await getAction(client, sendCalls, 'sendCalls')(parameters)
@@ -86,5 +89,13 @@ export async function sendCallsSync<
     id: result.id,
     timeout,
   })
+  if (status.status === 'success')
+    await chain?.onTransactionConfirmed?.({
+      account,
+      client,
+      id: result.id,
+      receipts: status.receipts,
+      request: parameters as ChainTransactionRequest,
+    })
   return status
 }

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -19,6 +19,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type {
   Chain,
+  ChainTransactionRequest,
   DeriveChain,
   GetChainParameter,
 } from '../../types/chain.js'
@@ -260,13 +261,20 @@ export async function sendTransaction<
         : 'eth_sendTransaction'
 
       try {
-        return await client.request(
+        const hash = await client.request(
           {
             method,
             params: [request],
           },
           { retryCount: 0 },
         )
+        await chain?.onTransactionSubmitted?.({
+          account: account ?? undefined,
+          client,
+          hash,
+          request,
+        })
+        return hash
       } catch (e) {
         if (isWalletNamespaceSupported === false) throw e
 
@@ -279,7 +287,7 @@ export async function sendTransaction<
           error.name === 'MethodNotFoundRpcError' ||
           error.name === 'MethodNotSupportedRpcError'
         ) {
-          return await client
+          const hash = await client
             .request(
               {
                 method: 'wallet_sendTransaction',
@@ -303,6 +311,13 @@ export async function sendTransaction<
 
               throw walletNamespaceError
             })
+          await chain?.onTransactionSubmitted?.({
+            account: account ?? undefined,
+            client,
+            hash,
+            request,
+          })
+          return hash
         }
 
         throw error
@@ -353,13 +368,20 @@ export async function sendTransaction<
           serializer,
         },
       )) as Hash
-      return await getAction(
+      const hash = await getAction(
         client,
         sendRawTransaction,
         'sendRawTransaction',
       )({
         serializedTransaction,
       })
+      await chain?.onTransactionSubmitted?.({
+        account,
+        client,
+        hash,
+        request: request as ChainTransactionRequest,
+      })
+      return hash
     }
 
     if (account?.type === 'smart')

--- a/src/actions/wallet/sendTransactionSync.ts
+++ b/src/actions/wallet/sendTransactionSync.ts
@@ -23,6 +23,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type {
   Chain,
+  ChainTransactionRequest,
   DeriveChain,
   GetChainParameter,
 } from '../../types/chain.js'
@@ -345,6 +346,12 @@ export async function sendTransactionSync<
       })
       if (throwOnReceiptRevert && receipt.status === 'reverted')
         throw new TransactionReceiptRevertedError({ receipt })
+      await chain?.onTransactionConfirmed?.({
+        account: account ?? undefined,
+        client,
+        receipt,
+        request,
+      })
       return receipt
     }
 
@@ -392,7 +399,7 @@ export async function sendTransactionSync<
           serializer,
         },
       )) as Hash
-      return (await getAction(
+      const receipt = (await getAction(
         client,
         sendRawTransactionSync,
         'sendRawTransactionSync',
@@ -401,6 +408,13 @@ export async function sendTransactionSync<
         throwOnReceiptRevert,
         timeout: parameters.timeout,
       })) as never
+      await chain?.onTransactionConfirmed?.({
+        account,
+        client,
+        receipt,
+        request: request as ChainTransactionRequest,
+      })
+      return receipt
     }
 
     if (account?.type === 'smart')

--- a/src/tempo/Account.test.ts
+++ b/src/tempo/Account.test.ts
@@ -158,6 +158,36 @@ describe('fromP256', () => {
       }
     `)
   })
+
+  test('behavior: access key with authorization', async () => {
+    const account = Account.fromSecp256k1(privateKey_secp256k1)
+    const accessKey = Account.fromP256(privateKey_p256, { access: account })
+    const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+      chainId: 1n,
+    })
+
+    const access = Account.fromP256(privateKey_p256, {
+      access: account,
+      authorization: keyAuthorization,
+    })
+
+    expect(access.accessKeyAuthorization?.status).toBe('ready')
+    expect(access.accessKeyAuthorization?.signed).toBe(keyAuthorization)
+  })
+
+  test('error: authorization without access', async () => {
+    const account = Account.fromSecp256k1(privateKey_secp256k1)
+    const accessKey = Account.fromP256(privateKey_p256, { access: account })
+    const keyAuthorization = await account.signKeyAuthorization(accessKey, {
+      chainId: 1n,
+    })
+
+    expect(() =>
+      Account.fromP256(privateKey_p256, {
+        authorization: keyAuthorization,
+      } as never),
+    ).toThrow('`authorization` requires `access`.')
+  })
 })
 
 describe('fromHeadlessWebAuthn', () => {

--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -56,21 +56,54 @@ export type RootAccount = Account_base<'root'> & {
 export type AccessKeyAccount = Account_base<'accessKey'> & {
   /** Access key ID. */
   accessKeyAddress: Address.Address
+  /** Key authorization to attach on first use. */
+  accessKeyAuthorization?: AccessKeyAuthorization | undefined
 }
 
 export type Account = OneOf<RootAccount | AccessKeyAccount>
+
+export type AccessKeyAuthorization = {
+  /** Signed key authorization. */
+  signed: KeyAuthorization.Signed
+  /** Authorization lifecycle status. */
+  status: 'ready' | 'pending' | 'consumed'
+}
 
 /** Instantiates an Account. */
 export function from<const parameters extends from.Parameters>(
   parameters: parameters | from.Parameters,
 ): from.ReturnValue<parameters> {
-  const { access } = parameters
+  const { access, authorization } = parameters
+  if (authorization && !access)
+    throw new Error('`authorization` requires `access`.')
   if (access) return fromAccessKey(parameters) as never
   return fromRoot(parameters) as never
 }
 
 export declare namespace from {
-  export type Parameters = OneOf<fromRoot.Parameters | fromAccessKey.Parameters>
+  export type Parameters = fromBase.Parameters & Options
+
+  export type Options = RootOptions | AccessKeyOptions
+
+  export type RootOptions = {
+    access?: undefined
+    authorization?: never
+    /** Access key version. Will be removed in a future release. @deprecated @internal */
+    internal_version?: 'v1' | 'v2' | undefined
+  }
+
+  export type AccessKeyOptions = {
+    /**
+     * Parent account to access.
+     * If defined, this account will act as an "access key", and use
+     * the parent account's address as the keychain address.
+     */
+    access: viem_Account | Address.Address
+    /** Signed key authorization to attach on first use. */
+    authorization?: KeyAuthorization.Signed | undefined
+    /** Access key version. Will be removed in a future release. @deprecated @internal */
+    internal_version?: 'v1' | 'v2' | undefined
+  }
 
   export type ReturnValue<
     parameters extends {
@@ -104,15 +137,16 @@ export function fromHeadlessWebAuthn<
   privateKey: Hex.Hex,
   options: options | fromHeadlessWebAuthn.Options,
 ): fromHeadlessWebAuthn.ReturnValue<options> {
-  const { access, rpId, origin, internal_version } = options
+  const { access, authorization, rpId, origin, internal_version } = options
 
   const publicKey = P256.getPublicKey({ privateKey })
 
   return from({
-    access,
-    internal_version,
     keyType: 'webAuthn',
     publicKey,
+    ...(access ? { access } : {}),
+    ...(authorization ? { authorization } : {}),
+    ...(internal_version ? { internal_version } : {}),
     async sign({ hash }) {
       const { metadata, payload } = WebAuthnP256.getSignPayload({
         ...options,
@@ -140,7 +174,7 @@ export declare namespace fromHeadlessWebAuthn {
     WebAuthnP256.getSignPayload.Options,
     'challenge' | 'rpId' | 'origin'
   > &
-    Pick<from.Parameters, 'access' | 'internal_version'> & {
+    Pick<from.Parameters, 'access' | 'authorization' | 'internal_version'> & {
       rpId: string
       origin: string
     }
@@ -166,14 +200,15 @@ export function fromP256<const options extends fromP256.Options>(
   privateKey: Hex.Hex,
   options: options | fromP256.Options = {},
 ): fromP256.ReturnValue<options> {
-  const { access, internal_version } = options
+  const { access, authorization, internal_version } = options
   const publicKey = P256.getPublicKey({ privateKey })
 
   return from({
-    access,
-    internal_version,
     keyType: 'p256',
     publicKey,
+    ...(access ? { access } : {}),
+    ...(authorization ? { authorization } : {}),
+    ...(internal_version ? { internal_version } : {}),
     async sign({ hash }) {
       const signature = P256.sign({ payload: hash, privateKey })
       return SignatureEnvelope.serialize({
@@ -186,7 +221,10 @@ export function fromP256<const options extends fromP256.Options>(
 }
 
 export declare namespace fromP256 {
-  export type Options = Pick<from.Parameters, 'access' | 'internal_version'>
+  export type Options = Pick<
+    from.Parameters,
+    'access' | 'authorization' | 'internal_version'
+  >
 
   export type ReturnValue<options extends Options = Options> =
     from.ReturnValue<options>
@@ -209,14 +247,15 @@ export function fromSecp256k1<const options extends fromSecp256k1.Options>(
   privateKey: Hex.Hex,
   options: options | fromSecp256k1.Options = {},
 ): fromSecp256k1.ReturnValue<options> {
-  const { access, internal_version } = options
+  const { access, authorization, internal_version } = options
   const publicKey = Secp256k1.getPublicKey({ privateKey })
 
   return from({
-    access,
-    internal_version,
     keyType: 'secp256k1',
     publicKey,
+    ...(access ? { access } : {}),
+    ...(authorization ? { authorization } : {}),
+    ...(internal_version ? { internal_version } : {}),
     async sign(parameters) {
       const { hash } = parameters
       const signature = Secp256k1.sign({ payload: hash, privateKey })
@@ -226,7 +265,10 @@ export function fromSecp256k1<const options extends fromSecp256k1.Options>(
 }
 
 export declare namespace fromSecp256k1 {
-  export type Options = Pick<from.Parameters, 'access' | 'internal_version'>
+  export type Options = Pick<
+    from.Parameters,
+    'access' | 'authorization' | 'internal_version'
+  >
 
   export type ReturnValue<options extends Options = Options> =
     from.ReturnValue<options>
@@ -293,11 +335,15 @@ export function fromWebAuthnP256(
   credential: fromWebAuthnP256.Credential,
   options: fromWebAuthnP256.Options = {},
 ): fromWebAuthnP256.ReturnValue {
+  const { access, authorization, internal_version } = options
   const { id } = credential
   const publicKey = PublicKey.fromHex(credential.publicKey)
   return from({
     keyType: 'webAuthn',
     publicKey,
+    ...(access ? { access } : {}),
+    ...(authorization ? { authorization } : {}),
+    ...(internal_version ? { internal_version } : {}),
     async sign({ hash }) {
       const { metadata, signature } = await WebAuthnP256.sign({
         ...options,
@@ -323,7 +369,7 @@ export declare namespace fromWebAuthnP256 {
   export type Options = {
     getFn?: WebAuthnP256.sign.Options['getFn'] | undefined
     rpId?: WebAuthnP256.sign.Options['rpId'] | undefined
-  }
+  } & Pick<from.Parameters, 'access' | 'authorization' | 'internal_version'>
 
   export type ReturnValue = from.ReturnValue
 }
@@ -350,14 +396,15 @@ export function fromWebCryptoP256<
   keyPair: Awaited<ReturnType<typeof WebCryptoP256.createKeyPair>>,
   options: options | fromWebCryptoP256.Options = {},
 ): fromWebCryptoP256.ReturnValue<options> {
-  const { access, internal_version } = options
+  const { access, authorization, internal_version } = options
   const { publicKey, privateKey } = keyPair
 
   return from({
-    access,
-    internal_version,
     keyType: 'p256',
     publicKey,
+    ...(access ? { access } : {}),
+    ...(authorization ? { authorization } : {}),
+    ...(internal_version ? { internal_version } : {}),
     async sign({ hash }) {
       const signature = await WebCryptoP256.sign({ payload: hash, privateKey })
       return SignatureEnvelope.serialize({
@@ -371,7 +418,10 @@ export function fromWebCryptoP256<
 }
 
 export declare namespace fromWebCryptoP256 {
-  export type Options = Pick<from.Parameters, 'access' | 'internal_version'>
+  export type Options = Pick<
+    from.Parameters,
+    'access' | 'authorization' | 'internal_version'
+  >
 
   export type ReturnValue<options extends Options = Options> =
     from.ReturnValue<options>
@@ -564,27 +614,46 @@ declare namespace fromRoot {
 
 // biome-ignore lint/correctness/noUnusedVariables: _
 function fromAccessKey(parameters: fromAccessKey.Parameters): AccessKeyAccount {
-  const { access } = parameters
+  const { access, authorization } = parameters
   const { address: parentAddress } = parseAccount(access)
   const account = fromBase({ ...parameters, parentAddress })
+  const accessKeyAddress = Address.fromPublicKey(parameters.publicKey)
   return {
     ...account,
-    accessKeyAddress: Address.fromPublicKey(parameters.publicKey),
+    accessKeyAddress,
+    ...(authorization
+      ? {
+          accessKeyAuthorization: createAccessKeyAuthorization(authorization, {
+            accessKeyAddress,
+            keyType: account.keyType,
+          }),
+        }
+      : {}),
     source: 'accessKey',
   }
 }
 
 declare namespace fromAccessKey {
-  export type Parameters = fromBase.Parameters & {
-    /**
-     * Parent account to access.
-     * If defined, this account will act as an "access key", and use
-     * the parent account's address as the keychain address.
-     */
-    access: viem_Account | Address.Address
-  }
+  export type Parameters = fromBase.Parameters & from.AccessKeyOptions
 
   export type ReturnValue = AccessKeyAccount
+}
+
+function createAccessKeyAuthorization(
+  keyAuthorization: KeyAuthorization.Signed,
+  parameters: Pick<AccessKeyAccount, 'accessKeyAddress' | 'keyType'>,
+): AccessKeyAuthorization {
+  if (
+    keyAuthorization.address.toLowerCase() !==
+    parameters.accessKeyAddress.toLowerCase()
+  )
+    throw new Error('keyAuthorization address does not match access key.')
+  if (keyAuthorization.type !== parameters.keyType)
+    throw new Error('keyAuthorization type does not match access key.')
+  return {
+    signed: keyAuthorization,
+    status: 'ready',
+  }
 }
 
 /** @internal */

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -5,6 +5,7 @@ import {
   getTransaction,
   getTransactionReceipt,
   prepareTransactionRequest,
+  sendTransaction,
   sendTransactionSync,
   signTransaction,
   verifyHash,
@@ -140,6 +141,98 @@ describe('prepareTransactionRequest', () => {
     })
     const request = await prepareTransactionRequest(clientWithFeeToken, {})
     expect(request.feeToken).toBe(feeToken)
+  })
+
+  test('behavior: attaches account key authorization', async () => {
+    const rootAccount = accounts.at(0)!
+    const privateKey = generatePrivateKey()
+    const accessKey = Account.fromP256(privateKey, { access: rootAccount })
+    const keyAuthorization = await accessKeyActions.signAuthorization(client, {
+      account: rootAccount,
+      accessKey,
+    })
+    const account = Account.fromP256(privateKey, {
+      access: rootAccount,
+      authorization: keyAuthorization,
+    })
+
+    const request = await prepareTransactionRequest(client, {
+      account,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(request.keyAuthorization).toBe(keyAuthorization)
+    expect(account.accessKeyAuthorization?.status).toBe('ready')
+  })
+
+  test('behavior: resolves pending account key authorization', async () => {
+    const rootAccount = accounts.at(0)!
+    const privateKey = generatePrivateKey()
+    const accessKey = Account.fromP256(privateKey, { access: rootAccount })
+    const keyAuthorization = await accessKeyActions.signAuthorization(client, {
+      account: rootAccount,
+      accessKey,
+    })
+    const account = Account.fromP256(privateKey, {
+      access: rootAccount,
+      authorization: keyAuthorization,
+    })
+
+    await accessKeyActions.authorizeSync(client, {
+      account: rootAccount,
+      accessKey,
+    })
+    account.accessKeyAuthorization!.status = 'pending'
+
+    const request = await prepareTransactionRequest(client, {
+      account,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(request.keyAuthorization).toBeUndefined()
+    expect(account.accessKeyAuthorization?.status).toBe('consumed')
+  })
+
+  test('behavior: marks account key authorization pending after async send', async () => {
+    const rootAccount = accounts.at(0)!
+    const privateKey = generatePrivateKey()
+    const accessKey = Account.fromP256(privateKey, { access: rootAccount })
+    const keyAuthorization = await accessKeyActions.signAuthorization(client, {
+      account: rootAccount,
+      accessKey,
+    })
+    const account = Account.fromP256(privateKey, {
+      access: rootAccount,
+      authorization: keyAuthorization,
+    })
+
+    await sendTransaction(client, {
+      account,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(account.accessKeyAuthorization?.status).toBe('pending')
+  })
+
+  test('behavior: consumes account key authorization after sync send', async () => {
+    const rootAccount = accounts.at(0)!
+    const privateKey = generatePrivateKey()
+    const accessKey = Account.fromP256(privateKey, { access: rootAccount })
+    const keyAuthorization = await accessKeyActions.signAuthorization(client, {
+      account: rootAccount,
+      accessKey,
+    })
+    const account = Account.fromP256(privateKey, {
+      access: rootAccount,
+      authorization: keyAuthorization,
+    })
+
+    await sendTransactionSync(client, {
+      account,
+      to: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(account.accessKeyAuthorization?.status).toBe('consumed')
   })
 })
 

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -39,7 +39,7 @@ export const chainConfig = {
     }),
   },
   prepareTransactionRequest: [
-    async (r, { phase }) => {
+    async (r, { client, phase }) => {
       const request = r as Transaction.TransactionRequest & {
         account?: Account | undefined
         chain?:
@@ -57,6 +57,31 @@ export const chainConfig = {
             request.gas = (request.gas ?? 0n) + 10_000n
         }
         return request as unknown as typeof r
+      }
+
+      const accessKeyAuthorization = request.account?.accessKeyAuthorization
+      if (
+        phase === 'beforeFillTransaction' &&
+        request.account?.source === 'accessKey' &&
+        accessKeyAuthorization &&
+        typeof request.keyAuthorization === 'undefined' &&
+        request.chain?.id === Number(accessKeyAuthorization.signed.chainId)
+      ) {
+        if (accessKeyAuthorization.status === 'pending') {
+          const keyInfo = await getMetadata(client, {
+            account: request.account.address,
+            accessKey: request.account.accessKeyAddress,
+          } as never)
+          if (
+            !keyInfo.isRevoked &&
+            keyInfo.keyType === request.account.keyType &&
+            keyInfo.expiry > BigInt(Math.floor(Date.now() / 1000))
+          )
+            accessKeyAuthorization.status = 'consumed'
+        }
+
+        if (accessKeyAuthorization.status === 'ready')
+          request.keyAuthorization = accessKeyAuthorization.signed
       }
 
       // Use expiring nonces for concurrent transactions (TIP-1009).
@@ -90,6 +115,25 @@ export const chainConfig = {
     },
     { runAt: ['beforeFillTransaction', 'afterFillParameters'] },
   ],
+  onTransactionSubmitted({ account, request }) {
+    const accessKeyAccount = account as Account | undefined
+    if (accessKeyAccount?.source !== 'accessKey') return
+    const authorization = accessKeyAccount.accessKeyAuthorization
+    if (!authorization || request.keyAuthorization !== authorization.signed)
+      return
+    authorization.status = 'pending'
+  },
+  onTransactionConfirmed({ account, receipt, receipts, request }) {
+    const accessKeyAccount = account as Account | undefined
+    if (accessKeyAccount?.source !== 'accessKey') return
+    const authorization = accessKeyAccount.accessKeyAuthorization
+    if (!authorization || request.keyAuthorization !== authorization.signed)
+      return
+    if (receipt && receipt.status !== 'success') return
+    if (receipts && !receipts.some((receipt) => receipt.status === 'success'))
+      return
+    authorization.status = 'consumed'
+  },
   serializers: {
     // TODO: casting to satisfy viem – viem v3 to have more flexible serializer type.
     transaction: ((transaction, signature) =>

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -10,7 +10,9 @@ import type { Client } from '../clients/createClient.js'
 import type { Transport } from '../clients/transports/createTransport.js'
 import type { Account } from '../types/account.js'
 import type { FeeValuesType } from '../types/fee.js'
+import type { Hash, Hex } from '../types/misc.js'
 import type {
+  TransactionReceipt,
   TransactionSerializable,
   TransactionSerializableGeneric,
   TransactionSerializedGeneric,
@@ -81,13 +83,44 @@ type PrepareTransactionRequestPhase =
   | 'afterFillParameters'
 type PrepareTransactionRequestFn = (
   args: PrepareTransactionRequestParameters,
-  options: { phase: PrepareTransactionRequestPhase },
+  options: { client: Client; phase: PrepareTransactionRequestPhase },
 ) => Promise<PrepareTransactionRequestParameters>
 
 type ChainVerifyHashFn = (
   client: Client,
   parameters: VerifyHashParameters,
 ) => Promise<VerifyHashReturnType>
+
+export type ChainTransactionRequest = {
+  account?: Account | Address | null | undefined
+  calls?: readonly unknown[] | undefined
+  data?: Hex | undefined
+  keyAuthorization?: unknown
+  to?: Address | null | undefined
+  value?: bigint | Hex | undefined
+}
+
+type ChainTransactionSubmittedFn = (parameters: {
+  account?: Account | undefined
+  client: Client
+  hash?: Hash | undefined
+  id?: string | undefined
+  request: ChainTransactionRequest
+}) => Promise<void> | void
+
+type ChainTransactionConfirmedFn = (parameters: {
+  account?: Account | undefined
+  client: Client
+  id?: string | undefined
+  receipt?: TransactionReceipt | undefined
+  receipts?:
+    | readonly {
+        status?: 'success' | 'reverted' | undefined
+        transactionHash: Hash
+      }[]
+    | undefined
+  request: ChainTransactionRequest
+}) => Promise<void> | void
 
 export type ChainConfig<
   formatters extends ChainFormatters | undefined = ChainFormatters | undefined,
@@ -124,6 +157,10 @@ export type ChainConfig<
   serializers?: ChainSerializers<formatters> | undefined
   /** Chain-specific signature verification. */
   verifyHash?: ChainVerifyHashFn | undefined
+  /** Chain-specific transaction lifecycle hook, called after a structured wallet action submits a transaction or call bundle. */
+  onTransactionSubmitted?: ChainTransactionSubmittedFn | undefined
+  /** Chain-specific transaction lifecycle hook, called after a structured wallet action confirms a transaction or call bundle. */
+  onTransactionConfirmed?: ChainTransactionConfirmedFn | undefined
 }
 
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
Adds wallet-action managed Tempo access key authorization state.

## Motivation
It's useful to pre-sign authorizations for access keys and attach them on the first transaction. 

This requires applications to manage the lifecycle of this key and makes Viem clients less composable. For example, after requesting a key authorization signature on wallet_connect, an app integrating with mppx can't pass the AccessKeyAccount to mppx without first submitting the authorization onchain.

## Behavior
A signed key authorization can be attached when creating an access key account:

```ts
const accessKey = Account.fromP256(privateKey, {
  access: rootAccount,
  authorization: keyAuthorization,
})

// attaches the authorization automatically until seen onchain
await sendTransaction(client, {
  account: accessKey,
  to,
})
```

## Changes
- Add chain transaction lifecycle hooks in `src/types/chain.ts`.
- Wire submit/confirm hooks through `sendTransaction`, `sendTransactionSync`, `sendCalls`, and `sendCallsSync`.
- Add `accessKeyAuthorization` state to Tempo access key accounts and attach it during `prepareTransactionRequest`.
- Mark authorizations pending after successful submission and consumed after successful confirmation in `src/tempo/chainConfig.ts`.
- Add Tempo and wallet hook tests for the new lifecycle behavior.