### PR TITLE
fix: retry whole send operation per fallback transport for local accounts

### DIFF
--- a/.changeset/fallback-operation-retry.md
+++ b/.changeset/fallback-operation-retry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `fallback` transport behavior for `sendTransaction`/`sendTransactionSync` with local accounts: the whole operation (nonce assignment, fee estimation, signing, submission) is now re-run against one transport at a time, so a transaction is no longer signed with chain state (e.g. a nonce) from one transport and broadcast through another. If a node explicitly rejects a submission (e.g. "nonce too low"), the next transport re-prepares and re-signs the transaction; if a submission fails ambiguously (e.g. a timeout), subsequent transports re-broadcast the same signed bytes to avoid double-sending.

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -15,6 +15,8 @@ import {
   type AccountTypeNotSupportedErrorType,
 } from '../../errors/account.js'
 import { BaseError } from '../../errors/base.js'
+import { RpcRequestError } from '../../errors/request.js'
+import { RpcError, UnknownRpcError } from '../../errors/rpc.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type {
@@ -52,6 +54,10 @@ import {
   type AssertRequestParameters,
   assertRequest,
 } from '../../utils/transaction/assertRequest.js'
+import {
+  getFallbackRetry,
+  withRetryingTransport,
+} from '../../utils/withRetryingTransport.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 import {
   defaultParameters,
@@ -310,56 +316,120 @@ export async function sendTransaction<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
+      // Serialized transaction of an attempt whose submission failed
+      // ambiguously (e.g. a timeout or network error): the transaction may
+      // have reached the node regardless, so subsequent attempts must
+      // re-broadcast the same signed bytes instead of re-signing with a fresh
+      // nonce (which could get both transactions mined).
+      let pendingSerializedTransaction: Hash | undefined
+
+      const send = async (
+        client_: Client<Transport, chain, account>,
+      ): Promise<SendTransactionReturnType> => {
+        if (pendingSerializedTransaction)
+          return await getAction(
+            client_,
+            sendRawTransaction,
+            'sendRawTransaction',
+          )({
+            serializedTransaction: pendingSerializedTransaction,
+          })
+
+        nonceManagerParameters = undefined
+        if (account.nonceManager && typeof nonce === 'undefined') {
+          const requestChainId = (rest as unknown as { chainId?: number })
+            .chainId
+          const chainId = await (async () => {
+            if (typeof requestChainId === 'number') return requestChainId
+            if (chain) return chain.id
+            return getAction(client_, getChainId, 'getChainId')({})
+          })()
+          nonceManagerParameters = { address: account.address, chainId }
+        }
+
+        // Prepare the request for signing (assign appropriate fees, etc.)
+        const request = await getAction(
+          client_,
+          prepareTransactionRequest,
+          'prepareTransactionRequest',
+        )({
+          account,
+          accessList,
+          authorizationList,
+          blobs,
+          chain,
+          data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
+          gas,
+          gasPrice,
+          maxFeePerBlobGas,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          nonce,
+          nonceManager: account.nonceManager,
+          parameters: [...defaultParameters, 'sidecars'],
+          type,
+          value,
+          ...rest,
+          to,
+        } as any)
+
+        const serializer = chain?.serializers?.transaction
+        const serializedTransaction = (await account.signTransaction(
+          request as never,
+          {
+            serializer,
+          },
+        )) as Hash
+        try {
+          return await getAction(
+            client_,
+            sendRawTransaction,
+            'sendRawTransaction',
+          )({
+            serializedTransaction,
+          })
+        } catch (err) {
+          // A node that responds with a JSON-RPC error has rejected the
+          // submission, so the transaction is provably not in its mempool and
+          // it is safe to re-prepare & re-sign against the next transport.
+          // Any other failure (e.g. a timeout) is ambiguous – the transaction
+          // may have been broadcast – so subsequent attempts must stick to
+          // the same signed bytes.
+          const rejected =
+            err instanceof BaseError &&
+            Boolean(
+              err.walk(
+                (error) =>
+                  error instanceof RpcRequestError ||
+                  (error instanceof RpcError &&
+                    !(error instanceof UnknownRpcError)),
+              ),
+            )
+          if (!rejected) pendingSerializedTransaction = serializedTransaction
+          throw err
+        }
       }
 
-      // Prepare the request for signing (assign appropriate fees, etc.)
-      const request = await getAction(
-        client,
-        prepareTransactionRequest,
-        'prepareTransactionRequest',
-      )({
-        account,
-        accessList,
-        authorizationList,
-        blobs,
-        chain,
-        data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
-        gas,
-        gasPrice,
-        maxFeePerBlobGas,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce,
-        nonceManager: account.nonceManager,
-        parameters: [...defaultParameters, 'sidecars'],
-        type,
-        value,
-        ...rest,
-        to,
-      } as any)
-
-      const serializer = chain?.serializers?.transaction
-      const serializedTransaction = (await account.signTransaction(
-        request as never,
-        {
-          serializer,
-        },
-      )) as Hash
-      return await getAction(
-        client,
-        sendRawTransaction,
-        'sendRawTransaction',
-      )({
-        serializedTransaction,
-      })
+      // If the client is backed by a fallback transport, re-run the whole
+      // operation (nonce assignment, fee estimation, signing, submission)
+      // against one transport at a time, so a single attempt cannot observe
+      // inconsistent chain state across transports.
+      const retry = getFallbackRetry(client)
+      if (retry)
+        return await retry(async ({ index, transport }) => {
+          try {
+            return await send(
+              withRetryingTransport(client, { index, transport }) as never,
+            )
+          } catch (err) {
+            if (nonceManagerParameters) {
+              account.nonceManager?.reset(nonceManagerParameters)
+              nonceManagerParameters = undefined
+            }
+            throw err
+          }
+        })
+      return await send(client as never)
     }
 
     if (account?.type === 'smart')

--- a/src/actions/wallet/sendTransactionSync.ts
+++ b/src/actions/wallet/sendTransactionSync.ts
@@ -15,6 +15,8 @@ import {
   type AccountTypeNotSupportedErrorType,
 } from '../../errors/account.js'
 import { BaseError } from '../../errors/base.js'
+import { RpcRequestError } from '../../errors/request.js'
+import { RpcError, UnknownRpcError } from '../../errors/rpc.js'
 import {
   TransactionReceiptRevertedError,
   type TransactionReceiptRevertedErrorType,
@@ -56,6 +58,10 @@ import {
   type AssertRequestParameters,
   assertRequest,
 } from '../../utils/transaction/assertRequest.js'
+import {
+  getFallbackRetry,
+  withRetryingTransport,
+} from '../../utils/withRetryingTransport.js'
 import { type GetChainIdErrorType, getChainId } from '../public/getChainId.js'
 import {
   type WaitForTransactionReceiptErrorType,
@@ -349,58 +355,140 @@ export async function sendTransactionSync<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
+      // Serialized transaction of an attempt whose submission failed
+      // ambiguously (e.g. a timeout or network error): the transaction may
+      // have reached the node regardless, so subsequent attempts must
+      // re-broadcast the same signed bytes instead of re-signing with a fresh
+      // nonce (which could get both transactions mined).
+      let pendingSerializedTransaction: Hash | undefined
+
+      const retry = getFallbackRetry(client)
+
+      const send = async (
+        client_: Client<Transport, chain, account>,
+      ): Promise<SendTransactionSyncReturnType> => {
+        if (pendingSerializedTransaction)
+          return (await getAction(
+            client_,
+            sendRawTransactionSync,
+            'sendRawTransactionSync',
+          )({
+            serializedTransaction: pendingSerializedTransaction,
+            // When retrying against fallback transports, the revert check is
+            // handled outside the retry loop (see below): a reverted receipt
+            // is an on-chain outcome, not a transport failure.
+            throwOnReceiptRevert: retry ? false : throwOnReceiptRevert,
+            timeout: parameters.timeout,
+          })) as never
+
+        nonceManagerParameters = undefined
+        if (account.nonceManager && typeof nonce === 'undefined') {
+          const requestChainId = (rest as unknown as { chainId?: number })
+            .chainId
+          const chainId = await (async () => {
+            if (typeof requestChainId === 'number') return requestChainId
+            if (chain) return chain.id
+            return getAction(client_, getChainId, 'getChainId')({})
+          })()
+          nonceManagerParameters = { address: account.address, chainId }
+        }
+
+        // Prepare the request for signing (assign appropriate fees, etc.)
+        const request = await getAction(
+          client_,
+          prepareTransactionRequest,
+          'prepareTransactionRequest',
+        )({
+          account,
+          accessList,
+          authorizationList,
+          blobs,
+          chain,
+          data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
+          gas,
+          gasPrice,
+          maxFeePerBlobGas,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          nonce,
+          nonceManager: account.nonceManager,
+          parameters: [...defaultParameters, 'sidecars'],
+          type,
+          value,
+          ...rest,
+          to,
+        } as any)
+
+        const serializer = chain?.serializers?.transaction
+        const serializedTransaction = (await account.signTransaction(
+          request as never,
+          {
+            serializer,
+          },
+        )) as Hash
+        try {
+          return (await getAction(
+            client_,
+            sendRawTransactionSync,
+            'sendRawTransactionSync',
+          )({
+            serializedTransaction,
+            // When retrying against fallback transports, the revert check is
+            // handled outside the retry loop (see below): a reverted receipt
+            // is an on-chain outcome, not a transport failure.
+            throwOnReceiptRevert: retry ? false : throwOnReceiptRevert,
+            timeout: parameters.timeout,
+          })) as never
+        } catch (err) {
+          // A node that responds with a JSON-RPC error has rejected the
+          // submission, so the transaction is provably not in its mempool and
+          // it is safe to re-prepare & re-sign against the next transport.
+          // Any other failure (e.g. a timeout) is ambiguous – the transaction
+          // may have been broadcast – so subsequent attempts must stick to
+          // the same signed bytes.
+          const rejected =
+            err instanceof BaseError &&
+            Boolean(
+              err.walk(
+                (error) =>
+                  error instanceof RpcRequestError ||
+                  (error instanceof RpcError &&
+                    !(error instanceof UnknownRpcError)),
+              ),
+            )
+          if (!rejected) pendingSerializedTransaction = serializedTransaction
+          throw err
+        }
       }
 
-      // Prepare the request for signing (assign appropriate fees, etc.)
-      const request = await getAction(
-        client,
-        prepareTransactionRequest,
-        'prepareTransactionRequest',
-      )({
-        account,
-        accessList,
-        authorizationList,
-        blobs,
-        chain,
-        data: dataSuffix ? concat([data ?? '0x', dataSuffix]) : data,
-        gas,
-        gasPrice,
-        maxFeePerBlobGas,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        nonce,
-        nonceManager: account.nonceManager,
-        parameters: [...defaultParameters, 'sidecars'],
-        type,
-        value,
-        ...rest,
-        to,
-      } as any)
+      // If the client is backed by a fallback transport, re-run the whole
+      // operation (nonce assignment, fee estimation, signing, submission)
+      // against one transport at a time, so a single attempt cannot observe
+      // inconsistent chain state across transports.
+      const receipt = await (async () => {
+        if (retry)
+          return await retry(async ({ index, transport }) => {
+            try {
+              return await send(
+                withRetryingTransport(client, { index, transport }) as never,
+              )
+            } catch (err) {
+              if (nonceManagerParameters) {
+                account.nonceManager?.reset(nonceManagerParameters)
+                nonceManagerParameters = undefined
+              }
+              throw err
+            }
+          })
+        return await send(client as never)
+      })()
 
-      const serializer = chain?.serializers?.transaction
-      const serializedTransaction = (await account.signTransaction(
-        request as never,
-        {
-          serializer,
-        },
-      )) as Hash
-      return (await getAction(
-        client,
-        sendRawTransactionSync,
-        'sendRawTransactionSync',
-      )({
-        serializedTransaction,
-        throwOnReceiptRevert,
-        timeout: parameters.timeout,
-      })) as never
+      // A receipt marks the transaction execution as final: a revert is an
+      // on-chain outcome, not a transport failure, so it must never trigger a
+      // fallback retry. The check therefore lives outside the retry loop.
+      if (throwOnReceiptRevert && receipt.status === 'reverted')
+        throw new TransactionReceiptRevertedError({ receipt })
+      return receipt as never
     }
 
     if (account?.type === 'smart')

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -1,18 +1,24 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { createHttpServer } from '~test/utils.js'
+import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
 import { getBlockNumber } from '../../actions/public/getBlockNumber.js'
-import { localhost } from '../../chains/index.js'
+import { sendTransaction } from '../../actions/wallet/sendTransaction.js'
+import { sendTransactionSync } from '../../actions/wallet/sendTransactionSync.js'
+import { localhost, mainnet } from '../../chains/index.js'
 import {
   InternalRpcError,
   MethodNotSupportedRpcError,
   UserRejectedRequestError,
   WalletConnectSessionSettlementError,
 } from '../../errors/rpc.js'
+import { TransactionReceiptRevertedError } from '../../errors/transaction.js'
 import { wait } from '../../utils/wait.js'
 import { createClient } from '../createClient.js'
 import { createPublicClient } from '../createPublicClient.js'
+import { createWalletClient } from '../createWalletClient.js'
 import type { Transport } from './createTransport.js'
+import { custom } from './custom.js'
 import {
   type FallbackTransport,
   fallback,
@@ -672,6 +678,25 @@ describe('request', () => {
   })
 })
 
+function getRawReceipt(status: '0x0' | '0x1') {
+  return {
+    blockHash: `0x${'22'.repeat(32)}`,
+    blockNumber: '0x1',
+    contractAddress: null,
+    cumulativeGasUsed: '0x5208',
+    effectiveGasPrice: '0x1',
+    from: `0x${'11'.repeat(20)}`,
+    gasUsed: '0x5208',
+    logs: [],
+    logsBloom: `0x${'00'.repeat(256)}`,
+    status,
+    to: `0x${'11'.repeat(20)}`,
+    transactionHash: `0x${'33'.repeat(32)}`,
+    transactionIndex: '0x0',
+    type: '0x2',
+  }
+}
+
 describe('client', () => {
   test('default', () => {
     const alchemy = http('https://alchemy.com/rpc')
@@ -811,6 +836,302 @@ describe('client', () => {
 
     expect(await getBlockNumber(client)).toBe(1n)
     expect(count).toBe(2)
+  })
+
+  test('sendTransaction (local account): re-prepares & re-signs against the next transport when a node rejects the submission', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const hash =
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+
+    const nonceRequests: string[] = []
+    const rawTransactions: Record<'a' | 'b', string[]> = { a: [], b: [] }
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        // Transport with a stale view of the chain: hands out an old nonce,
+        // then (correctly) rejects the submission.
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('a')
+              return '0x0'
+            }
+            if (method === 'eth_sendRawTransaction') {
+              rawTransactions.a.push((params as string[])[0])
+              throw { code: -32000, message: 'nonce too low' }
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('b')
+              return '0x1'
+            }
+            if (method === 'eth_sendRawTransaction') {
+              rawTransactions.b.push((params as string[])[0])
+              return hash
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    expect(
+      await sendTransaction(client, {
+        chainId: mainnet.id,
+        gas: 21_000n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        to: account.address,
+        type: 'eip1559',
+        value: 1n,
+      }),
+    ).toBe(hash)
+
+    // The operation was re-prepared against the second transport (instead of
+    // re-broadcasting the transaction signed with the first transport's stale
+    // nonce).
+    expect(nonceRequests).toEqual(['a', 'b'])
+    expect(rawTransactions.a).toHaveLength(1)
+    expect(rawTransactions.b).toHaveLength(1)
+    expect(rawTransactions.b[0]).not.toBe(rawTransactions.a[0])
+  })
+
+  test('sendTransaction (local account): re-broadcasts the same signed bytes when the submission failed ambiguously', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const hash =
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+
+    const nonceRequests: string[] = []
+    const rawTransactions: Record<'a' | 'b', string[]> = { a: [], b: [] }
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('a')
+              return '0x0'
+            }
+            if (method === 'eth_sendRawTransaction') {
+              rawTransactions.a.push((params as string[])[0])
+              // A non-JSON-RPC failure: the transaction may have reached the
+              // node regardless.
+              throw new Error('socket closed')
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('b')
+              return '0x1'
+            }
+            if (method === 'eth_sendRawTransaction') {
+              rawTransactions.b.push((params as string[])[0])
+              return hash
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    expect(
+      await sendTransaction(client, {
+        chainId: mainnet.id,
+        gas: 21_000n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+        to: account.address,
+        type: 'eip1559',
+        value: 1n,
+      }),
+    ).toBe(hash)
+
+    // The next transport must re-broadcast the exact same signed bytes: the
+    // first submission may have been broadcast despite the error, and signing
+    // a fresh transaction could get both mined.
+    expect(nonceRequests).toEqual(['a'])
+    expect(rawTransactions.a).toHaveLength(1)
+    expect(rawTransactions.b).toHaveLength(1)
+    expect(rawTransactions.b[0]).toBe(rawTransactions.a[0])
+  })
+
+  test('sendTransactionSync (local account): re-prepares & re-signs against the next transport when a node rejects the submission', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const nonceRequests: string[] = []
+    const rawTransactions: Record<'a' | 'b', string[]> = { a: [], b: [] }
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('a')
+              return '0x0'
+            }
+            if (method === 'eth_sendRawTransactionSync') {
+              rawTransactions.a.push((params as string[])[0])
+              throw { code: -32000, message: 'nonce too low' }
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('b')
+              return '0x1'
+            }
+            if (method === 'eth_sendRawTransactionSync') {
+              rawTransactions.b.push((params as string[])[0])
+              return getRawReceipt('0x1')
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    const receipt = await sendTransactionSync(client, {
+      chainId: mainnet.id,
+      gas: 21_000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      to: account.address,
+      type: 'eip1559',
+      value: 1n,
+    })
+    expect(receipt.status).toBe('success')
+
+    expect(nonceRequests).toEqual(['a', 'b'])
+    expect(rawTransactions.a).toHaveLength(1)
+    expect(rawTransactions.b).toHaveLength(1)
+    expect(rawTransactions.b[0]).not.toBe(rawTransactions.a[0])
+  })
+
+  test('sendTransactionSync (local account): re-broadcasts the same signed bytes when the submission failed ambiguously', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const nonceRequests: string[] = []
+    const rawTransactions: Record<'a' | 'b', string[]> = { a: [], b: [] }
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('a')
+              return '0x0'
+            }
+            if (method === 'eth_sendRawTransactionSync') {
+              rawTransactions.a.push((params as string[])[0])
+              throw new Error('socket closed')
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method, params }) {
+            if (method === 'eth_getTransactionCount') {
+              nonceRequests.push('b')
+              return '0x1'
+            }
+            if (method === 'eth_sendRawTransactionSync') {
+              rawTransactions.b.push((params as string[])[0])
+              return getRawReceipt('0x1')
+            }
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    const receipt = await sendTransactionSync(client, {
+      chainId: mainnet.id,
+      gas: 21_000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      to: account.address,
+      type: 'eip1559',
+      value: 1n,
+    })
+    expect(receipt.status).toBe('success')
+
+    expect(nonceRequests).toEqual(['a'])
+    expect(rawTransactions.b[0]).toBe(rawTransactions.a[0])
+  })
+
+  test('sendTransactionSync (local account): a reverted receipt is final and does not fall back to the next transport', async () => {
+    const account = privateKeyToAccount(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    )
+    const calls: Record<'a' | 'b', string[]> = { a: [], b: [] }
+
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: fallback([
+        custom({
+          async request({ method }) {
+            calls.a.push(method)
+            if (method === 'eth_getTransactionCount') return '0x0'
+            if (method === 'eth_sendRawTransactionSync')
+              // The transaction was mined, but reverted: an on-chain outcome,
+              // not a transport failure.
+              return getRawReceipt('0x0')
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+        custom({
+          async request({ method }) {
+            calls.b.push(method)
+            throw new Error(`unexpected method: ${method}`)
+          },
+        }),
+      ]),
+    })
+
+    const error = await sendTransactionSync(client, {
+      chainId: mainnet.id,
+      gas: 21_000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      throwOnReceiptRevert: true,
+      to: account.address,
+      type: 'eip1559',
+      value: 1n,
+    }).catch((error) => error)
+    expect(
+      error.walk((e: unknown) => e instanceof TransactionReceiptRevertedError),
+    ).toBeTruthy()
+
+    // The reverted transaction must not be retried (re-signed OR
+    // re-broadcast) against any other transport.
+    expect(
+      calls.a.filter((m) => m === 'eth_sendRawTransactionSync'),
+    ).toHaveLength(1)
+    expect(calls.b).toEqual([])
   })
 
   test('all error (non deterministic)', async () => {

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -34,6 +34,34 @@ export type OnResponseFn = (
   ),
 ) => void
 
+export type FallbackTransportRetryFn = <returnType>(
+  fn: (parameters: {
+    index: number
+    transport: ReturnType<Transport>
+  }) => Promise<returnType>,
+) => Promise<returnType>
+
+/**
+ * Registry mapping a fallback transport's `request` function to its
+ * operation-level retry function, so that multi-request actions (e.g.
+ * `sendTransaction` with a local account) can re-run an entire operation
+ * against each transport in turn instead of falling back per-request.
+ *
+ * Keyed by the `request` function as that is the only part of the transport
+ * an action can reach through a `Client`.
+ */
+const retryByRequest = new WeakMap<
+  ReturnType<Transport>['request'],
+  FallbackTransportRetryFn
+>()
+
+/** @internal */
+export function getFallbackTransportRetry(
+  request: ReturnType<Transport>['request'],
+): FallbackTransportRetryFn | undefined {
+  return retryByRequest.get(request)
+}
+
 type RankOptions = {
   /**
    * The polling interval (in ms) at which the ranker should ping the RPC URL.
@@ -121,6 +149,66 @@ export function fallback<const transports extends readonly Transport[]>(
 
     let onResponse: OnResponseFn = () => {}
 
+    const getTransport = (i: number) => {
+      const transport = transports[i]({
+        ...rest,
+        chain,
+        retryCount: 0,
+        timeout,
+      })
+      return {
+        ...transport,
+        async request({ method, params }: any, options?: any) {
+          try {
+            const response = await transport.request(
+              {
+                method,
+                params,
+              } as any,
+              options,
+            )
+
+            onResponse({
+              method,
+              params: params as unknown[],
+              response,
+              transport,
+              status: 'success',
+            })
+
+            return response
+          } catch (err) {
+            onResponse({
+              error: err as Error,
+              method,
+              params: params as unknown[],
+              transport,
+              status: 'error',
+            })
+
+            throw err
+          }
+        },
+      } as ReturnType<Transport>
+    }
+
+    const retry: FallbackTransportRetryFn = async (fn) => {
+      const attempt = async (i = 0): Promise<any> => {
+        try {
+          return await fn({ index: i, transport: getTransport(i) })
+        } catch (err) {
+          if (shouldThrow_(err as Error)) throw err
+
+          // If we've reached the end of the fallbacks, throw the error.
+          if (i === transports.length - 1) throw err
+
+          // Otherwise, re-run the operation against the next fallback.
+          return attempt(i + 1)
+        }
+      }
+      return attempt()
+    }
+
     const transport = createTransport(
       {
         key,
@@ -129,36 +217,13 @@ export function fallback<const transports extends readonly Transport[]>(
           let includes: boolean | undefined
 
           const fetch = async (i = 0): Promise<any> => {
-            const transport = transports[i]({
-              ...rest,
-              chain,
-              retryCount: 0,
-              timeout,
-            })
+            const transport = getTransport(i)
             try {
-              const response = await transport.request({
+              return await transport.request({
                 method,
                 params,
               } as any)
-
-              onResponse({
-                method,
-                params: params as unknown[],
-                response,
-                transport,
-                status: 'success',
-              })
-
-              return response
             } catch (err) {
-              onResponse({
-                error: err as Error,
-                method,
-                params: params as unknown[],
-                transport,
-                status: 'error',
-              })
-
               if (shouldThrow_(err as Error)) throw err
 
               // If we've reached the end of the fallbacks, throw the error.
@@ -189,6 +254,8 @@ export function fallback<const transports extends readonly Transport[]>(
         transports: transports.map((fn) => fn({ chain, retryCount: 0 })),
       },
     )
+
+    retryByRequest.set(transport.request, retry)
 
     if (rank) {
       const rankOptions = (typeof rank === 'object' ? rank : {}) as RankOptions

--- a/src/utils/withRetryingTransport.ts
+++ b/src/utils/withRetryingTransport.ts
@@ -1,0 +1,78 @@
+import type { Client } from '../clients/createClient.js'
+import type { Transport } from '../clients/transports/createTransport.js'
+import {
+  type FallbackTransportRetryFn,
+  getFallbackTransportRetry,
+} from '../clients/transports/fallback.js'
+
+/**
+ * Returns the operation-level retry function of the client's fallback
+ * transport, or `undefined` if the client is not backed by a fallback
+ * transport.
+ *
+ * @internal
+ */
+export function getFallbackRetry(
+  client: Client<Transport>,
+): FallbackTransportRetryFn | undefined {
+  return getFallbackTransportRetry(client.request)
+}
+
+/**
+ * Clones a client, pinning its `request` function to a single transport of a
+ * fallback transport. Actions invoked on the returned client are guaranteed
+ * to hit that one transport (with no per-request fallback), so a multi-step
+ * operation observes a consistent view of the chain.
+ *
+ * Note: the clone intentionally does NOT carry over decorated/extended
+ * actions. Decorated actions close over the original client (and therefore
+ * over the fallback `request`), so copying them would silently escape the
+ * pinned transport – e.g. the standard `walletActions`-decorated
+ * `prepareTransactionRequest` exists on every wallet client and would undo
+ * the pinning entirely. The trade-off is that user-provided action overrides
+ * (via `client.extend`) are bypassed while an operation is being retried
+ * against individual transports.
+ *
+ * @internal
+ */
+export function withRetryingTransport<client extends Client<Transport>>(
+  client: client,
+  {
+    index,
+    transport,
+  }: {
+    index: number
+    transport: ReturnType<Transport>
+  },
+): client {
+  const {
+    account,
+    batch,
+    cacheTime,
+    ccipRead,
+    chain,
+    dataSuffix,
+    experimental_blockTag,
+    key,
+    name,
+    pollingInterval,
+    type,
+  } = client
+
+  return {
+    account,
+    batch,
+    cacheTime,
+    ccipRead,
+    chain,
+    dataSuffix,
+    experimental_blockTag,
+    key,
+    name,
+    pollingInterval,
+    request: transport.request,
+    transport: { ...transport.config, ...transport.value },
+    type,
+    uid: `${client.uid}.${index}`,
+  } as client
+}


### PR DESCRIPTION
Fixes #4509. Reworks the approach sketched (and closed) in #4635.

### Problem

With a `fallback` transport and a local account, a single `sendTransaction` internally issues multiple requests (`eth_getTransactionCount` → `eth_estimateGas` → sign → `eth_sendRawTransaction`), but the fallback only ever falls through **per request**. Two consequences (as reported in #4509):

1. Requests of one logical operation can hit different transports with inconsistent views of the chain.
2. When a transport is healthy-but-stale (e.g. one provider lags behind after a hard fork), the stale nonce gets **baked into the signed transaction** — falling back per-request then re-broadcasts the same doomed bytes, so every transport fails with `nonce too low` and there is no way to recover without re-signing.

### Approach

Same shape as #4635: the fallback transport now exposes an operation-level retry (`getFallbackTransportRetry`, internal, keyed off the transport's `request` via a `WeakMap`), and `sendTransaction`/`sendTransactionSync` with a local account re-run the **whole operation** (nonce assignment, fee estimation, signing, submission) pinned to one transport at a time via a client clone (`withRetryingTransport`).

On top of that, two safety rules #4635 did not have — which I suspect are why it was closed:

1. **No re-signing after an ambiguous failure.** If a node *responds* with a JSON-RPC error (`nonce too low`, underpriced, …), the submission provably never entered its mempool, so the next transport safely re-prepares & re-signs. But if the submission fails **ambiguously** (timeout, socket error), the transaction may have been broadcast regardless — re-signing with a fresh nonce could get *both* transactions mined. From that point on, every remaining transport re-broadcasts the **same signed bytes** (same nonce ⇒ at most one can land). Classifier: the error's cause chain contains an `RpcRequestError`, or an `RpcError` other than `UnknownRpcError` (covers both HTTP/WebSocket and EIP-1193 `custom` transports, which surface node errors differently through `buildRequest`).
2. **A reverted receipt is final.** For `sendTransactionSync`, a receipt with `status: 'reverted'` is an on-chain outcome, not a transport failure — it must never trigger a fallback retry (nor a re-sign). The revert check is moved outside the retry loop; for non-fallback clients the original `throwOnReceiptRevert` value is passed through unchanged, so single-transport behavior (including custom `sendRawTransactionSync` overrides) is untouched.

Behavior for everything else is unchanged: JSON-RPC accounts, single (non-fallback) transports, and per-request fallback for all other actions work exactly as before.

### Known trade-off

The pinned client clone intentionally does **not** carry over decorated/extended actions: decorated actions close over the original client (and thus over the fallback `request`), so copying them would silently escape the pinned transport — e.g. the standard `walletActions`-decorated `prepareTransactionRequest` exists on every wallet client and would undo the pinning entirely. The cost is that user-provided action overrides (via `client.extend`) are bypassed *while an operation is being retried against individual transports* (same trade-off as #4635; documented in `withRetryingTransport`). Happy to rework if you have a preferred way to thread pinning through decorated actions.

### Tests

Five new tests in `fallback.test.ts` (runnable without anvil via `SKIP_GLOBAL_SETUP=1 vitest run -c ./test/vitest.config.ts --project core src/clients/transports/fallback.test.ts`):

- `sendTransaction` / `sendTransactionSync`: node rejection → next transport re-fetches the nonce and the re-signed bytes differ.
- `sendTransaction` / `sendTransactionSync`: ambiguous failure → next transport receives byte-identical signed bytes and the nonce is never re-fetched.
- `sendTransactionSync`: a reverted receipt throws `TransactionReceiptRevertedError` (wrapped as before) and the second transport is never called.

All 25 pre-existing `fallback.test.ts` tests pass unchanged, `tsc` and biome are clean, and a changeset is included.
