### PR TITLE
Improve Tempo Zone SDK helpers

### DIFF
--- a/.changeset/tempo-zone-sdk-helpers.md
+++ b/.changeset/tempo-zone-sdk-helpers.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Added Tempo Zone helpers for preparing encrypted deposit recipients and withdrawals without broadcasting. Zone withdrawal actions now use `callbackGas` for the parent-chain callback limit, leaving `gas` for the Zone transaction limit.

--- a/site/pages/tempo/actions/zone.encryptedDeposit.mdx
+++ b/site/pages/tempo/actions/zone.encryptedDeposit.mdx
@@ -80,6 +80,20 @@ export const broadcaster = client
 
 :::
 
+### Prepare Only the Encrypted Recipient
+
+Use `zone.encryptedDeposit.prepareRecipient` when another contract or service controls token movement and only needs the ZonePortal encryption fields.
+
+```ts twoslash
+import { client } from './viem.config'
+
+const { encrypted, keyIndex } =
+  await client.zone.encryptedDeposit.prepareRecipient({
+    recipient: '0x0000000000000000000000000000000000000001',
+    zoneId: 7,
+  })
+```
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
+++ b/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
@@ -30,7 +30,7 @@ console.log('Fee:', fee)
 import { client } from './zones.config'
 
 const fee = await client.zone.getWithdrawalFee({
-  gas: 100_000n,
+  callbackGas: 100_000n,
 })
 ```
 
@@ -44,7 +44,7 @@ The withdrawal fee as a bigint.
 
 ## Parameters
 
-### gas (optional)
+### callbackGas (optional)
 
 - **Type:** `bigint`
 - **Default:** `0n`

--- a/site/pages/tempo/actions/zone.requestWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestWithdrawal.mdx
@@ -46,6 +46,23 @@ const hash = await client.zone.requestWithdrawal({
 const receipt = await client.waitForTransactionReceipt({ hash })
 ```
 
+### Prepare a Withdrawal
+
+Use `zone.requestWithdrawal.prepare` to inspect the calls and protocol withdrawal fee without broadcasting. Set `estimateTransactionFee` to also estimate the Zone transaction fee.
+
+```ts twoslash
+import { parseUnits } from 'viem'
+import { client } from './zones.config'
+
+const prepared = await client.zone.requestWithdrawal.prepare({
+  amount: parseUnits('100', 6),
+  callbackGas: 10_000_000n,
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log('Total fee:', prepared.totalFee)
+```
+
 ## Return Type
 
 ```ts
@@ -90,12 +107,18 @@ Optional callback data for the recipient.
 
 Fallback address if callback fails.
 
-### gas (optional)
+### callbackGas (optional)
 
 - **Type:** `bigint`
 - **Default:** `0n`
 
 Gas limit reserved for the withdrawal callback on the parent chain.
+
+### gas (optional)
+
+- **Type:** `bigint`
+
+Transaction gas limit on the Zone chain.
 
 ### memo (optional)
 

--- a/src/tempo/Decorator.test.ts
+++ b/src/tempo/Decorator.test.ts
@@ -56,6 +56,10 @@ describe('decorator', () => {
     expect(typeof client2.token.transfer.estimateGas).toBe('function')
     expect(typeof client2.token.transfer.simulate).toBe('function')
     expect(typeof client2.zone.encryptedDeposit.prepare).toBe('function')
+    expect(typeof client2.zone.encryptedDeposit.prepareRecipient).toBe(
+      'function',
+    )
+    expect(typeof client2.zone.requestWithdrawal.prepare).toBe('function')
     expect(typeof client2.zone.getEncryptionKey.calls).toBe('function')
   })
 

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -5164,6 +5164,9 @@ type BoundActionHelpers<action> = (action extends { call: infer helper }
   (action extends { prepare: infer helper }
     ? { prepare: BoundHelper<helper> }
     : {}) &
+  (action extends { prepareRecipient: infer helper }
+    ? { prepareRecipient: BoundHelper<helper> }
+    : {}) &
   (action extends { simulate: infer helper }
     ? { simulate: BoundHelper<helper> }
     : {}) &

--- a/src/tempo/actions/zone.test-d.ts
+++ b/src/tempo/actions/zone.test-d.ts
@@ -28,6 +28,55 @@ test('encryptedDeposit.prepare returns a reusable encrypted deposit payload', as
   zoneActions.encryptedDeposit.calls(prepared)
   await zoneActions.encryptedDeposit(client, prepared)
   await zoneActions.encryptedDepositSync(client, prepared)
+  await zoneActions.encryptedDepositSync(client, {
+    ...prepared,
+    pollingInterval: 100,
+    timeout: 1_000,
+  })
+})
+
+test('encryptedDeposit.prepareRecipient returns reusable encrypted recipient data', async () => {
+  const prepared = await zoneActions.encryptedDeposit.prepareRecipient(client, {
+    portalAddress: '0x0000000000000000000000000000000000000002',
+    recipient: '0x0000000000000000000000000000000000000001',
+    zoneId: 7,
+  })
+
+  expectTypeOf(
+    prepared,
+  ).toEqualTypeOf<zoneActions.PreparedEncryptedDepositRecipient>()
+})
+
+test('requestWithdrawal.prepare returns calls and fee details', async () => {
+  const prepared = await zoneActions.requestWithdrawal.prepare(client, {
+    token: '0x20c0000000000000000000000000000000000000',
+    amount: 1n,
+    callbackGas: 10_000_000n,
+    to: '0x0000000000000000000000000000000000000001',
+    estimateTransactionFee: true,
+    transactionFeeScale: 1_000_000_000_000n,
+  })
+
+  expectTypeOf(
+    prepared,
+  ).toEqualTypeOf<zoneActions.requestWithdrawal.prepare.ReturnType>()
+
+  // @ts-expect-error transactionFeeScale is required when estimating.
+  await zoneActions.requestWithdrawal.prepare(client, {
+    token: '0x20c0000000000000000000000000000000000000',
+    amount: 1n,
+    to: '0x0000000000000000000000000000000000000001',
+    estimateTransactionFee: true,
+  })
+})
+
+test('withdrawal callback gas is distinct from transaction gas', async () => {
+  await zoneActions.requestWithdrawal(client, {
+    token: '0x20c0000000000000000000000000000000000000',
+    amount: 1n,
+    callbackGas: 10_000_000n,
+    gas: 1_000_000n,
+  })
 })
 
 test('encryptedDeposit still accepts plaintext parameters', async () => {

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -387,11 +387,11 @@ describe('getWithdrawalFee', () => {
     expect(fee).toBeGreaterThanOrEqual(0n)
   })
 
-  test('behavior: accepts custom gas limit', async () => {
+  test('behavior: accepts custom callback gas limit', async () => {
     await zoneActions.signAuthorizationToken(zoneClient, { zoneId })
 
     const fee = await zoneActions.getWithdrawalFee(zoneClient, {
-      gas: 100_000n,
+      callbackGas: 100_000n,
     })
 
     expect(typeof fee).toBe('bigint')
@@ -539,6 +539,23 @@ describe('encryptedDeposit', () => {
     const receipt = await waitForTransactionReceipt(mainnetClient, { hash })
 
     expect(receipt.status).toBe('success')
+  })
+
+  test('behavior: prepares an encrypted recipient without a deposit', async () => {
+    const prepared = await zoneActions.encryptedDeposit.prepareRecipient(
+      mainnetClient,
+      {
+        portalAddress,
+        recipient: account.address,
+        zoneId,
+      },
+    )
+
+    expect(prepared.chainId).toBe(chain.id)
+    expect(prepared.portalAddress).toBe(portalAddress)
+    expect(prepared.zoneId).toBe(zoneId)
+    expect(prepared.keyIndex).toBeGreaterThanOrEqual(0n)
+    expect(prepared.encrypted.ciphertext).toBeDefined()
   })
 
   test('error: prepare without chain', async () => {
@@ -749,8 +766,36 @@ describe('requestWithdrawal', () => {
 
     expect(call.functionName).toBe('requestWithdrawal')
     expect(call.args).toHaveLength(8)
+    expect(call.args[4]).toBe(0n)
     expect(call.args[6]).toBe('0x')
     expect(call.args[7]).toBe('0x')
+  })
+
+  test('behavior: keeps callback gas separate from transaction gas', () => {
+    const [, call] = zoneActions.requestWithdrawal.calls({
+      amount: 1n,
+      callbackGas: 10_000_000n,
+      to: account.address,
+      token: '0x20c0000000000000000000000000000000000001',
+    })
+
+    expect(call.args[4]).toBe(10_000_000n)
+  })
+
+  test('behavior: prepares a withdrawal without broadcasting', async () => {
+    await zoneActions.signAuthorizationToken(zoneClient, { zoneId })
+    const info = await zoneActions.getZoneInfo(zoneClient)
+    const zoneToken = info.zoneTokens[0]!
+
+    const prepared = await zoneActions.requestWithdrawal.prepare(zoneClient, {
+      amount: 1n,
+      callbackGas: 100_000n,
+      token: zoneToken,
+    })
+
+    expect(prepared.calls).toHaveLength(2)
+    expect(prepared.callbackGas).toBe(100_000n)
+    expect(prepared.totalFee).toBe(prepared.withdrawalFee)
   })
 
   test('behavior: requests withdrawal without waiting', async () => {

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -7,6 +7,14 @@ import { TokenId, ZoneId, ZoneRpcAuthentication } from 'ox/tempo'
 import type { Account } from '../../accounts/types.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import {
+  type EstimateGasErrorType,
+  estimateGas,
+} from '../../actions/public/estimateGas.js'
+import {
+  type GetGasPriceErrorType,
+  getGasPrice,
+} from '../../actions/public/getGasPrice.js'
+import {
   type MulticallErrorType,
   type MulticallParameters,
   multicall,
@@ -38,8 +46,13 @@ import type {
   GetAccountParameter,
   ReadParameters,
   WriteParameters,
+  WriteSyncParameters,
 } from '../internal/types.js'
-import { defineCall, pickWriteParameters } from '../internal/utils.js'
+import {
+  defineCall,
+  pickWriteParameters,
+  pickWriteSyncParameters,
+} from '../internal/utils.js'
 import * as Storage from '../Storage.js'
 import type { TransactionReceipt } from '../Transaction.js'
 import * as ZoneAbis from '../zones/Abis.js'
@@ -68,6 +81,19 @@ export type PreparedEncryptedDeposit = {
   portalAddress: Address
   /** Token address or ID to deposit. */
   token: TokenId.TokenIdOrAddress
+  /** Zone ID (e.g. `7`). */
+  zoneId: number
+}
+
+export type PreparedEncryptedDepositRecipient = {
+  /** Parent chain ID (e.g. `42431` for moderato). */
+  chainId: number
+  /** Encrypted recipient and memo payload. */
+  encrypted: EncryptedPayload
+  /** Encryption key index from the portal contract. */
+  keyIndex: bigint
+  /** Zone portal address on the parent chain. */
+  portalAddress: Address
   /** Zone ID (e.g. `7`). */
   zoneId: number
 }
@@ -627,6 +653,93 @@ export namespace encryptedDeposit {
   }
 
   /**
+   * Prepares encrypted Zone recipient instructions without constructing a token
+   * deposit.
+   *
+   * Use this when another contract or service controls the token movement and
+   * only needs the ZonePortal `keyIndex` and encrypted recipient payload.
+   *
+   * @example
+   * ```ts
+   * import { createClient, http } from 'viem'
+   * import { tempoModerato } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({
+   *   chain: tempoModerato,
+   *   transport: http(),
+   * })
+   *
+   * const recipient = await Actions.zone.encryptedDeposit.prepareRecipient(client, {
+   *   recipient: '0x...',
+   *   zoneId: 7,
+   * })
+   * ```
+   *
+   * @param client - Public client connected to the parent Tempo chain.
+   * @param parameters - Encrypted recipient preparation parameters.
+   * @returns Prepared encrypted recipient instructions.
+   */
+  export async function prepareRecipient<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: prepareRecipient.Parameters,
+  ): Promise<prepareRecipient.ReturnValue> {
+    const chainId = client.chain?.id
+    if (!chainId) throw new Error('`chain` is required.')
+
+    const {
+      memo,
+      portalAddress: portalAddress_,
+      recipient,
+      zoneId,
+      ...rest
+    } = parameters
+    const portalAddress = portalAddress_ ?? getPortalAddress(chainId, zoneId)
+    const { keyIndex, publicKey } = await getEncryptionKey(client, {
+      ...rest,
+      portalAddress,
+      zoneId,
+    })
+    const encrypted = await encryptDepositPayload(
+      publicKey,
+      recipient,
+      portalAddress,
+      keyIndex,
+      memo,
+    )
+
+    return {
+      chainId,
+      encrypted,
+      keyIndex,
+      portalAddress,
+      zoneId,
+    }
+  }
+
+  export namespace prepareRecipient {
+    export type Parameters = ReadParameters & Args
+
+    export type Args = {
+      /** Optional deposit memo. @default `0x00...00` */
+      memo?: Hex.Hex | undefined
+      /** Zone portal address. @default resolved via the portal registry. */
+      portalAddress?: Address | undefined
+      /** Recipient address in the zone. */
+      recipient: Address
+      /** Zone ID (e.g. `7`). */
+      zoneId: number
+    }
+
+    export type ReturnValue = PreparedEncryptedDepositRecipient
+
+    export type ErrorType = getEncryptionKey.ErrorType | BaseErrorType
+  }
+
+  /**
    * Defines the calls to approve and deposit tokens into a zone (encrypted).
    *
    * @param args - Arguments.
@@ -731,6 +844,7 @@ export async function encryptedDepositSync<
     }
     const receipt = await sendTransactionSync(client, {
       ...pickWriteParameters(parameters as never),
+      ...pickWriteSyncParameters(parameters as never),
       throwOnReceiptRevert,
       calls: encryptedDeposit.calls({
         ...parameters,
@@ -764,7 +878,8 @@ export namespace encryptedDepositSync {
   export type Parameters<
     chain extends Chain | undefined = Chain | undefined,
     account extends Account | undefined = Account | undefined,
-  > = encryptedDeposit.Parameters<chain, account>
+  > = encryptedDeposit.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
 
   export type Args = encryptedDeposit.Args
 
@@ -1047,7 +1162,8 @@ export namespace waitForDepositStatus {
 }
 
 /**
- * Returns the fee required for a withdrawal from a zone, given a gas limit.
+ * Returns the fee required for a withdrawal from a zone, given a callback gas
+ * limit.
  *
  * The client must be connected to the **zone chain**.
  *
@@ -1066,7 +1182,7 @@ export namespace waitForDepositStatus {
  * ```
  *
  * @param client - Zone client.
- * @param parameters - Optional gas limit parameter.
+ * @param parameters - Optional callback gas limit parameter.
  * @returns The withdrawal fee as a bigint.
  */
 export async function getWithdrawalFee<
@@ -1076,20 +1192,20 @@ export async function getWithdrawalFee<
   client: Client<Transport, chain, account>,
   parameters: getWithdrawalFee.Parameters = {},
 ): Promise<getWithdrawalFee.ReturnType> {
-  const { gas = 0n, ...rest } = parameters
+  const { callbackGas = 0n, ...rest } = parameters
   return readContract(client, {
     ...rest,
     address: Addresses.zoneOutbox,
     abi: ZoneAbis.zoneOutbox,
     functionName: 'calculateWithdrawalFee',
-    args: [gas],
+    args: [callbackGas],
   })
 }
 
 export namespace getWithdrawalFee {
   export type Parameters = ReadParameters & {
-    /** Gas limit for the withdrawal callback. @default `0n` */
-    gas?: bigint | undefined
+    /** Gas limit reserved for the withdrawal callback on the parent chain. @default `0n` */
+    callbackGas?: bigint | undefined
   }
 
   export type ReturnType = bigint
@@ -1192,7 +1308,7 @@ export async function requestWithdrawal<
   client: Client<Transport, chain, account>,
   parameters: requestWithdrawal.Parameters<chain, account>,
 ): Promise<requestWithdrawal.ReturnValue> {
-  const { account = client.account, ...rest } = parameters
+  const { account = client.account } = parameters
 
   const account_ = account ? parseAccount(account) : undefined
   if (!account) throw new Error('`account` is required.')
@@ -1202,7 +1318,7 @@ export async function requestWithdrawal<
 
   const args = { ...parameters, to }
   return sendTransaction(client, {
-    ...rest,
+    ...pickWriteParameters(parameters as never),
     calls: requestWithdrawal.calls(args),
   } as never) as never
 }
@@ -1220,12 +1336,12 @@ export namespace requestWithdrawal {
   export type Args = {
     /** Amount of tokens to withdraw. */
     amount: bigint
+    /** Gas limit reserved for the withdrawal callback on the parent chain. @default `0n` */
+    callbackGas?: bigint | undefined
     /** Optional callback data for the recipient. @default `'0x'` */
     data?: Hex.Hex | undefined
     /** Fallback address if callback fails. @default `to` */
     fallbackRecipient?: Address | undefined
-    /** Gas limit reserved for the withdrawal callback on the parent chain. @default `0n` */
-    gas?: bigint | undefined
     /** Optional withdrawal memo. @default `0x00...00` */
     memo?: Hex.Hex | undefined
     /** Recipient address on the parent Tempo chain. */
@@ -1248,9 +1364,9 @@ export namespace requestWithdrawal {
   export function calls(args: Args) {
     const {
       amount,
+      callbackGas = 0n,
       data = '0x',
       fallbackRecipient = args.to,
-      gas = 0n,
       memo = zeroHash,
       to,
       token,
@@ -1271,7 +1387,7 @@ export namespace requestWithdrawal {
           to,
           amount,
           memo,
-          gas,
+          callbackGas,
           fallbackRecipient,
           data,
           '0x',
@@ -1279,7 +1395,174 @@ export namespace requestWithdrawal {
       }),
     ]
   }
+
+  /**
+   * Prepares a zone withdrawal without broadcasting it.
+   *
+   * Use this to inspect the ZoneOutbox calls and fees before submitting a
+   * withdrawal. When `estimateTransactionFee` is enabled, viem also estimates
+   * the zone transaction gas and converts it with `transactionFeeScale`.
+   *
+   * @example
+   * ```ts
+   * import { createClient } from 'viem'
+   * import { http, zoneModerato } from 'viem/tempo/zones'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({
+   *   chain: zoneModerato(7),
+   *   transport: http(),
+   * })
+   *
+   * const prepared = await Actions.zone.requestWithdrawal.prepare(client, {
+   *   token: '0x20c0...0001',
+   *   amount: 1_000_000n,
+   *   to: '0x...',
+   * })
+   * ```
+   *
+   * @param client - Zone client.
+   * @param parameters - Withdrawal preparation parameters.
+   * @returns Prepared calls and fee details.
+   */
+  export async function prepare<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: prepare.Parameters<chain, account>,
+  ): Promise<prepare.ReturnType> {
+    const {
+      account = client.account,
+      amount,
+      callbackGas = 0n,
+      data = '0x',
+      estimateTransactionFee = false,
+      fallbackRecipient,
+      memo = zeroHash,
+      to: to_,
+      token,
+      transactionFeeScale,
+      ...transactionRequest
+    } = parameters
+
+    const account_ = account ? parseAccount(account) : undefined
+    const to = to_ ?? account_?.address
+    if (!to) throw new Error('`to` is required.')
+
+    const calls = requestWithdrawal.calls({
+      amount,
+      callbackGas,
+      data,
+      fallbackRecipient,
+      memo,
+      to,
+      token,
+    })
+
+    const transactionEstimatePromise = estimateTransactionFee
+      ? (async () => {
+          if (!account) throw new Error('`account` is required.')
+          if (transactionFeeScale === undefined)
+            throw new Error(
+              '`transactionFeeScale` is required when `estimateTransactionFee` is `true`.',
+            )
+
+          const [estimatedGas, gasPrice] = await Promise.all([
+            estimateGas(client, {
+              ...transactionRequest,
+              account,
+              calls,
+              prepare: false,
+            } as never),
+            getGasPrice(client),
+          ])
+          return {
+            estimatedGas,
+            gasPrice,
+            transactionFee: ceilDiv(
+              estimatedGas * gasPrice,
+              transactionFeeScale,
+            ),
+          }
+        })()
+      : Promise.resolve(undefined)
+
+    const [transactionEstimate, withdrawalFee] = await Promise.all([
+      transactionEstimatePromise,
+      getWithdrawalFee(client, { callbackGas }),
+    ])
+
+    return {
+      amount,
+      callbackGas,
+      calls,
+      data,
+      estimatedGas: transactionEstimate?.estimatedGas,
+      fallbackRecipient: fallbackRecipient ?? to,
+      gasPrice: transactionEstimate?.gasPrice,
+      memo,
+      to,
+      token,
+      totalFee: withdrawalFee + (transactionEstimate?.transactionFee ?? 0n),
+      transactionFee: transactionEstimate?.transactionFee,
+      withdrawalFee,
+    }
+  }
+
+  export namespace prepare {
+    export type Parameters<
+      chain extends Chain | undefined = Chain | undefined,
+      account extends Account | undefined = Account | undefined,
+    > = UnionOmit<
+      WriteParameters<chain, account>,
+      'account' | 'throwOnReceiptRevert'
+    > &
+      GetAccountParameter<account, Account | Address, false> &
+      PrepareArgs
+
+    export type PrepareArgs = Omit<Args, 'to'> & {
+      /** Recipient address on the parent Tempo chain. @default `account.address` */
+      to?: Address | undefined
+    } & (
+        | {
+            /** Whether to estimate and include the zone transaction fee. @default false */
+            estimateTransactionFee?: false | undefined
+            transactionFeeScale?: undefined
+          }
+        | {
+            /** Whether to estimate and include the zone transaction fee. */
+            estimateTransactionFee: true
+            /** Divisor converting `estimatedGas * gasPrice` into fee-token base units. */
+            transactionFeeScale: bigint
+          }
+      )
+
+    export type ReturnType = Compute<{
+      amount: bigint
+      callbackGas: bigint
+      calls: WithdrawalCalls
+      data: Hex.Hex
+      estimatedGas?: bigint | undefined
+      fallbackRecipient: Address
+      gasPrice?: bigint | undefined
+      memo: Hex.Hex
+      to: Address
+      token: TokenId.TokenIdOrAddress
+      totalFee: bigint
+      transactionFee?: bigint | undefined
+      withdrawalFee: bigint
+    }>
+
+    export type ErrorType =
+      | EstimateGasErrorType
+      | GetGasPriceErrorType
+      | getWithdrawalFee.ErrorType
+      | BaseErrorType
+  }
 }
+
+type WithdrawalCalls = ReturnType<typeof requestWithdrawal.calls>
 
 /**
  * Requests a withdrawal from a zone to the parent Tempo chain and waits for
@@ -1315,11 +1598,7 @@ export async function requestWithdrawalSync<
   client: Client<Transport, chain, account>,
   parameters: requestWithdrawalSync.Parameters<chain, account>,
 ): Promise<requestWithdrawalSync.ReturnValue> {
-  const {
-    account = client.account,
-    throwOnReceiptRevert = true,
-    ...rest
-  } = parameters
+  const { account = client.account, throwOnReceiptRevert = true } = parameters
 
   const account_ = account ? parseAccount(account) : undefined
   if (!account) throw new Error('`account` is required.')
@@ -1329,7 +1608,8 @@ export async function requestWithdrawalSync<
 
   const args = { ...parameters, to }
   const receipt = await sendTransactionSync(client, {
-    ...rest,
+    ...pickWriteParameters(parameters as never),
+    ...pickWriteSyncParameters(parameters as never),
     calls: requestWithdrawal.calls(args),
     throwOnReceiptRevert,
   } as never)
@@ -1340,7 +1620,8 @@ export namespace requestWithdrawalSync {
   export type Parameters<
     chain extends Chain | undefined = Chain | undefined,
     account extends Account | undefined = Account | undefined,
-  > = requestWithdrawal.Parameters<chain, account>
+  > = requestWithdrawal.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
 
   export type Args = requestWithdrawal.Args
 
@@ -1391,7 +1672,7 @@ export async function requestVerifiableWithdrawal<
   client: Client<Transport, chain, account>,
   parameters: requestVerifiableWithdrawal.Parameters<chain, account>,
 ): Promise<requestVerifiableWithdrawal.ReturnValue> {
-  const { account = client.account, ...rest } = parameters
+  const { account = client.account } = parameters
 
   const account_ = account ? parseAccount(account) : undefined
   if (!account) throw new Error('`account` is required.')
@@ -1401,7 +1682,7 @@ export async function requestVerifiableWithdrawal<
 
   const args = { ...parameters, to }
   return sendTransaction(client, {
-    ...rest,
+    ...pickWriteParameters(parameters as never),
     calls: requestVerifiableWithdrawal.calls(args),
   } as never) as never
 }
@@ -1435,9 +1716,9 @@ export namespace requestVerifiableWithdrawal {
   export function calls(args: Args) {
     const {
       amount,
+      callbackGas = 0n,
       data = '0x',
       fallbackRecipient = args.to,
-      gas = 0n,
       memo = zeroHash,
       revealTo,
       to,
@@ -1459,7 +1740,7 @@ export namespace requestVerifiableWithdrawal {
           to,
           amount,
           memo,
-          gas,
+          callbackGas,
           fallbackRecipient,
           data,
           revealTo,
@@ -1504,11 +1785,7 @@ export async function requestVerifiableWithdrawalSync<
   client: Client<Transport, chain, account>,
   parameters: requestVerifiableWithdrawalSync.Parameters<chain, account>,
 ): Promise<requestVerifiableWithdrawalSync.ReturnValue> {
-  const {
-    account = client.account,
-    throwOnReceiptRevert = true,
-    ...rest
-  } = parameters
+  const { account = client.account, throwOnReceiptRevert = true } = parameters
 
   const account_ = account ? parseAccount(account) : undefined
   if (!account) throw new Error('`account` is required.')
@@ -1518,7 +1795,8 @@ export async function requestVerifiableWithdrawalSync<
 
   const args = { ...parameters, to }
   const receipt = await sendTransactionSync(client, {
-    ...rest,
+    ...pickWriteParameters(parameters as never),
+    ...pickWriteSyncParameters(parameters as never),
     calls: requestVerifiableWithdrawal.calls(args),
     throwOnReceiptRevert,
   } as never)
@@ -1529,7 +1807,8 @@ export namespace requestVerifiableWithdrawalSync {
   export type Parameters<
     chain extends Chain | undefined = Chain | undefined,
     account extends Account | undefined = Account | undefined,
-  > = requestVerifiableWithdrawal.Parameters<chain, account>
+  > = requestVerifiableWithdrawal.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
 
   export type Args = requestVerifiableWithdrawal.Args
 
@@ -1737,4 +2016,9 @@ function buildDepositHkdfInfo(
     Bytes.fromNumber(keyIndex, { size: 32 }),
     Bytes.from(ephemeralPubkeyX),
   )
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint) {
+  if (denominator <= 0n) throw new Error('`denominator` must be positive.')
+  return (numerator + denominator - 1n) / denominator
 }

--- a/src/tempo/internal/types.ts
+++ b/src/tempo/internal/types.ts
@@ -77,3 +77,11 @@ export type WriteParameters<
     | 'validAfter'
     | 'validBefore'
   >
+
+export type WriteSyncParameters<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = UnionPick<
+  viem_WriteContractSyncParameters<never, never, never, chain, account>,
+  'pollingInterval' | 'timeout'
+>

--- a/src/tempo/internal/utils.ts
+++ b/src/tempo/internal/utils.ts
@@ -216,6 +216,12 @@ export function pickWriteParameters(parameters: Record<string, unknown>) {
   }
 }
 
+/** @internal */
+export function pickWriteSyncParameters(parameters: Record<string, unknown>) {
+  const { pollingInterval, timeout } = parameters
+  return { pollingInterval, timeout }
+}
+
 /**
  * Parameters of an action's `.call` builder: the call arguments, optionally
  * preceded by a Client. The Client is used to resolve token symbols declared


### PR DESCRIPTION
## Summary

- build on #4828 instead of duplicating its Zone portal, encryption-key, and deposit-status abstractions
- add `encryptedDeposit.prepareRecipient` for flows where another contract controls token movement and only needs the encrypted Zone recipient payload
- add `requestWithdrawal.prepare` for inspecting withdrawal calls and protocol/transaction fees without broadcasting
- separate parent-chain `callbackGas` from the Zone transaction `gas` override
- allow receipt polling options on Zone sync actions

## Validation

- `pnpm biome check --write --unsafe src/tempo/actions/zone.ts src/tempo/actions/zone.test.ts src/tempo/actions/zone.test-d.ts src/tempo/internal/types.ts src/tempo/internal/utils.ts src/tempo/Decorator.ts src/tempo/Decorator.test.ts`
- `pnpm clean && pnpm check:types`
- `git diff --check`

## Notes

- The focused Tempo runtime suite currently stops in the shared local fixture before these tests run: the fixture's `eth_getBlockByNumber` request returns HTTP 400 during setup. This is independent of the changed actions.
