### PR TITLE
docs: title case extension guide headings

### DIFF
--- a/site/pages/account-abstraction.mdx
+++ b/site/pages/account-abstraction.mdx
@@ -34,9 +34,9 @@ The most common Actions for **User Operations** are:
 Once Account Abstraction is enshrined on the protocol, we anticipate the above Actions will become redundant in favor of Viem's Transaction APIs.
 :::
 
-## Sending your first User Operation
+## Sending Your First User Operation
 
-### 1. Set up a Client
+### 1. Set Up a Client
 
 A Smart Account needs access to the Network to query for information about its state (e.g. nonce, address, etc). Let's set up a Client that we can use for the Smart Account:
 
@@ -54,7 +54,7 @@ const client = createPublicClient({
 
 [See `createPublicClient` Docs](/docs/clients/public)
 
-### 2. Set up a Bundler Client
+### 2. Set Up a Bundler Client
 
 Next, we need to set up a Bundler Client. A Bundler is required to submit User Operations to the Network for the Smart Account.
 

--- a/site/pages/op-stack.mdx
+++ b/site/pages/op-stack.mdx
@@ -10,7 +10,7 @@ The OP Stack is a set of modular open-source software that enable developers to 
 
 ## Quick Start
 
-### 1. Set up your Client & Transport
+### 1. Set Up Your Client & Transport
 
 Firstly, set up your [Client](/docs/clients/intro) with a desired [Transport](/docs/clients/intro) & [OP Stack Chain](/op-stack/chains).
 

--- a/site/pages/zksync.mdx
+++ b/site/pages/zksync.mdx
@@ -14,7 +14,7 @@ ZKsync is a Layer-2 protocol that scales Ethereum with cutting-edge ZK tech.
 
 ## Quick Start
 
-### 1. Set up your Client & Transport
+### 1. Set Up Your Client & Transport
 
 Firstly, set up your [Client](/docs/clients/intro) with a desired [Transport](/docs/clients/intro) & [ZKsync Chain](./zksync/chains.md) and extend it with ZKsync EIP712 actions.
 


### PR DESCRIPTION
## Summary
- Updates extension guide headings to Title Case in the ZKsync, OP Stack, and Account Abstraction landing docs.
- Keeps the change limited to docs heading style.

## Test Plan
- `python3 - <<'PY' ...` asserted the updated headings are present and no em dashes exist in the touched docs.
- `git diff --check`