### PR TITLE
fix(account-abstraction): prepare fees when estimating user operation gas

### DIFF
--- a/.changeset/fix-estimate-user-operation-gas-fees.md
+++ b/.changeset/fix-estimate-user-operation-gas-fees.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `estimateUserOperationGas` omitting `fees` during User Operation preparation, which caused strict bundlers to reject gas estimation requests.

--- a/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
+++ b/src/account-abstraction/actions/bundler/estimateUserOperationGas.ts
@@ -177,11 +177,10 @@ export async function estimateUserOperationGas<
         parameters: [
           'authorization',
           'factory',
+          'fees',
           'nonce',
           'paymaster',
           'signature',
-          'maxFeePerGas',
-          'maxPriorityFeePerGas',
         ],
       } as unknown as PrepareUserOperationParameters)
     : parameters


### PR DESCRIPTION
## Description
Fixes #4726.

`estimateUserOperationGas` was passing `maxFeePerGas` and `maxPriorityFeePerGas` in the `prepareUserOperation` `parameters` list, but those are User Operation field names, not valid preparation keys.

This updates the call to use the existing `fees` preparation key instead, so `prepareUserOperation` runs the `client.userOperation.estimateFeesPerGas` hook before sending `eth_estimateUserOperationGas`.

This makes the outgoing gas estimation request include `maxFeePerGas` and `maxPriorityFeePerGas` for strict bundlers.

Included a patch changeset.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have followed the steps in the CONTRIBUTING.md document.
- [x] My code follows the code style of this project.

