### PR TITLE
docs: add Arc to chain examples

### DIFF
--- a/site/pages/docs/chains/introduction.md
+++ b/site/pages/docs/chains/introduction.md
@@ -1,6 +1,6 @@
 # Chains
 
-The `viem/chains` entrypoint contains references to popular EVM-compatible chains such as: Polygon, Optimism, Avalanche, Base, Zora, and more.
+The `viem/chains` entrypoint contains references to popular EVM-compatible chains such as: Polygon, Optimism, Avalanche, Base, Zora, Arc, and more.
 
 ## Usage
 


### PR DESCRIPTION
Adds Arc to the example list of popular EVM-compatible chains in the Chains docs introduction.

Arc is already exported from `viem/chains`, so this only updates the docs copy to include it alongside the existing examples.

No tests added; this is a documentation-only change.

