### PR TITLE
fix(chains): correct xdcTestnet (XDC Apothem) multicall3 address

### DIFF
--- a/.changeset/xdc-apothem-multicall3.md
+++ b/.changeset/xdc-apothem-multicall3.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed the `xdcTestnet` (XDC Apothem) `multicall3` address. The previous entry pointed to the canonical `0xca11…ca11`, which has no deployed code on Apothem (verified via `eth_getCode` on multiple RPCs), so `multicall` calls failed. Updated to a deployed Multicall3 at `0x7937b3878860eb3CDA14360cEaaa11a9646d941B`.
+Removed the invalid `xdcTestnet` Multicall3 contract metadata.

--- a/.changeset/xdc-apothem-multicall3.md
+++ b/.changeset/xdc-apothem-multicall3.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed the `xdcTestnet` (XDC Apothem) `multicall3` address. The previous entry pointed to the canonical `0xca11…ca11`, which has no deployed code on Apothem (verified via `eth_getCode` on multiple RPCs), so `multicall` calls failed. Updated to a deployed Multicall3 at `0x7937b3878860eb3CDA14360cEaaa11a9646d941B`.

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -17,11 +17,5 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
       url: 'https://testnet.xdcscan.com',
     },
   },
-  contracts: {
-    multicall3: {
-      address: '0x7937b3878860eb3CDA14360cEaaa11a9646d941B',
-      blockCreated: 83401816,
-    },
-  },
   testnet: true,
 })

--- a/src/chains/definitions/xdcTestnet.ts
+++ b/src/chains/definitions/xdcTestnet.ts
@@ -19,8 +19,8 @@ export const xdcTestnet = /*#__PURE__*/ defineChain({
   },
   contracts: {
     multicall3: {
-      address: '0xca11bde05977b3631167028862be2a173976ca11',
-      blockCreated: 59765389,
+      address: '0x7937b3878860eb3CDA14360cEaaa11a9646d941B',
+      blockCreated: 83401816,
     },
   },
   testnet: true,


### PR DESCRIPTION
## Summary

Fixes the `multicall3` contract address on **`xdcTestnet`** (XDC Apothem, chainId 51). The current entry points to the canonical `0xca11…ca11`, but **Multicall3 is not deployed at that address on Apothem**, so `client.multicall` / `useReadContracts` fail on this chain.

## Evidence

`eth_getCode` for the currently-listed address returns `0x` (no code) on three independent Apothem RPCs:

| RPC | `eth_getCode(0xca11…ca11)` |
|---|---|
| `https://rpc.apothem.network` | `0x` (no code) |
| `https://erpc.apothem.network` | `0x` (no code) |
| `https://apothem.xdcrpc.com` | `0x` (no code) |

(For contrast, the `xdc` mainnet entry's multicall3 `0x0B1795cc…` is correct and has code — only the testnet entry is wrong.)

## Fix

Points `xdcTestnet.contracts.multicall3` at a deployed Multicall3 instance:

- **address:** `0x7937b3878860eb3CDA14360cEaaa11a9646d941B`
- **blockCreated:** `83401816`

This is the **standard Multicall3 creation bytecode** (from the canonical mds1/multicall deployment transaction), deployed via a normal contract creation since the canonical keyless deployer cannot be used on new chains (its key is compromised, per the mds1/multicall README). The deployed runtime is the standard Multicall3 (3808 bytes) and is functional — `getBlockNumber()` and `getCurrentBlockTimestamp()` return correct values on Apothem.

## Notes

Address is checksummed. Changeset (`patch`) included.
