### PR TITLE
feat(tempo): add `logoURI` to token metadata

### DIFF
--- a/.changeset/tempo-precompile-abis.md
+++ b/.changeset/tempo-precompile-abis.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Updated generated Tempo precompile ABIs from latest Tempo main and added `logoURI` to TIP-20 metadata.

--- a/site/pages/tempo/actions/fee.validateToken.mdx
+++ b/site/pages/tempo/actions/fee.validateToken.mdx
@@ -39,6 +39,7 @@ type ReturnType = {
   metadata: {
     currency: string
     decimals: number
+    logoURI: string
     name: string
     paused?: boolean
     quoteToken?: Address

--- a/site/pages/tempo/actions/index.mdx
+++ b/site/pages/tempo/actions/index.mdx
@@ -77,7 +77,7 @@
 | [`token.create`](/tempo/actions/token.create) | Creates a new TIP-20 token and assigns the admin role to the calling account |
 | [`token.getAllowance`](/tempo/actions/token.getAllowance) | Gets the amount of tokens that a spender is approved to transfer on behalf of an owner |
 | [`token.getBalance`](/tempo/actions/token.getBalance) | Gets the token balance of an address |
-| [`token.getMetadata`](/tempo/actions/token.getMetadata) | Gets the metadata for a TIP-20 token, including name, symbol, decimals, currency, and total supply |
+| [`token.getMetadata`](/tempo/actions/token.getMetadata) | Gets the metadata for a TIP-20 token, including name, symbol, logo URI, decimals, currency, and total supply |
 | [`token.grantRoles`](/tempo/actions/token.grantRoles) | Grants one or more roles to an address |
 | [`token.mint`](/tempo/actions/token.mint) | Mints new TIP-20 tokens to a recipient |
 | [`token.pause`](/tempo/actions/token.pause) | Pauses a TIP-20 token, preventing all transfers |

--- a/site/pages/tempo/actions/setup.mdx
+++ b/site/pages/tempo/actions/setup.mdx
@@ -90,10 +90,11 @@ console.log(
   'Alpha USD Metadata:', 
   metadata.name,
   metadata.symbol,
+  metadata.logoURI,
   metadata.decimals,
   metadata.totalSupply
 )
-// @log: Alpha USD Metadata: Alpha USD, AlphaUSD, 6, 1000000000000000000000n
+// @log: Alpha USD Metadata: Alpha USD, AlphaUSD, https://example.com/token.svg, 6, 1000000000000000000000n
 ```
 
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"

--- a/site/pages/tempo/actions/token.getMetadata.mdx
+++ b/site/pages/tempo/actions/token.getMetadata.mdx
@@ -2,7 +2,7 @@ import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
 
 # `token.getMetadata`
 
-Gets the metadata for a TIP-20 token, including name, symbol, decimals, currency, and total supply.
+Gets the metadata for a TIP-20 token, including name, symbol, logo URI, decimals, currency, and total supply.
 
 ## Usage
 
@@ -21,6 +21,8 @@ console.log('Decimals:', metadata.decimals)
 // @log: Decimals: 18
 console.log('Name:', metadata.name)
 // @log: Name: United States Dollar
+console.log('Logo URI:', metadata.logoURI)
+// @log: Logo URI: https://example.com/token.svg
 console.log('Symbol:', metadata.symbol)
 // @log: Symbol: USD
 console.log('Total Supply:', metadata.totalSupply)
@@ -39,6 +41,7 @@ console.log('Total Supply:', metadata.totalSupply)
 type ReturnType = {
   currency: string
   decimals: number
+  logoURI: string
   name: string
   paused?: boolean
   quoteToken?: Address
@@ -58,4 +61,3 @@ type ReturnType = {
 Address or ID of the TIP-20 token.
 
 <ReadParameters />
-

--- a/site/pages/tempo/index.mdx
+++ b/site/pages/tempo/index.mdx
@@ -115,10 +115,11 @@ console.log(
   'Alpha USD Metadata:', 
   metadata.name,
   metadata.symbol,
+  metadata.logoURI,
   metadata.decimals,
   metadata.totalSupply
 )
-// @log: Alpha USD Metadata: Alpha USD, AlphaUSD, 6, 1000000000000000000000n
+// @log: Alpha USD Metadata: Alpha USD, AlphaUSD, https://example.com/token.svg, 6, 1000000000000000000000n
 ```
 
 ```ts twoslash [viem.config.ts] filename="viem.config.ts"

--- a/src/tempo/Abis.ts
+++ b/src/tempo/Abis.ts
@@ -1,5 +1,341 @@
 // Generated with `pnpm gen:abis`. Do not modify manually.
 
+export const tip20ChannelReserve = [
+  {
+    name: 'CLOSE_GRACE_PERIOD',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint64' }],
+  },
+  {
+    name: 'VOUCHER_TYPEHASH',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'bytes32' }],
+  },
+  {
+    name: 'open',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { type: 'address', name: 'payee' },
+      { type: 'address', name: 'operator' },
+      { type: 'address', name: 'token' },
+      { type: 'uint96', name: 'deposit' },
+      { type: 'bytes32', name: 'salt' },
+      { type: 'address', name: 'authorizedSigner' },
+    ],
+    outputs: [{ type: 'bytes32', name: 'channelId' }],
+  },
+  {
+    name: 'settle',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+      { type: 'uint96', name: 'cumulativeAmount' },
+      { type: 'bytes', name: 'signature' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'topUp',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+      { type: 'uint96', name: 'additionalDeposit' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'close',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+      { type: 'uint96', name: 'cumulativeAmount' },
+      { type: 'uint96', name: 'captureAmount' },
+      { type: 'bytes', name: 'signature' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'requestClose',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'withdraw',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'getChannel',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'descriptor',
+        components: [
+          { type: 'address', name: 'payer' },
+          { type: 'address', name: 'payee' },
+          { type: 'address', name: 'operator' },
+          { type: 'address', name: 'token' },
+          { type: 'bytes32', name: 'salt' },
+          { type: 'address', name: 'authorizedSigner' },
+          { type: 'bytes32', name: 'expiringNonceHash' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        type: 'tuple',
+        components: [
+          {
+            type: 'tuple',
+            name: 'descriptor',
+            components: [
+              { type: 'address', name: 'payer' },
+              { type: 'address', name: 'payee' },
+              { type: 'address', name: 'operator' },
+              { type: 'address', name: 'token' },
+              { type: 'bytes32', name: 'salt' },
+              { type: 'address', name: 'authorizedSigner' },
+              { type: 'bytes32', name: 'expiringNonceHash' },
+            ],
+          },
+          {
+            type: 'tuple',
+            name: 'state',
+            components: [
+              { type: 'uint96', name: 'settled' },
+              { type: 'uint96', name: 'deposit' },
+              { type: 'uint32', name: 'closeRequestedAt' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'getChannelState',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'bytes32', name: 'channelId' }],
+    outputs: [
+      {
+        type: 'tuple',
+        components: [
+          { type: 'uint96', name: 'settled' },
+          { type: 'uint96', name: 'deposit' },
+          { type: 'uint32', name: 'closeRequestedAt' },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'getChannelStatesBatch',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'bytes32[]', name: 'channelIds' }],
+    outputs: [
+      {
+        type: 'tuple[]',
+        components: [
+          { type: 'uint96', name: 'settled' },
+          { type: 'uint96', name: 'deposit' },
+          { type: 'uint32', name: 'closeRequestedAt' },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'computeChannelId',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'address', name: 'payer' },
+      { type: 'address', name: 'payee' },
+      { type: 'address', name: 'operator' },
+      { type: 'address', name: 'token' },
+      { type: 'bytes32', name: 'salt' },
+      { type: 'address', name: 'authorizedSigner' },
+      { type: 'bytes32', name: 'expiringNonceHash' },
+    ],
+    outputs: [{ type: 'bytes32' }],
+  },
+  {
+    name: 'getVoucherDigest',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'bytes32', name: 'channelId' },
+      { type: 'uint96', name: 'cumulativeAmount' },
+    ],
+    outputs: [{ type: 'bytes32' }],
+  },
+  {
+    name: 'domainSeparator',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'bytes32' }],
+  },
+  {
+    name: 'ChannelOpened',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+      { type: 'address', name: 'operator' },
+      { type: 'address', name: 'token' },
+      { type: 'address', name: 'authorizedSigner' },
+      { type: 'bytes32', name: 'salt' },
+      { type: 'bytes32', name: 'expiringNonceHash' },
+      { type: 'uint96', name: 'deposit' },
+    ],
+  },
+  {
+    name: 'Settled',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+      { type: 'uint96', name: 'cumulativeAmount' },
+      { type: 'uint96', name: 'deltaPaid' },
+      { type: 'uint96', name: 'newSettled' },
+    ],
+  },
+  {
+    name: 'TopUp',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+      { type: 'uint96', name: 'additionalDeposit' },
+      { type: 'uint96', name: 'newDeposit' },
+    ],
+  },
+  {
+    name: 'CloseRequested',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+      { type: 'uint256', name: 'closeGraceEnd' },
+    ],
+  },
+  {
+    name: 'ChannelClosed',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+      { type: 'uint96', name: 'settledToPayee' },
+      { type: 'uint96', name: 'refundedToPayer' },
+    ],
+  },
+  {
+    name: 'CloseRequestCancelled',
+    type: 'event',
+    inputs: [
+      { type: 'bytes32', name: 'channelId', indexed: true },
+      { type: 'address', name: 'payer', indexed: true },
+      { type: 'address', name: 'payee', indexed: true },
+    ],
+  },
+  { name: 'ChannelAlreadyExists', type: 'error', inputs: [] },
+  { name: 'ChannelNotFound', type: 'error', inputs: [] },
+  { name: 'NotPayer', type: 'error', inputs: [] },
+  { name: 'NotPayeeOrOperator', type: 'error', inputs: [] },
+  { name: 'InvalidPayee', type: 'error', inputs: [] },
+  { name: 'ZeroDeposit', type: 'error', inputs: [] },
+  { name: 'ExpiringNonceHashNotSet', type: 'error', inputs: [] },
+  { name: 'InvalidSignature', type: 'error', inputs: [] },
+  { name: 'AmountExceedsDeposit', type: 'error', inputs: [] },
+  { name: 'AmountNotIncreasing', type: 'error', inputs: [] },
+  { name: 'CaptureAmountInvalid', type: 'error', inputs: [] },
+  { name: 'CloseNotReady', type: 'error', inputs: [] },
+  { name: 'DepositOverflow', type: 'error', inputs: [] },
+] as const
+
 export const tip20 = [
   {
     name: 'name',
@@ -18,7 +354,7 @@ export const tip20 = [
   {
     name: 'decimals',
     type: 'function',
-    stateMutability: 'view',
+    stateMutability: 'pure',
     inputs: [],
     outputs: [{ type: 'uint8' }],
   },
@@ -135,6 +471,20 @@ export const tip20 = [
     stateMutability: 'view',
     inputs: [],
     outputs: [{ type: 'uint64' }],
+  },
+  {
+    name: 'logoURI',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+  {
+    name: 'setLogoURI',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ type: 'string', name: 'newLogoURI' }],
+    outputs: [],
   },
   {
     name: 'burnBlocked',
@@ -456,6 +806,14 @@ export const tip20 = [
     ],
   },
   {
+    name: 'LogoURIUpdated',
+    type: 'event',
+    inputs: [
+      { type: 'address', name: 'updater', indexed: true },
+      { type: 'string', name: 'newLogoURI' },
+    ],
+  },
+  {
     name: 'InsufficientBalance',
     type: 'error',
     inputs: [
@@ -468,13 +826,11 @@ export const tip20 = [
   { name: 'SupplyCapExceeded', type: 'error', inputs: [] },
   { name: 'InvalidSupplyCap', type: 'error', inputs: [] },
   { name: 'InvalidPayload', type: 'error', inputs: [] },
-  { name: 'StringTooLong', type: 'error', inputs: [] },
   { name: 'PolicyForbids', type: 'error', inputs: [] },
   { name: 'InvalidRecipient', type: 'error', inputs: [] },
   { name: 'ContractPaused', type: 'error', inputs: [] },
   { name: 'InvalidCurrency', type: 'error', inputs: [] },
   { name: 'InvalidQuoteToken', type: 'error', inputs: [] },
-  { name: 'TransfersDisabled', type: 'error', inputs: [] },
   { name: 'InvalidAmount', type: 'error', inputs: [] },
   { name: 'NoOptedInSupply', type: 'error', inputs: [] },
   { name: 'Unauthorized', type: 'error', inputs: [] },
@@ -484,6 +840,8 @@ export const tip20 = [
   { name: 'InvalidTransferPolicyId', type: 'error', inputs: [] },
   { name: 'PermitExpired', type: 'error', inputs: [] },
   { name: 'InvalidSignature', type: 'error', inputs: [] },
+  { name: 'LogoURITooLong', type: 'error', inputs: [] },
+  { name: 'InvalidLogoURI', type: 'error', inputs: [] },
   {
     name: 'hasRole',
     type: 'function',
@@ -1224,6 +1582,19 @@ export const stablecoinDex = [
     ],
   },
   {
+    name: 'OrderFlipped',
+    type: 'event',
+    inputs: [
+      { type: 'uint128', name: 'orderId', indexed: true },
+      { type: 'address', name: 'maker', indexed: true },
+      { type: 'address', name: 'token', indexed: true },
+      { type: 'uint128', name: 'amount' },
+      { type: 'bool', name: 'isBid' },
+      { type: 'int16', name: 'tick' },
+      { type: 'int16', name: 'flipTick' },
+    ],
+  },
+  {
     name: 'OrderCancelled',
     type: 'event',
     inputs: [{ type: 'uint128', name: 'orderId', indexed: true }],
@@ -1300,6 +1671,13 @@ export const addressRegistry = [
       { type: 'bytes4', name: 'masterId' },
       { type: 'bytes6', name: 'userTag' },
     ],
+  },
+  {
+    name: 'isImplicitlyApproved',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'address', name: 'addr' }],
+    outputs: [{ type: 'bool' }],
   },
   {
     name: 'MasterRegistered',
@@ -1393,15 +1771,9 @@ export const feeManager = [
       { type: 'uint256', name: 'amount' },
     ],
   },
-  { name: 'OnlyValidator', type: 'error', inputs: [] },
-  { name: 'OnlySystemContract', type: 'error', inputs: [] },
   { name: 'InvalidToken', type: 'error', inputs: [] },
-  { name: 'PoolDoesNotExist', type: 'error', inputs: [] },
   { name: 'InsufficientFeeTokenBalance', type: 'error', inputs: [] },
-  { name: 'InternalError', type: 'error', inputs: [] },
   { name: 'CannotChangeWithinBlock', type: 'error', inputs: [] },
-  { name: 'CannotChangeWithPendingFees', type: 'error', inputs: [] },
-  { name: 'TokenPolicyForbids', type: 'error', inputs: [] },
 ] as const
 
 export const feeAmm = [
@@ -1642,6 +2014,57 @@ export const accountKeychain = [
     outputs: [],
   },
   {
+    name: 'authorizeKey',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { type: 'address', name: 'keyId' },
+      { type: 'uint8', name: 'signatureType' },
+      {
+        type: 'tuple',
+        name: 'config',
+        components: [
+          { type: 'uint64', name: 'expiry' },
+          { type: 'bool', name: 'enforceLimits' },
+          {
+            type: 'tuple[]',
+            name: 'limits',
+            components: [
+              { type: 'address', name: 'token' },
+              { type: 'uint256', name: 'amount' },
+              { type: 'uint64', name: 'period' },
+            ],
+          },
+          { type: 'bool', name: 'allowAnyCalls' },
+          {
+            type: 'tuple[]',
+            name: 'allowedCalls',
+            components: [
+              { type: 'address', name: 'target' },
+              {
+                type: 'tuple[]',
+                name: 'selectorRules',
+                components: [
+                  { type: 'bytes4', name: 'selector' },
+                  { type: 'address[]', name: 'recipients' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'bytes32', name: 'witness' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'burnKeyAuthorizationWitness',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ type: 'bytes32', name: 'witness' }],
+    outputs: [],
+  },
+  {
     name: 'revokeKey',
     type: 'function',
     stateMutability: 'nonpayable',
@@ -1767,6 +2190,16 @@ export const accountKeychain = [
     ],
   },
   {
+    name: 'isKeyAuthorizationWitnessBurned',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { type: 'address', name: 'account' },
+      { type: 'bytes32', name: 'witness' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+  {
     name: 'getTransactionKey',
     type: 'function',
     stateMutability: 'view',
@@ -1812,6 +2245,22 @@ export const accountKeychain = [
       { type: 'uint256', name: 'remainingLimit' },
     ],
   },
+  {
+    name: 'KeyAuthorizationWitness',
+    type: 'event',
+    inputs: [
+      { type: 'address', name: 'account', indexed: true },
+      { type: 'bytes32', name: 'witness', indexed: true },
+    ],
+  },
+  {
+    name: 'KeyAuthorizationWitnessBurned',
+    type: 'event',
+    inputs: [
+      { type: 'address', name: 'account', indexed: true },
+      { type: 'bytes32', name: 'witness', indexed: true },
+    ],
+  },
   { name: 'UnauthorizedCaller', type: 'error', inputs: [] },
   { name: 'KeyAlreadyExists', type: 'error', inputs: [] },
   { name: 'KeyNotFound', type: 'error', inputs: [] },
@@ -1832,6 +2281,8 @@ export const accountKeychain = [
   },
   { name: 'CallNotAllowed', type: 'error', inputs: [] },
   { name: 'InvalidCallScope', type: 'error', inputs: [] },
+  { name: 'InvalidKeyAuthorizationWitness', type: 'error', inputs: [] },
+  { name: 'KeyAuthorizationWitnessAlreadyBurned', type: 'error', inputs: [] },
   {
     name: 'LegacyAuthorizeKeySelectorChanged',
     type: 'error',
@@ -1883,6 +2334,21 @@ export const tip20Factory = [
     outputs: [{ type: 'address' }],
   },
   {
+    name: 'createToken',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { type: 'string', name: 'name' },
+      { type: 'string', name: 'symbol' },
+      { type: 'string', name: 'currency' },
+      { type: 'address', name: 'quoteToken' },
+      { type: 'address', name: 'admin' },
+      { type: 'bytes32', name: 'salt' },
+      { type: 'string', name: 'logoURI' },
+    ],
+    outputs: [{ type: 'address' }],
+  },
+  {
     name: 'isTIP20',
     type: 'function',
     stateMutability: 'view',
@@ -1892,7 +2358,7 @@ export const tip20Factory = [
   {
     name: 'getTokenAddress',
     type: 'function',
-    stateMutability: 'view',
+    stateMutability: 'pure',
     inputs: [
       { type: 'address', name: 'sender' },
       { type: 'bytes32', name: 'salt' },
@@ -2271,6 +2737,7 @@ export const validatorConfig = [
 ] as const
 
 export const abis = [
+  ...tip20ChannelReserve,
   ...tip20,
   ...validatorConfigV2,
   ...signatureVerifier,

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -2602,7 +2602,7 @@ export type Decorator<
       parameters: tokenActions.getBalance.Parameters<account>,
     ) => Promise<tokenActions.getBalance.ReturnValue>
     /**
-     * Gets TIP20 token metadata including name, symbol, currency, decimals, and total supply.
+     * Gets TIP20 token metadata including name, symbol, logo URI, currency, decimals, and total supply.
      *
      * @example
      * ```ts

--- a/src/tempo/actions/fee.test.ts
+++ b/src/tempo/actions/fee.test.ts
@@ -40,6 +40,7 @@ describe('validateToken', () => {
         "metadata": {
           "currency": "USD",
           "decimals": 6,
+          "logoURI": "",
           "name": "pathUSD",
           "symbol": "pathUSD",
           "totalSupply": 184467440737095516150n,

--- a/src/tempo/actions/token.test.ts
+++ b/src/tempo/actions/token.test.ts
@@ -322,6 +322,7 @@ describe('getMetadata', () => {
       {
         "currency": "USD",
         "decimals": 6,
+        "logoURI": "",
         "name": "AlphaUSD",
         "paused": false,
         "quoteToken": "0x20C0000000000000000000000000000000000000",
@@ -348,6 +349,7 @@ describe('getMetadata', () => {
       {
         "currency": "USD",
         "decimals": 6,
+        "logoURI": "",
         "name": "Test USD",
         "paused": false,
         "quoteToken": "0x20C0000000000000000000000000000000000000",
@@ -369,6 +371,7 @@ describe('getMetadata', () => {
         {
           "currency": "USD",
           "decimals": 6,
+          "logoURI": "",
           "name": "pathUSD",
           "symbol": "pathUSD",
           "totalSupply": 184467440737095516150n,
@@ -385,6 +388,7 @@ describe('getMetadata', () => {
         {
           "currency": "USD",
           "decimals": 6,
+          "logoURI": "",
           "name": "pathUSD",
           "symbol": "pathUSD",
           "totalSupply": 184467440737095516150n,
@@ -408,6 +412,7 @@ describe('getMetadata', () => {
       {
         "currency": "USD",
         "decimals": 6,
+        "logoURI": "",
         "name": "Test USD",
         "paused": false,
         "quoteToken": "0x20C0000000000000000000000000000000000000",
@@ -417,6 +422,28 @@ describe('getMetadata', () => {
         "transferPolicyId": 1n,
       }
     `)
+  })
+
+  test('behavior: custom token with logo URI', async () => {
+    const logoURI = 'https://example.com/test-usd.svg'
+    const { token } = await actions.token.createSync(client, {
+      currency: 'USD',
+      name: 'Logo USD',
+      symbol: 'LUSD',
+    })
+
+    await writeContractSync(client, {
+      abi: Abis.tip20,
+      address: token,
+      functionName: 'setLogoURI',
+      args: [logoURI],
+    })
+
+    const metadata = await actions.token.getMetadata(client, {
+      token,
+    })
+
+    expect(metadata.logoURI).toBe(logoURI)
   })
 })
 

--- a/src/tempo/actions/token.ts
+++ b/src/tempo/actions/token.ts
@@ -1264,7 +1264,7 @@ export namespace getBalance {
 }
 
 /**
- * Gets TIP20 token metadata including name, symbol, currency, decimals, and total supply.
+ * Gets TIP20 token metadata including name, symbol, logo URI, currency, decimals, and total supply.
  *
  * @example
  * ```ts
@@ -1313,6 +1313,11 @@ export async function getMetadata<chain extends Chain | undefined>(
         {
           address,
           abi,
+          functionName: 'logoURI',
+        },
+        {
+          address,
+          abi,
           functionName: 'name',
         },
         {
@@ -1326,14 +1331,15 @@ export async function getMetadata<chain extends Chain | undefined>(
           functionName: 'totalSupply',
         },
       ] as const,
-      allowFailure: false,
+      allowFailure: true,
       deployless: true,
-    }).then(([currency, decimals, name, symbol, totalSupply]) => ({
-      name,
-      symbol,
-      currency,
-      decimals,
-      totalSupply,
+    }).then(([currency, decimals, logoURI, name, symbol, totalSupply]) => ({
+      name: unwrapMulticallResult(name),
+      symbol: unwrapMulticallResult(symbol),
+      currency: unwrapMulticallResult(currency),
+      decimals: unwrapMulticallResult(decimals),
+      logoURI: unwrapMulticallResult(logoURI, ''),
+      totalSupply: unwrapMulticallResult(totalSupply),
     }))
 
   return multicall(client, {
@@ -1348,6 +1354,11 @@ export async function getMetadata<chain extends Chain | undefined>(
         address,
         abi,
         functionName: 'decimals',
+      },
+      {
+        address,
+        abi,
+        functionName: 'logoURI',
       },
       {
         address,
@@ -1385,12 +1396,13 @@ export async function getMetadata<chain extends Chain | undefined>(
         functionName: 'transferPolicyId',
       },
     ] as const,
-    allowFailure: false,
+    allowFailure: true,
     deployless: true,
   }).then(
     ([
       currency,
       decimals,
+      logoURI,
       quoteToken,
       name,
       paused,
@@ -1399,17 +1411,42 @@ export async function getMetadata<chain extends Chain | undefined>(
       totalSupply,
       transferPolicyId,
     ]) => ({
-      name,
-      symbol,
-      currency,
-      decimals,
-      quoteToken,
-      totalSupply,
-      paused,
-      supplyCap,
-      transferPolicyId,
+      name: unwrapMulticallResult(name),
+      symbol: unwrapMulticallResult(symbol),
+      currency: unwrapMulticallResult(currency),
+      decimals: unwrapMulticallResult(decimals),
+      logoURI: unwrapMulticallResult(logoURI, ''),
+      quoteToken: unwrapMulticallResult(quoteToken),
+      totalSupply: unwrapMulticallResult(totalSupply),
+      paused: unwrapMulticallResult(paused),
+      supplyCap: unwrapMulticallResult(supplyCap),
+      transferPolicyId: unwrapMulticallResult(transferPolicyId),
     }),
   )
+}
+
+function unwrapMulticallResult<result>(
+  response:
+    | { result: result; status: 'success' }
+    | { error: unknown; status: 'failure' },
+): result
+function unwrapMulticallResult<result>(
+  response:
+    | { result: result; status: 'success' }
+    | { error: unknown; status: 'failure' },
+  fallback: result,
+): result
+function unwrapMulticallResult<result>(
+  response:
+    | { result: result; status: 'success' }
+    | { error: unknown; status: 'failure' },
+  ...fallback: [] | [result]
+) {
+  if (response.status === 'failure') {
+    if (fallback.length > 0) return fallback[0]
+    throw response.error
+  }
+  return response.result
 }
 
 export declare namespace getMetadata {
@@ -1427,6 +1464,11 @@ export declare namespace getMetadata {
      * Decimals of the token.
      */
     decimals: number
+    /**
+     * Logo URI of the token. Returns an empty string if unset or unsupported
+     * by the active Tempo hardfork.
+     */
+    logoURI: string
     /**
      * Quote token.
      *


### PR DESCRIPTION
Updated the generated Tempo precompile ABIs against latest Tempo main, including the T5 TIP-20 logo URI selectors and related ABI additions.

`token.getMetadata` now returns `logoURI` and tolerates pre-T5 nodes by treating a failed logo URI multicall as an empty string while preserving failures for required metadata fields. Docs and metadata snapshots cover the new field.
