### PR TITLE
Fix: ENS `getEnsName()` should enforce normalization

### DIFF
--- a/src/actions/ens/getEnsName.test.ts
+++ b/src/actions/ens/getEnsName.test.ts
@@ -22,7 +22,7 @@ const client = anvilMainnet.getClient()
 
 beforeAll(async () => {
   await reset(client, {
-    blockNumber: 23_093_073n,
+    blockNumber: 25_382_400n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
   await setVitalikResolver()
@@ -136,6 +136,22 @@ describe('primary name with non-contract resolver', () => {
       }),
     ).rejects.toThrow('The contract function "reverseWithGateways" reverted')
   })
+})
+
+test('primary name with offchain resolver', async () => {
+  await expect(
+    getEnsName(client, {
+      address: '0xEB4200f750335eFb67E726485445d302D64B1c8A',
+    }),
+  ).resolves.toMatchInlineSnapshot('"test.antistupid.com"')
+})
+
+test('unnormalized primary name', async () => {
+  await expect(
+    getEnsName(client, {
+      address: '0xb404Af9A235Be881335d8898B5B487dc9Cd5ed9D',
+    }),
+  ).resolves.toMatchInlineSnapshot('null')
 })
 
 describe('http error', () => {

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -19,6 +19,7 @@ import {
   type ReadContractParameters,
   readContract,
 } from '../public/readContract.js'
+import { normalize } from '../../ens/index.js'
 
 export type GetEnsNameParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
@@ -131,10 +132,20 @@ export async function getEnsName<chain extends Chain | undefined>(
 
     const [name] = await readContractAction(readContractParameters)
 
+    if (!isNormalized(name)) return null
+
     return name || null
   } catch (err) {
     if (strict) throw err
     if (isNullUniversalResolverError(err)) return null
     throw err
+  }
+}
+
+function isNormalized(name: string) {
+  try {
+    return name === normalize(name)
+  } catch {
+    return
   }
 }


### PR DESCRIPTION
[ENSIP-23](https://docs.ens.domains/ensip/23) states:
> If the primary name is [unnormalized](https://docs.ens.domains/ensip/15), eg. `normalize("Nick.eth") != "Nick.eth"`, then name and resolver are invalid.

---

* changed `getEnsName()` to return `null` if not normalized
* added test with unnormalized name
* added test with offchain reverse resolver

---

- [ ] Replace ENS names with official test cases