### PR TITLE
Add GMAChain (Chain ID 4189)

### DIFF
--- a/src/chains/definitions/gmachain.ts
+++ b/src/chains/definitions/gmachain.ts
@@ -1,0 +1,19 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const gmachain = /*#__PURE__*/ defineChain({
+  id: 4189,
+  name: 'GMAChain',
+  nativeCurrency: { name: 'GMA', symbol: 'GMA', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://api.gmachain.xyz'],
+      webSocket: ['wss://api.gmachain.xyz/ws'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'GMAChain Explorer',
+      url: 'https://gmachain.xyz',
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -990,3 +990,4 @@ export type {
   ZksyncTransactionType as ZkSyncTransactionType,
   ZksyncTransactionType,
 } from '../zksync/types/transaction.js'
+export { gmachain } from './definitions/gmachain.js'


### PR DESCRIPTION
Adds GMAChain EVM-compatible Clique PoA mainnet.
- Chain ID: 4189
- RPC: https://api.gmachain.xyz
- WebSocket: wss://api.gmachain.xyz/ws
- Native token: GMA (18 decimals)
- Website: https://gmachain.xyz