### PR TITLE
docs: enable twoslash `checkOnly`

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -3191,6 +3191,7 @@ export default defineConfig({
     },
   ],
   twoslash: {
+    checkOnly: true,
     throws: false,
     twoslashOptions: {
       vfsRoot: '..',


### PR DESCRIPTION
Enable Vocs twoslash `checkOnly` mode for the docs site. Production builds can still typecheck snippets while rendering plain highlighted code instead of interactive twoslash metadata.

This keeps code example validation active without carrying the extra runtime annotation UI into rendered docs.
