### PR TITLE
docs: fix duplicate words

### DIFF
--- a/site/pages/docs/actions/wallet/sendCalls.mdx
+++ b/site/pages/docs/actions/wallet/sendCalls.mdx
@@ -330,7 +330,7 @@ const { id } = await walletClient.sendCalls({
 })
 ```
 
-When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
+When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
 
 ```ts twoslash
 import { parseAbi } from 'viem'

--- a/site/pages/docs/actions/wallet/sendCallsSync.mdx
+++ b/site/pages/docs/actions/wallet/sendCallsSync.mdx
@@ -336,7 +336,7 @@ const status = await walletClient.sendCallsSync({
 })
 ```
 
-When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
+When calling functions on contracts, it may be more convenient to pass in a [Contract Call](#contract-calls), providing the `abi`, `functionName`, and `args` properties which will then be encoded into the appropriate `calls.data`.
 
 ```ts twoslash
 import { parseAbi } from 'viem'

--- a/site/pages/docs/contract/parseEventLogs.md
+++ b/site/pages/docs/contract/parseEventLogs.md
@@ -437,7 +437,7 @@ export const client = createPublicClient({
 
 ### Partial Decode
 
-By default, if the `topics` and `data` does not conform to the ABI (a mismatch between the number of indexed/non-indexed arguments), `parseEventLogs` will not return return the decoded log.
+By default, if the `topics` and `data` does not conform to the ABI (a mismatch between the number of indexed/non-indexed arguments), `parseEventLogs` will not return the decoded log.
 
 For example, the following will not return the nonconforming log as there is a mismatch in non-`indexed` arguments & `data` length.
 

--- a/site/pages/docs/utilities/toHex.md
+++ b/site/pages/docs/utilities/toHex.md
@@ -4,7 +4,7 @@ description: Encodes a string, number, boolean or byte array to a hex value.
 
 # toHex
 
-Encodes a string, number, boolean or byte array to a hex value value.
+Encodes a string, number, boolean or byte array to a hex value.
 
 Shortcut Functions: 
 


### PR DESCRIPTION
Fixes duplicate words in docs for `sendCalls`, `sendCallsSync`, `parseEventLogs`, and `toHex`.

Recreated from https://github.com/wevm/viem/pull/4629 on a maintainer-owned branch.
