### PR TITLE
feat(tempo): key authorization witness actions

### DIFF
--- a/.changeset/tempo-key-authorization-witness.md
+++ b/.changeset/tempo-key-authorization-witness.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+**`viem/tempo`:** Added access-key witness actions.

--- a/site/pages/tempo/actions/accessKey.authorize.mdx
+++ b/site/pages/tempo/actions/accessKey.authorize.mdx
@@ -149,6 +149,25 @@ const { receipt } = await client.accessKey.authorizeSync({
 })
 ```
 
+### With a Witness
+
+Use `witness` to bind a 32-byte value into the authorization's signing hash. This lets you bind a single signature to an arbitrary offchain context (e.g. a server-issued challenge), or use it as a revocation handle that can be burned onchain (via [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness)) to invalidate the authorization before it is submitted ([TIP-1053](https://tips.sh/1053)):
+
+```ts twoslash
+import { Account, P256 } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const { receipt } = await client.accessKey.authorizeSync({
+  accessKey,
+  witness: '0x...', // [!code focus]
+})
+```
+
 ### Authorize Public Keys
 
 Instead of passing an `AccessKeyAccount`, you can authorize a key by its public key or address directly:
@@ -252,5 +271,11 @@ Spending limits per token. Optionally include `period` (in seconds) to make the 
 - **Type:** `{ address: Address; selector?: Hex | string; recipients?: Address[] }[]`
 
 Call scopes restricting which contracts/selectors this key can call. Each scope entry specifies a contract address, an optional 4-byte function selector, and optional recipient addresses (for transfer-like functions). If `scopes` is set to `[]` (empty array), the key cannot make any calls.
+
+### witness (optional)
+
+- **Type:** `Hex`
+
+Optional 32-byte witness bound into the authorization's signing hash. Can be burned onchain via [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness) to invalidate the authorization before it is submitted ([TIP-1053](https://tips.sh/1053)).
 
 <WriteParameters />

--- a/site/pages/tempo/actions/accessKey.burnWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.burnWitness.mdx
@@ -1,0 +1,72 @@
+import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
+
+# `accessKey.burnWitness`
+
+Burns a key-authorization witness, invalidating any authorization bound to it before it is submitted onchain.
+
+A witness is an optional 32-byte value bound into a key authorization's signing hash (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize)). Once burned, an authorization carrying the same witness can no longer be submitted, giving applications a revocation handle for signed-but-not-yet-submitted authorizations.
+
+[TIP-1053](https://tips.sh/1053)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.accessKey.burnWitnessSync({
+  witness: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+})
+
+console.log('Transaction hash:', receipt.transactionHash)
+// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `accessKey.burnWitness` action and wait for inclusion manually:
+
+```ts twoslash
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const hash = await client.accessKey.burnWitness({
+  witness: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+
+const { args }
+  = Actions.accessKey.burnWitness.extractEvent(receipt.logs)
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** The account that burned the witness. */
+  account: Address
+  /** The witness that was burned. */
+  witness: Hex
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+}
+```
+
+## Parameters
+
+### witness
+
+- **Type:** `Hex`
+
+The 32-byte witness to burn.
+
+<WriteParameters />

--- a/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
@@ -1,0 +1,53 @@
+import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
+
+# `accessKey.isWitnessBurned`
+
+Checks whether a key-authorization witness has been burned for an account.
+
+See [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness) for details on witnesses.
+
+[TIP-1053](https://tips.sh/1053)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const isBurned = await client.accessKey.isWitnessBurned({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  witness: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+})
+
+console.log('Burned:', isBurned)
+// @log: Burned: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = boolean
+```
+
+## Parameters
+
+### account
+
+- **Type:** `Address | Account`
+
+Account address.
+
+### witness
+
+- **Type:** `Hex`
+
+The 32-byte witness to check.
+
+<ReadParameters />

--- a/site/pages/tempo/actions/accessKey.signAuthorization.mdx
+++ b/site/pages/tempo/actions/accessKey.signAuthorization.mdx
@@ -188,3 +188,9 @@ Spending limits per token. Optionally include `period` (in seconds) to make the 
 - **Type:** `{ address: Address; selector?: Hex | string; recipients?: Address[] }[]`
 
 Call scopes restricting which contracts/selectors this key can call.
+
+### witness (optional)
+
+- **Type:** `Hex`
+
+Optional 32-byte witness bound into the authorization's signing hash. Can be burned onchain via [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness) to invalidate the authorization before it is submitted ([TIP-1053](https://tips.sh/1053)).

--- a/site/pages/tempo/actions/accessKey.watchWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitness.mdx
@@ -1,0 +1,83 @@
+# `accessKey.watchWitness`
+
+Watches for key-authorization witness events (`KeyAuthorizationWitness`), emitted when a key is authorized with a `witness` (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize)).
+
+[TIP-1053](https://tips.sh/1053)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const unwatch = client.accessKey.watchWitness({
+  onWitness: (args, log) => {
+    console.log('Witness used:', args)
+  },
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onWitness
+
+- **Type:** `function`
+
+```ts
+declare function onWitness(args: Args, log: Log): void
+
+type Args = {
+  /** The account that authorized the key. */
+  account: Address
+  /** The witness bound to the authorization. */
+  witness: Hex
+}
+```
+
+Callback to invoke when a witness is used.
+
+### fromBlock (optional)
+
+- **Type:** `bigint`
+
+Block to start listening from.
+
+### onError (optional)
+
+- **Type:** `function`
+
+```ts
+declare function onError(error: Error): void
+```
+
+The callback to call when an error occurred when trying to get for a new block.
+
+### poll (optional)
+
+- **Type:** `true`
+
+Whether to use polling.
+
+### pollingInterval (optional)
+
+- **Type:** `number`
+
+Polling frequency (in ms). Defaults to Client's pollingInterval config.

--- a/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
@@ -1,0 +1,83 @@
+# `accessKey.watchWitnessBurned`
+
+Watches for key-authorization witness burned events (`KeyAuthorizationWitnessBurned`), emitted when a witness is burned (see [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness)).
+
+[TIP-1053](https://tips.sh/1053)
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const unwatch = client.accessKey.watchWitnessBurned({
+  onBurned: (args, log) => {
+    console.log('Witness burned:', args)
+  },
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onBurned
+
+- **Type:** `function`
+
+```ts
+declare function onBurned(args: Args, log: Log): void
+
+type Args = {
+  /** The account that burned the witness. */
+  account: Address
+  /** The witness that was burned. */
+  witness: Hex
+}
+```
+
+Callback to invoke when a witness is burned.
+
+### fromBlock (optional)
+
+- **Type:** `bigint`
+
+Block to start listening from.
+
+### onError (optional)
+
+- **Type:** `function`
+
+```ts
+declare function onError(error: Error): void
+```
+
+The callback to call when an error occurred when trying to get for a new block.
+
+### poll (optional)
+
+- **Type:** `true`
+
+Whether to use polling.
+
+### pollingInterval (optional)
+
+- **Type:** `number`
+
+Polling frequency (in ms). Defaults to Client's pollingInterval config.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -1870,12 +1870,20 @@ export const sidebar = {
                 link: '/tempo/actions/accessKey.authorize',
               },
               {
+                text: 'burnWitness',
+                link: '/tempo/actions/accessKey.burnWitness',
+              },
+              {
                 text: 'getMetadata',
                 link: '/tempo/actions/accessKey.getMetadata',
               },
               {
                 text: 'getRemainingLimit',
                 link: '/tempo/actions/accessKey.getRemainingLimit',
+              },
+              {
+                text: 'isWitnessBurned',
+                link: '/tempo/actions/accessKey.isWitnessBurned',
               },
               {
                 text: 'revoke',
@@ -1888,6 +1896,14 @@ export const sidebar = {
               {
                 text: 'updateLimit',
                 link: '/tempo/actions/accessKey.updateLimit',
+              },
+              {
+                text: 'watchWitness',
+                link: '/tempo/actions/accessKey.watchWitness',
+              },
+              {
+                text: 'watchWitnessBurned',
+                link: '/tempo/actions/accessKey.watchWitnessBurned',
               },
             ],
           },

--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -55,7 +55,7 @@ export type RootAccount = Account_base<'root'> & {
     key: resolveAccessKey.Parameters,
     parameters: Pick<
       KeyAuthorization.KeyAuthorization,
-      'chainId' | 'expiry' | 'limits' | 'scopes'
+      'chainId' | 'expiry' | 'limits' | 'scopes' | 'witness'
     >,
   ) => Promise<KeyAuthorization.Signed>
 }
@@ -462,7 +462,7 @@ export async function signKeyAuthorization(
   account: LocalAccount,
   parameters: signKeyAuthorization.Parameters,
 ): Promise<signKeyAuthorization.ReturnValue> {
-  const { chainId, key, expiry, limits, scopes } = parameters
+  const { chainId, key, expiry, limits, scopes, witness } = parameters
   const { accessKeyAddress, keyType: type } = resolveAccessKey(key)
 
   const signature = await account.sign!({
@@ -473,6 +473,7 @@ export async function signKeyAuthorization(
       limits,
       scopes,
       type,
+      witness,
     }),
   })
   return KeyAuthorization.from({
@@ -483,13 +484,14 @@ export async function signKeyAuthorization(
     scopes,
     signature: SignatureEnvelope.from(signature),
     type,
+    witness,
   })
 }
 
 export declare namespace signKeyAuthorization {
   type Parameters = Pick<
     KeyAuthorization.KeyAuthorization,
-    'chainId' | 'expiry' | 'limits' | 'scopes'
+    'chainId' | 'expiry' | 'limits' | 'scopes' | 'witness'
   > & {
     key: resolveAccessKey.Parameters
   }
@@ -618,7 +620,7 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
     ...account,
     source: 'root',
     async signKeyAuthorization(key, parameters) {
-      const { chainId, expiry, limits, scopes } = parameters
+      const { chainId, expiry, limits, scopes, witness } = parameters
       const { accessKeyAddress, keyType: type } = resolveAccessKey(key)
 
       const signature = await account.sign({
@@ -629,6 +631,7 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
           limits,
           scopes,
           type,
+          witness,
         }),
       })
       const keyAuthorization = KeyAuthorization.from({
@@ -639,6 +642,7 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
         scopes,
         signature: SignatureEnvelope.from(signature),
         type,
+        witness,
       })
       return keyAuthorization
     },

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -91,6 +91,61 @@ export type Decorator<
       parameters: accessKeyActions.authorizeSync.Parameters<chain, account>,
     ) => Promise<accessKeyActions.authorizeSync.ReturnValue>
     /**
+     * Burns a key-authorization witness, invalidating any authorization bound
+     * to it before it is submitted onchain.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     * import { privateKeyToAccount } from 'viem/accounts'
+     *
+     * const client = createClient({
+     *   account: privateKeyToAccount('0x...'),
+     *   chain: tempo,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const hash = await client.accessKey.burnWitness({
+     *   witness: '0x...',
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns The transaction hash.
+     */
+    burnWitness: (
+      parameters: accessKeyActions.burnWitness.Parameters<chain, account>,
+    ) => Promise<accessKeyActions.burnWitness.ReturnValue>
+    /**
+     * Burns a key-authorization witness and waits for the transaction receipt.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     * import { privateKeyToAccount } from 'viem/accounts'
+     *
+     * const client = createClient({
+     *   account: privateKeyToAccount('0x...'),
+     *   chain: tempo,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const { receipt, ...result } = await client.accessKey.burnWitnessSync({
+     *   witness: '0x...',
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns The transaction receipt and event data.
+     */
+    burnWitnessSync: (
+      parameters: accessKeyActions.burnWitnessSync.Parameters<chain, account>,
+    ) => Promise<accessKeyActions.burnWitnessSync.ReturnValue>
+    /**
      * Gets access key information.
      *
      * @example
@@ -143,6 +198,32 @@ export type Decorator<
     getRemainingLimit: (
       parameters: accessKeyActions.getRemainingLimit.Parameters<account>,
     ) => Promise<accessKeyActions.getRemainingLimit.ReturnValue>
+    /**
+     * Checks whether a key-authorization witness has been burned for an account.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     *
+     * const client = createClient({
+     *   chain: tempo,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const isBurned = await client.accessKey.isWitnessBurned({
+     *   account: '0x...',
+     *   witness: '0x...',
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns Whether the witness has been burned.
+     */
+    isWitnessBurned: (
+      parameters: accessKeyActions.isWitnessBurned.Parameters<account>,
+    ) => Promise<accessKeyActions.isWitnessBurned.ReturnValue>
     /**
      * Revokes an authorized access key.
      *
@@ -255,6 +336,60 @@ export type Decorator<
     updateLimitSync: (
       parameters: accessKeyActions.updateLimitSync.Parameters<chain, account>,
     ) => Promise<accessKeyActions.updateLimitSync.ReturnValue>
+    /**
+     * Watches for key-authorization witness events.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     *
+     * const client = createClient({
+     *   chain: tempo,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const unwatch = client.accessKey.watchWitness({
+     *   onWitness: (args, log) => {
+     *     console.log('Witness used:', args)
+     *   },
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns A function to unsubscribe from the event.
+     */
+    watchWitness: (
+      parameters: accessKeyActions.watchWitness.Parameters,
+    ) => ReturnType<typeof accessKeyActions.watchWitness>
+    /**
+     * Watches for key-authorization witness burned events.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempo } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     *
+     * const client = createClient({
+     *   chain: tempo,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const unwatch = client.accessKey.watchWitnessBurned({
+     *   onBurned: (args, log) => {
+     *     console.log('Witness burned:', args)
+     *   },
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns A function to unsubscribe from the event.
+     */
+    watchWitnessBurned: (
+      parameters: accessKeyActions.watchWitnessBurned.Parameters,
+    ) => ReturnType<typeof accessKeyActions.watchWitnessBurned>
   }
   amm: {
     /**
@@ -4900,10 +5035,16 @@ export function decorator() {
           accessKeyActions.authorize(client, parameters),
         authorizeSync: (parameters) =>
           accessKeyActions.authorizeSync(client, parameters),
+        burnWitness: (parameters) =>
+          accessKeyActions.burnWitness(client, parameters),
+        burnWitnessSync: (parameters) =>
+          accessKeyActions.burnWitnessSync(client, parameters),
         getMetadata: (parameters) =>
           accessKeyActions.getMetadata(client, parameters),
         getRemainingLimit: (parameters) =>
           accessKeyActions.getRemainingLimit(client, parameters),
+        isWitnessBurned: (parameters) =>
+          accessKeyActions.isWitnessBurned(client, parameters),
         revoke: (parameters) => accessKeyActions.revoke(client, parameters),
         revokeSync: (parameters) =>
           accessKeyActions.revokeSync(client, parameters),
@@ -4911,6 +5052,10 @@ export function decorator() {
           accessKeyActions.updateLimit(client, parameters),
         updateLimitSync: (parameters) =>
           accessKeyActions.updateLimitSync(client, parameters),
+        watchWitness: (parameters) =>
+          accessKeyActions.watchWitness(client, parameters),
+        watchWitnessBurned: (parameters) =>
+          accessKeyActions.watchWitnessBurned(client, parameters),
       },
       amm: {
         getPool: (parameters) => ammActions.getPool(client, parameters),

--- a/src/tempo/actions/accessKey.test.ts
+++ b/src/tempo/actions/accessKey.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import * as P256 from 'ox/P256'
 import * as PublicKey from 'ox/PublicKey'
 import { Period } from 'ox/tempo'
@@ -393,5 +394,173 @@ describe('getRemainingLimit', () => {
     })
 
     expect(remaining).toBe(0n)
+  })
+})
+
+/** Returns a random 32-byte witness. */
+function randomWitness(): `0x${string}` {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return `0x${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`
+}
+
+describe('authorize (witness)', () => {
+  test('behavior: with witness', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: account,
+    })
+    const witness = randomWitness()
+
+    const { receipt } = await actions.accessKey.authorizeSync(client, {
+      accessKey,
+      expiry: Math.floor((Date.now() + 30_000) / 1000),
+      witness,
+    })
+
+    expect(receipt.status).toBe('success')
+
+    // Witness should not be burned after a successful authorization.
+    const isBurned = await actions.accessKey.isWitnessBurned(client, {
+      account: account.address,
+      witness,
+    })
+    expect(isBurned).toBe(false)
+  })
+
+  test('behavior: reverts when witness already burned', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: account,
+    })
+    const witness = randomWitness()
+
+    await actions.accessKey.burnWitnessSync(client, { witness })
+
+    await expect(
+      actions.accessKey.authorizeSync(client, {
+        accessKey,
+        expiry: Math.floor((Date.now() + 30_000) / 1000),
+        witness,
+      }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('signAuthorization (witness)', () => {
+  test('behavior: with witness', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: account,
+    })
+    const witness = randomWitness()
+
+    const keyAuthorization = await actions.accessKey.signAuthorization(client, {
+      account,
+      accessKey,
+      expiry: Math.floor((Date.now() + 30_000) / 1000),
+      witness,
+    })
+
+    expect(keyAuthorization.witness).toBe(witness)
+  })
+})
+
+describe('burnWitness', () => {
+  test('default', async () => {
+    const witness = randomWitness()
+
+    const isBurnedBefore = await actions.accessKey.isWitnessBurned(client, {
+      account: account.address,
+      witness,
+    })
+    expect(isBurnedBefore).toBe(false)
+
+    const { receipt, ...result } = await actions.accessKey.burnWitnessSync(
+      client,
+      { witness },
+    )
+
+    expect(receipt.status).toBe('success')
+    expect(result.witness).toBe(witness)
+    expect(result.account.toLowerCase()).toBe(account.address.toLowerCase())
+
+    const isBurnedAfter = await actions.accessKey.isWitnessBurned(client, {
+      account: account.address,
+      witness,
+    })
+    expect(isBurnedAfter).toBe(true)
+  })
+
+  test('behavior: reverts when already burned', async () => {
+    const witness = randomWitness()
+
+    await actions.accessKey.burnWitnessSync(client, { witness })
+
+    await expect(
+      actions.accessKey.burnWitnessSync(client, { witness }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('isWitnessBurned', () => {
+  test('default', async () => {
+    const witness = randomWitness()
+
+    expect(
+      await actions.accessKey.isWitnessBurned(client, {
+        account: account.address,
+        witness,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('watchWitness', () => {
+  test('default', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: account,
+    })
+    const witness = randomWitness()
+
+    const logs: any[] = []
+    const unwatch = actions.accessKey.watchWitness(client, {
+      onWitness: (args, log) => {
+        logs.push({ args, log })
+      },
+    })
+
+    await actions.accessKey.authorizeSync(client, {
+      accessKey,
+      expiry: Math.floor((Date.now() + 30_000) / 1000),
+      witness,
+    })
+
+    await setTimeout(500)
+    unwatch()
+
+    expect(logs.length).toBeGreaterThanOrEqual(1)
+    expect(
+      logs.some((l) => l.args.witness.toLowerCase() === witness.toLowerCase()),
+    ).toBe(true)
+  })
+})
+
+describe('watchWitnessBurned', () => {
+  test('default', async () => {
+    const witness = randomWitness()
+
+    const logs: any[] = []
+    const unwatch = actions.accessKey.watchWitnessBurned(client, {
+      onBurned: (args, log) => {
+        logs.push({ args, log })
+      },
+    })
+
+    await actions.accessKey.burnWitnessSync(client, { witness })
+
+    await setTimeout(500)
+    unwatch()
+
+    expect(logs.length).toBeGreaterThanOrEqual(1)
+    expect(
+      logs.some((l) => l.args.witness.toLowerCase() === witness.toLowerCase()),
+    ).toBe(true)
   })
 })

--- a/src/tempo/actions/accessKey.ts
+++ b/src/tempo/actions/accessKey.ts
@@ -2,7 +2,10 @@ import type { Address } from 'abitype'
 import type { KeyAuthorization } from 'ox/tempo'
 import type { Account } from '../../accounts/types.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
+import type { ReadContractReturnType } from '../../actions/public/readContract.js'
 import { readContract } from '../../actions/public/readContract.js'
+import type { WatchContractEventParameters } from '../../actions/public/watchContractEvent.js'
+import { watchContractEvent } from '../../actions/public/watchContractEvent.js'
 import { sendTransaction } from '../../actions/wallet/sendTransaction.js'
 import { sendTransactionSync } from '../../actions/wallet/sendTransactionSync.js'
 import type { WriteContractReturnType } from '../../actions/wallet/writeContract.js'
@@ -12,9 +15,10 @@ import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import type { BaseErrorType } from '../../errors/base.js'
 import type { Chain } from '../../types/chain.js'
-import type { GetEventArgs } from '../../types/contract.js'
-import type { Log } from '../../types/log.js'
-import type { Compute } from '../../types/utils.js'
+import type { ExtractAbiItem, GetEventArgs } from '../../types/contract.js'
+import type { Log, Log as viem_Log } from '../../types/log.js'
+import type { Hex } from '../../types/misc.js'
+import type { Compute, UnionOmit } from '../../types/utils.js'
 import { parseEventLogs } from '../../utils/abi/parseEventLogs.js'
 import * as Abis from '../Abis.js'
 import type { AccessKeyAccount, resolveAccessKey } from '../Account.js'
@@ -102,6 +106,17 @@ export namespace authorize {
       | undefined
     /** Call scopes restricting which contracts/selectors this key can call. */
     scopes?: KeyAuthorization.Scope[] | undefined
+    /**
+     * Optional 32-byte witness bound into the authorization's signing hash.
+     *
+     * Applications use this to bind a single signature to an arbitrary offchain
+     * context (e.g. a server-issued challenge), or as a revocation handle that
+     * can be burned onchain (see {@link burnWitness}) to invalidate the
+     * authorization before it is submitted.
+     *
+     * [TIP-1053](https://tips.sh/1053)
+     */
+    witness?: Hex | undefined
   }
 
   export type ReturnValue = WriteContractReturnType
@@ -125,6 +140,7 @@ export namespace authorize {
       expiry,
       limits,
       scopes,
+      witness,
       ...rest
     } = parameters
     const account_ = rest.account ?? client.account
@@ -137,6 +153,7 @@ export namespace authorize {
       expiry,
       limits,
       scopes,
+      witness,
     })
     return (await action(client, {
       ...rest,
@@ -229,7 +246,14 @@ export namespace authorizeSync {
 }
 
 /**
- * Revokes an authorized access key.
+ * Burns a key-authorization witness, invalidating any authorization bound to
+ * it before it is submitted onchain.
+ *
+ * Once burned, an `authorizeKey` call carrying the same `witness` will revert.
+ * This lets applications issue a signed authorization offchain (see
+ * {@link authorize}) while retaining the ability to revoke it.
+ *
+ * [TIP-1053](https://tips.sh/1053)
  *
  * @example
  * ```ts
@@ -244,8 +268,8 @@ export namespace authorizeSync {
  *   transport: http(),
  * })
  *
- * const hash = await Actions.accessKey.revoke(client, {
- *   accessKey: '0x...',
+ * const hash = await Actions.accessKey.burnWitness(client, {
+ *   witness: '0x...',
  * })
  * ```
  *
@@ -253,25 +277,25 @@ export namespace authorizeSync {
  * @param parameters - Parameters.
  * @returns The transaction hash.
  */
-export async function revoke<
+export async function burnWitness<
   chain extends Chain | undefined,
   account extends Account | undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: revoke.Parameters<chain, account>,
-): Promise<revoke.ReturnValue> {
-  return revoke.inner(writeContract, client, parameters)
+  parameters: burnWitness.Parameters<chain, account>,
+): Promise<burnWitness.ReturnValue> {
+  return burnWitness.inner(writeContract, client, parameters)
 }
 
-export namespace revoke {
+export namespace burnWitness {
   export type Parameters<
     chain extends Chain | undefined = Chain | undefined,
     account extends Account | undefined = Account | undefined,
   > = WriteParameters<chain, account> & Args
 
   export type Args = {
-    /** The access key to revoke. */
-    accessKey: Address | AccessKeyAccount
+    /** The 32-byte witness to burn. */
+    witness: Hex
   }
 
   export type ReturnValue = WriteContractReturnType
@@ -287,10 +311,10 @@ export namespace revoke {
   >(
     action: action,
     client: Client<Transport, chain, account>,
-    parameters: revoke.Parameters<chain, account>,
+    parameters: burnWitness.Parameters<chain, account>,
   ): Promise<ReturnType<action>> {
-    const { accessKey, ...rest } = parameters
-    const call = revoke.call({ accessKey })
+    const { witness, ...rest } = parameters
+    const call = burnWitness.call({ witness })
     return (await action(client, {
       ...rest,
       ...call,
@@ -298,7 +322,7 @@ export namespace revoke {
   }
 
   /**
-   * Defines a call to the `revokeKey` function.
+   * Defines a call to the `burnKeyAuthorizationWitness` function.
    *
    * Can be passed as a parameter to:
    * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
@@ -318,7 +342,7 @@ export namespace revoke {
    *
    * const hash = await client.sendTransaction({
    *   calls: [
-   *     Actions.accessKey.revoke.call({ accessKey: '0x...' }),
+   *     Actions.accessKey.burnWitness.call({ witness: '0x...' }),
    *   ],
    * })
    * ```
@@ -327,12 +351,12 @@ export namespace revoke {
    * @returns The call.
    */
   export function call(args: Args) {
-    const { accessKey } = args
+    const { witness } = args
     return defineCall({
       address: Addresses.accountKeychain,
       abi: Abis.accountKeychain,
-      functionName: 'revokeKey',
-      args: [resolveAccessKeyAddress(accessKey)],
+      functionName: 'burnKeyAuthorizationWitness',
+      args: [witness],
     })
   }
 
@@ -340,16 +364,17 @@ export namespace revoke {
     const [log] = parseEventLogs({
       abi: Abis.accountKeychain,
       logs,
-      eventName: 'KeyRevoked',
+      eventName: 'KeyAuthorizationWitnessBurned',
       strict: true,
     })
-    if (!log) throw new Error('`KeyRevoked` event not found.')
+    if (!log)
+      throw new Error('`KeyAuthorizationWitnessBurned` event not found.')
     return log
   }
 }
 
 /**
- * Revokes an authorized access key and waits for the transaction receipt.
+ * Burns a key-authorization witness and waits for the transaction receipt.
  *
  * @example
  * ```ts
@@ -364,8 +389,8 @@ export namespace revoke {
  *   transport: http(),
  * })
  *
- * const result = await Actions.accessKey.revokeSync(client, {
- *   accessKey: '0x...',
+ * const { receipt, ...result } = await Actions.accessKey.burnWitnessSync(client, {
+ *   witness: '0x...',
  * })
  * ```
  *
@@ -373,246 +398,42 @@ export namespace revoke {
  * @param parameters - Parameters.
  * @returns The transaction receipt and event data.
  */
-export async function revokeSync<
+export async function burnWitnessSync<
   chain extends Chain | undefined,
   account extends Account | undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: revokeSync.Parameters<chain, account>,
-): Promise<revokeSync.ReturnValue> {
+  parameters: burnWitnessSync.Parameters<chain, account>,
+): Promise<burnWitnessSync.ReturnValue> {
   const { throwOnReceiptRevert = true, ...rest } = parameters
-  const receipt = await revoke.inner(writeContractSync, client, {
+  const receipt = await burnWitness.inner(writeContractSync, client, {
     ...rest,
     throwOnReceiptRevert,
   } as never)
-  const { args } = revoke.extractEvent(receipt.logs)
+  const { args } = burnWitness.extractEvent(receipt.logs)
   return {
     ...args,
     receipt,
   } as never
 }
 
-export namespace revokeSync {
+export namespace burnWitnessSync {
   export type Parameters<
     chain extends Chain | undefined = Chain | undefined,
     account extends Account | undefined = Account | undefined,
-  > = revoke.Parameters<chain, account>
+  > = burnWitness.Parameters<chain, account>
 
-  export type Args = revoke.Args
+  export type Args = burnWitness.Args
 
   export type ReturnValue = Compute<
     GetEventArgs<
       typeof Abis.accountKeychain,
-      'KeyRevoked',
+      'KeyAuthorizationWitnessBurned',
       { IndexedOnly: false; Required: true }
     > & {
       receipt: TransactionReceipt
     }
   >
-
-  // TODO: exhaustive error type
-  export type ErrorType = BaseErrorType
-}
-
-/**
- * Updates the spending limit for a specific token on an authorized access key.
- *
- * @example
- * ```ts
- * import { createClient, http } from 'viem'
- * import { tempo } from 'viem/chains'
- * import { Actions } from 'viem/tempo'
- * import { privateKeyToAccount } from 'viem/accounts'
- *
- * const client = createClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
- *   transport: http(),
- * })
- *
- * const hash = await Actions.accessKey.updateLimit(client, {
- *   accessKey: '0x...',
- *   token: '0x...',
- *   limit: 1000000000000000000n,
- * })
- * ```
- *
- * @param client - Client.
- * @param parameters - Parameters.
- * @returns The transaction hash.
- */
-export async function updateLimit<
-  chain extends Chain | undefined,
-  account extends Account | undefined,
->(
-  client: Client<Transport, chain, account>,
-  parameters: updateLimit.Parameters<chain, account>,
-): Promise<updateLimit.ReturnValue> {
-  return updateLimit.inner(writeContract, client, parameters)
-}
-
-export namespace updateLimit {
-  export type Parameters<
-    chain extends Chain | undefined = Chain | undefined,
-    account extends Account | undefined = Account | undefined,
-  > = WriteParameters<chain, account> & Args
-
-  export type Args = {
-    /** The access key to update. */
-    accessKey: Address | AccessKeyAccount
-    /** The token address. */
-    token: Address
-    /** The new spending limit. */
-    limit: bigint
-  }
-
-  export type ReturnValue = WriteContractReturnType
-
-  // TODO: exhaustive error type
-  export type ErrorType = BaseErrorType
-
-  /** @internal */
-  export async function inner<
-    action extends typeof writeContract | typeof writeContractSync,
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    action: action,
-    client: Client<Transport, chain, account>,
-    parameters: updateLimit.Parameters<chain, account>,
-  ): Promise<ReturnType<action>> {
-    const { accessKey, token, limit, ...rest } = parameters
-    const call = updateLimit.call({ accessKey, token, limit })
-    return (await action(client, {
-      ...rest,
-      ...call,
-    } as never)) as never
-  }
-
-  /**
-   * Defines a call to the `updateSpendingLimit` function.
-   *
-   * Can be passed as a parameter to:
-   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
-   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
-   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
-   *
-   * @example
-   * ```ts
-   * import { createClient, http, walletActions } from 'viem'
-   * import { tempo } from 'viem/chains'
-   * import { Actions } from 'viem/tempo'
-   *
-   * const client = createClient({
-   *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
-   *   transport: http(),
-   * }).extend(walletActions)
-   *
-   * const hash = await client.sendTransaction({
-   *   calls: [
-   *     Actions.accessKey.updateLimit.call({
-   *       accessKey: '0x...',
-   *       token: '0x...',
-   *       limit: 1000000000000000000n,
-   *     }),
-   *   ],
-   * })
-   * ```
-   *
-   * @param args - Arguments.
-   * @returns The call.
-   */
-  export function call(args: Args) {
-    const { accessKey, token, limit } = args
-    return defineCall({
-      address: Addresses.accountKeychain,
-      abi: Abis.accountKeychain,
-      functionName: 'updateSpendingLimit',
-      args: [resolveAccessKeyAddress(accessKey), token, limit],
-    })
-  }
-
-  export function extractEvent(logs: Log[]) {
-    const [log] = parseEventLogs({
-      abi: Abis.accountKeychain,
-      logs,
-      eventName: 'SpendingLimitUpdated',
-      strict: true,
-    })
-    if (!log) throw new Error('`SpendingLimitUpdated` event not found.')
-    return log
-  }
-}
-
-/**
- * Updates the spending limit and waits for the transaction receipt.
- *
- * @example
- * ```ts
- * import { createClient, http } from 'viem'
- * import { tempo } from 'viem/chains'
- * import { Actions } from 'viem/tempo'
- * import { privateKeyToAccount } from 'viem/accounts'
- *
- * const client = createClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
- *   transport: http(),
- * })
- *
- * const result = await Actions.accessKey.updateLimitSync(client, {
- *   accessKey: '0x...',
- *   token: '0x...',
- *   limit: 1000000000000000000n,
- * })
- * ```
- *
- * @param client - Client.
- * @param parameters - Parameters.
- * @returns The transaction receipt and event data.
- */
-export async function updateLimitSync<
-  chain extends Chain | undefined,
-  account extends Account | undefined,
->(
-  client: Client<Transport, chain, account>,
-  parameters: updateLimitSync.Parameters<chain, account>,
-): Promise<updateLimitSync.ReturnValue> {
-  const { throwOnReceiptRevert = true, ...rest } = parameters
-  const receipt = await updateLimit.inner(writeContractSync, client, {
-    ...rest,
-    throwOnReceiptRevert,
-  } as never)
-  const { args } = updateLimit.extractEvent(receipt.logs)
-  return {
-    account: args.account,
-    publicKey: args.publicKey,
-    token: args.token,
-    limit: args.newLimit,
-    receipt,
-  }
-}
-
-export namespace updateLimitSync {
-  export type Parameters<
-    chain extends Chain | undefined = Chain | undefined,
-    account extends Account | undefined = Account | undefined,
-  > = updateLimit.Parameters<chain, account>
-
-  export type Args = updateLimit.Args
-
-  export type ReturnValue = {
-    /** The account that owns the key. */
-    account: Address
-    /** The access key address. */
-    publicKey: Address
-    /** The token address. */
-    token: Address
-    /** The new spending limit. */
-    limit: bigint
-    /** The transaction receipt. */
-    receipt: TransactionReceipt
-  }
 
   // TODO: exhaustive error type
   export type ErrorType = BaseErrorType
@@ -829,6 +650,268 @@ export namespace getRemainingLimit {
 }
 
 /**
+ * Checks whether a key-authorization witness has been burned for an account.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const isBurned = await Actions.accessKey.isWitnessBurned(client, {
+ *   account: '0x...',
+ *   witness: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns Whether the witness has been burned.
+ */
+export async function isWitnessBurned<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: isWitnessBurned.Parameters<account>,
+): Promise<isWitnessBurned.ReturnValue> {
+  const { account: account_ = client.account, witness, ...rest } = parameters
+  if (!account_) throw new Error('account is required.')
+  const account = parseAccount(account_)
+  return readContract(client, {
+    ...rest,
+    account: null as never,
+    ...isWitnessBurned.call({ account: account.address, witness }),
+  })
+}
+
+export namespace isWitnessBurned {
+  export type Parameters<
+    account extends Account | undefined = Account | undefined,
+  > = ReadParameters & GetAccountParameter<account> & Pick<Args, 'witness'>
+
+  export type Args = {
+    /** Account address. */
+    account: Address
+    /** The 32-byte witness to check. */
+    witness: Hex
+  }
+
+  export type ReturnValue = ReadContractReturnType<
+    typeof Abis.accountKeychain,
+    'isKeyAuthorizationWitnessBurned',
+    never
+  >
+
+  /**
+   * Defines a call to the `isKeyAuthorizationWitnessBurned` function.
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    const { account, witness } = args
+    return defineCall({
+      address: Addresses.accountKeychain,
+      abi: Abis.accountKeychain,
+      functionName: 'isKeyAuthorizationWitnessBurned',
+      args: [account, witness],
+    })
+  }
+}
+
+/**
+ * Revokes an authorized access key.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const hash = await Actions.accessKey.revoke(client, {
+ *   accessKey: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction hash.
+ */
+export async function revoke<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: revoke.Parameters<chain, account>,
+): Promise<revoke.ReturnValue> {
+  return revoke.inner(writeContract, client, parameters)
+}
+
+export namespace revoke {
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = WriteParameters<chain, account> & Args
+
+  export type Args = {
+    /** The access key to revoke. */
+    accessKey: Address | AccessKeyAccount
+  }
+
+  export type ReturnValue = WriteContractReturnType
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+
+  /** @internal */
+  export async function inner<
+    action extends typeof writeContract | typeof writeContractSync,
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    action: action,
+    client: Client<Transport, chain, account>,
+    parameters: revoke.Parameters<chain, account>,
+  ): Promise<ReturnType<action>> {
+    const { accessKey, ...rest } = parameters
+    const call = revoke.call({ accessKey })
+    return (await action(client, {
+      ...rest,
+      ...call,
+    } as never)) as never
+  }
+
+  /**
+   * Defines a call to the `revokeKey` function.
+   *
+   * Can be passed as a parameter to:
+   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
+   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
+   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
+   *
+   * @example
+   * ```ts
+   * import { createClient, http, walletActions } from 'viem'
+   * import { tempo } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({
+   *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+   *   transport: http(),
+   * }).extend(walletActions)
+   *
+   * const hash = await client.sendTransaction({
+   *   calls: [
+   *     Actions.accessKey.revoke.call({ accessKey: '0x...' }),
+   *   ],
+   * })
+   * ```
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    const { accessKey } = args
+    return defineCall({
+      address: Addresses.accountKeychain,
+      abi: Abis.accountKeychain,
+      functionName: 'revokeKey',
+      args: [resolveAccessKeyAddress(accessKey)],
+    })
+  }
+
+  export function extractEvent(logs: Log[]) {
+    const [log] = parseEventLogs({
+      abi: Abis.accountKeychain,
+      logs,
+      eventName: 'KeyRevoked',
+      strict: true,
+    })
+    if (!log) throw new Error('`KeyRevoked` event not found.')
+    return log
+  }
+}
+
+/**
+ * Revokes an authorized access key and waits for the transaction receipt.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const result = await Actions.accessKey.revokeSync(client, {
+ *   accessKey: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction receipt and event data.
+ */
+export async function revokeSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: revokeSync.Parameters<chain, account>,
+): Promise<revokeSync.ReturnValue> {
+  const { throwOnReceiptRevert = true, ...rest } = parameters
+  const receipt = await revoke.inner(writeContractSync, client, {
+    ...rest,
+    throwOnReceiptRevert,
+  } as never)
+  const { args } = revoke.extractEvent(receipt.logs)
+  return {
+    ...args,
+    receipt,
+  } as never
+}
+
+export namespace revokeSync {
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = revoke.Parameters<chain, account>
+
+  export type Args = revoke.Args
+
+  export type ReturnValue = Compute<
+    GetEventArgs<
+      typeof Abis.accountKeychain,
+      'KeyRevoked',
+      { IndexedOnly: false; Required: true }
+    > & {
+      receipt: TransactionReceipt
+    }
+  >
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+/**
  * Signs a key authorization for an access key.
  *
  * @example
@@ -890,9 +973,381 @@ export namespace signAuthorization {
       | undefined
     /** Call scopes restricting which contracts/selectors this key can call. */
     scopes?: KeyAuthorization.Scope[] | undefined
+    /**
+     * Optional 32-byte witness bound into the authorization's signing hash.
+     *
+     * Applications use this to bind a single signature to an arbitrary offchain
+     * context (e.g. a server-issued challenge), or as a revocation handle that
+     * can be burned onchain (see {@link burnWitness}) to invalidate the
+     * authorization before it is submitted.
+     *
+     * [TIP-1053](https://tips.sh/1053)
+     */
+    witness?: Hex | undefined
   }
 
   export type ReturnValue = Awaited<ReturnType<typeof signKeyAuthorization>>
+}
+
+/**
+ * Updates the spending limit for a specific token on an authorized access key.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const hash = await Actions.accessKey.updateLimit(client, {
+ *   accessKey: '0x...',
+ *   token: '0x...',
+ *   limit: 1000000000000000000n,
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction hash.
+ */
+export async function updateLimit<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: updateLimit.Parameters<chain, account>,
+): Promise<updateLimit.ReturnValue> {
+  return updateLimit.inner(writeContract, client, parameters)
+}
+
+export namespace updateLimit {
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = WriteParameters<chain, account> & Args
+
+  export type Args = {
+    /** The access key to update. */
+    accessKey: Address | AccessKeyAccount
+    /** The token address. */
+    token: Address
+    /** The new spending limit. */
+    limit: bigint
+  }
+
+  export type ReturnValue = WriteContractReturnType
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+
+  /** @internal */
+  export async function inner<
+    action extends typeof writeContract | typeof writeContractSync,
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    action: action,
+    client: Client<Transport, chain, account>,
+    parameters: updateLimit.Parameters<chain, account>,
+  ): Promise<ReturnType<action>> {
+    const { accessKey, token, limit, ...rest } = parameters
+    const call = updateLimit.call({ accessKey, token, limit })
+    return (await action(client, {
+      ...rest,
+      ...call,
+    } as never)) as never
+  }
+
+  /**
+   * Defines a call to the `updateSpendingLimit` function.
+   *
+   * Can be passed as a parameter to:
+   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
+   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
+   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
+   *
+   * @example
+   * ```ts
+   * import { createClient, http, walletActions } from 'viem'
+   * import { tempo } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({
+   *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+   *   transport: http(),
+   * }).extend(walletActions)
+   *
+   * const hash = await client.sendTransaction({
+   *   calls: [
+   *     Actions.accessKey.updateLimit.call({
+   *       accessKey: '0x...',
+   *       token: '0x...',
+   *       limit: 1000000000000000000n,
+   *     }),
+   *   ],
+   * })
+   * ```
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    const { accessKey, token, limit } = args
+    return defineCall({
+      address: Addresses.accountKeychain,
+      abi: Abis.accountKeychain,
+      functionName: 'updateSpendingLimit',
+      args: [resolveAccessKeyAddress(accessKey), token, limit],
+    })
+  }
+
+  export function extractEvent(logs: Log[]) {
+    const [log] = parseEventLogs({
+      abi: Abis.accountKeychain,
+      logs,
+      eventName: 'SpendingLimitUpdated',
+      strict: true,
+    })
+    if (!log) throw new Error('`SpendingLimitUpdated` event not found.')
+    return log
+  }
+}
+
+/**
+ * Updates the spending limit and waits for the transaction receipt.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const result = await Actions.accessKey.updateLimitSync(client, {
+ *   accessKey: '0x...',
+ *   token: '0x...',
+ *   limit: 1000000000000000000n,
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction receipt and event data.
+ */
+export async function updateLimitSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: updateLimitSync.Parameters<chain, account>,
+): Promise<updateLimitSync.ReturnValue> {
+  const { throwOnReceiptRevert = true, ...rest } = parameters
+  const receipt = await updateLimit.inner(writeContractSync, client, {
+    ...rest,
+    throwOnReceiptRevert,
+  } as never)
+  const { args } = updateLimit.extractEvent(receipt.logs)
+  return {
+    account: args.account,
+    publicKey: args.publicKey,
+    token: args.token,
+    limit: args.newLimit,
+    receipt,
+  }
+}
+
+export namespace updateLimitSync {
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = updateLimit.Parameters<chain, account>
+
+  export type Args = updateLimit.Args
+
+  export type ReturnValue = {
+    /** The account that owns the key. */
+    account: Address
+    /** The access key address. */
+    publicKey: Address
+    /** The token address. */
+    token: Address
+    /** The new spending limit. */
+    limit: bigint
+    /** The transaction receipt. */
+    receipt: TransactionReceipt
+  }
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+/**
+ * Watches for key-authorization witness events.
+ *
+ * Emitted when a key is authorized with a `witness` (see {@link authorize}).
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const unwatch = Actions.accessKey.watchWitness(client, {
+ *   onWitness: (args, log) => {
+ *     console.log('Witness used:', args)
+ *   },
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns A function to unsubscribe from the event.
+ */
+export function watchWitness<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: watchWitness.Parameters,
+) {
+  const { onWitness, ...rest } = parameters
+  return watchContractEvent(client, {
+    ...rest,
+    address: Addresses.accountKeychain,
+    abi: Abis.accountKeychain,
+    eventName: 'KeyAuthorizationWitness',
+    onLogs: (logs) => {
+      for (const log of logs) onWitness(log.args, log)
+    },
+    strict: true,
+  })
+}
+
+export declare namespace watchWitness {
+  export type Args = Compute<
+    GetEventArgs<
+      typeof Abis.accountKeychain,
+      'KeyAuthorizationWitness',
+      { IndexedOnly: false; Required: true }
+    >
+  >
+
+  export type Log = viem_Log<
+    bigint,
+    number,
+    false,
+    ExtractAbiItem<typeof Abis.accountKeychain, 'KeyAuthorizationWitness'>,
+    true
+  >
+
+  export type Parameters = UnionOmit<
+    WatchContractEventParameters<
+      typeof Abis.accountKeychain,
+      'KeyAuthorizationWitness',
+      true
+    >,
+    'abi' | 'address' | 'batch' | 'eventName' | 'onLogs' | 'strict'
+  > & {
+    /** Callback to invoke when a witness is used. */
+    onWitness: (args: Args, log: Log) => void
+  }
+}
+
+/**
+ * Watches for key-authorization witness burned events.
+ *
+ * Emitted when a witness is burned (see {@link burnWitness}).
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempo } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempo.extend({ feeToken: '0x20c0000000000000000000000000000000000001' }),
+ *   transport: http(),
+ * })
+ *
+ * const unwatch = Actions.accessKey.watchWitnessBurned(client, {
+ *   onBurned: (args, log) => {
+ *     console.log('Witness burned:', args)
+ *   },
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns A function to unsubscribe from the event.
+ */
+export function watchWitnessBurned<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: watchWitnessBurned.Parameters,
+) {
+  const { onBurned, ...rest } = parameters
+  return watchContractEvent(client, {
+    ...rest,
+    address: Addresses.accountKeychain,
+    abi: Abis.accountKeychain,
+    eventName: 'KeyAuthorizationWitnessBurned',
+    onLogs: (logs) => {
+      for (const log of logs) onBurned(log.args, log)
+    },
+    strict: true,
+  })
+}
+
+export declare namespace watchWitnessBurned {
+  export type Args = Compute<
+    GetEventArgs<
+      typeof Abis.accountKeychain,
+      'KeyAuthorizationWitnessBurned',
+      { IndexedOnly: false; Required: true }
+    >
+  >
+
+  export type Log = viem_Log<
+    bigint,
+    number,
+    false,
+    ExtractAbiItem<
+      typeof Abis.accountKeychain,
+      'KeyAuthorizationWitnessBurned'
+    >,
+    true
+  >
+
+  export type Parameters = UnionOmit<
+    WatchContractEventParameters<
+      typeof Abis.accountKeychain,
+      'KeyAuthorizationWitnessBurned',
+      true
+    >,
+    'abi' | 'address' | 'batch' | 'eventName' | 'onLogs' | 'strict'
+  > & {
+    /** Callback to invoke when a witness is burned. */
+    onBurned: (args: Args, log: Log) => void
+  }
 }
 
 /** @internal */


### PR DESCRIPTION
Adds support for **TIP-1053** (witness on key authorizations) to `viem/tempo`.

A witness is an optional 32-byte value bound into a key authorization's signing hash. Applications use it to bind a single signature to an arbitrary offchain context (e.g. a server-issued challenge), or as a revocation handle that can be burned onchain to invalidate an authorization before it is submitted.

## Changes

**Witness threading (existing actions)**
- `Account.signKeyAuthorization` now accepts and forwards `witness` through `KeyAuthorization.getSignPayload` / `KeyAuthorization.from`.
- `accessKey.authorize` / `authorizeSync` / `signAuthorization` accept an optional `witness`.

**New `accessKey` actions**
- `burnWitness` / `burnWitnessSync` — burns a witness, invalidating any authorization bound to it.
- `isWitnessBurned` — reads whether a witness has been burned for an account.
- `watchWitness` — watches `KeyAuthorizationWitness` events.
- `watchWitnessBurned` — watches `KeyAuthorizationWitnessBurned` events.

**Wiring / housekeeping**
- All new actions wired into the client decorator.
- `accessKey` module exports reordered to be alphabetized (matching the `receivePolicy` convention).

**Docs & tests**
- New doc pages for `burnWitness`, `isWitnessBurned`, `watchWitness`, `watchWitnessBurned`; `witness` documented on `authorize` / `signAuthorization`; sidebar updated.
- Tests covering witness threading, burn lifecycle, reads, and watchers.

## Verification
- `biome check` — clean
- `tsc --noEmit` — passes
- `vitest` (tempo) accessKey + Decorator suites — pass
