### PR TITLE
refactor(tempo): omit `witness` from KeyAuthorization when undefined

### DIFF
--- a/src/tempo/Account.test.ts
+++ b/src/tempo/Account.test.ts
@@ -703,7 +703,6 @@ describe('signKeyAuthorization', () => {
           "type": "secp256k1",
         },
         "type": "secp256k1",
-        "witness": undefined,
       }
     `)
   })

--- a/src/tempo/Account.ts
+++ b/src/tempo/Account.ts
@@ -484,7 +484,7 @@ export async function signKeyAuthorization(
     scopes,
     signature: SignatureEnvelope.from(signature),
     type,
-    witness,
+    ...(witness ? { witness } : {}),
   })
 }
 
@@ -642,7 +642,7 @@ function fromRoot(parameters: fromRoot.Parameters): RootAccount {
         scopes,
         signature: SignatureEnvelope.from(signature),
         type,
-        witness,
+        ...(witness ? { witness } : {}),
       })
       return keyAuthorization
     },


### PR DESCRIPTION
Spreads `witness` conditionally into `KeyAuthorization.from(...)` so the returned authorization object omits the `witness` key when it isn't provided, rather than including it as an own property with value `undefined`.

Applied in both `signKeyAuthorization` (top-level) and the `fromRoot` override in `src/tempo/Account.ts`. Inline snapshot for `signKeyAuthorization > default` in `src/tempo/Account.test.ts` updated to reflect the omitted key.

All 46 `Account.test.ts` tests pass locally.