### PR TITLE
docs(tempo): remove t6 launch labels

### DIFF
--- a/site/pages/tempo/actions/accessKey.isAdmin.mdx
+++ b/site/pages/tempo/actions/accessKey.isAdmin.mdx
@@ -2,10 +2,6 @@ import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
 
 # `accessKey.isAdmin`
 
-:::warning
-**Coming soon:** [TIP-1049](https://tips.sh/1049) ships in the **T6** hardfork, live on **Testnet** June 18, 2026 at 4pm CEST and **Mainnet** June 23, 2026 at 4pm CEST.
-:::
-
 Checks whether an access key is an admin key for an account.
 
 Returns `true` for the account's root key or for an active admin access key (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize) with `admin: true`).

--- a/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
+++ b/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
@@ -1,9 +1,5 @@
 # `accessKey.watchAdminAuthorized`
 
-:::warning
-**Coming soon:** [TIP-1049](https://tips.sh/1049) ships in the **T6** hardfork, live on **Testnet** June 18, 2026 at 4pm CEST and **Mainnet** June 23, 2026 at 4pm CEST.
-:::
-
 Watches for admin key authorization events (`AdminKeyAuthorized`), emitted when an admin key is authorized (see [`accessKey.authorize`](/tempo/actions/accessKey.authorize) with `admin: true`).
 
 [TIP-1049](https://tips.sh/1049)

--- a/site/pages/tempo/actions/receivePolicy.burn.mdx
+++ b/site/pages/tempo/actions/receivePolicy.burn.mdx
@@ -2,10 +2,6 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.burn`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Burns the funds backing a blocked receipt. Requires the caller to hold the token's `BURN_BLOCKED_ROLE`, and is only valid when the receipt's policy subject is currently unauthorized as a sender under the token's TIP-403 policy. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.claim.mdx
+++ b/site/pages/tempo/actions/receivePolicy.claim.mdx
@@ -2,10 +2,6 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.claim`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Claims blocked funds for a receipt, releasing them to a destination. The caller must be authorized to reclaim the funds per the policy's `claimer` setting. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.get.mdx
+++ b/site/pages/tempo/actions/receivePolicy.get.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.get`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Gets the receive policy configured for an account. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
+++ b/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.getBlockedBalance`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Gets the blocked balance held by the `ReceivePolicyGuard` for an encoded claim receipt. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.set.mdx
+++ b/site/pages/tempo/actions/receivePolicy.set.mdx
@@ -2,10 +2,6 @@ import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
 
 # `receivePolicy.set`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Sets the receive policy for the calling account. A receive policy controls which TIP-20 tokens and which senders an account accepts. Inbound transfers and mints that violate the policy are not reverted – instead the funds are redirected to the `ReceivePolicyGuard` and can be reclaimed later (see [`receivePolicy.claim`](/tempo/actions/receivePolicy.claim)). [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.validate.mdx
+++ b/site/pages/tempo/actions/receivePolicy.validate.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.validate`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Checks whether a transfer or mint to a receiver is allowed by the receiver's receive policy. [Learn more about transfer policies](https://docs.tempo.xyz/protocol/tip403/spec)
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.watchBlocked`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Watches for blocked transfer events (`TransferBlocked`) emitted by the `ReceivePolicyGuard` when an inbound transfer or mint violates a receive policy.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.watchBurned`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Watches for receipt burned events (`ReceiptBurned`) emitted by the `ReceivePolicyGuard` when blocked funds are burned.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.watchClaimed`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Watches for receipt claimed events (`ReceiptClaimed`) emitted by the `ReceivePolicyGuard` when blocked funds are reclaimed.
 
 ## Usage

--- a/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
@@ -1,9 +1,5 @@
 # `receivePolicy.watchUpdated`
 
-:::warning
-**Coming soon:** [TIP-1028](https://tips.sh/1028) ships in the **T6** hardfork — live on **Testnet** June 11 and **Mainnet** June 15.
-:::
-
 Watches for receive policy update events (`ReceivePolicyUpdated`) on the TIP-403 Registry.
 
 ## Usage

--- a/site/pages/tempo/guides/access-keys/admin.mdx
+++ b/site/pages/tempo/guides/access-keys/admin.mdx
@@ -13,11 +13,6 @@ as authorizing and revoking them, without using the root key each time. Admin ke
 an `expiry`, `limits`, or `scopes` (those are ignored), so treat them as powerful as the root
 key itself.
 
-:::warning
-Admin access keys require the T6 hardfork ([TIP-1049](https://tips.sh/1049)), live on Testnet
-June 18, 2026 at 4pm CEST and Mainnet June 23, 2026 at 4pm CEST.
-:::
-
 ## Recipes
 
 These recipes assume you have [set up a Tempo client](/tempo).

--- a/site/pages/tempo/guides/receive-policies/blocked.mdx
+++ b/site/pages/tempo/guides/receive-policies/blocked.mdx
@@ -15,11 +15,6 @@ balance and resolving it.
 
 [See the Policy Registry specification](https://docs.tempo.xyz/protocol/tip403/overview)
 
-:::warning
-Receive policies require the T6 hardfork ([TIP-1028](https://tips.sh/1028)), live on Testnet June 11
-and Mainnet June 15.
-:::
-
 ## Recipes
 
 These recipes assume you have [set up a Tempo client](/tempo). Each recipe uses the claim receipt

--- a/site/pages/tempo/guides/receive-policies/index.mdx
+++ b/site/pages/tempo/guides/receive-policies/index.mdx
@@ -15,11 +15,6 @@ their account.
 
 [See the Policy Registry specification](https://docs.tempo.xyz/protocol/tip403/overview)
 
-:::warning
-Receive policies require the T6 hardfork ([TIP-1028](https://tips.sh/1028)), live on Testnet June 11
-and Mainnet June 15.
-:::
-
 ## See More
 
 <Cards>

--- a/site/pages/tempo/guides/receive-policies/set.mdx
+++ b/site/pages/tempo/guides/receive-policies/set.mdx
@@ -14,11 +14,6 @@ funds that get blocked. Set the policy once and update it whenever your requirem
 
 [See the Policy Registry specification](https://docs.tempo.xyz/protocol/tip403/overview)
 
-:::warning
-Receive policies require the T6 hardfork ([TIP-1028](https://tips.sh/1028)), live on Testnet June 11
-and Mainnet June 15.
-:::
-
 ## Recipes
 
 These recipes assume you have [set up a Tempo client](/tempo).

--- a/site/pages/tempo/guides/receive-policies/validate.mdx
+++ b/site/pages/tempo/guides/receive-policies/validate.mdx
@@ -14,11 +14,6 @@ Validation reports whether the transfer is authorized and, if not, why it was bl
 
 [See the Policy Registry specification](https://docs.tempo.xyz/protocol/tip403/overview)
 
-:::warning
-Receive policies require the T6 hardfork ([TIP-1028](https://tips.sh/1028)), live on Testnet June 11
-and Mainnet June 15.
-:::
-
 ## Recipes
 
 These recipes assume you have [set up a Tempo client](/tempo).

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -2111,7 +2111,6 @@ export default defineConfig({
                   link: '/tempo/guides/access-keys/manage',
                 },
                 {
-                  badge: { text: 'T6', variant: 'warning' },
                   text: 'Admin Access Keys',
                   link: '/tempo/guides/access-keys/admin',
                 },
@@ -2174,7 +2173,6 @@ export default defineConfig({
               ],
             },
             {
-              badge: { text: 'T6', variant: 'warning' },
               text: 'Receive Policies',
               collapsed: true,
               items: [


### PR DESCRIPTION
Removes launch-era T6 labels from Tempo docs now that the features are live.

The Tempo sidebar no longer badges Admin Access Keys or Receive Policies with T6, and the affected action and guide pages no longer show availability warning banners. Feature-specific hardfork notes in API parameter docs remain intact.
