### PR TITLE
feat: add stablecoins USDC entrypoint

### DIFF
--- a/.changeset/usdc-stablecoins-entrypoint.md
+++ b/.changeset/usdc-stablecoins-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `viem/stablecoins` entrypoint with native USDC contract addresses for EVM chains (`usdcAddresses`, `getUsdcAddress`) and a `getUsdcContract` helper that resolves the address from the client's chain.

--- a/src/package.json
+++ b/src/package.json
@@ -114,6 +114,11 @@
       "import": "./_esm/siwe/index.js",
       "default": "./_cjs/siwe/index.js"
     },
+    "./stablecoins": {
+      "types": "./_types/stablecoins/index.d.ts",
+      "import": "./_esm/stablecoins/index.js",
+      "default": "./_cjs/stablecoins/index.js"
+    },
     "./tempo": {
       "types": "./_types/tempo/index.d.ts",
       "import": "./_esm/tempo/index.js",
@@ -194,6 +199,9 @@
       ],
       "siwe": [
         "./_types/siwe/index.d.ts"
+      ],
+      "stablecoins": [
+        "./_types/stablecoins/index.d.ts"
       ],
       "tempo": [
         "./_types/tempo/index.d.ts"

--- a/src/stablecoins/getUsdcContract.test.ts
+++ b/src/stablecoins/getUsdcContract.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+
+import { base, localhost, mainnet } from '../chains/index.js'
+import { createPublicClient, http } from '../index.js'
+import { getUsdcContract } from './getUsdcContract.js'
+import { usdcAddresses } from './usdc.js'
+import { getUsdcAddress } from './utils.js'
+
+describe('usdcAddresses', () => {
+  test('exposes native USDC on mainnet', () => {
+    expect(usdcAddresses[mainnet.id]).toBe(
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    )
+  })
+})
+
+describe('getUsdcAddress', () => {
+  test('resolves by chain id', () => {
+    expect(getUsdcAddress(base.id)).toBe(
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    )
+  })
+})
+
+describe('getUsdcContract', () => {
+  test('builds a contract instance at the chain USDC address', () => {
+    const client = createPublicClient({ chain: base, transport: http() })
+    const usdc = getUsdcContract(client)
+    expect(usdc.address).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913')
+    expect(usdc.read.balanceOf).toBeDefined()
+  })
+
+  test('throws on a chain without native USDC', () => {
+    const client = createPublicClient({ chain: localhost, transport: http() })
+    expect(() => getUsdcContract(client)).toThrowError(/not available/)
+  })
+})

--- a/src/stablecoins/getUsdcContract.ts
+++ b/src/stablecoins/getUsdcContract.ts
@@ -1,0 +1,61 @@
+import type { Account } from '../accounts/types.js'
+import {
+  type GetContractReturnType,
+  getContract,
+} from '../actions/getContract.js'
+import type { Client } from '../clients/createClient.js'
+import type { Transport } from '../clients/transports/createTransport.js'
+import { erc20Abi } from '../constants/abis.js'
+import type { ErrorType } from '../errors/utils.js'
+import type { Chain } from '../types/chain.js'
+import { type UsdcChainId, usdcAddresses } from './usdc.js'
+
+export type GetUsdcContractReturnType<
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = GetContractReturnType<
+  typeof erc20Abi,
+  Client<transport, chain, account>,
+  (typeof usdcAddresses)[UsdcChainId]
+>
+
+export type GetUsdcContractErrorType = ErrorType
+
+/**
+ * Returns a ready-to-use [Contract Instance](https://viem.sh/docs/contract/getContract)
+ * for native USDC, resolving the contract address from the client's chain.
+ *
+ * @example
+ * ```ts
+ * import { createWalletClient, http, parseUnits } from 'viem'
+ * import { base } from 'viem/chains'
+ * import { getUsdcContract } from 'viem/stablecoins'
+ *
+ * const client = createWalletClient({ account, chain: base, transport: http() })
+ * const usdc = getUsdcContract(client)
+ *
+ * const balance = await usdc.read.balanceOf([account.address])
+ * const hash = await usdc.write.transfer([recipient, parseUnits('10', 6)])
+ * ```
+ */
+export function getUsdcContract<
+  transport extends Transport,
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<transport, chain, account>,
+): GetUsdcContractReturnType<transport, chain, account> {
+  const chainId = client.chain?.id
+  const address = usdcAddresses[chainId as UsdcChainId]
+  if (!address)
+    throw new Error(
+      `Native USDC is not available on chain "${chainId ?? 'unknown'}". ` +
+        'See https://developers.circle.com/stablecoins/usdc-contract-addresses for supported chains.',
+    )
+  return getContract({
+    abi: erc20Abi,
+    address,
+    client,
+  }) as GetUsdcContractReturnType<transport, chain, account>
+}

--- a/src/stablecoins/index.ts
+++ b/src/stablecoins/index.ts
@@ -1,0 +1,8 @@
+// biome-ignore lint/performance/noBarrelFile: entrypoint module
+export {
+  type GetUsdcContractErrorType,
+  type GetUsdcContractReturnType,
+  getUsdcContract,
+} from './getUsdcContract.js'
+export { type UsdcChainId, usdcAddresses } from './usdc.js'
+export { getUsdcAddress } from './utils.js'

--- a/src/stablecoins/package.json
+++ b/src/stablecoins/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "types": "../_types/stablecoins/index.d.ts",
+  "module": "../_esm/stablecoins/index.js",
+  "main": "../_cjs/stablecoins/index.js"
+}

--- a/src/stablecoins/usdc.ts
+++ b/src/stablecoins/usdc.ts
@@ -1,0 +1,75 @@
+import type { Address } from 'abitype'
+
+import {
+  arbitrum,
+  arbitrumSepolia,
+  arcTestnet,
+  avalanche,
+  avalancheFuji,
+  base,
+  baseSepolia,
+  codex,
+  codexTestnet,
+  ink,
+  inkSepolia,
+  linea,
+  lineaSepolia,
+  mainnet,
+  optimism,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  sei,
+  seiTestnet,
+  sepolia,
+  sonic,
+  sonicBlazeTestnet,
+  unichain,
+  unichainSepolia,
+  worldchain,
+  worldchainSepolia,
+} from '../chains/index.js'
+
+/**
+ * Native (Circle-issued) USDC token contract addresses, keyed by chain id.
+ *
+ * Only includes native USDC on EVM chains. Bridged representations (e.g.
+ * `USDC.e`) are intentionally excluded to avoid ambiguity.
+ *
+ * @see https://developers.circle.com/stablecoins/usdc-contract-addresses
+ */
+export const usdcAddresses = {
+  // Mainnets
+  [mainnet.id]: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  [base.id]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  [optimism.id]: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+  [polygon.id]: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+  [avalanche.id]: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+  [unichain.id]: '0x078D782b760474a361dDA0AF3839290b0EF57AD6',
+  [linea.id]: '0x176211869cA2b568f2A7D4EE941E073a821EE1ff',
+  [sonic.id]: '0x29219dd400f2Bf60E5a23d13Be72B486D4038894',
+  [worldchain.id]: '0x79A02482A880bCE3F13e09Da970dC34db4CD24d1',
+  [sei.id]: '0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392',
+  [codex.id]: '0xd996633a415985DBd7D6D12f4A4343E31f5037cf',
+  [ink.id]: '0x2D270e6886d130D724215A266106e6832161EAEd',
+  // Testnets
+  [sepolia.id]: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+  [baseSepolia.id]: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  [arbitrumSepolia.id]: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d',
+  [optimismSepolia.id]: '0x5fd84259d66Cd46123540766Be93DFE6D43130D7',
+  [polygonAmoy.id]: '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582',
+  [avalancheFuji.id]: '0x5425890298aed601595a70AB815c96711a31Bc65',
+  [unichainSepolia.id]: '0x31d0220469e10c4E71834a79b1f276d740d3768F',
+  [lineaSepolia.id]: '0xFEce4462D57bD51A6A552365A011b95f0E16d9B7',
+  [sonicBlazeTestnet.id]: '0xA4879Fed32Ecbef99399e5cbC247E533421C4eC6',
+  [worldchainSepolia.id]: '0x66145f38cBAC35Ca6F1Dfb4914dF98F1614aeA88',
+  [seiTestnet.id]: '0x4fCF1784B31630811181f670Aea7A7bEF803eaED',
+  [codexTestnet.id]: '0x6d7f141b6819C2c9CC2f818e6ad549E7Ca090F8f',
+  [inkSepolia.id]: '0xFabab97dCE620294D2B0b0e46C68964e326300Ac',
+  // Arc Testnet exposes USDC (the native gas token) via an ERC-20 interface.
+  [arcTestnet.id]: '0x3600000000000000000000000000000000000000',
+} as const satisfies Record<number, Address>
+
+/** Chain ids that have a known native USDC deployment. */
+export type UsdcChainId = keyof typeof usdcAddresses

--- a/src/stablecoins/utils.ts
+++ b/src/stablecoins/utils.ts
@@ -1,0 +1,20 @@
+import { type UsdcChainId, usdcAddresses } from './usdc.js'
+
+/**
+ * Returns the native USDC contract address for a given chain id.
+ *
+ * Accepts only chain ids with a known native USDC deployment, so passing an
+ * unsupported chain is a compile-time error.
+ *
+ * @example
+ * ```ts
+ * import { base } from 'viem/chains'
+ * import { getUsdcAddress } from 'viem/stablecoins'
+ *
+ * const address = getUsdcAddress(base.id)
+ * // '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+ * ```
+ */
+export function getUsdcAddress<chainId extends UsdcChainId>(chainId: chainId) {
+  return usdcAddresses[chainId]
+}


### PR DESCRIPTION
Adds a new `viem/stablecoins` entrypoint for native Circle-issued USDC on supported EVM chains.

The entrypoint includes:

- `usdcAddresses`: native USDC contract addresses keyed by viem chain ID
- `getUsdcAddress`: typed helper for resolving a native USDC address by chain ID
- `getUsdcContract`: convenience helper that returns a ready-to-use ERC-20 contract instance from the client's configured chain

Only native USDC deployments are included. Bridged representations such as `USDC.e` are intentionally excluded.

### Notes

Sonic Testnet is intentionally not included. We have Sonic Testnet USDC address, but the current `sonicTestnet` chain definition in viem uses chain ID `64165`, while the live Sonic Testnet RPC and Chainlist report chain ID `14601`. To avoid exposing a USDC address under the wrong viem chain ID, this PR only includes Sonic mainnet and Sonic Blaze Testnet for now.

### Validation

- Matched included addresses against Circle's USDC contract address page.
- Live-called `symbol()`, `decimals()`, and `name()` for included addresses where public RPCs were available.
- Confirmed Arc Testnet USDC responds with `symbol = USDC`, `decimals = 6`, and `name = USDC`.
- `git diff --check` passes.
