### PR TITLE
fix(tempo): raw sign access key vouchers

### DIFF
--- a/.changeset/fixed-tempo-vouchers.md
+++ b/.changeset/fixed-tempo-vouchers.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Fixed `signVoucher` to raw sign channel vouchers with access key accounts.

--- a/src/tempo/Account.test.ts
+++ b/src/tempo/Account.test.ts
@@ -589,11 +589,17 @@ describe('signVoucher', () => {
     })
     const signature = await access.signVoucher(voucher)
 
-    expect(signature).toBe(await access.sign({ hash: payload }))
+    expect(signature).toBe(await access.sign({ hash: payload, raw: true }))
     expect(SignatureEnvelope.deserialize(signature)).toMatchObject({
-      type: 'keychain',
-      userAddress: account.address,
+      type: 'secp256k1',
     })
+    expect(
+      await verifyHash(client, {
+        address: access.accessKeyAddress,
+        hash: payload,
+        signature,
+      }),
+    ).toBe(true)
   })
 
   test('standalone', async () => {
@@ -602,6 +608,27 @@ describe('signVoucher', () => {
     expect(await Account.signVoucher(account, voucher)).toBe(
       await account.signVoucher(voucher),
     )
+  })
+
+  test('standalone: access key', async () => {
+    const account = Account.fromSecp256k1(privateKey_secp256k1)
+    const access = Account.fromSecp256k1(
+      '0x06a952d58c24d287245276dd8b4272d82a921d27d90874a6c27a3bc19ff4bfde',
+      {
+        access: account,
+      },
+    )
+    const payload = Channel.getVoucherSignPayload({
+      chainId: voucher.chainId,
+      channelId: voucher.channel,
+      cumulativeAmount: voucher.cumulativeAmount,
+    })
+    const signature = await Account.signVoucher(access, voucher)
+
+    expect(signature).toBe(await access.sign({ hash: payload, raw: true }))
+    expect(SignatureEnvelope.deserialize(signature)).toMatchObject({
+      type: 'secp256k1',
+    })
   })
 })
 

--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -402,9 +402,9 @@ export async function signVoucher(
   account: LocalAccount,
   parameters: signVoucher.Parameters,
 ): Promise<signVoucher.ReturnValue> {
-  return account.sign!({
-    hash: getVoucherSignPayload(parameters),
-  })
+  const hash = getVoucherSignPayload(parameters)
+  if (isAccessKeyAccount(account)) return account.sign({ hash, raw: true })
+  return account.sign!({ hash })
 }
 
 function getVoucherSignPayload(parameters: signVoucher.Parameters) {
@@ -434,6 +434,12 @@ export declare namespace signVoucher {
   }
 
   type ReturnValue = Hex.Hex
+}
+
+function isAccessKeyAccount(
+  account: LocalAccount,
+): account is AccessKeyAccount {
+  return account.source === 'accessKey' && 'accessKeyAddress' in account
 }
 
 export async function signKeyAuthorization(
@@ -557,9 +563,9 @@ function fromBase(parameters: fromBase.Parameters): Account_base {
       return await sign({ hash: hashTypedData(typedData) })
     },
     async signVoucher(parameters) {
-      return await sign({
-        hash: getVoucherSignPayload(parameters),
-      })
+      const hash = getVoucherSignPayload(parameters)
+      if (parentAddress) return await sign({ hash, raw: true })
+      return await sign({ hash })
     },
     publicKey,
     source,


### PR DESCRIPTION
## Summary
Fix Tempo channel voucher signing for access key accounts.

## Motivation
Access key accounts normally sign through a keychain envelope, but channel vouchers must be signed by the voucher signer itself. `signVoucher` was producing keychain signatures for access keys, which cannot verify as raw channel voucher signatures.

## Changes
- Updated `src/tempo/Account.ts` so access key voucher signing uses raw signing.
- Kept the access key type guard private to avoid adding public API surface.
- Added regression coverage for both `access.signVoucher(...)` and `Account.signVoucher(access, ...)`.
- Added a patch changeset for `viem/tempo`.

## Testing
- `pnpm exec biome check --write src/tempo/Account.ts src/tempo/Account.test.ts`
- `pnpm test --project tempo src/tempo/Account.test.ts --run`
  - 46 tests passed
