### PR TITLE
test: bump simulateBlocks gasUsed snapshot

### DIFF
--- a/src/tempo/actions/simulate.test.ts
+++ b/src/tempo/actions/simulate.test.ts
@@ -89,7 +89,7 @@ describe('simulateBlocks', () => {
       ),
     }).toMatchInlineSnapshot(`
       {
-        "gasUsed": 299870n,
+        "gasUsed": 287370n,
         "logs": [
           {
             "address": "0x20c0000000000000000000000000000000000001",


### PR DESCRIPTION
Updates the `simulateBlocks > behavior: tip20 transfer` inline snapshot from `299870n` → `287370n` to match the latest tempo gas accounting.

Fixes the failing snapshot in [these CI runs](https://github.com/wevm/viem/actions/runs/26726148325).