### PR TITLE
ci: pin foundry to v1.7.1

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: v1.7.1
 
     - name: Set up pnpm
       uses: wevm/actions/.github/actions/pnpm@main

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.7.1
 
       - name: Set up pnpm
         uses: wevm/actions/.github/actions/pnpm@main

--- a/src/actions/public/fillTransaction.test.ts
+++ b/src/actions/public/fillTransaction.test.ts
@@ -19,7 +19,7 @@ test('default', async () => {
 
   expect(result).toMatchInlineSnapshot(`
     {
-      "raw": "0x02f0018203b9843b9aca0084607d7d8a8252a89400000000000000000000000000000000000000008084deadbeefc0800101",
+      "raw": "0x02f0018203b9843b9aca0084607d7d8a8252a89400000000000000000000000000000000000000008084deadbeefc0808080",
       "transaction": {
         "accessList": [],
         "chainId": 1,
@@ -27,7 +27,7 @@ test('default', async () => {
         "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
         "gas": 21160n,
         "gasPrice": 1942604248n,
-        "hash": "0x1b55c62b7d06b0bc1917c18db61b2676ae4092a4ca13884a07737b18b4454014",
+        "hash": "0x742547d24fb3c352745ac8f604fd2db258d13fb6b586c53f82ac18c8dd8ace4f",
         "input": "0xdeadbeef",
         "maxFeePerGas": 1942604248n,
         "maxPriorityFeePerGas": 1000000000n,

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -22,7 +22,7 @@ describe('request', () => {
       {
         "id": 1,
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
   })
@@ -37,7 +37,7 @@ describe('request', () => {
       {
         "id": 1,
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
   })
@@ -498,12 +498,12 @@ describe('http (batch)', () => {
         {
           "id": 1,
           "jsonrpc": "2.0",
-          "result": "anvil/v1.7.2",
+          "result": "anvil/v1.7.1",
         },
         {
           "id": 2,
           "jsonrpc": "2.0",
-          "result": "anvil/v1.7.2",
+          "result": "anvil/v1.7.1",
         },
       ]
     `)
@@ -524,7 +524,7 @@ describe('http (batch)', () => {
         {
           "id": 1,
           "jsonrpc": "2.0",
-          "result": "anvil/v1.7.2",
+          "result": "anvil/v1.7.1",
         },
         {
           "error": {
@@ -550,7 +550,7 @@ describe('http (batch)', () => {
         {
           "id": 1,
           "jsonrpc": "2.0",
-          "result": "anvil/v1.7.2",
+          "result": "anvil/v1.7.1",
         },
         {
           "error": {

--- a/src/utils/rpc/ipc.test.ts
+++ b/src/utils/rpc/ipc.test.ts
@@ -64,7 +64,7 @@ describe('request', () => {
     expect(version).toMatchInlineSnapshot(`
       {
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
     expect(rpcClient.requests.size).toBe(0)
@@ -315,7 +315,7 @@ describe('requestAsync', () => {
     expect(version).toMatchInlineSnapshot(`
       {
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
     expect(client.requests.size).toBe(0)

--- a/src/utils/rpc/webSocket.test.ts
+++ b/src/utils/rpc/webSocket.test.ts
@@ -217,7 +217,7 @@ describe.runIf(process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket')(
       expect(version).toMatchInlineSnapshot(`
       {
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
       expect(socketClient.requests.size).toBe(0)
@@ -731,7 +731,7 @@ describe.runIf(process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket')(
       expect(version).toMatchInlineSnapshot(`
       {
         "jsonrpc": "2.0",
-        "result": "anvil/v1.7.2",
+        "result": "anvil/v1.7.1",
       }
     `)
       expect(client.requests.size).toBe(0)


### PR DESCRIPTION
Pins `foundry-rs/foundry-toolchain` to `v1.7.1` (latest stable) instead of `nightly`.

`version: nightly` makes `foundryup` hit unauthenticated `GET /repos/foundry-rs/foundry/releases` to resolve the latest nightly tag, which intermittently 403s when the runner's NAT egress IP exhausts the 60 req/hr/IP GitHub API quota (e.g. [this run](https://github.com/wevm/viem/actions/runs/26735534384/job/78787929670)).

A pinned tag skips the API call entirely ([foundryup source](https://github.com/foundry-rs/foundry/blob/master/foundryup/foundryup#L706-L716)) and goes straight to the release asset URL.