### PR TITLE
Update estimateUserOperationGas.ts

### DIFF
--- a/.changeset/fix-estimate-user-operation-gas-fees.md
+++ b/.changeset/fix-estimate-user-operation-gas-fees.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `estimateUserOperationGas` omitting `maxFeePerGas` and `maxPriorityFeePerGas` during User Operation preparation, which caused strict bundlers to reject gas estimation requests.

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
@@ -180,6 +180,8 @@ export async function estimateUserOperationGas<
           'nonce',
           'paymaster',
           'signature',
+          'maxFeePerGas',
+          'maxPriorityFeePerGas',
         ],
       } as unknown as PrepareUserOperationParameters)
     : parameters


### PR DESCRIPTION
## Description
Fixes an issue in `estimateUserOperationGas` where `maxFeePerGas` and `maxPriorityFeePerGas` are stripped out during the `prepareUserOperation` phase for EntryPoint 0.7. Strict bundlers (like Pimlico v2 RPC endpoints) reject the simulation payload if these gas price fields are missing or undefined.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have followed the steps in the CONTRIBUTING.md document.
- [x] My code follows the code style of this project.