### PR TITLE
fix(rlp): reject trailing bytes in fromRlp

### DIFF
--- a/src/utils/encoding/fromRlp.test.ts
+++ b/src/utils/encoding/fromRlp.test.ts
@@ -35,6 +35,51 @@ describe('list', () => {
   })
 })
 
+describe('trailing bytes', () => {
+  // RLP is a bijection (Ethereum Yellow Paper, Appendix B): a payload encodes
+  // exactly one item with no leftover bytes. geth rejects with `rlp: input
+  // contains more than one value` and ethers with `unexpected junk after rlp
+  // payload`. viem must not silently drop the trailing bytes.
+  test('after string item', () => {
+    // `0x80` encodes `''`; the trailing `deadbeef` is junk.
+    expect(() =>
+      fromRlp('0x80deadbeef', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [BaseError: Unexpected trailing bytes: RLP payload encodes a single item but 4 byte(s) remain after it.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('after list item', () => {
+    // `0xc2 0x01 0x02` is a 2-byte list `['0x01','0x02']`; trailing `03` is junk.
+    expect(() =>
+      fromRlp('0xc2010203', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [BaseError: Unexpected trailing bytes: RLP payload encodes a single item but 1 byte(s) remain after it.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('after empty list', () => {
+    // `0xc0` is the empty list `[]`; trailing `00` is junk.
+    expect(() => fromRlp('0xc000', 'hex')).toThrowErrorMatchingInlineSnapshot(`
+      [BaseError: Unexpected trailing bytes: RLP payload encodes a single item but 1 byte(s) remain after it.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('valid single items still decode', () => {
+    // No trailing bytes: these must keep working.
+    expect(fromRlp('0x80', 'hex')).toEqual('0x')
+    expect(fromRlp('0xc0', 'hex')).toEqual([])
+    expect(fromRlp('0xc1c0', 'hex')).toEqual([[]])
+    expect(fromRlp('0x83646f67', 'hex')).toEqual('0x646f67')
+  })
+})
+
 function getNestedList(depth: number) {
   let payload = new Uint8Array()
   for (let i = 0; i < depth; i++) payload = encodeList(payload)

--- a/src/utils/encoding/fromRlp.ts
+++ b/src/utils/encoding/fromRlp.ts
@@ -51,6 +51,16 @@ export function fromRlp<to extends To = 'hex'>(
   })
   const result = fromRlpCursor(cursor, to)
 
+  // RLP is a bijection (Ethereum Yellow Paper, Appendix B): the payload encodes
+  // exactly one item with no leftover bytes. Reject trailing bytes instead of
+  // silently dropping them.
+  if (cursor.position < cursor.bytes.length)
+    throw new BaseError(
+      `Unexpected trailing bytes: RLP payload encodes a single item but ${
+        cursor.bytes.length - cursor.position
+      } byte(s) remain after it.`,
+    )
+
   return result as FromRlpReturnType<to>
 }
 


### PR DESCRIPTION
## Summary

`fromRlp` decodes a single item via `fromRlpCursor(cursor, to)` and returns **without** asserting that the cursor consumed all input. Any bytes after the first RLP item are silently dropped.

RLP is a bijection (Ethereum Yellow Paper, Appendix B): a payload encodes exactly one item, with no leftover bytes. Both geth and ethers reject over-long input; viem instead returns a partial value, which is unsafe in the transaction-decode path (`parseTransaction`).

## Reproduction

```ts
fromRlp('0x80deadbeef', 'hex') // before: '0x'             (4 trailing bytes dropped)
fromRlp('0xc2010203', 'hex')   // before: ['0x01','0x02']  (trailing 0x03 dropped)
fromRlp('0xc000', 'hex')       // before: []               (trailing 0x00 dropped)
```

## Oracle

- geth: `rlp: input contains more than one value`
- ethers `decodeRlp`: `unexpected junk after rlp payload`

Both reject all three inputs above.

## Fix

In the public `fromRlp` wrapper (not in the `fromRlpCursor` recursion, so nested lists are unaffected), after decoding assert that the cursor reached the end of the input, otherwise throw a `BaseError` naming the count of leftover bytes.

```ts
fromRlp('0x80deadbeef', 'hex')
// BaseError: Unexpected trailing bytes: RLP payload encodes a single item but 4 byte(s) remain after it.
```

Valid single-item inputs (`0x80`, the empty list `0xc0`, nested lists `0xc1c0`, byte strings) keep decoding unchanged, and the full `parseTransaction` suite still passes (well-formed transactions consume all bytes).

Added tests cover all three trailing-byte cases plus a control that valid single items still decode.

This is a separate root cause from #4770 (Infinity `recursiveReadLimit` / deep-nesting stack overflow) and from the ABI zero-width encode fix in a sibling PR.
