### PR TITLE
fix(abi): encode zero-width static aggregates as empty bytes

### DIFF
--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1921,3 +1921,33 @@ test('https://github.com/wevm/viem/issues/1960', () => {
     Version: viem@x.y.z]
   `)
 })
+
+describe('zero-width static aggregate', () => {
+  // Per the ABI spec, `enc(T[0])` and `enc(())` are zero-length: an empty fixed
+  // array or empty tuple contributes no bytes. The neighbouring uint256 must be
+  // the only output. ethers `AbiCoder.encode(['uint256[0]','uint256'], [[], 3n])`
+  // returns the 32-byte uint256 below.
+  test('empty fixed array', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        [[], 3n],
+      ),
+    ).toEqual(
+      '0x0000000000000000000000000000000000000000000000000000000000000003',
+    )
+  })
+
+  // ethers `AbiCoder.encode(['uint256','tuple()'], [5n, []])` returns the
+  // 32-byte uint256 below.
+  test('empty tuple', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        [5n, []],
+      ),
+    ).toEqual(
+      '0x0000000000000000000000000000000000000000000000000000000000000005',
+    )
+  })
+})

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -278,7 +278,12 @@ function encodeArray<const param extends AbiParameter>(
   }
   return {
     dynamic: false,
-    encoded: concat(preparedParams.map(({ encoded }) => encoded)),
+    // A zero-width static array (`T[0]`) contributes no bytes per the ABI spec.
+    // `concat([])` would return an empty `Uint8Array`, so emit `'0x'` directly.
+    encoded:
+      preparedParams.length > 0
+        ? concat(preparedParams.map(({ encoded }) => encoded))
+        : '0x',
   }
 }
 
@@ -411,9 +416,13 @@ function encodeTuple<
   }
   return {
     dynamic,
+    // An empty tuple (`()`) contributes no bytes per the ABI spec. `concat([])`
+    // would return an empty `Uint8Array`, so emit `'0x'` directly.
     encoded: dynamic
       ? encodeParams(preparedParams)
-      : concat(preparedParams.map(({ encoded }) => encoded)),
+      : preparedParams.length > 0
+        ? concat(preparedParams.map(({ encoded }) => encoded))
+        : '0x',
   }
 }
 


### PR DESCRIPTION
## Summary

An empty fixed array (`T[0]`) or empty tuple (`()`) is a **zero-width static** type. In `encodeAbiParameters.ts`, the static branches of `encodeArray` and `encodeTuple` build their encoding with `concat(preparedParams.map(p => p.encoded))` over an **empty** array.

`concat([])` (in `utils/data/concat.ts`) checks `typeof values[0] === 'string'`. For an empty input `values[0]` is `undefined`, so it routes to `concatBytes([])` and returns an empty **`Uint8Array`** rather than the hex string `'0x'`. That `Uint8Array` then leaks back into `encodeParams`, poisoning the string-vs-bytes detection and producing either **wrong bytes** or an uncaught **`TypeError`**.

The function's documented return type is `Hex`, never `Uint8Array`.

## Reproduction

```ts
encodeAbiParameters([{ type: 'uint256[0]' }, { type: 'uint256' }], [[], 3n])
// before: Uint8Array(66)            (33 leading zero bytes + the uint256)
// after:  the 32-byte uint256 0x..0003

encodeAbiParameters([{ type: 'uint256' }, { type: 'tuple', components: [] }], [5n, []])
// before: throws TypeError: x.replace is not a function   (concatHex on a Uint8Array)
// after:  the 32-byte uint256 0x..0005
```

## Oracle

Per the [ABI spec](https://docs.soliditylang.org/en/latest/abi-spec), `enc(T[0])` and `enc(())` are zero-length: an empty fixed array or empty tuple contributes no bytes. ethers agrees:

```ts
AbiCoder.defaultAbiCoder().encode(['uint256[0]', 'uint256'], [[], 3n])
// '0x0000000000000000000000000000000000000000000000000000000000000003'
AbiCoder.defaultAbiCoder().encode(['uint256', 'tuple()'], [5n, []])
// '0x0000000000000000000000000000000000000000000000000000000000000005'
```

## Fix

Emit `'0x'` directly when `preparedParams` is empty in the static branch of `encodeArray` and `encodeTuple`, instead of relying on `concat([])`. The change is local to the two aggregate encoders; `concat`'s behaviour is untouched (it has other callers).

Added tests cover both repros against the ethers/ABI-spec oracle.

This is a separate root cause from #921 (empty **dynamic** `bytes[]`) and from the RLP trailing-bytes fix in a sibling PR.
