### PR TITLE
fix(site): patch dynamic vocs route rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,9 @@
       "bun",
       "protobufjs",
       "simple-git-hooks"
-    ]
+    ],
+    "patchedDependencies": {
+      "vocs@2.0.4": "patches/vocs@2.0.4.patch"
+    }
   }
 }

--- a/patches/vocs@2.0.4.patch
+++ b/patches/vocs@2.0.4.patch
@@ -1,0 +1,218 @@
+diff --git a/dist/waku/internal/patches/router.js b/dist/waku/internal/patches/router.js
+index 212ed6f81f4bf68559e3e68045b06b2f0e62cb3b..e9bb5c40431ca87a8bd269a74bcac2347386ce3a 100644
+--- a/dist/waku/internal/patches/router.js
++++ b/dist/waku/internal/patches/router.js
+@@ -3,6 +3,7 @@ import { createPages } from 'waku/router/server';
+ import * as DedupeHead from '../dedupe-head.js';
+ import { getApiHandlers, hasInvalidStaticApiExports, } from './api-routes.js';
+ import { isIgnoredPath } from './utils/fs-router.js';
++import { config as vocsConfig } from 'virtual:vocs/config';
+ const wrapRenderHtml = (renderHtml) => async (...args) => {
+     const response = await renderHtml(...args);
+     const body = response.body;
+@@ -64,6 +65,7 @@ modules, options) {
+         consumerPaths.add(srcPath.slice(pagesDirPrefix.length).replace(/\.\w+$/, ''));
+     }
+     const allModules = { ...defaultPages, ...modules };
++    const defaultRender = vocsConfig.renderStrategy === 'dynamic' ? 'dynamic' : 'static';
+     return wrapPages(createPages(async ({ createPage, createLayout, createRoot, createApi, createSlice }) => {
+         for (const file in allModules) {
+             const importFn = allModules[file];
+@@ -106,7 +108,7 @@ modules, options) {
+                 else if (pathItems.at(0) === slicesDir) {
+                     createSlice({
+                         component,
+-                        render: 'static',
++                        render: defaultRender,
+                         id: pathItems.slice(1).join('/'),
+                         ...sourceFileProperty,
+                     });
+@@ -114,7 +116,7 @@ modules, options) {
+                 else if (pathItems.at(-1) === '_root') {
+                     createRoot({
+                         component,
+-                        render: 'static',
++                        render: defaultRender,
+                         ...sourceFileProperty,
+                     });
+                 }
+@@ -122,23 +124,23 @@ modules, options) {
+                     createPage({
+                         path,
+                         component,
+-                        render: 'static',
++                        render: defaultRender,
+                         ...sourceFileProperty,
+                     });
+                 }
+                 continue;
+             }
+             const mod = (await importFn());
+-            const config = await mod.getConfig?.();
++            const routeConfig = await mod.getConfig?.();
+             if (pathItems.at(0) === apiDir) {
+                 // Strip the apiDir prefix from the path (e.g., _api/hello.txt -> hello.txt)
+                 const apiPath = '/' + pathItems.slice(1).join('/');
+-                if (config?.render === 'static') {
++                if (routeConfig?.render === 'static') {
+                     if (hasInvalidStaticApiExports(mod) || !mod.GET) {
+                         console.warn(`API ${path} is invalid. For static API routes, only a single GET handler is supported.`);
+                     }
+                     createApi({
+-                        ...config,
++                        ...routeConfig,
+                         path: apiPath,
+                         render: 'static',
+                         method: 'GET',
+@@ -165,9 +167,9 @@ modules, options) {
+             else if (pathItems.at(0) === slicesDir) {
+                 createSlice({
+                     component: mod.default,
+-                    render: 'static',
++                    render: defaultRender,
+                     id: pathItems.slice(1).join('/'),
+-                    ...config,
++                    ...routeConfig,
+                     ...sourceFileProperty,
+                 }); // FIXME avoid as never
+             }
+@@ -175,16 +177,16 @@ modules, options) {
+                 createLayout({
+                     path,
+                     component: mod.default,
+-                    render: 'static',
+-                    ...config,
++                    render: defaultRender,
++                    ...routeConfig,
+                     ...sourceFileProperty,
+                 });
+             }
+             else if (pathItems.at(-1) === '_root') {
+                 createRoot({
+                     component: mod.default,
+-                    render: 'static',
+-                    ...config,
++                    render: defaultRender,
++                    ...routeConfig,
+                     ...sourceFileProperty,
+                 });
+             }
+@@ -192,8 +194,8 @@ modules, options) {
+                 createPage({
+                     path,
+                     component: mod.default,
+-                    render: 'static',
+-                    ...config,
++                    render: defaultRender,
++                    ...routeConfig,
+                     ...sourceFileProperty,
+                 }); // FIXME avoid as never
+             }
+diff --git a/src/waku/internal/patches/router.ts b/src/waku/internal/patches/router.ts
+index b097a5645c202317f435f125a851916002e8e155..6304522b1684cb0ed839744208f4fac061e59476 100644
+--- a/src/waku/internal/patches/router.ts
++++ b/src/waku/internal/patches/router.ts
+@@ -8,6 +8,7 @@ import {
+   hasInvalidStaticApiExports,
+ } from './api-routes.js'
+ import { isIgnoredPath } from './utils/fs-router.js'
++import { config as vocsConfig } from 'virtual:vocs/config'
+ 
+ type Pages = ReturnType<typeof createPages>
+ type RouteModule = ApiRouteModule & {
+@@ -111,6 +112,7 @@ export function router(
+   }
+ 
+   const allModules = { ...defaultPages, ...modules }
++  const defaultRender = vocsConfig.renderStrategy === 'dynamic' ? 'dynamic' : 'static'
+ 
+   return wrapPages(
+     createPages(
+@@ -161,21 +163,21 @@ export function router(
+             } else if (pathItems.at(0) === slicesDir) {
+               createSlice({
+                 component,
+-                render: 'static',
++                render: defaultRender,
+                 id: pathItems.slice(1).join('/'),
+                 ...sourceFileProperty,
+               } as never)
+             } else if (pathItems.at(-1) === '_root') {
+               createRoot({
+                 component,
+-                render: 'static',
++                render: defaultRender,
+                 ...sourceFileProperty,
+               })
+             } else {
+               createPage({
+                 path,
+                 component,
+-                render: 'static',
++                render: defaultRender,
+                 ...sourceFileProperty,
+               } as never)
+             }
+@@ -184,18 +186,18 @@ export function router(
+ 
+           const mod = (await importFn()) as RouteModule
+ 
+-          const config = await mod.getConfig?.()
++          const routeConfig = await mod.getConfig?.()
+           if (pathItems.at(0) === apiDir) {
+             // Strip the apiDir prefix from the path (e.g., _api/hello.txt -> hello.txt)
+             const apiPath = '/' + pathItems.slice(1).join('/')
+-            if (config?.render === 'static') {
++            if (routeConfig?.render === 'static') {
+               if (hasInvalidStaticApiExports(mod) || !mod.GET) {
+                 console.warn(
+                   `API ${path} is invalid. For static API routes, only a single GET handler is supported.`,
+                 )
+               }
+               createApi({
+-                ...config,
++                ...routeConfig,
+                 path: apiPath,
+                 render: 'static',
+                 method: 'GET',
+@@ -220,32 +222,32 @@ export function router(
+           } else if (pathItems.at(0) === slicesDir) {
+             createSlice({
+               component: mod.default,
+-              render: 'static',
++              render: defaultRender,
+               id: pathItems.slice(1).join('/'),
+-              ...config,
++              ...routeConfig,
+               ...sourceFileProperty,
+             } as never) // FIXME avoid as never
+           } else if (pathItems.at(-1) === '_layout') {
+             createLayout({
+               path,
+               component: mod.default,
+-              render: 'static',
+-              ...config,
++              render: defaultRender,
++              ...routeConfig,
+               ...sourceFileProperty,
+             })
+           } else if (pathItems.at(-1) === '_root') {
+             createRoot({
+               component: mod.default,
+-              render: 'static',
+-              ...config,
++              render: defaultRender,
++              ...routeConfig,
+               ...sourceFileProperty,
+             })
+           } else {
+             createPage({
+               path,
+               component: mod.default,
+-              render: 'static',
+-              ...config,
++              render: defaultRender,
++              ...routeConfig,
+               ...sourceFileProperty,
+             } as never) // FIXME avoid as never
+           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,11 @@ overrides:
   basic-ftp@<=5.3.0: 5.3.1
   fast-uri@<=3.1.1: 3.1.2
 
+patchedDependencies:
+  vocs@2.0.4:
+    hash: 90b4b4a4f3a7db459cc607e0dae3067e5a733c286c3b956e06e8146af0b5fe69
+    path: patches/vocs@2.0.4.patch
+
 importers:
 
   .:
@@ -645,7 +650,7 @@ importers:
         version: 8.0.14(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3)
       vocs:
         specifier: ^2.0.4
-        version: 2.0.4(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))(waku@1.0.0-beta.1(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.4(patch_hash=90b4b4a4f3a7db459cc607e0dae3067e5a733c286c3b956e06e8146af0b5fe69)(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))(waku@1.0.0-beta.1(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))
       waku:
         specifier: ^1.0.0-beta.1
         version: 1.0.0-beta.1(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -13451,7 +13456,7 @@ snapshots:
       - tsx
       - yaml
 
-  vocs@2.0.4(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))(waku@1.0.0-beta.1(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vocs@2.0.4(patch_hash=90b4b4a4f3a7db459cc607e0dae3067e5a733c286c3b956e06e8146af0b5fe69)(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3))(waku@1.0.0-beta.1(@types/node@24.5.2)(esbuild@0.27.2)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.2)))(react@19.2.6)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@base-ui/react': 1.1.0(@types/react@19.0.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
Patched `vocs@2.0.4` so its Vocs router respects `renderStrategy: 'dynamic'` for MDX pages, layouts, roots, and slices.\n\nThe production deployment with the config-only fix still ran Waku static generation for every docs MDX page. That generated the large output set, hit a Vercel OOM during output deployment, and left the Ready deployment serving 404s.\n\nWith this patch, the local site build reaches Waku SSG and generates one file in under 100ms instead of hundreds of static docs pages.