### PR TITLE
docs(tempo): add coming-soon warnings for T6 & T7 features

### DIFF
--- a/site/pages/tempo/actions/accessKey.burnWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.burnWitness.mdx
@@ -2,6 +2,10 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `accessKey.burnWitness`
 
+:::warning
+**Coming soon:** [TIP-1053](https://tips.sh/1053) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Burns a key-authorization witness, invalidating any authorization bound to it before it is submitted onchain.
 
 A witness is an optional 32-byte value bound into a key authorization's signing hash (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize)). Once burned, an authorization carrying the same witness can no longer be submitted, giving applications a revocation handle for signed-but-not-yet-submitted authorizations.

--- a/site/pages/tempo/actions/accessKey.isAdmin.mdx
+++ b/site/pages/tempo/actions/accessKey.isAdmin.mdx
@@ -2,6 +2,10 @@ import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
 
 # `accessKey.isAdmin`
 
+:::warning
+**Coming soon:** [TIP-1049](https://tips.sh/1049) ships in the **T7** hardfork — live on **Testnet** June 25 and **Mainnet** June 29.
+:::
+
 Checks whether an access key is an admin key for an account.
 
 Returns `true` for the account's root key or for an active admin access key (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize) with `admin: true`).

--- a/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
@@ -2,6 +2,10 @@ import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
 
 # `accessKey.isWitnessBurned`
 
+:::warning
+**Coming soon:** [TIP-1053](https://tips.sh/1053) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Checks whether a key-authorization witness has been burned for an account.
 
 See [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness) for details on witnesses.

--- a/site/pages/tempo/actions/accessKey.verifyHash.mdx
+++ b/site/pages/tempo/actions/accessKey.verifyHash.mdx
@@ -2,6 +2,10 @@ import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
 
 # `accessKey.verifyHash`
 
+:::warning
+**Coming soon:** [TIP-1049](https://tips.sh/1049) ships in the **T7** hardfork — live on **Testnet** June 25 and **Mainnet** June 29.
+:::
+
 Verifies that a keychain signature was produced by an active access key for the expected account.
 
 By default (`admin: true`), returns `true` only if the signature was produced by the account's root key or an active admin access key. Set `admin: false` to accept any active access key.

--- a/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
+++ b/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
@@ -1,5 +1,9 @@
 # `accessKey.watchAdminAuthorized`
 
+:::warning
+**Coming soon:** [TIP-1049](https://tips.sh/1049) ships in the **T7** hardfork — live on **Testnet** June 25 and **Mainnet** June 29.
+:::
+
 Watches for admin key authorization events (`AdminKeyAuthorized`), emitted when an admin key is authorized (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize) with `admin: true`).
 
 [TIP-1049](https://tips.sh/1049)

--- a/site/pages/tempo/actions/accessKey.watchWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitness.mdx
@@ -1,5 +1,9 @@
 # `accessKey.watchWitness`
 
+:::warning
+**Coming soon:** [TIP-1053](https://tips.sh/1053) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for key-authorization witness events (`KeyAuthorizationWitness`), emitted when a key is authorized with a `witness` (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize)).
 
 [TIP-1053](https://tips.sh/1053)

--- a/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
@@ -1,5 +1,9 @@
 # `accessKey.watchWitnessBurned`
 
+:::warning
+**Coming soon:** [TIP-1053](https://tips.sh/1053) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for key-authorization witness burned events (`KeyAuthorizationWitnessBurned`), emitted when a witness is burned (see [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness)).
 
 [TIP-1053](https://tips.sh/1053)

--- a/site/pages/tempo/actions/receivePolicy.burn.mdx
+++ b/site/pages/tempo/actions/receivePolicy.burn.mdx
@@ -2,6 +2,10 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.burn`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Burns the funds backing a blocked receipt. Requires the caller to hold the token's `BURN_BLOCKED_ROLE`, and is only valid when the receipt's policy subject is currently unauthorized as a sender under the token's TIP-403 policy. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.claim.mdx
+++ b/site/pages/tempo/actions/receivePolicy.claim.mdx
@@ -2,6 +2,10 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.claim`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Claims blocked funds for a receipt, releasing them to a destination. The caller must be authorized to reclaim the funds per the policy's `claimer` setting. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.get.mdx
+++ b/site/pages/tempo/actions/receivePolicy.get.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.get`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Gets the receive policy configured for an account. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
+++ b/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.getBlockedBalance`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Gets the blocked balance held by the `ReceivePolicyGuard` for an encoded claim receipt. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.set.mdx
+++ b/site/pages/tempo/actions/receivePolicy.set.mdx
@@ -2,6 +2,10 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.set`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Sets the receive policy for the calling account. A receive policy controls which TIP-20 tokens and which senders an account accepts. Inbound transfers and mints that violate the policy are not reverted – instead the funds are redirected to the `ReceivePolicyGuard` and can be reclaimed later (see [`receivePolicy.claim`](/tempo/actions/receivePolicy.claim)). [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.validate.mdx
+++ b/site/pages/tempo/actions/receivePolicy.validate.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.validate`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Checks whether a transfer or mint to a receiver is allowed by the receiver's receive policy. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.watchBlocked`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for blocked transfer events (`TransferBlocked`) emitted by the `ReceivePolicyGuard` when an inbound transfer or mint violates a receive policy.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.watchBurned`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for receipt burned events (`ReceiptBurned`) emitted by the `ReceivePolicyGuard` when blocked funds are burned.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.watchClaimed`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for receipt claimed events (`ReceiptClaimed`) emitted by the `ReceivePolicyGuard` when blocked funds are reclaimed.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
@@ -1,5 +1,9 @@
 # `receivePolicy.watchUpdated`
 
+:::warning
+**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
+:::
+
 Watches for receive policy update events (`ReceivePolicyUpdated`) on the TIP-403 Registry.
 
 ## Usage


### PR DESCRIPTION
Adds `:::warning` callouts to action pages for not-yet-live hardfork features:

- **TIP-1028** (receive policy, **T6**) — Testnet Jun 11 / Mainnet Jun 15 — 10 `receivePolicy.*` pages.
- **TIP-1053** (witness, **T6**) — Testnet Jun 11 / Mainnet Jun 15 — 4 witness `accessKey.*` pages.
- **TIP-1049** (admin access keys, **T7**) — Testnet Jun 25 / Mainnet Jun 29 — `accessKey.isAdmin`, `accessKey.verifyHash`, `accessKey.watchAdminAuthorized`.

Callout is placed directly under each page's `# <title>` heading.