### PR TITLE
ci: skip latest typescript benchmarks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,6 +88,7 @@ jobs:
         run: pnpm check:types
 
       - name: Bench types
+        # TODO: Re-enable for latest TypeScript when @ark/attest supports its compiler API.
         if: matrix.version != 'latest'
         run: pnpm bench:types
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        version: ['5.9.3', 'latest']
+        version: ['5.9.3', '6.0.3', 'latest']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,6 +88,7 @@ jobs:
         run: pnpm check:types
 
       - name: Bench types
+        if: matrix.version != 'latest'
         run: pnpm bench:types
 
   test:


### PR DESCRIPTION
Keeps TypeScript latest compilation required while skipping type benchmarks that depend on its removed compiler API. Stable TypeScript continues enforcing benchmark thresholds.
