### PR TITLE
docs: title case getting started headings

### DIFF
--- a/site/pages/docs/getting-started.mdx
+++ b/site/pages/docs/getting-started.mdx
@@ -31,7 +31,7 @@ bun i viem
 
 ## Quick Start
 
-### 1. Set up your Client & Transport
+### 1. Set Up Your Client & Transport
 
 Firstly, set up your [Client](/docs/clients/intro) with a desired [Transport](/docs/clients/intro) & [Chain](/docs/chains/introduction).
 
@@ -67,6 +67,6 @@ const client = createPublicClient({
 const blockNumber = await client.getBlockNumber() // [!code focus]
 ```
 
-## Live example
+## Live Example
 
 <iframe className="mt-6" width="100%" height="600px" frameBorder="0" src="https://stackblitz.com/edit/viem-getting-started?embed=1&file=index.ts&hideNavigation=1&hideDevTools=true&terminalHeight=1&hideExplorer=1&devtoolsheight=1&ctl=1"></iframe>


### PR DESCRIPTION
## Summary
- Updates Getting Started headings to use title case.
- Keeps the change scoped to docs style only.

## Test Plan
- `python3 - <<'PY' ... PY` targeted heading-case check for `site/pages/docs/getting-started.mdx`

Refs: docs heading style guidance