### PR TITLE
fix(parseUnits): round on digit chars instead of a JS float (fixes 1-unit over-rounding)

### DIFF
--- a/.changeset/parseunits-float-rounding.md
+++ b/.changeset/parseunits-float-rounding.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix(parseUnits): round on digit chars instead of a JS float. `Number(".4999999999999999999")` evaluated to `0.5`, so the previous `Math.round(Number(...))` rounded values strictly below the midpoint up by a whole unit (e.g. `parseUnits("3.4999999999999999999", 0)` returned `4n` instead of `3n`).

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -100,3 +100,14 @@ test('decimals < fraction length', () => {
   expect(parseUnits('69.59000000059', 9)).toMatchInlineSnapshot('69590000001n')
   expect(parseUnits('69.59000002359', 9)).toMatchInlineSnapshot('69590000024n')
 })
+
+test('float-precision rounding (regression)', () => {
+  // `Number('.4999999999999999999')` evaluates to 0.5 due to float precision,
+  // so a value strictly *below* the rounding midpoint was previously rounded
+  // up by a whole unit. These must round down.
+  expect(parseUnits('3.4999999999999999999', 0)).toBe(3n)
+  expect(parseUnits('0.4999999999999999999', 0)).toBe(0n)
+  expect(parseUnits('123.4999999999999999999', 0)).toBe(123n)
+  expect(parseUnits('1.04999999999999999999', 1)).toBe(10n)
+})
+

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -18,7 +18,7 @@ export function parseUnits(value: string, decimals: number) {
   if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(value))
     throw new InvalidDecimalNumberError({ value })
 
-  let [integer, fraction = '0'] = value.split('.')
+  let [integer = '', fraction = ''] = value.split('.')
 
   const negative = integer.startsWith('-')
   if (negative) integer = integer.slice(1)
@@ -26,32 +26,22 @@ export function parseUnits(value: string, decimals: number) {
   // trim trailing zeros.
   fraction = fraction.replace(/(0+)$/, '')
 
-  // round off if the fraction is larger than the number of decimals.
-  if (decimals === 0) {
-    if (Math.round(Number(`.${fraction}`)) === 1)
-      integer = `${BigInt(integer) + 1n}`
-    fraction = ''
-  } else if (fraction.length > decimals) {
-    const [left, unit, right] = [
-      fraction.slice(0, decimals - 1),
-      fraction.slice(decimals - 1, decimals),
-      fraction.slice(decimals),
-    ]
-
-    const rounded = Math.round(Number(`${unit}.${right}`))
-    if (rounded > 9)
-      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(left.length + 1, '0')
-    else fraction = `${left}${rounded}`
-
-    if (fraction.length > decimals) {
-      fraction = fraction.slice(1)
-      integer = `${BigInt(integer) + 1n}`
-    }
-
-    fraction = fraction.slice(0, decimals)
-  } else {
+  // Fraction fits within `decimals`: just pad it out, nothing to round.
+  if (fraction.length <= decimals) {
     fraction = fraction.padEnd(decimals, '0')
+    return BigInt(`${negative ? '-' : ''}${integer || '0'}${fraction}`)
   }
 
-  return BigInt(`${negative ? '-' : ''}${integer}${fraction}`)
+  // Fraction is longer than `decimals`: round half-up based on the first
+  // dropped digit. We compare the digit *characters* directly instead of
+  // routing the fraction through a JS float (the previous implementation used
+  // `Math.round(Number(...))`). `Number('.4999999999999999999')` evaluates to
+  // `0.5` due to float precision, which rounded a value strictly *below* the
+  // midpoint up by a whole unit. Concatenating the kept digits into a single
+  // BigInt also lets the carry propagate into the integer part automatically.
+  const keep = fraction.slice(0, decimals)
+  const roundUp = fraction[decimals] >= '5'
+  let scaled = BigInt(`${integer || '0'}${keep}`)
+  if (roundUp) scaled += 1n
+  return BigInt(negative ? '-1' : '1') * scaled
 }


### PR DESCRIPTION
## Summary

`parseUnits` rounds using `Math.round(Number(\`${unit}.${right}\`))`, routing the fraction through a JS float. `Number(".4999999999999999999")` evaluates to **`0.5`** (float precision), so a value strictly *below* the rounding midpoint is rounded **up by a whole unit**.

```ts
parseUnits("3.4999999999999999999", 0)   // → 4n   (should be 3n)
parseUnits("0.4999999999999999999", 0)   // → 1n   (should be 0n)
parseUnits("123.4999999999999999999", 0) // → 124n (should be 123n)
parseUnits("1.04999999999999999999", 1)  // → 11n  (should be 10n)
```

For 0-decimal tokens (or any case where the dropped fraction is `4999…9` past ~15–17 digits) this silently over-credits the parsed amount by one base unit — an incorrect-rounding bug in the core human-amount → BigInt money path.

## Fix

Round half-up by comparing the first **dropped digit character** directly, and concatenate the kept digits into a single `BigInt` so the carry propagates into the integer part automatically — no float involved.

```ts
const keep = fraction.slice(0, decimals)
const roundUp = fraction[decimals] >= "5"
let scaled = BigInt(`${integer || "0"}${keep}`)
if (roundUp) scaled += 1n
return BigInt(negative ? "-1" : "1") * scaled
```

## Tests

- Passes the **entire existing `parseUnits.test.ts` suite** (verified all documented cases — `69.56789`/`0` → `70n`, `999999.99999`/`3` → `1000000000n`, `12301000000000000020000.5`/`0` → `…20001n`, the 50-decimal cases, negatives, etc. — unchanged).
- Adds a `float-precision rounding (regression)` test block covering the cases above.

No public API or behavior change except correcting the mis-rounded edge cases.