### PR TITLE
fix(account-abstraction): serialize 7702 authorization yParity as 1 byte

### DIFF
--- a/.changeset/fix-eip7702-yparity-serialization.md
+++ b/.changeset/fix-eip7702-yparity-serialization.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `formatUserOperationRequest` serializing an EIP-7702 authorization `yParity` of `0` as a 32-byte value instead of a single byte. The malformed value was sent to both `pm_getPaymasterData` and `eth_sendUserOperation`, which could cause paymaster signature validation (`AA34`) to fail for 7702 User Operations.

--- a/src/account-abstraction/utils/formatters/userOperationRequest.test.ts
+++ b/src/account-abstraction/utils/formatters/userOperationRequest.test.ts
@@ -70,3 +70,29 @@ test('default', () => {
     }
   `)
 })
+
+test('args: authorization (yParity serialization)', () => {
+  const request = {
+    callData: '0xdeadbeef',
+    sender: '0x0000000000000000000000000000000000000000',
+    signature: '0xdeadbeef',
+    authorization: {
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 1,
+      nonce: 0,
+      r: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      s: '0x0000000000000000000000000000000000000000000000000000000000000002',
+      yParity: 0,
+    },
+  } as const
+
+  // A `yParity` of `0` must serialize to a single byte (`0x00`), not 32 bytes.
+  expect(formatUserOperationRequest(request).eip7702Auth?.yParity).toBe('0x00')
+
+  expect(
+    formatUserOperationRequest({
+      ...request,
+      authorization: { ...request.authorization, yParity: 1 },
+    }).eip7702Auth?.yParity,
+  ).toBe('0x01')
+})

--- a/src/account-abstraction/utils/formatters/userOperationRequest.ts
+++ b/src/account-abstraction/utils/formatters/userOperationRequest.ts
@@ -69,8 +69,9 @@ function formatAuthorization(authorization: SignedAuthorization) {
     s: authorization.s
       ? numberToHex(BigInt(authorization.s), { size: 32 })
       : pad('0x', { size: 32 }),
-    yParity: authorization.yParity
-      ? numberToHex(authorization.yParity, { size: 1 })
-      : pad('0x', { size: 32 }),
+    yParity:
+      typeof authorization.yParity === 'number'
+        ? numberToHex(authorization.yParity, { size: 1 })
+        : pad('0x', { size: 1 }),
   }
 }


### PR DESCRIPTION
## Summary

`formatUserOperationRequest` serializes an EIP-7702 authorization `yParity` of `0` as a **32-byte** value instead of a single byte.

`src/account-abstraction/utils/formatters/userOperationRequest.ts`:

```ts
// before
yParity: authorization.yParity
  ? numberToHex(authorization.yParity, { size: 1 })
  : pad('0x', { size: 32 }),
```

The guard is a truthiness check, so the valid value `0` is treated as absent and falls through to the `pad('0x', { size: 32 })` branch — which is also the wrong size (32 bytes vs 1).

## Impact

The malformed value is sent identically to `pm_getPaymasterData` and `eth_sendUserOperation`. In practice this can cause paymaster signature validation to fail with `AA34 signature error` for EIP-7702 User Operations. Because roughly half of signed authorizations have a `yParity` of `0`, the failure is **intermittent** and hard to track down.

Observed on a sponsored EIP-7702 UserOperation (EntryPoint v0.8), where the request body contained:

```json
"eip7702Auth": { ..., "yParity": "0x0000000000000000000000000000000000000000000000000000000000000000" }
```

## Fix

Use a presence check and serialize as a single byte in both branches:

```ts
yParity:
  typeof authorization.yParity === 'number'
    ? numberToHex(authorization.yParity, { size: 1 })
    : pad('0x', { size: 1 }),
```

`r` / `s` are left as-is: their fallback size of 32 bytes is correct, and a zero `r` / `s` is not a real case.

## Test

Added a regression test asserting `yParity: 0` -> `0x00` and `yParity: 1` -> `0x01`.