### PR TITLE
ci: fix main snapshot + size-limit budgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     {
       "name": "import * from 'viem/chains'",
       "path": "./src/_esm/chains/index.js",
-      "limit": "107 kB",
+      "limit": "108 kB",
       "import": "*"
     },
     {
@@ -200,7 +200,7 @@
     {
       "name": "import { tempoTestnet } from 'viem/chains'",
       "path": "./src/_esm/chains/index.js",
-      "limit": "65 kB",
+      "limit": "66 kB",
       "import": "{ tempoTestnet }"
     },
     {

--- a/src/tempo/Account.test.ts
+++ b/src/tempo/Account.test.ts
@@ -703,6 +703,7 @@ describe('signKeyAuthorization', () => {
           "type": "secp256k1",
         },
         "type": "secp256k1",
+        "witness": undefined,
       }
     `)
   })


### PR DESCRIPTION
- Add `witness: undefined` to `signKeyAuthorization > default` snapshot in `src/tempo/Account.test.ts` (was missing after #4688).
- Bump size-limit budgets after #4688:
  - `import * from 'viem/chains'`: 107 → 108 kB (was 107.37 kB).
  - `import { tempoTestnet } from 'viem/chains'`: 65 → 66 kB (was 65.02 kB).

Fixes [Verify / Test Local](https://github.com/wevm/viem/actions/runs/26689466518/job/78663223953) and [Verify / Build](https://github.com/wevm/viem/actions/runs/26689466518/job/78663277435).