### PR TITLE
docs: remove em dashes from docs prose

### DIFF
--- a/site/pages/circle-usdc.mdx
+++ b/site/pages/circle-usdc.mdx
@@ -8,7 +8,7 @@ This extension and guides are maintained by [Circle](https://www.circle.com).
 
 This section provides a set of tutorials that demonstrate how to integrate and interact with USDC using the Viem library.
 
-These guides walk through core patterns and advanced capabilities that developers can build on top of USDC — including basic token operations, cross-chain transfers, and gas abstraction via stablecoins.
+These guides walk through core patterns and advanced capabilities that developers can build on top of USDC, including basic token operations, cross-chain transfers, and gas abstraction via stablecoins.
 
 Whether you're building a wallet, protocol integration, or a developer tool, this section will help you implement USDC support using Viem's type-safe primitives and modern client architecture.
 

--- a/site/pages/circle-usdc/guides/integrating.mdx
+++ b/site/pages/circle-usdc/guides/integrating.mdx
@@ -23,7 +23,7 @@ By the end of this guide, you'll know how to:
 * Monitor on-chain Transfer events in real-time  
 * Optimize data loading with batched readContract calls
 
-Each step is self-contained and modular — designed to be easily copied into your own project, whether you're building a wallet, a dashboard, a DeFi tool, or anything else powered by stable digital dollars.
+Each step is self-contained and modular, designed to be easily copied into your own project, whether you're building a wallet, a dashboard, a DeFi tool, or anything else powered by stable digital dollars.
 
 Let's get started.
 
@@ -123,11 +123,11 @@ export const usdcAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 :::
 
-Note: USDC uses 6 decimals — unlike ETH which uses 18. Always remember to format your values accordingly.
+Note: USDC uses 6 decimals, unlike ETH which uses 18. Always remember to format your values accordingly.
 
 ### Transfer USDC
 
-Now we'll transfer USDC from your wallet to another address. This is the most common action in USDC-based apps — whether it's sending payments, tipping, or moving funds between accounts.
+Now we'll transfer USDC from your wallet to another address. This is the most common action in USDC-based apps, whether it's sending payments, tipping, or moving funds between accounts.
 
 :::code-group
 

--- a/site/pages/docs/introduction.mdx
+++ b/site/pages/docs/introduction.mdx
@@ -2,7 +2,7 @@
 
 ## The Problems
 
-The current state of low-level Ethereum interface abstractions lack in at least one of the following four areas: **developer experience**, **stability**, **bundle size** and/or **performance** — a quadrilemma.
+The current state of low-level Ethereum interface abstractions lack in at least one of the following four areas: **developer experience**, **stability**, **bundle size** and/or **performance**: a quadrilemma.
 
 As the authors of [wagmi](https://wagmi.sh), a popular React Hooks library for Ethereum, we struggled to work with the existing low-level TypeScript Ethereum libraries. We wanted to provide the users of wagmi with the best possible developer experience, but we were limited by the underlying technologies wagmi was built on. We knew an _always_ stable, predictable implementation with a tiny bundle size and performant modules was paramount to interacting with the world's largest blockchain ecosystem.
 

--- a/site/pages/tempo/actions/receivePolicy.set.mdx
+++ b/site/pages/tempo/actions/receivePolicy.set.mdx
@@ -72,7 +72,7 @@ await client.receivePolicy.setSync({
 })
 ```
 
-You can also combine both — e.g. restrict senders **and** tokens — by passing a custom policy id to each field.
+You can also combine both (e.g. restrict senders **and** tokens) by passing a custom policy id to each field.
 
 ### Choosing who can reclaim
 

--- a/site/pages/tempo/actions/wallet.transfer.mdx
+++ b/site/pages/tempo/actions/wallet.transfer.mdx
@@ -36,7 +36,7 @@ export const client = createClient({
 
 ## Editable mode
 
-By default, `wallet.transfer` is read-only — the wallet signs and submits the transfer programmatically (using an access key when one matches, otherwise prompting the user with a confirm dialog).
+By default, `wallet.transfer` is read-only: the wallet signs and submits the transfer programmatically (using an access key when one matches, otherwise prompting the user with a confirm dialog).
 
 Pass `editable: true` to open the wallet's send UI instead, with any supplied fields pre-filled for the user to confirm or edit before signing. In this mode all fields are optional.
 

--- a/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
@@ -15,7 +15,7 @@ import { parseUnits } from 'viem'
 import { client } from './zones.config'
 
 // Generate a keypair for decrypting the sender identity later.
-// Store the private key securely — the holder can reveal the sender.
+// Store the private key securely. The holder can reveal the sender.
 const { privateKey, publicKey } = Secp256k1.createKeyPair()
 const revealTo = PublicKey.toHex(PublicKey.compress(publicKey))
 


### PR DESCRIPTION
## Summary
- replace remaining em dashes in docs prose with commas, colons, parentheses, or separate sentences
- keep the edits limited to wording so generated examples and formatting stay unchanged

## Test Plan
- `git diff --check`
- searched `site/pages` for `—` and found no matches
- `pnpm clean && pnpm --filter site build`

Refs viem agent docs prose guideline