### PR TITLE
Make Monadscan the default Monad explorer

### DIFF
--- a/.changeset/neat-radios-grab.md
+++ b/.changeset/neat-radios-grab.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Changed Monad's default block explorer to Monadscan.

--- a/src/chains/definitions/monad.ts
+++ b/src/chains/definitions/monad.ts
@@ -17,13 +17,13 @@ export const monad = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'MonadVision',
-      url: 'https://monadvision.com',
-    },
-    monadscan: {
       name: 'Monadscan',
       url: 'https://monadscan.com',
-      apiUrl: 'https://api.monadscan.com/api',
+      apiUrl: 'https://api.etherscan.io/v2/api?chainid=143',
+    },
+    monadvision: {
+      name: 'MonadVision',
+      url: 'https://monadvision.com',
     },
   },
   testnet: false,


### PR DESCRIPTION
## Summary

Changes Monad mainnet's default block explorer from MonadVision to Monadscan.

The default explorer now includes Monadscan's Etherscan V2 API URL for Monad mainnet. MonadVision remains available under `monadvision`, and the separate `monadscan` key is removed because Monadscan is now the default.

## Validation

- `pnpm exec biome check src/chains/definitions/monad.ts .changeset/neat-radios-grab.md`
- `pnpm exec vitest test/scripts/chains.test.ts --run --testNamePattern "Monad.*blockExplorer.url"`

Notes:

- `pnpm exec vitest test/scripts/chains.test.ts --run --testNamePattern "Monad.*blockExplorer.apiUrl"` reaches Etherscan V2 and returns `Missing/Invalid API Key` without an API key.
- `pnpm check:types` fails in this local checkout because generated contract artifacts are missing after installing dependencies with scripts disabled.
