### PR TITLE
docs: add bundler actions introduction

### DIFF
--- a/site/pages/account-abstraction/actions/bundler/introduction.md
+++ b/site/pages/account-abstraction/actions/bundler/introduction.md
@@ -1,1 +1,7 @@
-# TODO
+# Introduction to Bundler Actions [A brief introduction to Bundler Actions in viem.]
+
+Bundler Actions are actions that map to **ERC-4337 Bundler** JSON-RPC methods (`eth_sendUserOperation`, `eth_estimateUserOperationGas`, etc). They are used with a [Bundler Client](/account-abstraction/clients/bundler).
+
+Bundler Actions are used to prepare, estimate, send, and retrieve **User Operations**. Examples of Bundler Actions include [estimating the gas values for a User Operation](/account-abstraction/actions/bundler/estimateUserOperationGas), [sending a User Operation](/account-abstraction/actions/bundler/sendUserOperation), and [waiting for a User Operation receipt](/account-abstraction/actions/bundler/waitForUserOperationReceipt).
+
+Bundler Actions provide the main interface for Account Abstraction workflows. They can work with a [Smart Account](/account-abstraction/accounts/smart), a [Paymaster Client](/account-abstraction/clients/paymaster), and the underlying Public Client to construct User Operations before submitting them to a bundler.

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -1507,6 +1507,10 @@ export default defineConfig({
           text: 'Bundler Actions',
           items: [
             {
+              text: 'Introduction',
+              link: '/account-abstraction/actions/bundler/introduction',
+            },
+            {
               text: 'estimateUserOperationGas',
               link: '/account-abstraction/actions/bundler/estimateUserOperationGas',
             },


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

## Summary

Adds the missing Bundler Actions introduction page for the Account Abstraction docs and links it from the Account Abstraction sidebar.

This replaces the existing `# TODO` placeholder with a short overview of Bundler Actions, including links to the Bundler Client and the main User Operation actions.

No changeset is included because this is documentation-only.
