### PR TITLE
fix: limit `fromRlp` decode depth

### DIFF
--- a/.changeset/quiet-rlp-depth.md
+++ b/.changeset/quiet-rlp-depth.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added an RLP depth limit for decoding deeply nested payloads.

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -66,6 +66,17 @@ export class InvalidHexValueError extends BaseError {
   }
 }
 
+export type RlpDepthLimitExceededErrorType = RlpDepthLimitExceededError & {
+  name: 'RlpDepthLimitExceededError'
+}
+export class RlpDepthLimitExceededError extends BaseError {
+  constructor({ limit }: { limit: number }) {
+    super(`RLP depth limit of \`${limit}\` exceeded.`, {
+      name: 'RlpDepthLimitExceededError',
+    })
+  }
+}
+
 export type SizeOverflowErrorType = SizeOverflowError & {
   name: 'SizeOverflowError'
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -201,6 +201,7 @@ test('exports', () => {
       "InvalidBytesBooleanError",
       "InvalidHexBooleanError",
       "InvalidHexValueError",
+      "RlpDepthLimitExceededError",
       "SizeOverflowError",
       "EnsAvatarInvalidNftUriError",
       "EnsAvatarUnsupportedNamespaceError",

--- a/src/index.ts
+++ b/src/index.ts
@@ -878,6 +878,8 @@ export {
   type InvalidHexBooleanErrorType,
   InvalidHexValueError,
   type InvalidHexValueErrorType,
+  RlpDepthLimitExceededError,
+  type RlpDepthLimitExceededErrorType,
   SizeOverflowError,
   type SizeOverflowErrorType,
 } from './errors/encoding.js'

--- a/src/utils/encoding/fromRlp.test.ts
+++ b/src/utils/encoding/fromRlp.test.ts
@@ -23,4 +23,43 @@ describe('list', () => {
     // hex -> bytes
     expect(fromRlp('0xc1c0', 'bytes')).toEqual([[]])
   })
+
+  test('deeply nested list', () => {
+    expect(() =>
+      fromRlp(getNestedList(1025), 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpDepthLimitExceededError: RLP depth limit of \`1024\` exceeded.
+
+      Version: viem@x.y.z]
+    `)
+  })
 })
+
+function getNestedList(depth: number) {
+  let payload = new Uint8Array()
+  for (let i = 0; i < depth; i++) payload = encodeList(payload)
+  return payload
+}
+
+function encodeList(payload: Uint8Array) {
+  const length = payload.length
+  if (length <= 55) {
+    const out = new Uint8Array(1 + length)
+    out[0] = 0xc0 + length
+    out.set(payload, 1)
+    return out
+  }
+
+  const lengthBytes = []
+  let remaining = length
+  while (remaining > 0) {
+    lengthBytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  }
+
+  const out = new Uint8Array(1 + lengthBytes.length + length)
+  out[0] = 0xf7 + lengthBytes.length
+  out.set(lengthBytes, 1)
+  out.set(payload, 1 + lengthBytes.length)
+  return out
+}

--- a/src/utils/encoding/fromRlp.ts
+++ b/src/utils/encoding/fromRlp.ts
@@ -2,6 +2,8 @@ import { BaseError, type BaseErrorType } from '../../errors/base.js'
 import {
   InvalidHexValueError,
   type InvalidHexValueErrorType,
+  RlpDepthLimitExceededError,
+  type RlpDepthLimitExceededErrorType,
 } from '../../errors/encoding.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
@@ -17,6 +19,8 @@ import type { RecursiveArray } from './toRlp.js'
 
 type To = 'hex' | 'bytes'
 
+const rlpDepthLimit = 1_024
+
 export type FromRlpReturnType<to extends To> =
   | (to extends 'bytes' ? RecursiveArray<ByteArray> : never)
   | (to extends 'hex' ? RecursiveArray<Hex> : never)
@@ -26,6 +30,7 @@ export type FromRlpErrorType =
   | FromRlpCursorErrorType
   | HexToBytesErrorType
   | InvalidHexValueErrorType
+  | RlpDepthLimitExceededErrorType
   | ErrorType
 
 export function fromRlp<to extends To = 'hex'>(
@@ -58,7 +63,11 @@ type FromRlpCursorErrorType =
 function fromRlpCursor<to extends To = 'hex'>(
   cursor: Cursor,
   to: to | To | undefined = 'hex',
+  recursiveDepth = 0,
 ): FromRlpReturnType<to> {
+  if (recursiveDepth >= rlpDepthLimit)
+    throw new RlpDepthLimitExceededError({ limit: rlpDepthLimit })
+
   if (cursor.bytes.length === 0)
     return (
       to === 'hex' ? bytesToHex(cursor.bytes) : cursor.bytes
@@ -76,7 +85,12 @@ function fromRlpCursor<to extends To = 'hex'>(
 
   // list
   const length = readLength(cursor, prefix, 0xc0)
-  return readList(cursor, length, to) as {} as FromRlpReturnType<to>
+  return readList(
+    cursor,
+    length,
+    to,
+    recursiveDepth + 1,
+  ) as {} as FromRlpReturnType<to>
 }
 
 type ReadLengthErrorType = BaseErrorType | ErrorType
@@ -93,10 +107,15 @@ function readLength(cursor: Cursor, prefix: number, offset: number) {
 
 type ReadListErrorType = ErrorType
 
-function readList<to extends To>(cursor: Cursor, length: number, to: to | To) {
+function readList<to extends To>(
+  cursor: Cursor,
+  length: number,
+  to: to | To,
+  recursiveDepth: number,
+) {
   const position = cursor.position
   const value: FromRlpReturnType<to>[] = []
   while (cursor.position - position < length)
-    value.push(fromRlpCursor(cursor, to))
+    value.push(fromRlpCursor(cursor, to, recursiveDepth))
   return value
 }


### PR DESCRIPTION
Limits `fromRlp` decoding to 1,024 nested RLP lists and returns a typed `RlpDepthLimitExceededError` rather than recursing until the runtime stack overflows.

Deeply nested untrusted RLP can otherwise crash processes that decode arbitrary payloads. Fixes https://github.com/wevm/viem/issues/4770 and adds coverage for a valid deeply nested payload.
