### PR TITLE
Update access key sidebar labels

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -2111,17 +2111,15 @@ export default defineConfig({
                   link: '/tempo/guides/access-keys/manage',
                 },
                 {
-                  badge: { text: 'T7', variant: 'warning' },
+                  badge: { text: 'T6', variant: 'warning' },
                   text: 'Admin Access Keys',
                   link: '/tempo/guides/access-keys/admin',
                 },
                 {
-                  badge: { text: 'T6', variant: 'warning' },
                   text: 'Witnesses',
                   link: '/tempo/guides/access-keys/witnesses',
                 },
                 {
-                  badge: { text: 'T7', variant: 'warning' },
                   text: 'Verify Signatures',
                   link: '/tempo/guides/access-keys/verify',
                 },


### PR DESCRIPTION
Updates access key guide sidebar badges.

Verify Signatures links to `accessKey.verifyHash`, which references TIP-1049.

Checks: `git diff --check`
