### PR TITLE
docs(fromHex): fix hexToNumber @example calling hexToBigInt

### DIFF
--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -208,7 +208,7 @@ export type HexToNumberErrorType =
  *
  * @example
  * import { hexToNumber } from 'viem'
- * const data = hexToBigInt('0x00000000000000000000000000000000000000000000000000000000000001a4', { size: 32 })
+ * const data = hexToNumber('0x00000000000000000000000000000000000000000000000000000000000001a4', { size: 32 })
  * // 420
  */
 export function hexToNumber(hex: Hex, opts: HexToNumberOpts = {}): number {


### PR DESCRIPTION
The second `@example` on `hexToNumber` imports `hexToNumber` but calls `hexToBigInt`. The `// 420` result comment (not `420n`) confirms the example should call `hexToNumber`.

This is an example-only documentation fix, a copy-paste slip from the `hexToBigInt` block directly above. The function body is unchanged.