### PR TITLE
fix: handle zero-width types in `encodeAbiParameters` and `decodeAbiParameters`

### DIFF
--- a/.changeset/zero-width-abi-types.md
+++ b/.changeset/zero-width-abi-types.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `encodeAbiParameters` and `decodeAbiParameters` handling of zero-width types (zero-length fixed arrays and empty tuples).

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -1507,7 +1507,7 @@ test('data size too small', () => {
       '0x0000000000000000000000000000000000000000000000000000000000010f2c',
     ),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [PositionOutOfBoundsError: Position \`32\` is out of bounds (\`0 < position < 32\`).
+    [PositionOutOfBoundsError: Position \`63\` is out of bounds (\`0 < position < 32\`).
 
     Version: viem@x.y.z]
   `)
@@ -1577,14 +1577,14 @@ test('zst', () => {
   expect(() =>
     decodeAbiParameters([{ type: 'uint256[0][4294967295]' }], payload),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [PositionOutOfBoundsError: Position \`64\` is out of bounds (\`0 < position < 64\`).
+    [RecursiveReadLimitExceededError: Recursive read limit of \`8192\` exceeded (recursive read count: \`8193\`).
 
     Version: viem@x.y.z]
   `)
   expect(() =>
     decodeAbiParameters([{ type: 'uint32[0][4294967295]' }], payload),
   ).toThrowErrorMatchingInlineSnapshot(`
-    [PositionOutOfBoundsError: Position \`64\` is out of bounds (\`0 < position < 64\`).
+    [RecursiveReadLimitExceededError: Recursive read limit of \`8192\` exceeded (recursive read count: \`8193\`).
 
     Version: viem@x.y.z]
   `)
@@ -1745,4 +1745,75 @@ test('recursive 2', () => {
 
     Version: viem@x.y.z]
   `)
+})
+
+describe('zero-width types', () => {
+  test('zero-length fixed array', () => {
+    expect(
+      decodeAbiParameters(
+        [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        '0x0000000000000000000000000000000000000000000000000000000000000003',
+      ),
+    ).toEqual([[], 3n])
+  })
+
+  test('trailing empty tuple', () => {
+    expect(
+      decodeAbiParameters(
+        [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        '0x0000000000000000000000000000000000000000000000000000000000000005',
+      ),
+    ).toEqual([5n, []])
+  })
+
+  test('zero-length fixed array of dynamic type', () => {
+    expect(
+      decodeAbiParameters(
+        [{ type: 'string[0]' }, { type: 'uint256' }],
+        '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003',
+      ),
+    ).toEqual([[], 3n])
+  })
+
+  test('round-trip', () => {
+    const cases = [
+      {
+        params: [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        values: [[], 3n],
+      },
+      {
+        params: [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        values: [5n, []],
+      },
+      {
+        params: [{ type: 'string[0]' }, { type: 'uint256' }],
+        values: [[], 3n],
+      },
+      {
+        params: [{ type: 'uint256[0]' }, { type: 'string' }],
+        values: [[], 'hello'],
+      },
+      {
+        params: [{ type: 'uint256[0][2]' }, { type: 'uint256' }],
+        values: [[[], []], 9n],
+      },
+      {
+        params: [
+          {
+            type: 'tuple',
+            components: [{ type: 'string' }, { type: 'tuple', components: [] }],
+          },
+        ],
+        values: [['hi', []]],
+      },
+    ] as const
+    for (const { params, values } of cases) {
+      expect(
+        decodeAbiParameters(
+          params,
+          encodeAbiParameters(params, values as never),
+        ),
+      ).toEqual(values)
+    }
+  })
 })

--- a/src/utils/abi/decodeAbiParameters.ts
+++ b/src/utils/abi/decodeAbiParameters.ts
@@ -75,7 +75,9 @@ export function decodeAbiParameters<
   const values = []
   for (let i = 0; i < params.length; ++i) {
     const param = params[i]
-    cursor.setPosition(consumed)
+    // Zero-width types (e.g. `uint256[0]`, empty tuples) at the end of the
+    // data consume no bytes, so the cursor may already be exhausted.
+    if (consumed < bytes.length) cursor.setPosition(consumed)
     const [data, consumed_] = decodeParameter(cursor, param, {
       staticPosition: 0,
     })
@@ -146,7 +148,8 @@ function decodeArray(
 ) {
   // If the length of the array is not known in advance (dynamic array),
   // this means we will need to wonder off to the pointer and decode.
-  if (!length) {
+  // Note: zero-length fixed arrays (`T[0]`) are not dynamic.
+  if (length === null) {
     // Dealing with a dynamic type, so get the offset of the array data.
     const offset = bytesToNumber(cursor.readBytes(sizeOfOffset))
 
@@ -172,6 +175,12 @@ function decodeArray(
       })
       consumed += consumed_
       value.push(data)
+      // Charge zero-width elements against the read limit to bound work
+      // on huge lengths of zero-width types (e.g. `uint256[0][]`).
+      if (consumed_ === 0) {
+        cursor.assertReadLimit()
+        cursor._touch()
+      }
     }
 
     // As we have gone wondering, restore to the original position + next slot.
@@ -214,6 +223,12 @@ function decodeArray(
     })
     consumed += consumed_
     value.push(data)
+    // Charge zero-width elements against the read limit to bound work
+    // on huge lengths of zero-width types (e.g. `uint256[0][4294967295]`).
+    if (consumed_ === 0) {
+      cursor.assertReadLimit()
+      cursor._touch()
+    }
   }
   return [value, consumed]
 }

--- a/src/utils/abi/encodeAbiParameters.test.ts
+++ b/src/utils/abi/encodeAbiParameters.test.ts
@@ -1921,3 +1921,105 @@ test('https://github.com/wevm/viem/issues/1960', () => {
     Version: viem@x.y.z]
   `)
 })
+
+describe('zero-width types', () => {
+  // Per the ABI spec, `enc(T[0])` and `enc(())` are zero-length: a zero-length
+  // fixed array or empty tuple contributes no bytes. Expected values verified
+  // against ethers `AbiCoder.defaultAbiCoder()`.
+  test('zero-length fixed array', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        [[], 3n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000003')
+  })
+
+  test('empty tuple', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        [5n, []],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000005')
+  })
+
+  test('empty tuple only', () => {
+    expect(encodeAbiParameters([{ type: 'tuple', components: [] }], [[]])).toBe(
+      '0x',
+    )
+  })
+
+  test('tuple of empty tuples', () => {
+    expect(
+      encodeAbiParameters(
+        [
+          {
+            type: 'tuple',
+            components: [
+              { type: 'tuple', components: [] },
+              { type: 'tuple', components: [] },
+            ],
+          },
+          { type: 'uint256' },
+        ],
+        [[[], []], 7n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000007')
+  })
+
+  test('nested zero-length fixed arrays', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256[0][2]' }, { type: 'uint256' }],
+        [[[], []], 9n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000009')
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256[2][0]' }, { type: 'uint256' }],
+        [[], 9n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000009')
+  })
+
+  test('offsets skip zero-width parameters', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'uint256[0]' }, { type: 'string' }],
+        [[], 'hello'],
+      ),
+    ).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000',
+    )
+  })
+
+  test('empty tuple inside dynamic tuple', () => {
+    expect(
+      encodeAbiParameters(
+        [
+          {
+            type: 'tuple',
+            components: [{ type: 'string' }, { type: 'tuple', components: [] }],
+          },
+        ],
+        [['hi', []]],
+      ),
+    ).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000026869000000000000000000000000000000000000000000000000000000000000',
+    )
+  })
+
+  // `T[0]` of a dynamic `T` is dynamic per the ABI spec: 32-byte offset
+  // pointing at a zero-length tail.
+  test('zero-length fixed array of dynamic type', () => {
+    expect(
+      encodeAbiParameters(
+        [{ type: 'string[0]' }, { type: 'uint256' }],
+        [[], 3n],
+      ),
+    ).toBe(
+      '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003',
+    )
+  })
+})

--- a/src/utils/abi/encodeAbiParameters.ts
+++ b/src/utils/abi/encodeAbiParameters.ts
@@ -26,7 +26,7 @@ import { IntegerOutOfRangeError } from '../../errors/encoding.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Hex } from '../../types/misc.js'
 import { type IsAddressErrorType, isAddress } from '../address/isAddress.js'
-import { type ConcatErrorType, concat } from '../data/concat.js'
+import { type ConcatHexErrorType, concatHex } from '../data/concat.js'
 import { type PadHexErrorType, padHex } from '../data/pad.js'
 import { type SizeErrorType, size } from '../data/size.js'
 import { type SliceErrorType, slice } from '../data/slice.js'
@@ -101,9 +101,7 @@ export function encodeAbiParameters<
     params: params as readonly AbiParameter[],
     values: values as any,
   })
-  const data = encodeParams(preparedParams)
-  if (data.length === 0) return '0x'
-  return data
+  return encodeParams(preparedParams)
 }
 
 /////////////////////////////////////////////////////////////////
@@ -212,7 +210,8 @@ function encodeParams(preparedParams: PreparedParam[]): Hex {
   }
 
   // 3. Concatenate static and dynamic parts.
-  return concat([...staticParams, ...dynamicParams])
+  // `concatHex` returns `'0x'` for empty input (zero-width parameters).
+  return concatHex([...staticParams, ...dynamicParams])
 }
 
 /////////////////////////////////////////////////////////////////
@@ -229,7 +228,7 @@ function encodeAddress(value: Hex): PreparedParam {
 
 type EncodeArrayErrorType =
   | AbiEncodingArrayLengthMismatchErrorType
-  | ConcatErrorType
+  | ConcatHexErrorType
   | EncodeParamsErrorType
   | InvalidArrayErrorType
   | NumberToHexErrorType
@@ -257,7 +256,9 @@ function encodeArray<const param extends AbiParameter>(
       type: `${param.type}[${length}]`,
     })
 
-  let dynamicChild = false
+  // Zero-length fixed arrays of dynamic types (e.g. `string[0]`) are dynamic
+  // per the ABI spec, even though they have no elements to inspect.
+  let dynamicChild = value.length === 0 && isDynamicType(param)
   const preparedParams: PreparedParam[] = []
   for (let i = 0; i < value.length; i++) {
     const preparedParam = prepareParam({ param, value: value[i] })
@@ -271,20 +272,20 @@ function encodeArray<const param extends AbiParameter>(
       const length = numberToHex(preparedParams.length, { size: 32 })
       return {
         dynamic: true,
-        encoded: preparedParams.length > 0 ? concat([length, data]) : length,
+        encoded: concatHex([length, data]),
       }
     }
     if (dynamicChild) return { dynamic: true, encoded: data }
   }
   return {
     dynamic: false,
-    encoded: concat(preparedParams.map(({ encoded }) => encoded)),
+    encoded: concatHex(preparedParams.map(({ encoded }) => encoded)),
   }
 }
 
 type EncodeBytesErrorType =
   | AbiEncodingBytesSizeMismatchErrorType
-  | ConcatErrorType
+  | ConcatHexErrorType
   | PadHexErrorType
   | NumberToHexErrorType
   | SizeErrorType
@@ -307,7 +308,10 @@ function encodeBytes<const param extends AbiParameter>(
       })
     return {
       dynamic: true,
-      encoded: concat([padHex(numberToHex(bytesSize, { size: 32 })), value_]),
+      encoded: concatHex([
+        padHex(numberToHex(bytesSize, { size: 32 })),
+        value_,
+      ]),
     }
   }
   if (bytesSize !== Number.parseInt(paramSize, 10))
@@ -356,7 +360,7 @@ function encodeNumber(
 }
 
 type EncodeStringErrorType =
-  | ConcatErrorType
+  | ConcatHexErrorType
   | NumberToHexErrorType
   | PadHexErrorType
   | SizeErrorType
@@ -377,7 +381,7 @@ function encodeString(value: string): PreparedParam {
   }
   return {
     dynamic: true,
-    encoded: concat([
+    encoded: concatHex([
       padHex(numberToHex(size(hexValue), { size: 32 })),
       ...parts,
     ]),
@@ -385,7 +389,7 @@ function encodeString(value: string): PreparedParam {
 }
 
 type EncodeTupleErrorType =
-  | ConcatErrorType
+  | ConcatHexErrorType
   | EncodeParamsErrorType
   // TODO: Add back once circular type reference is resolved
   // | PrepareParamErrorType
@@ -413,7 +417,7 @@ function encodeTuple<
     dynamic,
     encoded: dynamic
       ? encodeParams(preparedParams)
-      : concat(preparedParams.map(({ encoded }) => encoded)),
+      : concatHex(preparedParams.map(({ encoded }) => encoded)),
   }
 }
 
@@ -427,4 +431,17 @@ export function getArrayComponents(
     ? // Return `null` if the array is dynamic.
       [matches[2] ? Number(matches[2]) : null, matches[1]]
     : undefined
+}
+
+function isDynamicType(param: AbiParameter): boolean {
+  const { type } = param
+  if (type === 'string') return true
+  if (type === 'bytes') return true
+  if (type.endsWith('[]')) return true
+  if (type === 'tuple')
+    return (param as TupleAbiParameter).components.some(isDynamicType)
+  const arrayComponents = getArrayComponents(type)
+  if (arrayComponents)
+    return isDynamicType({ ...param, type: arrayComponents[1] })
+  return false
 }


### PR DESCRIPTION
`decodeAbiParameters` mishandled zero-width types. Zero-length fixed arrays (`uint256[0]`) were conflated with dynamic arrays (`T[]`), and zero-width parameters at the end of data threw `PositionOutOfBoundsError`. `encodeAbiParameters` returned a `Uint8Array` (or threw) for zero-width static aggregates, and misclassified zero-length fixed arrays of dynamic types (`string[0]`) as static.

Per the [ABI spec](https://docs.soliditylang.org/en/latest/abi-spec.html), `enc(T[0])` and `enc(())` are zero-length, and `T[k]` is dynamic for any dynamic `T` and any `k >= 0`. Encode and decode now match ethers byte-for-byte on these types and round-trip each other.

The static aggregate encoders now use `concatHex`, which returns `'0x'` for empty input. Decoding zero-width elements charges the cursor read limit, preserving the zero-sized type hardening: huge lengths (e.g. `uint256[0][4294967295]`) throw `RecursiveReadLimitExceededError` instead of looping unbounded.

Supersedes https://github.com/wevm/viem/pull/4777 (adds the decode half and `string[0]` classification). Counterpart: https://github.com/wevm/ox/pull/284.
