### PR TITLE
test(tempo): skip unconfigured local zone tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,5 @@ VITE_TEMPO_CREDENTIALS=                     # credentials for Tempo RPCs. format
 VITE_TEMPO_ENV=localnet                     # node environment. values: localnet|devnet|testnet
 VITE_TEMPO_LOG=false                        # whether to enable logs, if VITE_TEMPO_ENV=localnet. values: true|debug|error|trace|warn|info
 VITE_TEMPO_TAG=latest                       # docker image tag, if VITE_TEMPO_ENV=localnet.
+VITE_TEMPO_ZONES=false                      # whether to run local Zone tests. values: true|false
 VITE_TEMPO_HTTP_LOG=false                   # whether to enable logs on HTTP RPC requests. values: true|false

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -1,6 +1,10 @@
 import { join } from 'node:path'
 import { defineConfig, type TestProjectConfiguration } from 'vitest/config'
 
+const zoneNodeConfigured =
+  (process.env.VITE_TEMPO_ENV || 'localnet') !== 'localnet' ||
+  process.env.VITE_TEMPO_ZONES === 'true'
+
 export default defineConfig({
   test: {
     alias: [
@@ -72,6 +76,7 @@ export default defineConfig({
         extends: true,
         test: {
           name: 'tempo',
+          exclude: [zoneNodeConfigured ? '' : 'src/tempo/actions/zone.test.ts'],
           include: ['src/tempo/**/*.test.ts'],
           setupFiles: [join(__dirname, './src/tempo/setup.ts')],
           globalSetup: [join(__dirname, './src/tempo/setup.global.ts')],


### PR DESCRIPTION
Skip local Tempo Zone action tests unless `VITE_TEMPO_ZONES=true`, while retaining deployed-environment coverage. This avoids unavailable private image pulls until the Zone image is public.
