### PR TITLE
ci: authenticate GHCR for Tempo zone tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,6 +118,16 @@ jobs:
         shell: bash
         run: pnpm contracts:build
 
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          if [ -z "$GHCR_TOKEN" ]; then
+            echo 'Skipping GHCR login; token unavailable.'
+            exit 0
+          fi
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username jxom --password-stdin
+
       - name: Test Local
         uses: nick-fields/retry@v3
         with:


### PR DESCRIPTION
Authenticate local Tempo tests to GHCR with the existing `GHCR_TOKEN` secret. This lets Testcontainers pull the private `tempo-zone` image instead of failing with an unauthorized registry response.
