### PR TITLE
feat(chains): set t5 hardfork on Tempo Testnet (Moderato)

### DIFF
--- a/.changeset/tempo-testnet-hardfork-t5.md
+++ b/.changeset/tempo-testnet-hardfork-t5.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+**Tempo:** Set the `t5` hardfork on the Tempo Testnet (Moderato) chain.

--- a/src/chains/definitions/tempoModerato.ts
+++ b/src/chains/definitions/tempoModerato.ts
@@ -4,6 +4,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const tempoModerato = /*#__PURE__*/ defineChain({
   ...chainConfig,
   id: 42431,
+  hardfork: 't5',
   blockExplorers: {
     default: {
       name: 'Tempo Explorer',


### PR DESCRIPTION
Sets the `t5` hardfork flag on the Tempo Testnet (Moderato) chain (`tempoTestnet` / `tempoModerato`, id `42431`), which previously had no `hardfork` set.
