### PR TITLE
fix(tempo): add `storageCredits` selector map

### DIFF
--- a/.changeset/storage-credits-selectors.md
+++ b/.changeset/storage-credits-selectors.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Storage Credits (TIP-1060) precompile selectors to Tempo exports.

--- a/src/tempo/Selectors.test.ts
+++ b/src/tempo/Selectors.test.ts
@@ -19,6 +19,7 @@ const selectorMaps = {
   receivePolicyGuard: Selectors.receivePolicyGuard,
   signatureVerifier: Selectors.signatureVerifier,
   stablecoinDex: Selectors.stablecoinDex,
+  storageCredits: Selectors.storageCredits,
   tip20: Selectors.tip20,
   tip20ChannelReserve: Selectors.tip20ChannelReserve,
   tip20Factory: Selectors.tip20Factory,

--- a/src/tempo/Selectors.ts
+++ b/src/tempo/Selectors.ts
@@ -94,6 +94,14 @@ export const stablecoinDex = {
   withdraw: '0x08fab167',
 } as const satisfies FunctionSelectors<typeof Abis.stablecoinDex>
 
+export const storageCredits = {
+  balanceOf: '0x70a08231',
+  budgetOf: '0x7865e71f',
+  modeOf: '0x13668995',
+  setBudget: '0xffe295c3',
+  setMode: '0x21175b4a',
+} as const satisfies FunctionSelectors<typeof Abis.storageCredits>
+
 export const tip20 = {
   BURN_BLOCKED_ROLE: '0x32ad9be8',
   DOMAIN_SEPARATOR: '0x3644e515',


### PR DESCRIPTION
https://github.com/wevm/viem/pull/4784 added the Storage Credits (TIP-1060) precompile ABI and address without a matching `Selectors.storageCredits` map, breaking the one-selector-map-per-ABI invariant in `Selectors.test.ts` on `main` ([failing run](https://github.com/wevm/viem/actions/runs/28621384184)).

Adds the missing `storageCredits` selector map and test fixture entry. The map matches what `pnpm gen:tempo-abis` would emit; regenerating outright is deferred until the `test/tempo` submodule is bumped to a revision that includes `storage_credits.rs`.
