### PR TITLE
fix(site): restore dynamic vocs rendering

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
       McpSource.github({ name: 'tempo', repo: 'tempoxyz/tempo' }),
     ],
   },
-  renderStrategy: 'partial-static',
+  renderStrategy: 'dynamic',
   rootDir: '.',
   srcDir: '.',
   search: {


### PR DESCRIPTION
Restored the viem docs Vocs config to dynamic rendering for Vercel builds.

This avoids the Vocs v2 partial-static output path that generated a large static artifact set and left the production deployment with empty build output.