### PR TITLE
fix(tempo): read access key metadata without sender

### DIFF
--- a/.changeset/tiny-keys-read.md
+++ b/.changeset/tiny-keys-read.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed access key metadata reads incorrectly using the client account.

--- a/src/tempo/actions/accessKey.ts
+++ b/src/tempo/actions/accessKey.ts
@@ -654,6 +654,7 @@ export async function getMetadata<
   const account = parseAccount(account_)
   const result = await readContract(client, {
     ...rest,
+    account: null as never,
     ...getMetadata.call({ account: account.address, accessKey }),
   })
   return {

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { accounts, feeToken, getClient } from '~test/tempo/config.js'
 import { generatePrivateKey } from '../accounts/generatePrivateKey.js'
 import {
@@ -16,6 +16,7 @@ import { hashMessage } from '../utils/index.js'
 import * as accessKeyActions from './actions/accessKey.js'
 import {
   Account,
+  Addresses,
   KeyAuthorizationManager,
   P256,
   WebCryptoP256,
@@ -176,6 +177,49 @@ describe('prepareTransactionRequest', () => {
     })
 
     expect(request.keyAuthorization).toBe(keyAuthorization)
+  })
+
+  test('behavior: keyAuthorizationManager reads metadata without client account', async () => {
+    const rootAccount = accounts.at(0)!
+    const keyAuthorizationManager = KeyAuthorizationManager.memory()
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: rootAccount,
+      keyAuthorizationManager,
+    })
+    const accessKeyClient = getClient({
+      account: accessKey,
+    })
+    const expiry = Math.floor((Date.now() + 30_000) / 1000)
+    const keyAuthorization = await accessKeyActions.signAuthorization(client, {
+      account: rootAccount,
+      accessKey,
+      expiry,
+    })
+
+    await keyAuthorizationManager.set(
+      {
+        address: accessKey.address,
+        accessKey: accessKey.accessKeyAddress,
+        chainId: accessKeyClient.chain.id,
+      },
+      keyAuthorization,
+    )
+
+    const requestSpy = vi.spyOn(accessKeyClient, 'request')
+    const request = await prepareTransactionRequest(accessKeyClient, {
+      parameters: ['chainId'],
+    })
+    const metadataCall = requestSpy.mock.calls.find(([request]) => {
+      if (request.method !== 'eth_call') return false
+      const call = request.params?.[0] as { to?: string } | undefined
+      return call?.to?.toLowerCase() === Addresses.accountKeychain.toLowerCase()
+    })
+    const call = metadataCall?.[0].params?.[0] as
+      | { from?: string | undefined }
+      | undefined
+
+    expect(request.keyAuthorization).toBe(keyAuthorization)
+    expect(call?.from).toBeUndefined()
   })
 
   test('behavior: keyAuthorizationManager removes authorization for authorized key', async () => {


### PR DESCRIPTION
## Summary
Read Tempo access key metadata without inheriting the client account.

## Motivation
The prepare transaction request hook checks whether a pending key authorization is already on chain. When the client account is an access-key account and the hook is deciding whether to attach its pending key authorization, the metadata read inherited that access-key account.

That changed the read from a plain AccountKeychain.getKey state lookup into a Tempo eth_call with from, type, calls, keyId, and keyType. Tempo nodes can then validate it like access-key simulation and reject before the state read completes.

## Changes
- Set account null for src/tempo/actions/accessKey.ts getMetadata reads so eth_call has no from or derived access-key fields.
- Add a regression test in src/tempo/chainConfig.test.ts for a client whose default account is the access key with pending key authorization.

## Testing
- pnpm exec vitest run src/tempo/chainConfig.test.ts --config test/vitest.config.ts
- pnpm exec biome check src/tempo/actions/accessKey.ts src/tempo/chainConfig.test.ts
- git diff --check