### PR TITLE
docs: document Tempo selectors and scopes

### DIFF
--- a/site/pages/tempo/actions/accessKey.authorize.mdx
+++ b/site/pages/tempo/actions/accessKey.authorize.mdx
@@ -157,7 +157,7 @@ const { receipt } = await client.accessKey.authorizeSync({
 })
 ```
 
-```ts twoslash [Builder]
+```ts twoslash [Scopes]
 import { parseUnits } from 'viem'
 import { Account, P256, Scopes } from 'viem/tempo'
 import { client } from './viem.config'
@@ -356,7 +356,7 @@ Unix timestamp when the key expires.
 
 - **Type:** `{ token: Address; limit: bigint; period?: number }[]`
 
-Spending limits per token. Optionally include `period` (in seconds) to make the limit periodic — it resets after each period. Use `Period.months(1)`, `Period.seconds(n)`, etc. from `ox/tempo` for convenience.
+Spending limits per token. Optionally include `period` (in seconds) to make the limit periodic. It resets after each period. Use `Period.months(1)`, `Period.seconds(n)`, etc. from `ox/tempo` for convenience.
 
 ### scopes (optional)
 

--- a/site/pages/tempo/actions/accessKey.signAuthorization.mdx
+++ b/site/pages/tempo/actions/accessKey.signAuthorization.mdx
@@ -1,6 +1,6 @@
 # `accessKey.signAuthorization`
 
-Signs a key authorization for an access key. This is a local signing operation — no transaction is sent.
+Signs a key authorization for an access key. This is a local signing operation, so no transaction is sent.
 
 :::info
 If you want to authorize a key and send the transaction in one step, use [`accessKey.authorize`](/tempo/actions/accessKey.authorize) instead.
@@ -104,7 +104,7 @@ const keyAuthorization = await client.accessKey.signAuthorization(
 )
 ```
 
-```ts twoslash [Builder]
+```ts twoslash [Scopes]
 import { parseUnits } from 'viem'
 import { Account, P256, Scopes } from 'viem/tempo'
 import { client } from './viem.config'
@@ -227,7 +227,7 @@ Unix timestamp when the key expires.
 
 - **Type:** `{ token: Address; limit: bigint; period?: number }[]`
 
-Spending limits per token. Optionally include `period` (in seconds) to make the limit periodic — it resets after each period.
+Spending limits per token. Optionally include `period` (in seconds) to make the limit periodic. It resets after each period.
 
 ### scopes (optional)
 

--- a/site/pages/tempo/guides/access-keys/authorize.mdx
+++ b/site/pages/tempo/guides/access-keys/authorize.mdx
@@ -53,6 +53,60 @@ const { receipt } = await client.accessKey.authorizeSync({
 
 :::
 
+### Authorize with Call Scopes
+
+Use `scopes` to restrict an access key to specific contract calls. You can pass raw scope objects
+directly, or use [`Scopes`](/tempo/utilities/Scopes) builders for typed selectors.
+
+:::code-group
+
+```ts twoslash [Raw]
+import { Account, P256 } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const { receipt } = await client.accessKey.authorizeSync({
+  accessKey,
+  scopes: [
+    {
+      address: '0x20c0000000000000000000000000000000000001',
+      selector: 'transfer(address,uint256)',
+      recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+    },
+  ],
+})
+```
+
+```ts twoslash [Scopes]
+import { Account, P256, Scopes } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const { receipt } = await client.accessKey.authorizeSync({
+  accessKey,
+  scopes: [
+    Scopes.tip20('0x20c0000000000000000000000000000000000001')
+      .transfer({
+        recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+      }),
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ### Defer Authorization to a Transaction
 
 Sign the authorization offline with [`accessKey.signAuthorization`](/tempo/actions/accessKey.signAuthorization),

--- a/site/pages/tempo/guides/access-keys/permissions.mdx
+++ b/site/pages/tempo/guides/access-keys/permissions.mdx
@@ -119,7 +119,7 @@ const { receipt } = await client.accessKey.authorizeSync({
 })
 ```
 
-```ts twoslash [Builder]
+```ts twoslash [Scopes]
 import { Account, P256, Scopes } from 'viem/tempo'
 import { client } from './viem.config'
 

--- a/site/pages/tempo/utilities/Scopes.mdx
+++ b/site/pages/tempo/utilities/Scopes.mdx
@@ -1,0 +1,112 @@
+# `Scopes`
+
+Builds typed call scopes for Tempo access keys.
+
+:::warning
+This API is experimental and may change in future releases.
+:::
+
+## Usage
+
+Use `Scopes` when authorizing or signing an access-key authorization with
+[`accessKey.authorize`](/tempo/actions/accessKey.authorize) or
+[`accessKey.signAuthorization`](/tempo/actions/accessKey.signAuthorization). The builders return
+scope objects that restrict which target, function selector, and optional recipients an access key
+can call.
+
+### TIP-20 Scopes
+
+```ts twoslash
+import { Scopes } from 'viem/tempo'
+
+const scopes = [
+  Scopes.tip20('0x20c0000000000000000000000000000000000001').transfer({
+    recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+  }),
+]
+```
+
+### Target Scopes
+
+```ts twoslash
+import { Scopes } from 'viem/tempo'
+
+const target = Scopes.target('0x20c0000000000000000000000000000000000001')
+
+const scopes = [
+  target.selector('0xa9059cbb', {
+    recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+  }),
+]
+```
+
+### Contract Scopes
+
+```ts twoslash
+import { Scopes, Selectors } from 'viem/tempo'
+
+const tip20 = Scopes.contract(
+  '0x20c0000000000000000000000000000000000001',
+  Selectors.tip20,
+)
+
+const scopes = [
+  tip20.approve({
+    recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+  }),
+]
+```
+
+## Return Type
+
+Each builder returns a scope object.
+
+```ts
+type Scope = {
+  address: Address
+  recipients?: readonly Address[]
+  selector?: Hex
+}
+```
+
+## Functions
+
+### `Scopes.tip20`
+
+- **Type:** `(address: Address) => Scopes.Tip20`
+
+Creates a typed scope builder for a TIP-20 token using [`Selectors.tip20`](/tempo/utilities/Selectors).
+
+### `Scopes.contract`
+
+- **Type:** `(address: Address, selectors: Scopes.SelectorMap) => Scopes.Contract`
+
+Creates a typed scope builder from any selector map.
+
+### `Scopes.target`
+
+- **Type:** `(address: Address) => Scopes.Target`
+
+Creates a scope builder for an arbitrary target. Use `target.any()` to allow any selector on the
+target, or `target.selector(selector, options)` to allow a specific selector.
+
+## Parameters
+
+### address
+
+- **Type:** `Address`
+
+Contract address the access key can call.
+
+### selectors
+
+- **Type:** `Scopes.SelectorMap`
+
+Selector map used by [`Scopes.contract`](#scopescontract). Generated selector maps are exported from
+[`Selectors`](/tempo/utilities/Selectors).
+
+### recipients
+
+- **Type:** `readonly Address[] | undefined`
+
+Optional recipient allowlist for selectors that support recipient restrictions.

--- a/site/pages/tempo/utilities/Selectors.mdx
+++ b/site/pages/tempo/utilities/Selectors.mdx
@@ -1,0 +1,85 @@
+# `Selectors`
+
+Generated Tempo precompile function selectors.
+
+:::warning
+This API is experimental and may change in future releases.
+:::
+
+## Usage
+
+Use `Selectors` when you need the `bytes4` selector for a Tempo precompile function, or when building
+typed access-key scopes with [`Scopes.contract`](/tempo/utilities/Scopes#scopescontract).
+
+### TIP-20 Selector
+
+```ts twoslash
+import { Selectors } from 'viem/tempo'
+
+const selector = Selectors.tip20.transfer
+//    ^? const selector: "0xa9059cbb"
+```
+
+### Overloaded Selector
+
+Some precompile functions are overloaded. For those functions, the selector is keyed by full
+function signature.
+
+```ts twoslash
+import { Selectors } from 'viem/tempo'
+
+const selector = Selectors.tip20Factory.createToken[
+  'createToken(string,string,string,address,address,bytes32,string)'
+]
+//    ^? const selector: "0x5323d222"
+```
+
+### Access-Key Scope Builder
+
+```ts twoslash
+import { Scopes, Selectors } from 'viem/tempo'
+
+const tip20 = Scopes.contract(
+  '0x20c0000000000000000000000000000000000001',
+  Selectors.tip20,
+)
+
+const scope = tip20.transfer({
+  recipients: ['0xcafebabecafebabecafebabecafebabecafebabe'],
+})
+```
+
+## Return Type
+
+Selector values are hex strings.
+
+```ts
+type Selector = Hex
+```
+
+Selector maps are grouped by Tempo precompile.
+
+```ts
+type SelectorMap = Record<string, Selector | Record<string, Selector>>
+```
+
+## Exports
+
+```ts
+import { Selectors } from 'viem/tempo'
+
+Selectors.accountKeychain
+Selectors.addressRegistry
+Selectors.nonce
+Selectors.receivePolicyGuard
+Selectors.signatureVerifier
+Selectors.stablecoinDex
+Selectors.tip20
+Selectors.tip20ChannelReserve
+Selectors.tip20Factory
+Selectors.tip403Registry
+Selectors.feeManager
+Selectors.feeAmm
+Selectors.validatorConfig
+Selectors.validatorConfigV2
+```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -2564,6 +2564,10 @@ export default defineConfig({
                   link: '/tempo/actions/fee.setUserToken',
                 },
                 {
+                  text: 'validateToken',
+                  link: '/tempo/actions/fee.validateToken',
+                },
+                {
                   text: 'watchSetUserToken',
                   link: '/tempo/actions/fee.watchSetUserToken',
                 },
@@ -3080,6 +3084,16 @@ export default defineConfig({
                   link: '/tempo/utilities/TempoAddress.validate',
                 },
               ],
+            },
+            {
+              badge: { text: 'EXP', variant: 'warning' },
+              text: 'Scopes',
+              link: '/tempo/utilities/Scopes',
+            },
+            {
+              badge: { text: 'EXP', variant: 'warning' },
+              text: 'Selectors',
+              link: '/tempo/utilities/Selectors',
             },
             {
               text: 'Storage',


### PR DESCRIPTION
## Summary

- Add Tempo utility docs for experimental `Selectors` and `Scopes`.
- Add sidebar entries for `Selectors`, `Scopes`, and `fee.validateToken`.
- Expand access-key examples to show raw scope objects and `Scopes` helper usage.

## Motivation

Tempo access-key scope helpers and generated selectors are exported from `viem/tempo`, but they were not documented as standalone utilities. Access-key docs now show both raw scope objects and typed helper patterns.

## Key design considerations

- Keep the change limited to documentation and navigation.
- Mark experimental utilities with existing warning/badge conventions.
- Preserve existing access-key examples while standardizing helper tabs as `Scopes`.
