### PR TITLE
feat(tempo): add raw access key signing

### DIFF
--- a/.changeset/tempo-access-key-raw-sign.md
+++ b/.changeset/tempo-access-key-raw-sign.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `raw` signing support to Tempo access key accounts.

--- a/src/tempo/Account.test.ts
+++ b/src/tempo/Account.test.ts
@@ -85,6 +85,39 @@ describe('fromSecp256k1', () => {
       }
     `)
   })
+
+  test('behavior: access key raw signature', async () => {
+    const account = Account.fromSecp256k1(privateKey_secp256k1)
+    const access = Account.fromSecp256k1(
+      '0x06a952d58c24d287245276dd8b4272d82a921d27d90874a6c27a3bc19ff4bfde',
+      {
+        access: account,
+      },
+    )
+
+    const signature = await access.sign({
+      hash: '0xdeadbeef',
+      raw: true,
+    })
+
+    expect(SignatureEnvelope.deserialize(signature)).toMatchInlineSnapshot(`
+      {
+        "signature": {
+          "r": 17986519448152736741806679848301503760738507672285374215138617395147700232421n,
+          "s": 50573419219106101097329274608677894804280434221354410855341207650465321473558n,
+          "yParity": 0,
+        },
+        "type": "secp256k1",
+      }
+    `)
+    expect(
+      await verifyHash(client, {
+        address: access.accessKeyAddress,
+        hash: '0xdeadbeef',
+        signature,
+      }),
+    ).toBe(true)
+  })
 })
 
 describe('fromP256', () => {
@@ -157,6 +190,22 @@ describe('fromP256', () => {
         "version": "v2",
       }
     `)
+  })
+
+  test('behavior: access key raw signature', async () => {
+    const account = Account.fromP256(privateKey_p256)
+    const access = Account.fromP256(privateKey_p256, {
+      access: account,
+    })
+
+    const signature = await access.sign({
+      hash: '0xdeadbeef',
+      raw: true,
+    })
+
+    expect(SignatureEnvelope.deserialize(signature)).toMatchObject({
+      type: 'p256',
+    })
   })
 })
 

--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -27,6 +27,8 @@ export type Account_base<source extends string = string> = RequiredBy<
 > & {
   /** Key type. */
   keyType: SignatureEnvelope.Type
+  /** Sign fn. */
+  sign: NonNullable<LocalAccount['sign']>
   /** Sign transaction fn. */
   signTransaction: <
     serializer extends
@@ -56,6 +58,21 @@ export type RootAccount = Account_base<'root'> & {
 export type AccessKeyAccount = Account_base<'accessKey'> & {
   /** Access key ID. */
   accessKeyAddress: Address.Address
+  /**
+   * Signs a hash.
+   *
+   * By default, access key accounts sign through a keychain envelope so the
+   * signature authorizes the parent account.
+   *
+   * Set `raw` to `true` to sign directly with the access key, without keychain
+   * hashing or keychain enveloping.
+   */
+  sign: (parameters: {
+    /** Hash to sign. */
+    hash: Hex.Hex
+    /** Sign directly with the access key, without keychain hashing or enveloping. */
+    raw?: boolean | undefined
+  }) => Promise<Hex.Hex>
 }
 
 export type Account = OneOf<RootAccount | AccessKeyAccount>
@@ -431,7 +448,8 @@ function fromBase(parameters: fromBase.Parameters): Account_base {
     includePrefix: false,
   })
 
-  async function sign({ hash }: { hash: Hex.Hex }) {
+  async function sign({ hash, raw }: { hash: Hex.Hex; raw?: boolean }) {
+    if (raw) return await parameters.sign({ hash })
     const innerHash =
       parentAddress && internal_version === 'v2'
         ? keccak256(Hex.concat('0x04', hash, parentAddress))


### PR DESCRIPTION
## Summary
Adds `raw` signing for Tempo access key accounts.

## Motivation
MPP session vouchers need signatures from the access key itself, without the keychain envelope used by normal access-key account signing.

## Changes
- Added `raw?: boolean` to `AccessKeyAccount.sign` in `src/tempo/Account.ts`.
- Skipped keychain hashing/enveloping when access key signing uses `raw: true`.
- Documented `raw` behavior on the access key `sign` TSDoc.
- Added secp256k1 and p256 access-key coverage in `src/tempo/Account.test.ts`.

## Testing
- `pnpm test src/tempo/Account.test.ts`
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.json`
- `pnpm exec biome check .changeset/tempo-access-key-raw-sign.md src/tempo/Account.ts src/tempo/Account.test.ts`
- `git diff --check`
