### PR TITLE
Bump ws to fix memory exhaustion DoS

### DIFF
--- a/.changeset/ws-memory-exhaustion-dos.md
+++ b/.changeset/ws-memory-exhaustion-dos.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Bumped `ws` dependency to `8.21.0` to fix a memory exhaustion denial-of-service vulnerability.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,7 +682,7 @@ importers:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.4.3)
       ws:
-        specifier: ^8.21.0
+        specifier: 8.21.0
         version: 8.21.0
 
 packages:

--- a/src/package.json
+++ b/src/package.json
@@ -236,7 +236,7 @@
     "abitype": "1.2.3",
     "isows": "1.0.7",
     "ox": "0.14.29",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "license": "MIT",
   "homepage": "https://viem.sh",


### PR DESCRIPTION
## Summary
- Bumps the `ws` dependency from `8.20.1` to `8.21.0`, which contains the upstream fix for a memory exhaustion DoS (a peer can send a high volume of tiny fragments/data chunks to force allocation of oversized structural wrappers, leading to OOM).
- Adds a changeset for the patch release.

Fixes #4779

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds, confirming the lockfile matches the bumped manifest
- [x] `pnpm check:types` passes
- [x] `pnpm check:repo` shows no new issues