### PR TITLE
fix: validate `yParity` and cap rpc response bodies

### DIFF
--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -457,6 +457,35 @@ describe('request', () => {
     await server.close()
   })
 
+  test('behavior: maxResponseBodySize', async () => {
+    const body = JSON.stringify({ result: '0x1' })
+    const server = await createHttpServer((_, res) => {
+      res.writeHead(200, {
+        'Content-Length': body.length,
+        'Content-Type': 'application/json',
+      })
+      res.end(body)
+    })
+
+    const transport = http(server.url, {
+      key: 'mock',
+      maxResponseBodySize: body.length - 1,
+    })({ chain: localhost })
+
+    await expect(() =>
+      transport.request({ method: 'eth_blockNumber' }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [ResponseBodyTooLargeError: HTTP response body exceeded the size limit.
+
+      Max: 15 bytes
+      Received: 16 bytes
+
+      Version: viem@x.y.z]
+    `)
+
+    await server.close()
+  })
+
   test('behavior: methods.exclude', async () => {
     const server = await createHttpServer((_, res) => {
       res.end(JSON.stringify({ result: '0x1' }))

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -42,6 +42,8 @@ export type HttpTransportConfig<
    * @link https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
   fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
+  /** Maximum response body size in bytes. Set to `false` to disable. @default 10_485_760 */
+  maxResponseBodySize?: HttpRpcClientOptions['maxResponseBodySize'] | undefined
   /** A callback to handle the response from `fetch`. */
   onFetchRequest?: HttpRpcClientOptions['onRequest'] | undefined
   /** A callback to handle the response from `fetch`. */
@@ -108,6 +110,7 @@ export function http<
     fetchFn,
     fetchOptions,
     key = 'http',
+    maxResponseBodySize,
     methods,
     name = 'HTTP JSON-RPC',
     onFetchRequest,
@@ -126,6 +129,7 @@ export function http<
     const rpcClient = getHttpRpcClient(url_, {
       fetchFn,
       fetchOptions,
+      maxResponseBodySize,
       onRequest: onFetchRequest,
       onResponse: onFetchResponse,
       timeout,

--- a/src/errors/request.test.ts
+++ b/src/errors/request.test.ts
@@ -5,6 +5,7 @@ import { numberToHex } from '../utils/encoding/toHex.js'
 
 import {
   HttpRequestError,
+  ResponseBodyTooLargeError,
   RpcRequestError,
   SocketClosedError,
   TimeoutError,
@@ -50,6 +51,23 @@ test('HttpRequestError', () => {
     Version: viem@x.y.z]
   `)
   expect(err.url).toBeDefined()
+})
+
+test('ResponseBodyTooLargeError', () => {
+  const err = new ResponseBodyTooLargeError({
+    maxSize: 10,
+    size: 11,
+  })
+  expect(err).toMatchInlineSnapshot(`
+    [ResponseBodyTooLargeError: HTTP response body exceeded the size limit.
+
+    Max: 10 bytes
+    Received: 11 bytes
+
+    Version: viem@x.y.z]
+  `)
+  expect(err.maxSize).toBe(10)
+  expect(err.size).toBe(11)
 })
 
 test('WebSocketRequestError', () => {

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -44,6 +44,23 @@ export class HttpRequestError extends BaseError {
   }
 }
 
+export type ResponseBodyTooLargeErrorType = ResponseBodyTooLargeError & {
+  name: 'ResponseBodyTooLargeError'
+}
+export class ResponseBodyTooLargeError extends BaseError {
+  maxSize: number
+  size: number
+
+  constructor({ maxSize, size }: { maxSize: number; size: number }) {
+    super('HTTP response body exceeded the size limit.', {
+      metaMessages: [`Max: ${maxSize} bytes`, `Received: ${size} bytes`],
+      name: 'ResponseBodyTooLargeError',
+    })
+    this.maxSize = maxSize
+    this.size = size
+  }
+}
+
 export type WebSocketRequestErrorType = WebSocketRequestError & {
   name: 'WebSocketRequestError'
 }

--- a/src/errors/transaction.test.ts
+++ b/src/errors/transaction.test.ts
@@ -11,6 +11,7 @@ import {
   InvalidSerializableTransactionError,
   InvalidSerializedTransactionError,
   InvalidSerializedTransactionTypeError,
+  InvalidYParityError,
   TransactionExecutionError,
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
@@ -20,6 +21,14 @@ import {
 test('InvalidLegacyVError', () => {
   expect(new InvalidLegacyVError({ v: 69n })).toMatchInlineSnapshot(`
     [InvalidLegacyVError: Invalid \`v\` value "69". Expected 27 or 28.
+
+    Version: viem@x.y.z]
+  `)
+})
+
+test('InvalidYParityError', () => {
+  expect(new InvalidYParityError({ yParity: 2n })).toMatchInlineSnapshot(`
+    [InvalidYParityError: Invalid \`yParity\` value "2". Expected 0 or 1.
 
     Version: viem@x.y.z]
   `)

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -53,6 +53,17 @@ export class InvalidLegacyVError extends BaseError {
   }
 }
 
+export type InvalidYParityErrorType = InvalidYParityError & {
+  name: 'InvalidYParityError'
+}
+export class InvalidYParityError extends BaseError {
+  constructor({ yParity }: { yParity: bigint }) {
+    super(`Invalid \`yParity\` value "${yParity}". Expected 0 or 1.`, {
+      name: 'InvalidYParityError',
+    })
+  }
+}
+
 export type InvalidSerializableTransactionErrorType =
   InvalidSerializableTransactionError & {
     name: 'InvalidSerializableTransactionError'

--- a/src/index.ts
+++ b/src/index.ts
@@ -938,6 +938,8 @@ export {
 export {
   HttpRequestError,
   type HttpRequestErrorType,
+  ResponseBodyTooLargeError,
+  type ResponseBodyTooLargeErrorType,
   RpcRequestError,
   type RpcRequestErrorType,
   SocketClosedError,
@@ -1025,6 +1027,8 @@ export {
   type InvalidSerializedTransactionTypeErrorType,
   InvalidStorageKeySizeError,
   type InvalidStorageKeySizeErrorType,
+  InvalidYParityError,
+  type InvalidYParityErrorType,
   TransactionExecutionError,
   type TransactionExecutionErrorType,
   TransactionNotFoundError,

--- a/src/utils/rpc/http.test.ts
+++ b/src/utils/rpc/http.test.ts
@@ -381,6 +381,59 @@ describe('request', () => {
     expect(fetchOverride).toHaveBeenCalled()
   })
 
+  test('maxResponseBodySize', async () => {
+    const body = JSON.stringify({ result: '0x1' })
+    const server = await createHttpServer((_req, res) => {
+      res.writeHead(200, {
+        'Content-Length': body.length,
+        'Content-Type': 'application/json',
+      })
+      res.end(body)
+    })
+
+    const client = getHttpRpcClient(server.url, {
+      maxResponseBodySize: body.length - 1,
+    })
+
+    await expect(() =>
+      client.request({
+        body: { method: 'web3_clientVersion' },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [ResponseBodyTooLargeError: HTTP response body exceeded the size limit.
+
+      Max: 15 bytes
+      Received: 16 bytes
+
+      Version: viem@x.y.z]
+    `)
+
+    await server.close()
+  })
+
+  test('maxResponseBodySize disabled', async () => {
+    const body = JSON.stringify({ result: '0x1' })
+    const server = await createHttpServer((_req, res) => {
+      res.writeHead(200, {
+        'Content-Length': body.length,
+        'Content-Type': 'application/json',
+      })
+      res.end(body)
+    })
+
+    const client = getHttpRpcClient(server.url, {
+      maxResponseBodySize: false,
+    })
+
+    await expect(
+      client.request({
+        body: { method: 'web3_clientVersion' },
+      }),
+    ).resolves.toEqual({ result: '0x1' })
+
+    await server.close()
+  })
+
   // TODO: This is flaky.
   test.skip('timeout', async () => {
     const client = getHttpRpcClient(anvilMainnet.rpcUrl.http)

--- a/src/utils/rpc/http.ts
+++ b/src/utils/rpc/http.ts
@@ -1,6 +1,8 @@
 import {
   HttpRequestError,
   type HttpRequestErrorType as HttpRequestErrorType_,
+  ResponseBodyTooLargeError,
+  type ResponseBodyTooLargeErrorType,
   TimeoutError,
   type TimeoutErrorType,
 } from '../../errors/request.js'
@@ -25,6 +27,8 @@ export type HttpRpcClientOptions = {
     | undefined
   /** Request configuration to pass to `fetch`. */
   fetchOptions?: Omit<RequestInit, 'body'> | undefined
+  /** Maximum response body size in bytes. Set to `false` to disable. @default 10_485_760 */
+  maxResponseBodySize?: number | false | undefined
   /** A callback to handle the request. */
   onRequest?:
     | ((
@@ -49,6 +53,8 @@ export type HttpRequestParameters<
   fetchFn?: HttpRpcClientOptions['fetchFn'] | undefined
   /** Request configuration to pass to `fetch`. */
   fetchOptions?: HttpRpcClientOptions['fetchOptions'] | undefined
+  /** Maximum response body size in bytes. Set to `false` to disable. */
+  maxResponseBodySize?: HttpRpcClientOptions['maxResponseBodySize'] | undefined
   /** A callback to handle the response. */
   onRequest?:
     | ((
@@ -70,9 +76,12 @@ export type HttpRequestReturnType<
 
 export type HttpRequestErrorType =
   | HttpRequestErrorType_
+  | ResponseBodyTooLargeErrorType
   | TimeoutErrorType
   | WithTimeoutErrorType
   | ErrorType
+
+const defaultMaxResponseBodySize = 10_485_760
 
 export type HttpRpcClient = {
   request<body extends RpcRequest | RpcRequest[]>(
@@ -91,6 +100,8 @@ export function getHttpRpcClient(
       const {
         body,
         fetchFn = options.fetchFn ?? fetch,
+        maxResponseBodySize = options.maxResponseBodySize ??
+          defaultMaxResponseBodySize,
         onRequest = options.onRequest,
         onResponse = options.onResponse,
         timeout = options.timeout ?? 10_000,
@@ -144,12 +155,15 @@ export function getHttpRpcClient(
         if (onResponse) await onResponse(response)
 
         let data: any
+        const responseBody = await readResponseBody(response, {
+          maxResponseBodySize,
+        })
         if (
           response.headers.get('Content-Type')?.startsWith('application/json')
         )
-          data = await response.json()
+          data = JSON.parse(responseBody)
         else {
-          data = await response.text()
+          data = responseBody
           try {
             data = JSON.parse(data || '{}')
           } catch (err) {
@@ -181,6 +195,7 @@ export function getHttpRpcClient(
         if (signal_?.aborted) throw getAbortError(signal_)
         if (isAbortError(err)) throw err
         if (err instanceof HttpRequestError) throw err
+        if (err instanceof ResponseBodyTooLargeError) throw err
         if (err instanceof TimeoutError) throw err
         throw new HttpRequestError({
           body,
@@ -189,6 +204,59 @@ export function getHttpRpcClient(
         })
       }
     },
+  }
+}
+
+async function readResponseBody(
+  response: Response,
+  { maxResponseBodySize }: { maxResponseBodySize: number | false },
+): Promise<string> {
+  if (maxResponseBodySize === false) return response.text()
+
+  const contentLength = response.headers.get('Content-Length')
+  if (contentLength) {
+    const size = Number(contentLength)
+    if (size > maxResponseBodySize)
+      throw new ResponseBodyTooLargeError({
+        maxSize: maxResponseBodySize,
+        size,
+      })
+  }
+
+  if (!response.body) {
+    const body = await response.text()
+    const size = new TextEncoder().encode(body).length
+    if (size > maxResponseBodySize)
+      throw new ResponseBodyTooLargeError({
+        maxSize: maxResponseBodySize,
+        size,
+      })
+    return body
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let body = ''
+  let size = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.byteLength
+      if (size > maxResponseBodySize) {
+        await reader.cancel()
+        throw new ResponseBodyTooLargeError({
+          maxSize: maxResponseBodySize,
+          size,
+        })
+      }
+      body += decoder.decode(value, { stream: true })
+    }
+    body += decoder.decode()
+    return body
+  } finally {
+    reader.releaseLock()
   }
 }
 

--- a/src/utils/transaction/parseTransaction.test.ts
+++ b/src/utils/transaction/parseTransaction.test.ts
@@ -197,6 +197,38 @@ describe('eip7702', () => {
       `)
     })
 
+    test('invalid authorization list yParity', () => {
+      expect(() =>
+        parseTransaction(
+          `0x04${toRlp([
+            toHex(1), // chainId
+            toHex(0), // nonce
+            toHex(1), // maxPriorityFeePerGas
+            toHex(1), // maxFeePerGas
+            toHex(1), // gas
+            '0x0000000000000000000000000000000000000000', // to
+            toHex(0), // value
+            '0x', // data
+            [], // accessList
+            [
+              [
+                toHex(1), // chainId
+                '0x0000000000000000000000000000000000000000', // address
+                toHex(0), // nonce
+                toHex(2), // yParity
+                toHex(69), // r
+                toHex(420), // s
+              ],
+            ], // authorizationList
+          ]).slice(2)}`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [InvalidYParityError: Invalid \`yParity\` value "2". Expected 0 or 1.
+
+        Version: viem@x.y.z]
+      `)
+    })
+
     test('invalid transaction (all missing)', () => {
       expect(() =>
         parseTransaction(`0x04${toRlp([]).slice(2)}`),
@@ -205,6 +237,31 @@ describe('eip7702', () => {
 
         Serialized Transaction: "0x04c0"
         Missing Attributes: chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gas, to, value, data, accessList, authorizationList
+
+        Version: viem@x.y.z]
+      `)
+    })
+
+    test('invalid yParity', () => {
+      expect(() =>
+        parseTransaction(
+          `0x02${toRlp([
+            toHex(1), // chainId
+            toHex(0), // nonce
+            toHex(1), // maxPriorityFeePerGas
+            toHex(1), // maxFeePerGas
+            toHex(1), // gas
+            '0x0000000000000000000000000000000000000000', // to
+            toHex(0), // value
+            '0x', // data
+            '0x', // accessList
+            toHex(2), // yParity
+            toHex(69), // r
+            toHex(420), // s
+          ]).slice(2)}`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [InvalidYParityError: Invalid \`yParity\` value "2". Expected 0 or 1.
 
         Version: viem@x.y.z]
       `)

--- a/src/utils/transaction/parseTransaction.ts
+++ b/src/utils/transaction/parseTransaction.ts
@@ -7,6 +7,8 @@ import {
   type InvalidLegacyVErrorType,
   InvalidSerializedTransactionError,
   type InvalidSerializedTransactionErrorType,
+  InvalidYParityError,
+  type InvalidYParityErrorType,
 } from '../../errors/transaction.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type {
@@ -593,6 +595,7 @@ function parseAuthorizationList(
 
 type ParseEIP155SignatureErrorType =
   | HexToBigIntErrorType
+  | InvalidYParityErrorType
   | PadHexErrorType
   | ErrorType
 
@@ -600,8 +603,10 @@ function parseEIP155Signature(
   transactionArray: RecursiveArray<Hex>,
 ): Signature & { yParity: number } {
   const signature = transactionArray.slice(-3)
-  const v =
-    signature[0] === '0x' || hexToBigInt(signature[0] as Hex) === 0n ? 27n : 28n
+  const yParity = signature[0] === '0x' ? 0n : hexToBigInt(signature[0] as Hex)
+  if (yParity !== 0n && yParity !== 1n)
+    throw new InvalidYParityError({ yParity })
+  const v = yParity === 0n ? 27n : 28n
   return {
     r: padHex(signature[1] as Hex, { size: 32 }),
     s: padHex(signature[2] as Hex, { size: 32 }),


### PR DESCRIPTION
Typed transaction parsing now rejects concrete `yParity` values outside `0` and `1`, including EIP-7702 authorization entries, instead of normalizing all nonzero values to parity `1`.

HTTP RPC responses now read through a bounded body parser with a 10 MiB default cap and opt-out or override via `maxResponseBodySize`. This limits memory exposure from malicious or compromised RPC endpoints while preserving explicit large-response use cases.

Closes https://github.com/wevm/viem/issues/4771
