### PR TITLE
chore: fix ladyChain formatting

### DIFF
--- a/src/chains/definitions/ladyChain.ts
+++ b/src/chains/definitions/ladyChain.ts
@@ -1,20 +1,19 @@
 import { defineChain } from '../../utils/chain/defineChain.js'
 
-  export const ladyChain = /*#__PURE__*/ defineChain({
-    id: 589,
-    name: 'LadyChain',
-    nativeCurrency: { name: 'Lady', symbol: 'LADY', decimals: 18 },
-    rpcUrls: {
-      default: {
-        http: ['https://ladyrpc.us/rpc'],
-      },
+export const ladyChain = /*#__PURE__*/ defineChain({
+  id: 589,
+  name: 'LadyChain',
+  nativeCurrency: { name: 'Lady', symbol: 'LADY', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://ladyrpc.us/rpc'],
     },
-    blockExplorers: {
-      default: {
-        name: 'LadyScan',
-        url: 'https://ladyscan.us',
-      },
+  },
+  blockExplorers: {
+    default: {
+      name: 'LadyScan',
+      url: 'https://ladyscan.us',
     },
-    testnet: false,
-  })
-  
+  },
+  testnet: false,
+})


### PR DESCRIPTION
Fixes the formatting of `src/chains/definitions/ladyChain.ts`, which was merged over-indented and breaks `pnpm biome check` (the CI Check job runs biome across the whole repo, so this blocks all PRs branched off `main`).

Autofixed via `biome check --write`.
