### PR TITLE
chore: use published ox package

### DIFF
--- a/.changeset/clever-bikes-compare.md
+++ b/.changeset/clever-bikes-compare.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Use the published `ox@0.14.24` package instead of a `pkg.pr.new` build.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ethers": "^6.15.0",
     "knip": "^5.64.0",
     "micro-eth-signer": "^0.14.0",
-    "ox": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
+    "ox": "0.14.24",
     "permissionless": "^0.2.57",
     "prool": "~0.2.3",
     "publint": "^0.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,11 +144,11 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0
       ox:
-        specifier: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a
-        version: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6)
+        specifier: 0.14.24
+        version: 0.14.24(typescript@5.9.3)(zod@4.3.6)
       permissionless:
         specifier: ^0.2.57
-        version: 0.2.57(ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6))
+        version: 0.2.57(ox@0.14.24(typescript@5.9.3)(zod@4.3.6))
       prool:
         specifier: ~0.2.3
         version: 0.2.3(@pimlico/alto@0.0.18(typescript@5.9.3))(testcontainers@11.10.0)
@@ -670,8 +670,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(ws@8.20.1)
       ox:
-        specifier: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a
-        version: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6)
+        specifier: 0.14.24
+        version: 0.14.24(typescript@5.9.3)(zod@4.3.6)
       ws:
         specifier: 8.20.1
         version: 8.20.1
@@ -5173,17 +5173,8 @@ packages:
       typescript:
         optional: true
 
-  ox@0.14.23:
-    resolution: {integrity: sha512-Lx3DB4OkGAC2+gqNEM6fQzbknyBPOjFZ60Bxg/liH2PyU4HnIFA6l37RDoZgfqIwqkACp6uGJvVQFzGfWvv7wA==}
-    peerDependencies:
-      typescript: ^5.9.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a:
-    resolution: {integrity: sha512-OHHm9re1yVjiMN66GZ2JSGuqmvJPrk40zh3PIS/3I6prZLbt6U/zKlgW18eIIkO0Y/ZyySKr6D/4mUXjBmky1g==, tarball: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a}
-    version: 0.14.26-386a343.0
+  ox@0.14.24:
+    resolution: {integrity: sha512-mviaFeN/cSkj/1B7EJKB3fYzQ4E3y7CDmR7Iqei1QUT0M1Zkuo0kNI/ewBnShf7h5r57gp68/DFltjNu5HJCYQ==}
     peerDependencies:
       typescript: ^5.9.3
     peerDependenciesMeta:
@@ -5296,7 +5287,6 @@ packages:
 
   permissionless@0.2.57:
     resolution: {integrity: sha512-QrzAoQGYPV/NJ2x5Sj18h7qed6f+kCyQAojrncN091UPiGqHjFNjgdsgreiv8pxlQgF4UcpuJUvsHLpOEBd6cQ==}
-    version: 0.2.57
     peerDependencies:
       ox: ^0.8.0
       viem: workspace:*
@@ -9254,7 +9244,7 @@ snapshots:
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       mppx: 0.6.5(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(express@5.2.1)(hono@4.12.18)(typescript@5.9.3)(viem@src)
-      ox: 0.14.23(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.24(typescript@5.9.3)(zod@4.3.6)
       webauthx: 0.1.2(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.13(@types/react@19.0.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -11712,22 +11702,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.23(typescript@5.9.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6):
+  ox@0.14.24(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -11864,9 +11839,9 @@ snapshots:
 
   pend@1.2.0: {}
 
-  permissionless@0.2.57(ox@https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6)):
+  permissionless@0.2.57(ox@0.14.24(typescript@5.9.3)(zod@4.3.6)):
     optionalDependencies:
-      ox: https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.24(typescript@5.9.3)(zod@4.3.6)
 
   picocolors@1.1.1: {}
 
@@ -13370,7 +13345,7 @@ snapshots:
 
   webauthx@0.1.2(typescript@5.9.3)(zod@4.3.6):
     dependencies:
-      ox: 0.14.23(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.24(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/src/package.json
+++ b/src/package.json
@@ -231,7 +231,7 @@
     "@scure/bip39": "1.6.0",
     "abitype": "1.2.3",
     "isows": "1.0.7",
-    "ox": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
+    "ox": "0.14.24",
     "ws": "8.20.1"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
Use the published `ox@0.14.24` package instead of the `pkg.pr.new` build.

## Motivation
`viem` and the published package manifest should depend on a stable npm release of `ox`, not a PR tarball URL.

## Changes
- Updated root `package.json` dev dependency from `pkg.pr.new/ox` to `0.14.24`
- Updated `src/package.json` dependency from `pkg.pr.new/ox` to `0.14.24`
- Regenerated `pnpm-lock.yaml` entries for the npm-published `ox` package
- Added `.changeset/clever-bikes-compare.md` for a patch release

## Testing
```sh
pnpm view ox version dist-tags --json
# latest: 0.14.24

pnpm --filter ./ --filter ./src install --lockfile-only
# Done in 3.1s using pnpm v10.33.2

pnpm --filter ./ --filter ./src install --lockfile-only --frozen-lockfile
# Done in 172ms using pnpm v10.33.2

git diff --check
# no output
```

Commit hook:
```sh
biome check --write --unsafe
# Checked 2122 files in 370ms. No fixes applied.
```
