### PR TITLE
feat(verifyHash): add blockHash and requireCanonical params for onchain verification

### DIFF
--- a/.changeset/verify-hash-block-hash.md
+++ b/.changeset/verify-hash-block-hash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `blockHash` and `requireCanonical` parameters to `verifyHash` (and `verifyMessage`/`verifyTypedData`), allowing onchain signature verification to be pinned to a specific block via EIP-1898.

--- a/site/pages/docs/actions/public/verifyHash.md
+++ b/site/pages/docs/actions/public/verifyHash.md
@@ -177,3 +177,40 @@ const valid = await publicClient.verifyHash({
 })
 ```
 
+### blockHash (optional)
+
+- **Type:** `Hash`
+
+Only used when verifying a message that was signed by a Smart Contract Account. The block hash to check if the contract was already deployed. Implements [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898).
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts]
+// ---cut---
+const valid = await publicClient.verifyHash({
+  blockHash: '0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d', // [!code focus]
+  address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  hash: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  signature:
+    '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+})
+```
+
+### requireCanonical (optional)
+
+- **Type:** `boolean`
+
+Whether or not to throw an error if the block is not in the canonical chain. Only allowed in conjunction with `blockHash`. Implements [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898).
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts]
+// ---cut---
+const valid = await publicClient.verifyHash({
+  blockHash: '0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d',
+  requireCanonical: true, // [!code focus]
+  address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  hash: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  signature:
+    '0x66edc32e2ab001213321ab7d959a2207fcef5190cc9abb6da5b0d2a8a9af2d4d2b0700e2c317c4106f337fd934fbbb0bf62efc8811a78603b33a8265d3b8f8cb1c',
+})
+```
+

--- a/site/pages/docs/actions/public/verifyTypedData.md
+++ b/site/pages/docs/actions/public/verifyTypedData.md
@@ -475,3 +475,94 @@ const valid = await publicClient.verifyTypedData({
 })
 ```
 
+
+### blockHash (optional)
+
+- **Type:** `Hash`
+
+Only used when verifying a typed data that was signed by a Smart Contract Account. The block hash to check if the contract was already deployed. Implements [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898).
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts]
+// ---cut---
+const valid = await publicClient.verifyTypedData({
+  blockHash: '0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d', // [!code focus]
+  address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  domain: {
+    name: 'Ether Mail',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+  },
+  types: {
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallet', type: 'address' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person' },
+      { name: 'contents', type: 'string' },
+    ],
+  },
+  primaryType: 'Mail',
+  message: {
+    from: {
+      name: 'Cow',
+      wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    },
+    to: {
+      name: 'Bob',
+      wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+    },
+    contents: 'Hello, Bob!',
+  },
+  signature: '0x...',
+})
+```
+
+### requireCanonical (optional)
+
+- **Type:** `boolean`
+
+Whether or not to throw an error if the block is not in the canonical chain. Only allowed in conjunction with `blockHash`. Implements [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898).
+
+```ts twoslash
+// [!include ~/snippets/publicClient.ts]
+// ---cut---
+const valid = await publicClient.verifyTypedData({
+  blockHash: '0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d',
+  requireCanonical: true, // [!code focus]
+  address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  domain: {
+    name: 'Ether Mail',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+  },
+  types: {
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallet', type: 'address' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person' },
+      { name: 'contents', type: 'string' },
+    ],
+  },
+  primaryType: 'Mail',
+  message: {
+    from: {
+      name: 'Cow',
+      wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    },
+    to: {
+      name: 'Bob',
+      wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+    },
+    contents: 'Hello, Bob!',
+  },
+  signature: '0x...',
+})
+```

--- a/src/actions/public/verifyHash.test.ts
+++ b/src/actions/public/verifyHash.test.ts
@@ -47,6 +47,7 @@ import { sendTransaction } from '../wallet/sendTransaction.js'
 import { signAuthorization } from '../wallet/signAuthorization.js'
 import { signMessage } from '../wallet/signMessage.js'
 import { writeContract } from '../wallet/writeContract.js'
+import { getBlock } from './getBlock.js'
 import { simulateContract } from './simulateContract.js'
 import { verifyHash } from './verifyHash.js'
 
@@ -414,6 +415,71 @@ describe('erc6492', async () => {
           data: factoryData,
           signature,
         }),
+      }),
+    ).resolves.toBe(true)
+  })
+})
+
+describe('args: blockHash (EIP-1898)', async () => {
+  test('blockHash', async () => {
+    const { factoryAddress } = await deploySoladyAccount_07()
+
+    const { request, result: verifier } = await simulateContract(client, {
+      account: localAccount,
+      abi: SoladyAccountFactory07.abi,
+      address: factoryAddress,
+      functionName: 'createAccount',
+      args: [localAccount.address, pad('0x0')],
+    })
+    await writeContract(client, request)
+    await mine(client, { blocks: 1 })
+
+    const signature = await signMessageErc1271(client, {
+      account: localAccount,
+      message: 'hello world',
+      verifier,
+    })
+
+    const block = await getBlock(client)
+
+    await expect(
+      verifyHash(client, {
+        address: verifier,
+        hash: hashMessage('hello world'),
+        signature,
+        blockHash: block.hash!,
+      }),
+    ).resolves.toBe(true)
+  })
+
+  test('blockHash + requireCanonical', async () => {
+    const { factoryAddress } = await deploySoladyAccount_07()
+
+    const { request, result: verifier } = await simulateContract(client, {
+      account: localAccount,
+      abi: SoladyAccountFactory07.abi,
+      address: factoryAddress,
+      functionName: 'createAccount',
+      args: [localAccount.address, pad('0x0')],
+    })
+    await writeContract(client, request)
+    await mine(client, { blocks: 1 })
+
+    const signature = await signMessageErc1271(client, {
+      account: localAccount,
+      message: 'hello world',
+      verifier,
+    })
+
+    const block = await getBlock(client)
+
+    await expect(
+      verifyHash(client, {
+        address: verifier,
+        hash: hashMessage('hello world'),
+        signature,
+        blockHash: block.hash!,
+        requireCanonical: true,
       }),
     ).resolves.toBe(true)
   })

--- a/src/actions/public/verifyHash.ts
+++ b/src/actions/public/verifyHash.ts
@@ -63,7 +63,7 @@ import { type ReadContractErrorType, readContract } from './readContract.js'
 
 export type VerifyHashParameters = Pick<
   CallParameters,
-  'blockNumber' | 'blockTag'
+  'blockHash' | 'blockNumber' | 'blockTag' | 'requireCanonical'
 > & {
   /** The address that signed the original message. */
   address: Address
@@ -184,7 +184,15 @@ export async function verifyErc8010(
   client: Client,
   parameters: verifyErc8010.Parameters,
 ) {
-  const { address, blockNumber, blockTag, hash, multicallAddress } = parameters
+  const {
+    address,
+    blockHash,
+    blockNumber,
+    blockTag,
+    hash,
+    multicallAddress,
+    requireCanonical,
+  } = parameters
 
   const {
     authorization: authorization_ox,
@@ -196,17 +204,21 @@ export async function verifyErc8010(
   // Check if already delegated
   const code = await getCode(client, {
     address,
+    blockHash,
     blockNumber,
     blockTag,
+    requireCanonical,
   } as never)
 
   // If already delegated, perform standard ERC-1271 verification.
   if (code === concatHex(['0xef0100', authorization_ox.address]))
     return await verifyErc1271(client, {
       address,
+      blockHash,
       blockNumber,
       blockTag,
       hash,
+      requireCanonical,
       signature,
     })
 
@@ -270,7 +282,10 @@ export async function verifyErc8010(
 }
 
 export namespace verifyErc8010 {
-  export type Parameters = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
+  export type Parameters = Pick<
+    CallParameters,
+    'blockHash' | 'blockNumber' | 'blockTag' | 'requireCanonical'
+  > & {
     /** The address that signed the original message. */
     address: Address
     /** The hash to be verified. */
@@ -348,7 +363,10 @@ async function verifyErc6492(
 }
 
 export namespace verifyErc6492 {
-  export type Parameters = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
+  export type Parameters = Pick<
+    CallParameters,
+    'blockHash' | 'blockNumber' | 'blockTag' | 'requireCanonical'
+  > & {
     /** The address that signed the original message. */
     address: Address
     /** The hash to be verified. */
@@ -365,7 +383,15 @@ export async function verifyErc1271(
   client: Client,
   parameters: verifyErc1271.Parameters,
 ) {
-  const { address, blockNumber, blockTag, hash, signature } = parameters
+  const {
+    address,
+    blockHash,
+    blockNumber,
+    blockTag,
+    hash,
+    requireCanonical,
+    signature,
+  } = parameters
 
   const result = await getAction(
     client,
@@ -375,9 +401,11 @@ export async function verifyErc1271(
     address,
     abi: erc1271Abi,
     args: [hash, signature],
+    blockHash,
     blockNumber,
     blockTag,
     functionName: 'isValidSignature',
+    requireCanonical,
   }).catch((error) => {
     if (error instanceof ContractFunctionExecutionError)
       throw new VerificationError()
@@ -389,7 +417,10 @@ export async function verifyErc1271(
 }
 
 export namespace verifyErc1271 {
-  export type Parameters = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
+  export type Parameters = Pick<
+    CallParameters,
+    'blockHash' | 'blockNumber' | 'blockTag' | 'requireCanonical'
+  > & {
     /** The address that signed the original message. */
     address: Address
     /** The hash to be verified. */


### PR DESCRIPTION
Extends EIP-1898 block-identifier support (#4186) to `verifyHash` / `verifyMessage` / `verifyTypedData`, which were not covered by the original PR. Adds `blockHash` and `requireCanonical` for pinning onchain signature verification to a specific block.

Addresses #3165, #4349.