### PR TITLE
feat(chains): add multicall3 for citrea mainnet (4114) and testnet (5115)

### DIFF
--- a/.changeset/multicall3-citrea-mainnet-and-testnet.md
+++ b/.changeset/multicall3-citrea-mainnet-and-testnet.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add multicall3 address for citrea mainnet and testnet.

--- a/src/chains/definitions/citrea.ts
+++ b/src/chains/definitions/citrea.ts
@@ -16,5 +16,11 @@ export const citrea = /*#__PURE__*/ defineChain({
       apiUrl: 'https://explorer.mainnet.citrea.xyz/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xA738e84fdE890Bc60b99AF7ccE43990E534304de',
+      blockCreated: 2450100,
+    },
+  },
   testnet: false,
 })

--- a/src/chains/definitions/citreaTestnet.ts
+++ b/src/chains/definitions/citreaTestnet.ts
@@ -16,5 +16,11 @@ export const citreaTestnet = /*#__PURE__*/ defineChain({
       apiUrl: 'https://explorer.testnet.citrea.xyz/api',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 104683,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Adds multicall3 addresses for citrea mainnet and testnet.

https://explorer.mainnet.citrea.xyz/address/0xA738e84fdE890Bc60b99AF7ccE43990E534304de?tab=contract
https://explorer.testnet.citrea.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract

Also added to the multicall3 repo https://github.com/mds1/multicall3/pull/419