### PR TITLE
fix: preserve sponsored `feeToken`

### DIFF
--- a/.changeset/polite-sponsors-pay.md
+++ b/.changeset/polite-sponsors-pay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Preserved sponsor-returned `feeToken` values from `eth_fillTransaction` responses with `feePayerSignature`.

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -828,6 +828,40 @@ describe('without `eth_fillTransaction`', () => {
     `)
   })
 
+  test('behavior: sponsor fill feeToken overrides prefilled feeToken', async () => {
+    const requestFeeToken = '0x20c0000000000000000000000000000000000001'
+    const sponsorFeeToken = '0x20c0000000000000000000000000000000000000'
+    const fillTransactionSpy = vi
+      .spyOn(fillTransaction, 'fillTransaction')
+      .mockResolvedValueOnce({
+        transaction: {
+          feePayerSignature: {
+            r: '0x1',
+            s: '0x2',
+            yParity: 0,
+          },
+          feeToken: sponsorFeeToken,
+          gas: 21000n,
+        },
+      } as never)
+
+    try {
+      const request = await prepareTransactionRequest(client, {
+        account: privateKeyToAccount(sourceAccount.privateKey),
+        feePayer: true,
+        feeToken: requestFeeToken,
+        parameters: ['gas'],
+        to: targetAccount.address,
+        value: parseEther('1'),
+      } as never)
+
+      expect(request.feePayerSignature).toBeDefined()
+      expect(request.feeToken).toBe(sponsorFeeToken)
+    } finally {
+      fillTransactionSpy.mockRestore()
+    }
+  })
+
   test('behavior: chain default priority fee', async () => {
     await setup()
 

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -423,6 +423,15 @@ export async function prepareTransactionRequest<
             type,
             ...rest
           } = result.transaction
+          const feeToken = 'feeToken' in rest ? rest.feeToken : undefined
+          const hasFilledFeePayerSignature =
+            'feePayerSignature' in rest &&
+            rest.feePayerSignature !== null &&
+            typeof rest.feePayerSignature !== 'undefined'
+          const shouldUseFilledFeeToken =
+            typeof feeToken !== 'undefined' &&
+            feeToken !== null &&
+            (!('feeToken' in request) || hasFilledFeePayerSignature)
           supportsFillTransaction.set(client.uid, true)
           return {
             ...request,
@@ -461,12 +470,7 @@ export async function prepareTransactionRequest<
             rest.feePayerSignature !== null
               ? { feePayerSignature: rest.feePayerSignature }
               : {}),
-            ...('feeToken' in rest &&
-            typeof rest.feeToken !== 'undefined' &&
-            rest.feeToken !== null &&
-            !('feeToken' in request)
-              ? { feeToken: rest.feeToken }
-              : {}),
+            ...(shouldUseFilledFeeToken ? { feeToken } : {}),
             ...(result.capabilities
               ? { _capabilities: result.capabilities }
               : {}),


### PR DESCRIPTION
Preserves sponsor-returned `feeToken` when `eth_fillTransaction` also returns `feePayerSignature`, keeping the final Tempo envelope aligned with the sponsor-signed fee fields.
