### PR TITLE
Update story and storyAeneid chain definitions

### DIFF
--- a/.changeset/story-to-data-rebrand.md
+++ b/.changeset/story-to-data-rebrand.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated the `story` (1514) and `storyAeneid` (1315) chains for the Story → Data rebrand: renamed to "Data Network" / "Data Network Aeneid", set the native currency to $DATA, the RPC URLs to `datarpc.io`, and the block explorer to `datanetscan.io`. Chain IDs and the `story` / `storyAeneid` exports are unchanged.

--- a/src/chains/definitions/story.ts
+++ b/src/chains/definitions/story.ts
@@ -2,11 +2,11 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const story = /*#__PURE__*/ defineChain({
   id: 1514,
-  name: 'Story',
+  name: 'Data Network',
   nativeCurrency: {
     decimals: 18,
-    name: 'IP Token',
-    symbol: 'IP',
+    name: 'DATA',
+    symbol: 'DATA',
   },
   contracts: {
     multicall3: {
@@ -23,13 +23,13 @@ export const story = /*#__PURE__*/ defineChain({
     },
   },
   rpcUrls: {
-    default: { http: ['https://mainnet.storyrpc.io'] },
+    default: { http: ['https://mainnet.datarpc.io'] },
   },
   blockExplorers: {
     default: {
-      name: 'Story explorer',
-      url: 'https://storyscan.io',
-      apiUrl: 'https://storyscan.io/api/v2',
+      name: 'Data Network explorer',
+      url: 'https://datanetscan.io',
+      apiUrl: 'https://datanetscan.io/api/v2',
     },
   },
   ensTlds: ['.ip'],

--- a/src/chains/definitions/storyAeneid.ts
+++ b/src/chains/definitions/storyAeneid.ts
@@ -2,12 +2,12 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 
 export const storyAeneid = /*#__PURE__*/ defineChain({
   id: 1315,
-  name: 'Story Aeneid',
-  network: 'story-aeneid',
+  name: 'Data Network Aeneid',
+  network: 'data-network-aeneid',
   nativeCurrency: {
     decimals: 18,
-    name: 'IP',
-    symbol: 'IP',
+    name: 'DATA',
+    symbol: 'DATA',
   },
   contracts: {
     multicall3: {
@@ -24,13 +24,13 @@ export const storyAeneid = /*#__PURE__*/ defineChain({
     },
   },
   rpcUrls: {
-    default: { http: ['https://aeneid.storyrpc.io'] },
+    default: { http: ['https://aeneid.datarpc.io'] },
   },
   blockExplorers: {
     default: {
-      name: 'Story Aeneid Explorer',
-      url: 'https://aeneid.storyscan.io',
-      apiUrl: 'https://aeneid.storyscan.io/api/v2',
+      name: 'Data Network Aeneid Explorer',
+      url: 'https://aeneid.datanetscan.io',
+      apiUrl: 'https://aeneid.datanetscan.io/api/v2',
     },
   },
   ensTlds: ['.ip'],


### PR DESCRIPTION
Updates the `story` and `storyAeneid` chain definitions:

- `name` → Data Network / Data Network Aeneid
- native currency → DATA
- default RPC → `mainnet.datarpc.io` / `aeneid.datarpc.io`
- block explorer → DatanetScan (`datanetscan.io` / `aeneid.datanetscan.io`)

Chain IDs (1514 / 1315), exports, and contract addresses are unchanged. Endpoints match the corresponding ethereum-lists/chains update (ethereum-lists/chains#8464). A `patch` changeset is included.
