### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/site/pages/docs/installation.mdx
+++ b/site/pages/docs/installation.mdx
@@ -22,6 +22,9 @@ yarn add viem
 ```bash [bun]
 bun add viem
 ```
+```bash [deno]
+deno add viem
+```
 :::
 
 ## CDN


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install `code-group` lists pnpm / npm / yarn / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity (viem resolves and runs the same way under Deno):

```sh
deno add viem
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
