### PR TITLE
Add chain client decorators

### DIFF
--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -158,6 +158,15 @@ export type Client<
     >
   }
 
+export type ChainActions<chain extends Chain | undefined = Chain | undefined> =
+  chain extends {
+    decorators?: {
+      client?: (...args: any) => infer actions
+    }
+  }
+    ? actions
+    : unknown
+
 type Client_Base<
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
@@ -295,6 +304,27 @@ export function createClient(parameters: ClientConfig): Client {
   }
 
   return Object.assign(client, { extend: extend(client) as any })
+}
+
+export function extendChainActions<
+  transport extends Transport,
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+  rpcSchema extends RpcSchema | undefined,
+  extended extends Extended | undefined,
+>(
+  client: Client<transport, chain, account, rpcSchema, extended>,
+): Client<
+  transport,
+  chain,
+  account,
+  rpcSchema,
+  Prettify<ChainActions<chain>> &
+    (extended extends Extended ? extended : unknown)
+> {
+  const decorator = client.chain?.decorators?.client
+  if (!decorator) return client as never
+  return client.extend(decorator as never) as never
 }
 
 /**

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -5,10 +5,12 @@ import type { Chain } from '../types/chain.js'
 import type { PublicRpcSchema, RpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import {
+  type ChainActions,
   type Client,
   type ClientConfig,
   type CreateClientErrorType,
   createClient,
+  extendChainActions,
 } from './createClient.js'
 import { type PublicActions, publicActions } from './decorators/public.js'
 import type { Transport } from './transports/createTransport.js'
@@ -47,7 +49,7 @@ export type PublicClient<
     rpcSchema extends RpcSchema
       ? [...PublicRpcSchema, ...rpcSchema]
       : PublicRpcSchema,
-    PublicActions<transport, chain>
+    PublicActions<transport, chain> & ChainActions<chain>
   >
 >
 
@@ -87,5 +89,5 @@ export function createPublicClient<
     name,
     type: 'publicClient',
   })
-  return client.extend(publicActions) as any
+  return extendChainActions(client.extend(publicActions)) as never
 }

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -7,10 +7,12 @@ import type { Chain } from '../types/chain.js'
 import type { RpcSchema, TestRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import {
+  type ChainActions,
   type Client,
   type ClientConfig,
   type CreateClientErrorType,
   createClient,
+  extendChainActions,
 } from './createClient.js'
 import { type TestActions, testActions } from './decorators/test.js'
 import type { Transport } from './transports/createTransport.js'
@@ -60,7 +62,8 @@ export type TestClient<
       : TestRpcSchema<mode>,
     { mode: mode } & (includeActions extends true
       ? TestActions
-      : Record<string, unknown>)
+      : Record<string, unknown>) &
+      ChainActions<chain>
   >
 >
 
@@ -120,8 +123,10 @@ export function createTestClient(parameters: TestClientConfig): TestClient {
     name,
     type: 'testClient',
   })
-  return client.extend((config) => ({
-    mode,
-    ...testActions({ mode })(config),
-  }))
+  return extendChainActions(
+    client.extend((config) => ({
+      mode,
+      ...testActions({ mode })(config),
+    })),
+  ) as never
 }

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -7,10 +7,12 @@ import type { Chain } from '../types/chain.js'
 import type { RpcSchema, WalletRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import {
+  type ChainActions,
   type Client,
   type ClientConfig,
   type CreateClientErrorType,
   createClient,
+  extendChainActions,
 } from './createClient.js'
 import { type WalletActions, walletActions } from './decorators/wallet.js'
 import type { Transport } from './transports/createTransport.js'
@@ -52,7 +54,7 @@ export type WalletClient<
     rpcSchema extends RpcSchema
       ? [...WalletRpcSchema, ...rpcSchema]
       : WalletRpcSchema,
-    WalletActions<chain, account>
+    WalletActions<chain, account> & ChainActions<chain>
   >
 >
 
@@ -114,5 +116,5 @@ export function createWalletClient(
     transport,
     type: 'walletClient',
   })
-  return client.extend(walletActions)
+  return extendChainActions(client.extend(walletActions)) as never
 }

--- a/src/tempo/chainConfig.test-d.ts
+++ b/src/tempo/chainConfig.test-d.ts
@@ -12,6 +12,8 @@ test('prepareTransactionRequest preserves tempo transaction type', async () => {
     transport: http(),
   })
 
+  expectTypeOf(client.token.transfer).toBeFunction()
+
   const request_action = await prepareTransactionRequest(client, {
     calls: [],
     type: 'tempo',

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -10,6 +10,7 @@ import {
   verifyHash,
 } from '../actions/index.js'
 import { mainnet, tempoLocalnet } from '../chains/index.js'
+import { createWalletClient } from '../clients/createWalletClient.js'
 import { createClient, http } from '../index.js'
 import { defineChain } from '../utils/chain/defineChain.js'
 import { hashMessage } from '../utils/index.js'
@@ -29,6 +30,15 @@ const client = getClient({
 const maxUint256 = 2n ** 256n - 1n
 
 describe('prepareTransactionRequest', () => {
+  test('behavior: chain config adds tempo client actions', () => {
+    const client = createWalletClient({
+      chain: tempoLocalnet,
+      transport: http(),
+    })
+
+    expect(client.token.transfer).toBeTypeOf('function')
+  })
+
   test('behavior: expiring nonces for feePayer transactions', async () => {
     const now = Math.floor(Date.now() / 1000)
     const requests = await Promise.all([

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -15,15 +15,20 @@ import { keccak256 } from '../utils/hash/keccak256.js'
 import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { Account, MultisigAccount } from './Account.js'
 import { getMetadata } from './actions/accessKey.js'
+import { decorator } from './Decorator.js'
 import * as Formatters from './Formatters.js'
 import type { Hardfork } from './Hardfork.js'
 import * as Concurrent from './internal/concurrent.js'
 import * as Transaction from './Transaction.js'
 
 const maxExpirySecs = 25
+const clientDecorator = decorator()
 
 export const chainConfig = {
   blockTime: 1_000,
+  decorators: {
+    client: clientDecorator,
+  },
   extendSchema: extendSchema<{
     feeToken?: TokenId.TokenIdOrAddress | undefined
     hardfork?: Hardfork | undefined

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -1,11 +1,12 @@
 import { ZoneId } from 'ox/tempo'
-import { tempo } from '../../chains/definitions/tempo.js'
-import { tempoModerato } from '../../chains/definitions/tempoModerato.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../chainConfig.js'
 
+const tempoId = 4217
+const tempoModeratoId = 42431
+
 export const portalAddresses = {
-  [tempoModerato.id]: {
+  [tempoModeratoId]: {
     6: '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23',
     7: '0x3F5296303400B56271b476F5A0B9cBF74350D6Ac',
   },
@@ -42,12 +43,12 @@ const overrides = {
 } as const satisfies Record<number, Override>
 
 export const zone = /*#__PURE__*/ from({
-  sourceId: tempo.id,
+  sourceId: tempoId,
   rpcHost: 'tempo.xyz',
 })
 
 export const zoneModerato = /*#__PURE__*/ from({
-  sourceId: tempoModerato.id,
+  sourceId: tempoModeratoId,
   rpcHost: 'tempoxyz.dev',
 })
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -24,6 +24,7 @@ export type Chain<
   extendSchema extends Record<string, unknown> | undefined =
     | Record<string, unknown>
     | undefined,
+  decorators extends ChainDecorators | undefined = ChainDecorators | undefined,
 > = {
   /** Collection of block explorers */
   blockExplorers?:
@@ -69,7 +70,7 @@ export type Chain<
   sourceId?: number | undefined
   /** Flag for test networks */
   testnet?: boolean | undefined
-} & ChainConfig<formatters, extendSchema>
+} & ChainConfig<formatters, extendSchema, decorators>
 
 /////////////////////////////////////////////////////////////////////
 // Config
@@ -90,14 +91,23 @@ type ChainVerifyHashFn = (
   parameters: VerifyHashParameters,
 ) => Promise<VerifyHashReturnType>
 
+type ChainClientDecoratorFn = (client: Client) => Record<string, unknown>
+
+type ChainDecorators = {
+  client?: ChainClientDecoratorFn | undefined
+}
+
 export type ChainConfig<
   formatters extends ChainFormatters | undefined = ChainFormatters | undefined,
   extendSchema extends Record<string, unknown> | undefined =
     | Record<string, unknown>
     | undefined,
+  decorators extends ChainDecorators | undefined = ChainDecorators | undefined,
 > = {
   /** Custom chain data. @deprecated use `.extend` instead. */
   custom?: extendSchema | undefined
+  /** Adds chain-specific actions to clients configured with this chain. */
+  decorators?: decorators | undefined
   /** Extend schema. */
   extendSchema?: extendSchema | undefined
   /** Modifies how fees are derived. */


### PR DESCRIPTION
Adds a generic chain-level client decorator hook and wires it into public, wallet, and test client creation after their standard actions are installed. Tempo uses the hook to expose `tempoActions()` automatically from Tempo chain configs, so `createWalletClient({ chain: tempoLocalnet, ... })` has `client.token.transfer` without an explicit `.extend(tempoActions())`.

Also removes a chain-definition import cycle in Tempo zone chains by using local Tempo chain ID constants.

Validation:
- `pnpm exec biome check --write --unsafe src/types/chain.ts src/clients/createClient.ts src/clients/createWalletClient.ts src/clients/createPublicClient.ts src/clients/createTestClient.ts src/tempo/chainConfig.ts src/tempo/chainConfig.test-d.ts src/tempo/chainConfig.test.ts src/tempo/zones/zone.ts`
- `pnpm check:types` fails because postinstall could not clone SSH submodules, so `contracts/generated.js` is missing; no errors remain from this patch.
- `SKIP_GLOBAL_SETUP=true pnpm exec vitest -c ./test/vitest.config.ts --project tempo src/tempo/chainConfig.test.ts --run` gets past module loading, then fails during Tempo fixture setup with HTTP 400 from local server minting.

Prompted by: @gakonst