### PR TITLE
perf(site): prebuild viem types and drop twoslash `paths` override on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "contracts:build": "forge build --config-path ./contracts/foundry.toml && bun scripts/generateTypedArtifacts.ts",
     "deps": "pnpx taze -r",
     "docs:dev": "pnpm --filter site dev",
-    "docs:build": "pnpm --filter site build",
+    "docs:build": "pnpm build:types && pnpm --filter site build",
     "check": "biome check --write --unsafe",
     "check:repo": "sherif",
     "check:types": "tsc -b",

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -1,7 +1,12 @@
+import * as fs from 'node:fs'
 import { defineConfig, McpSource } from 'vocs/config'
 
 import pkg from '../src/package.json' with { type: 'json' }
 import { sidebar } from './sidebar.js'
+
+const hasBuiltTypes = fs.existsSync(
+  new URL('../src/_types/index.d.ts', import.meta.url),
+)
 
 export const sponsors = {
   collaborators: [
@@ -182,16 +187,21 @@ export default defineConfig({
     },
   ],
   twoslash: {
-    checkOnly: true,
     throws: false,
     twoslashOptions: {
       vfsRoot: '..',
       compilerOptions: {
         baseUrl: '.',
-        paths: {
-          viem: ['../src/index.ts'],
-          'viem/*': ['../src/*/index.ts', '../src/*.ts'],
-        },
+        skipLibCheck: true,
+        skipDefaultLibCheck: true,
+        ...(hasBuiltTypes
+          ? {}
+          : {
+              paths: {
+                viem: ['../src/index.ts'],
+                'viem/*': ['../src/*/index.ts', '../src/*.ts'],
+              },
+            }),
       },
       handbookOptions: {
         // FIXME: fix all twoslash errors.


### PR DESCRIPTION
## Summary

Cuts the docs build time **~3.75× (7m30s → 2m)** and reduces peak vocs RSS by **~600 MB** by switching twoslash's TypeScript input from walking viem source to reading prebuilt `.d.ts` files via the package's `exports` map. Should resolve the Vercel OOM failures on the docs deploy.

Also fixes #4427 (twoslash showing `any` for viem imports) as a side effect.

## Changes

- **`package.json`** — `docs:build` now runs `pnpm build:types` first to ensure `src/_types/` exists.
- **`site/vocs.config.ts`**
  - Drops the `paths` override that forced twoslash to resolve `viem` to source files. With `_types/` present, twoslash now resolves through the package's `exports` map (flat `.d.ts` instead of walking ~thousands of `src/**/*.ts` files per snippet).
  - Falls back to source `paths` when `_types/` is missing, so `vocs dev` works on a fresh clone without an extra build step and preserves live HMR for viem core edits.
  - Adds `skipLibCheck` / `skipDefaultLibCheck` to twoslash's TS options.

## Local measurements (cold cache, M-class Mac)

| Variant | Build time | SSG time | Peak vocs RSS | Peak total RSS |
|---|---|---|---|---|
| Before (`paths` override, no `_types`) | ~7m30s | 123s | 5,392 MB | 6,816 MB |
| **After (`build:types` first + drop `paths`)** | **~2m0s** | **65s** | **4,799 MB** | **6,480 MB** |
| After, warm `.cache/twoslash` | ~1m36s | 61s | 5,052 MB | 6,787 MB |

The SSG phase is still the dominant peak (~4.8 GB during static generation). If we still hit OOMs after this lands, the next step is patching vocs upstream to fork SSG into a worker thread.

## Behavior matrix

| Scenario | `_types/index.d.ts` | twoslash resolution |
|---|---|---|
| `pnpm docs:build` | ✅ rebuilt by the script | flat `.d.ts` → fast, low memory |
| `pnpm docs:dev`, fresh clone | ❌ missing | viem source via `paths` → live HMR |
| `pnpm docs:dev`, after one types build | ✅ stale-ish | flat `.d.ts` → fast popovers, slightly stale |
| Working on viem core + dev docs | run `tsc --watch` on `_types`, or `rm -rf src/_types` | viem source via `paths` → live HMR |
