### PR TITLE
fix: handle `createAccessList` response errors

### DIFF
--- a/.changeset/cold-terms-visit.md
+++ b/.changeset/cold-terms-visit.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Handled `eth_createAccessList` responses that include an `error` field.

--- a/src/actions/public/createAccessList.test.ts
+++ b/src/actions/public/createAccessList.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest'
 import { wagmiContractConfig } from '~test/abis.js'
 import { anvilMainnet } from '~test/anvil.js'
 import { accounts } from '~test/constants.js'
+import { createPublicClient } from '../../clients/createPublicClient.js'
+import { custom } from '../../clients/transports/custom.js'
 import { encodeFunctionData, parseEther } from '../../utils/index.js'
 import { createAccessList } from './createAccessList.js'
 
@@ -72,6 +74,34 @@ test('behavior: revert', async () => {
       data:  0x42842e0e000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000de0b6b3a7640000
 
     Details: execution reverted: ERC721: operator query for nonexistent token
+    Version: viem@x.y.z]
+  `)
+})
+
+test('behavior: response error', async () => {
+  const client = createPublicClient({
+    transport: custom({
+      async request() {
+        return {
+          accessList: [],
+          error: 'execution reverted: nope',
+          gasUsed: '0x0',
+        }
+      },
+    }),
+  })
+
+  await expect(() =>
+    createAccessList(client, {
+      to: wagmiContractConfig.address,
+    }),
+  ).rejects.toMatchInlineSnapshot(`
+    [CallExecutionError: Execution reverted with reason: nope.
+
+    Raw Call Arguments:
+      to:  0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+
+    Details: execution reverted: nope
     Version: viem@x.y.z]
   `)
 })

--- a/src/actions/public/createAccessList.ts
+++ b/src/actions/public/createAccessList.ts
@@ -7,6 +7,7 @@ import {
 } from '../../accounts/utils/parseAccount.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
+import { BaseError, type BaseErrorType } from '../../errors/base.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
@@ -66,6 +67,7 @@ export type CreateAccessListReturnType = Prettify<{
 export type CreateAccessListErrorType = GetCallErrorReturnType<
   | ParseAccountErrorType
   | AssertRequestErrorType
+  | BaseErrorType
   | NumberToHexErrorType
   | FormatTransactionRequestErrorType
   | RequestErrorType
@@ -149,6 +151,8 @@ export async function createAccessList<chain extends Chain | undefined>(
       method: 'eth_createAccessList',
       params: [request as ExactPartial<RpcTransactionRequest>, block],
     })
+    if (response.error)
+      throw new BaseError(response.error, { details: response.error })
     return {
       accessList: response.accessList,
       gasUsed: BigInt(response.gasUsed),

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -706,6 +706,7 @@ export type PublicRpcSchema = [
         ]
     ReturnType: {
       accessList: AccessList
+      error?: string | undefined
       gasUsed: Quantity
     }
   },


### PR DESCRIPTION
Handles `eth_createAccessList` responses that resolve with an `error` field by routing them through the existing call error wrapper.

This keeps `createAccessList` behavior consistent across nodes that return access-list errors in-band instead of rejecting the RPC request. Fixes https://github.com/wevm/viem/actions/runs/26382155288/job/77654687110.
