### PR TITLE
feat(tempo): add `logoURI` to token creation

### DIFF
--- a/.changeset/tempo-precompile-abis.md
+++ b/.changeset/tempo-precompile-abis.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Updated generated Tempo precompile ABIs from latest Tempo main and added `logoURI` to TIP-20 metadata.
+Updated generated Tempo precompile ABIs from latest Tempo main and added `logoURI` to TIP-20 metadata and token creation.

--- a/site/pages/tempo/actions/index.mdx
+++ b/site/pages/tempo/actions/index.mdx
@@ -74,7 +74,7 @@
 | [`token.burn`](/tempo/actions/token.burn) | Burns TIP-20 tokens from the caller's balance |
 | [`token.burnBlocked`](/tempo/actions/token.burnBlocked) | Burns TIP-20 tokens from a blocked address |
 | [`token.changeTransferPolicy`](/tempo/actions/token.changeTransferPolicy) | Changes the transfer policy for a TIP-20 token |
-| [`token.create`](/tempo/actions/token.create) | Creates a new TIP-20 token and assigns the admin role to the calling account |
+| [`token.create`](/tempo/actions/token.create) | Creates a new TIP-20 token and assigns the admin role and optional logo URI |
 | [`token.getAllowance`](/tempo/actions/token.getAllowance) | Gets the amount of tokens that a spender is approved to transfer on behalf of an owner |
 | [`token.getBalance`](/tempo/actions/token.getBalance) | Gets the token balance of an address |
 | [`token.getMetadata`](/tempo/actions/token.getMetadata) | Gets the metadata for a TIP-20 token, including name, symbol, logo URI, decimals, currency, and total supply |

--- a/site/pages/tempo/actions/token.create.mdx
+++ b/site/pages/tempo/actions/token.create.mdx
@@ -16,6 +16,7 @@ import { client } from './viem.config'
 const { admin, receipt, token, tokenId } = await client.token.createSync({
   admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
   currency: 'USD',
+  logoURI: 'https://example.com/cusd.svg',
   name: 'My Company USD',
   symbol: 'CUSD',
 })
@@ -47,6 +48,7 @@ import { client } from './viem.config'
 const hash = await client.token.create({
   admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
   currency: 'USD',
+  logoURI: 'https://example.com/cusd.svg',
   name: 'My Company USD',
   symbol: 'CUSD',
 })
@@ -98,6 +100,12 @@ Currency code for the token.
 - **Type:** `string`
 
 Name of the token.
+
+### logoURI (optional)
+
+- **Type:** `string`
+
+Logo URI for the token. Requires a T5-enabled Tempo chain.
 
 ### quoteToken (optional)
 

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -2507,6 +2507,7 @@ export type Decorator<
      *   name: 'My Token',
      *   symbol: 'MTK',
      *   currency: 'USD',
+     *   logoURI: 'https://example.com/token.svg',
      * })
      * ```
      *
@@ -2537,6 +2538,7 @@ export type Decorator<
      *   name: 'My Token',
      *   symbol: 'MTK',
      *   currency: 'USD',
+     *   logoURI: 'https://example.com/token.svg',
      * })
      * ```
      *

--- a/src/tempo/actions/token.test.ts
+++ b/src/tempo/actions/token.test.ts
@@ -428,15 +428,9 @@ describe('getMetadata', () => {
     const logoURI = 'https://example.com/test-usd.svg'
     const { token } = await actions.token.createSync(client, {
       currency: 'USD',
+      logoURI,
       name: 'Logo USD',
       symbol: 'LUSD',
-    })
-
-    await writeContractSync(client, {
-      abi: Abis.tip20,
-      address: token,
-      functionName: 'setLogoURI',
-      args: [logoURI],
     })
 
     const metadata = await actions.token.getMetadata(client, {

--- a/src/tempo/actions/token.ts
+++ b/src/tempo/actions/token.ts
@@ -879,6 +879,7 @@ export namespace changeTransferPolicySync {
  *   name: 'My Token',
  *   symbol: 'MTK',
  *   currency: 'USD',
+ *   logoURI: 'https://example.com/token.svg',
  * })
  * ```
  *
@@ -913,6 +914,8 @@ export namespace create {
     currency: string
     /** Token name. */
     name: string
+    /** Logo URI. Requires a T5-enabled Tempo chain. */
+    logoURI?: string | undefined
     /** Quote token. */
     quoteToken?: TokenId.TokenIdOrAddress | undefined
     /** Unique salt. @default Hex.random(32) */
@@ -983,6 +986,7 @@ export namespace create {
    *       name: 'My Token',
    *       symbol: 'MTK',
    *       currency: 'USD',
+   *       logoURI: 'https://example.com/token.svg',
    *       admin: '0xfeed...fede',
    *     }),
    *   ]
@@ -997,6 +1001,7 @@ export namespace create {
       name,
       symbol,
       currency,
+      logoURI,
       quoteToken = Addresses.pathUsd,
       admin,
       salt = Hex.random(32),
@@ -1004,14 +1009,25 @@ export namespace create {
     return defineCall({
       address: Addresses.tip20Factory,
       abi: Abis.tip20Factory,
-      args: [
-        name,
-        symbol,
-        currency,
-        TokenId.toAddress(quoteToken),
-        admin,
-        salt,
-      ],
+      args:
+        typeof logoURI === 'string'
+          ? [
+              name,
+              symbol,
+              currency,
+              TokenId.toAddress(quoteToken),
+              admin,
+              salt,
+              logoURI,
+            ]
+          : [
+              name,
+              symbol,
+              currency,
+              TokenId.toAddress(quoteToken),
+              admin,
+              salt,
+            ],
       functionName: 'createToken',
     })
   }
@@ -1054,6 +1070,7 @@ export namespace create {
  *   name: 'My Token',
  *   symbol: 'MTK',
  *   currency: 'USD',
+ *   logoURI: 'https://example.com/token.svg',
  * })
  * ```
  *


### PR DESCRIPTION
Added `logoURI` to `token.create` and `token.createSync`, using the new T5 TIP-20 factory overload when a logo URI is provided.

Calls without `logoURI` continue to use the existing six-argument factory selector. Docs, examples, and the Tempo changeset now include create-time logo URI support.
