### PR TITLE
chore: bump chains size-limit budgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     {
       "name": "import * from 'viem/chains'",
       "path": "./src/_esm/chains/index.js",
-      "limit": "108 kB",
+      "limit": "110 kB",
       "import": "*"
     },
     {
@@ -200,7 +200,7 @@
     {
       "name": "import { tempoTestnet } from 'viem/chains'",
       "path": "./src/_esm/chains/index.js",
-      "limit": "66 kB",
+      "limit": "67 kB",
       "import": "{ tempoTestnet }"
     },
     {


### PR DESCRIPTION
The CI **Verify / Build** job was failing on `pnpm size`:

- `import * from 'viem/chains'` exceeded its 108 kB limit (109.06 kB)
- `import { tempoTestnet } from 'viem/chains'` exceeded its 66 kB limit (66.22 kB)

Both bundles grew from recently merged chain additions (VALYGO, Gravity, Citrate, LadyChain) and tempo work. Bumps the budgets to 110 kB and 67 kB respectively (small headroom).

`pnpm size` passes after the change.
