### PR TITLE
fix(rlp): reject trailing bytes and list overruns in `fromRlp`

### DIFF
--- a/.changeset/brave-rlp-trailing.md
+++ b/.changeset/brave-rlp-trailing.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Rejected RLP payloads in `fromRlp` with trailing bytes after the decoded item or list items extending beyond their declared list length.

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -77,6 +77,32 @@ export class RlpDepthLimitExceededError extends BaseError {
   }
 }
 
+export type RlpListBoundaryExceededErrorType = RlpListBoundaryExceededError & {
+  name: 'RlpListBoundaryExceededError'
+}
+export class RlpListBoundaryExceededError extends BaseError {
+  constructor({ consumed, declared }: { consumed: number; declared: number }) {
+    super(
+      `RLP list items consumed \`${consumed}\` bytes but the list declared a length of \`${declared}\`.`,
+      { name: 'RlpListBoundaryExceededError' },
+    )
+  }
+}
+
+export type RlpTrailingBytesErrorType = RlpTrailingBytesError & {
+  name: 'RlpTrailingBytesError'
+}
+export class RlpTrailingBytesError extends BaseError {
+  constructor({ count }: { count: number }) {
+    super(
+      `RLP payload encodes a single item, but \`${count}\` trailing ${
+        count === 1 ? 'byte remains' : 'bytes remain'
+      }.`,
+      { name: 'RlpTrailingBytesError' },
+    )
+  }
+}
+
 export type SizeOverflowErrorType = SizeOverflowError & {
   name: 'SizeOverflowError'
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -202,6 +202,8 @@ test('exports', () => {
       "InvalidHexBooleanError",
       "InvalidHexValueError",
       "RlpDepthLimitExceededError",
+      "RlpListBoundaryExceededError",
+      "RlpTrailingBytesError",
       "SizeOverflowError",
       "EnsAvatarInvalidNftUriError",
       "EnsAvatarUnsupportedNamespaceError",

--- a/src/index.ts
+++ b/src/index.ts
@@ -880,6 +880,10 @@ export {
   type InvalidHexValueErrorType,
   RlpDepthLimitExceededError,
   type RlpDepthLimitExceededErrorType,
+  RlpListBoundaryExceededError,
+  type RlpListBoundaryExceededErrorType,
+  RlpTrailingBytesError,
+  type RlpTrailingBytesErrorType,
   SizeOverflowError,
   type SizeOverflowErrorType,
 } from './errors/encoding.js'

--- a/src/utils/encoding/fromRlp.test.ts
+++ b/src/utils/encoding/fromRlp.test.ts
@@ -35,6 +35,88 @@ describe('list', () => {
   })
 })
 
+describe('trailing bytes', () => {
+  // RLP payloads encode exactly one item (Yellow Paper, Appendix B).
+  test('after string item', () => {
+    expect(() =>
+      fromRlp('0x80deadbeef', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpTrailingBytesError: RLP payload encodes a single item, but \`4\` trailing bytes remain.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('after list item', () => {
+    expect(() =>
+      fromRlp('0xc2010203', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpTrailingBytesError: RLP payload encodes a single item, but \`1\` trailing byte remains.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('after empty list', () => {
+    expect(() => fromRlp('0xc000', 'hex')).toThrowErrorMatchingInlineSnapshot(`
+      [RlpTrailingBytesError: RLP payload encodes a single item, but \`1\` trailing byte remains.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('bytes input', () => {
+    expect(() =>
+      fromRlp(Uint8Array.from([0x80, 0xde, 0xad]), 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpTrailingBytesError: RLP payload encodes a single item, but \`2\` trailing bytes remain.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('valid single items still decode', () => {
+    expect(fromRlp('0x80', 'hex')).toEqual('0x')
+    expect(fromRlp('0xc0', 'hex')).toEqual([])
+    expect(fromRlp('0xc1c0', 'hex')).toEqual([[]])
+    expect(fromRlp('0x83646f67', 'hex')).toEqual('0x646f67')
+  })
+})
+
+describe('list boundary', () => {
+  // Items must consume exactly the declared list length.
+  test('item extends beyond list', () => {
+    // `0xc1` declares 1 payload byte; `0x82aabb` consumes 3.
+    expect(() =>
+      fromRlp('0xc182aabb', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpListBoundaryExceededError: RLP list items consumed \`3\` bytes but the list declared a length of \`1\`.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('item extends beyond nested list', () => {
+    expect(() =>
+      fromRlp('0xc3c182aabb', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpListBoundaryExceededError: RLP list items consumed \`3\` bytes but the list declared a length of \`1\`.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('item extends beyond list with trailing bytes', () => {
+    expect(() =>
+      fromRlp('0xc182aabbff', 'hex'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [RlpListBoundaryExceededError: RLP list items consumed \`3\` bytes but the list declared a length of \`1\`.
+
+      Version: viem@x.y.z]
+    `)
+  })
+})
+
 function getNestedList(depth: number) {
   let payload = new Uint8Array()
   for (let i = 0; i < depth; i++) payload = encodeList(payload)

--- a/src/utils/encoding/fromRlp.ts
+++ b/src/utils/encoding/fromRlp.ts
@@ -4,6 +4,10 @@ import {
   type InvalidHexValueErrorType,
   RlpDepthLimitExceededError,
   type RlpDepthLimitExceededErrorType,
+  RlpListBoundaryExceededError,
+  type RlpListBoundaryExceededErrorType,
+  RlpTrailingBytesError,
+  type RlpTrailingBytesErrorType,
 } from '../../errors/encoding.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
@@ -31,6 +35,7 @@ export type FromRlpErrorType =
   | HexToBytesErrorType
   | InvalidHexValueErrorType
   | RlpDepthLimitExceededErrorType
+  | RlpTrailingBytesErrorType
   | ErrorType
 
 export function fromRlp<to extends To = 'hex'>(
@@ -50,6 +55,12 @@ export function fromRlp<to extends To = 'hex'>(
     recursiveReadLimit: Number.POSITIVE_INFINITY,
   })
   const result = fromRlpCursor(cursor, to)
+
+  // RLP payloads encode exactly one item (Yellow Paper, Appendix B).
+  if (cursor.position < cursor.bytes.length)
+    throw new RlpTrailingBytesError({
+      count: cursor.bytes.length - cursor.position,
+    })
 
   return result as FromRlpReturnType<to>
 }
@@ -105,7 +116,7 @@ function readLength(cursor: Cursor, prefix: number, offset: number) {
   throw new BaseError('Invalid RLP prefix')
 }
 
-type ReadListErrorType = ErrorType
+type ReadListErrorType = RlpListBoundaryExceededErrorType | ErrorType
 
 function readList<to extends To>(
   cursor: Cursor,
@@ -117,5 +128,11 @@ function readList<to extends To>(
   const value: FromRlpReturnType<to>[] = []
   while (cursor.position - position < length)
     value.push(fromRlpCursor(cursor, to, recursiveDepth))
+  // Items must consume exactly the declared list length.
+  if (cursor.position - position !== length)
+    throw new RlpListBoundaryExceededError({
+      consumed: cursor.position - position,
+      declared: length,
+    })
   return value
 }


### PR DESCRIPTION
`fromRlp` returned after decoding a single item without asserting the cursor consumed all input, so trailing bytes were silently dropped (`fromRlp('0x80deadbeef')` returned `'0x'`). RLP payloads encode exactly one item; geth and ethers both reject leftover bytes.

Decoding now throws `RlpTrailingBytesError` when bytes remain after the top-level item, and `RlpListBoundaryExceededError` when list items consume more bytes than the list header declared (e.g. `0xc182aabb`), matching geth's "element is larger than containing list" and ethers' "child data too short".

Supersedes https://github.com/wevm/viem/pull/4778, adding dedicated error classes and the list boundary check. Thanks @spokodev for the report and initial fix, credited as co-author.
