### PR TITLE
refactor(tempo): use `prepareTransactionRequest` for withdrawals

### DIFF
--- a/.changeset/tempo-zone-sdk-helpers.md
+++ b/.changeset/tempo-zone-sdk-helpers.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Added Tempo Zone helpers for preparing encrypted deposit recipients and withdrawals without broadcasting. Zone withdrawal actions now use `callbackGas` for the parent-chain callback limit, leaving `gas` for the Zone transaction limit.
+Added Tempo Zone helpers for preparing encrypted deposit recipients and withdrawal requests with normalized details, maximum fees, and distinct callback and Zone transaction gas limits.

--- a/site/pages/tempo/actions/zone.requestWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestWithdrawal.mdx
@@ -48,7 +48,9 @@ const receipt = await client.waitForTransactionReceipt({ hash })
 
 ### Prepare a Withdrawal
 
-Use `zone.requestWithdrawal.prepare` to inspect the calls and protocol withdrawal fee without broadcasting. Set `estimateTransactionFee` to also estimate the Zone transaction fee.
+Use `zone.requestWithdrawal.prepare` to populate and inspect the Zone transaction request without broadcasting. The result includes the request, normalized withdrawal details, and a `maxFee` rounded up into fee-token base units using Tempo's fixed gas-price conversion.
+
+Use [`zone.getWithdrawalFee`](/tempo/actions/zone.getWithdrawalFee) separately to inspect the protocol withdrawal fee.
 
 ```ts twoslash
 import { parseUnits } from 'viem'
@@ -60,7 +62,25 @@ const prepared = await client.zone.requestWithdrawal.prepare({
   token: '0x20c0000000000000000000000000000000000001',
 })
 
-console.log('Total fee:', prepared.totalFee)
+console.log('Maximum fee:', prepared.maxFee)
+console.log('Gas limit:', prepared.request.gas)
+console.log('Calls:', prepared.request.calls)
+```
+
+The prepare helper returns:
+
+```ts
+type PreparedWithdrawal = {
+  amount: bigint
+  callbackGas: bigint
+  data: Hex
+  fallbackRecipient: Address
+  maxFee: bigint
+  memo: Hex
+  request: PrepareTransactionRequestReturnType
+  to: Address
+  token: Address | bigint
+}
 ```
 
 ## Return Type

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -5036,9 +5036,25 @@ type DecoratorBase<
      * @param parameters - Parameters.
      * @returns The transaction hash.
      */
-    requestWithdrawal: (
+    requestWithdrawal: ((
       parameters: zoneActions.requestWithdrawal.Parameters<chain, account>,
-    ) => Promise<zoneActions.requestWithdrawal.ReturnValue>
+    ) => Promise<zoneActions.requestWithdrawal.ReturnValue>) & {
+      prepare: (
+        parameters: zoneActions.requestWithdrawal.prepare.Parameters<
+          chain,
+          account,
+          undefined,
+          undefined
+        >,
+      ) => Promise<
+        zoneActions.requestWithdrawal.prepare.ReturnType<
+          chain,
+          account,
+          undefined,
+          undefined
+        >
+      >
+    }
     /**
      * Requests a withdrawal and waits for the transaction receipt.
      *

--- a/src/tempo/actions/zone.test-d.ts
+++ b/src/tempo/actions/zone.test-d.ts
@@ -1,18 +1,28 @@
 import { expectTypeOf, test } from 'vitest'
+import { sendTransaction } from '../../actions/wallet/sendTransaction.js'
 import { tempoModerato } from '../../chains/index.js'
 import { createClient } from '../../clients/createClient.js'
 import { custom } from '../../clients/transports/custom.js'
+import { decorator } from '../Decorator.js'
+import { zoneModerato } from '../zones/index.js'
 import * as zoneActions from './zone.js'
 
+const transport = custom({
+  async request() {
+    return null
+  },
+})
 const client = createClient({
   account: '0x0000000000000000000000000000000000000001',
   chain: tempoModerato,
-  transport: custom({
-    async request() {
-      return null
-    },
-  }),
+  transport,
 })
+const zoneClient = createClient({
+  account: '0x0000000000000000000000000000000000000001',
+  chain: zoneModerato(7),
+  transport,
+})
+const decoratedZoneClient = zoneClient.extend(decorator())
 
 test('encryptedDeposit.prepare returns a reusable encrypted deposit payload', async () => {
   const prepared = await zoneActions.encryptedDeposit.prepare(client, {
@@ -47,36 +57,56 @@ test('encryptedDeposit.prepareRecipient returns reusable encrypted recipient dat
   ).toEqualTypeOf<zoneActions.PreparedEncryptedDepositRecipient>()
 })
 
-test('requestWithdrawal.prepare returns calls and fee details', async () => {
-  const prepared = await zoneActions.requestWithdrawal.prepare(client, {
+test('requestWithdrawal.prepare returns a request, maximum fee, and details', async () => {
+  const prepared = await zoneActions.requestWithdrawal.prepare(zoneClient, {
     token: '0x20c0000000000000000000000000000000000000',
     amount: 1n,
     callbackGas: 10_000_000n,
     to: '0x0000000000000000000000000000000000000001',
-    estimateTransactionFee: true,
-    transactionFeeScale: 1_000_000_000_000n,
   })
 
-  expectTypeOf(
-    prepared,
-  ).toEqualTypeOf<zoneActions.requestWithdrawal.prepare.ReturnType>()
+  expectTypeOf(prepared).toEqualTypeOf<
+    zoneActions.requestWithdrawal.prepare.ReturnType<
+      (typeof zoneClient)['chain'],
+      (typeof zoneClient)['account'],
+      undefined,
+      undefined
+    >
+  >()
+  expectTypeOf(prepared.request.type).toEqualTypeOf<'tempo'>()
+  expectTypeOf(prepared.request.gas).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.request.nonce).toEqualTypeOf<number>()
+  expectTypeOf(prepared.request.maxFeePerGas).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.request.maxPriorityFeePerGas).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.maxFee).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.amount).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.callbackGas).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared).not.toHaveProperty('totalFee')
+  expectTypeOf(prepared).not.toHaveProperty('transactionFee')
+  expectTypeOf(prepared).not.toHaveProperty('withdrawalFee')
+  expectTypeOf(prepared).not.toHaveProperty('estimatedGas')
 
-  // @ts-expect-error transactionFeeScale is required when estimating.
-  await zoneActions.requestWithdrawal.prepare(client, {
-    token: '0x20c0000000000000000000000000000000000000',
-    amount: 1n,
-    to: '0x0000000000000000000000000000000000000001',
-    estimateTransactionFee: true,
-  })
+  await sendTransaction(zoneClient, prepared.request)
 })
 
 test('withdrawal callback gas is distinct from transaction gas', async () => {
-  await zoneActions.requestWithdrawal(client, {
+  await zoneActions.requestWithdrawal(zoneClient, {
     token: '0x20c0000000000000000000000000000000000000',
     amount: 1n,
     callbackGas: 10_000_000n,
     gas: 1_000_000n,
   })
+})
+
+test('decorated requestWithdrawal.prepare preserves client types', async () => {
+  const prepared = await decoratedZoneClient.zone.requestWithdrawal.prepare({
+    amount: 1n,
+    token: '0x20c0000000000000000000000000000000000000',
+  })
+
+  expectTypeOf(prepared.maxFee).toEqualTypeOf<bigint>()
+  expectTypeOf(prepared.request.type).toEqualTypeOf<'tempo'>()
+  await sendTransaction(zoneClient, prepared.request)
 })
 
 test('encryptedDeposit still accepts plaintext parameters', async () => {

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -782,10 +782,11 @@ describe('requestWithdrawal', () => {
     expect(call.args[4]).toBe(10_000_000n)
   })
 
-  test('behavior: prepares a withdrawal without broadcasting', async () => {
+  test('behavior: prepares a withdrawal transaction request and maximum fee', async () => {
     await zoneActions.signAuthorizationToken(zoneClient, { zoneId })
     const info = await zoneActions.getZoneInfo(zoneClient)
     const zoneToken = info.zoneTokens[0]!
+    await ensureZoneBalance(zoneToken, 1n)
 
     const prepared = await zoneActions.requestWithdrawal.prepare(zoneClient, {
       amount: 1n,
@@ -793,9 +794,40 @@ describe('requestWithdrawal', () => {
       token: zoneToken,
     })
 
-    expect(prepared.calls).toHaveLength(2)
-    expect(prepared.callbackGas).toBe(100_000n)
-    expect(prepared.totalFee).toBe(prepared.withdrawalFee)
+    expect(prepared).toMatchObject({
+      amount: 1n,
+      callbackGas: 100_000n,
+      data: '0x',
+      fallbackRecipient: account.address,
+      memo: zeroHash,
+      to: account.address,
+      token: zoneToken,
+    })
+    expect(prepared.request.calls).toHaveLength(2)
+    expect(prepared.request.type).toBe('tempo')
+    expect(prepared.request.gas).toBeGreaterThan(0n)
+    const denominator = 1_000_000_000_000n
+    expect(prepared.maxFee).toBe(
+      (prepared.request.gas * prepared.request.maxFeePerGas +
+        denominator -
+        1n) /
+        denominator,
+    )
+    const withdrawalCall = prepared.request.calls?.[1]
+    if (!withdrawalCall?.data)
+      throw new Error('Prepared withdrawal call is unavailable.')
+    const decoded = decodeFunctionData({
+      abi: ZoneAbis.zoneOutbox,
+      data: withdrawalCall.data,
+    })
+    expect(decoded.functionName).toBe('requestWithdrawal')
+    if (decoded.functionName !== 'requestWithdrawal')
+      throw new Error('Unexpected prepared withdrawal call.')
+    expect(decoded.args[4]).toBe(100_000n)
+    expect(prepared).not.toHaveProperty('totalFee')
+    expect(prepared).not.toHaveProperty('transactionFee')
+    expect(prepared).not.toHaveProperty('withdrawalFee')
+    expect(prepared).not.toHaveProperty('estimatedGas')
   })
 
   test('behavior: requests withdrawal without waiting', async () => {

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -7,19 +7,17 @@ import { TokenId, ZoneId, ZoneRpcAuthentication } from 'ox/tempo'
 import type { Account } from '../../accounts/types.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import {
-  type EstimateGasErrorType,
-  estimateGas,
-} from '../../actions/public/estimateGas.js'
-import {
-  type GetGasPriceErrorType,
-  getGasPrice,
-} from '../../actions/public/getGasPrice.js'
-import {
   type MulticallErrorType,
   type MulticallParameters,
   multicall,
 } from '../../actions/public/multicall.js'
 import { readContract } from '../../actions/public/readContract.js'
+import {
+  type PrepareTransactionRequestErrorType,
+  type PrepareTransactionRequestRequest,
+  type PrepareTransactionRequestReturnType,
+  prepareTransactionRequest,
+} from '../../actions/wallet/prepareTransactionRequest.js'
 import {
   type SendTransactionReturnType,
   sendTransaction,
@@ -29,7 +27,7 @@ import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { zeroHash } from '../../constants/bytes.js'
 import type { BaseErrorType } from '../../errors/base.js'
-import type { Chain } from '../../types/chain.js'
+import type { Chain, GetChainParameter } from '../../types/chain.js'
 import type { Compute, UnionOmit } from '../../types/utils.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
@@ -1397,11 +1395,10 @@ export namespace requestWithdrawal {
   }
 
   /**
-   * Prepares a zone withdrawal without broadcasting it.
+   * Prepares a zone withdrawal transaction request without broadcasting it.
    *
-   * Use this to inspect the ZoneOutbox calls and fees before submitting a
-   * withdrawal. When `estimateTransactionFee` is enabled, viem also estimates
-   * the zone transaction gas and converts it with `transactionFeeScale`.
+   * Use this to inspect or modify the populated ZoneOutbox transaction request
+   * and its maximum transaction fee before submitting a withdrawal.
    *
    * @example
    * ```ts
@@ -1419,30 +1416,40 @@ export namespace requestWithdrawal {
    *   amount: 1_000_000n,
    *   to: '0x...',
    * })
+   *
+   * console.log(prepared.maxFee)
+   * console.log(prepared.request.gas)
    * ```
    *
    * @param client - Zone client.
    * @param parameters - Withdrawal preparation parameters.
-   * @returns Prepared calls and fee details.
+   * @returns The prepared transaction request, maximum fee, and withdrawal details.
    */
   export async function prepare<
     chain extends Chain | undefined,
     account extends Account | undefined,
+    chainOverride extends Chain | undefined = undefined,
+    accountOverride extends Account | Address | undefined = undefined,
   >(
     client: Client<Transport, chain, account>,
-    parameters: prepare.Parameters<chain, account>,
-  ): Promise<prepare.ReturnType> {
+    parameters: prepare.Parameters<
+      chain,
+      account,
+      chainOverride,
+      accountOverride
+    >,
+  ): Promise<
+    prepare.ReturnType<chain, account, chainOverride, accountOverride>
+  > {
     const {
       account = client.account,
       amount,
       callbackGas = 0n,
       data = '0x',
-      estimateTransactionFee = false,
       fallbackRecipient,
       memo = zeroHash,
       to: to_,
       token,
-      transactionFeeScale,
       ...transactionRequest
     } = parameters
 
@@ -1450,115 +1457,97 @@ export namespace requestWithdrawal {
     const to = to_ ?? account_?.address
     if (!to) throw new Error('`to` is required.')
 
-    const calls = requestWithdrawal.calls({
-      amount,
-      callbackGas,
-      data,
-      fallbackRecipient,
-      memo,
-      to,
-      token,
-    })
-
-    const transactionEstimatePromise = estimateTransactionFee
-      ? (async () => {
-          if (!account) throw new Error('`account` is required.')
-          if (transactionFeeScale === undefined)
-            throw new Error(
-              '`transactionFeeScale` is required when `estimateTransactionFee` is `true`.',
-            )
-
-          const [estimatedGas, gasPrice] = await Promise.all([
-            estimateGas(client, {
-              ...transactionRequest,
-              account,
-              calls,
-              prepare: false,
-            } as never),
-            getGasPrice(client),
-          ])
-          return {
-            estimatedGas,
-            gasPrice,
-            transactionFee: ceilDiv(
-              estimatedGas * gasPrice,
-              transactionFeeScale,
-            ),
-          }
-        })()
-      : Promise.resolve(undefined)
-
-    const [transactionEstimate, withdrawalFee] = await Promise.all([
-      transactionEstimatePromise,
-      getWithdrawalFee(client, { callbackGas }),
-    ])
+    const request = await prepareTransactionRequest(client, {
+      ...transactionRequest,
+      account,
+      calls: requestWithdrawal.calls({
+        amount,
+        callbackGas,
+        data,
+        fallbackRecipient,
+        memo,
+        to,
+        token,
+      }),
+    } as never)
+    const feePerGas = request.maxFeePerGas ?? request.gasPrice
+    if (typeof request.gas !== 'bigint' || typeof feePerGas !== 'bigint')
+      throw new Error('Prepared transaction fee parameters are unavailable.')
+    const maxFee = ceilDiv(request.gas * feePerGas, 1_000_000_000_000n)
 
     return {
+      request,
+      maxFee,
       amount,
       callbackGas,
-      calls,
       data,
-      estimatedGas: transactionEstimate?.estimatedGas,
       fallbackRecipient: fallbackRecipient ?? to,
-      gasPrice: transactionEstimate?.gasPrice,
       memo,
       to,
       token,
-      totalFee: withdrawalFee + (transactionEstimate?.transactionFee ?? 0n),
-      transactionFee: transactionEstimate?.transactionFee,
-      withdrawalFee,
-    }
+    } as never
   }
 
   export namespace prepare {
     export type Parameters<
       chain extends Chain | undefined = Chain | undefined,
       account extends Account | undefined = Account | undefined,
+      chainOverride extends Chain | undefined = Chain | undefined,
+      accountOverride extends Account | Address | undefined =
+        | Account
+        | Address
+        | undefined,
     > = UnionOmit<
       WriteParameters<chain, account>,
-      'account' | 'throwOnReceiptRevert'
+      'account' | 'chain' | 'throwOnReceiptRevert'
     > &
-      GetAccountParameter<account, Account | Address, false> &
+      GetAccountParameter<account, accountOverride, false> &
+      GetChainParameter<chain, chainOverride> &
       PrepareArgs
 
     export type PrepareArgs = Omit<Args, 'to'> & {
       /** Recipient address on the parent Tempo chain. @default `account.address` */
       to?: Address | undefined
-    } & (
-        | {
-            /** Whether to estimate and include the zone transaction fee. @default false */
-            estimateTransactionFee?: false | undefined
-            transactionFeeScale?: undefined
-          }
-        | {
-            /** Whether to estimate and include the zone transaction fee. */
-            estimateTransactionFee: true
-            /** Divisor converting `estimatedGas * gasPrice` into fee-token base units. */
-            transactionFeeScale: bigint
-          }
-      )
+    }
 
-    export type ReturnType = Compute<{
+    export type ReturnType<
+      chain extends Chain | undefined = Chain | undefined,
+      account extends Account | undefined = Account | undefined,
+      chainOverride extends Chain | undefined = Chain | undefined,
+      accountOverride extends Account | Address | undefined =
+        | Account
+        | Address
+        | undefined,
+    > = Compute<{
+      /** Amount of tokens to withdraw. */
       amount: bigint
+      /** Gas limit reserved for the callback on the parent chain. */
       callbackGas: bigint
-      calls: WithdrawalCalls
+      /** Callback data for the recipient. */
       data: Hex.Hex
-      estimatedGas?: bigint | undefined
+      /** Fallback address if the callback fails. */
       fallbackRecipient: Address
-      gasPrice?: bigint | undefined
+      /** Maximum Zone transaction fee in fee-token base units. */
+      maxFee: bigint
+      /** Withdrawal memo. */
       memo: Hex.Hex
+      /** Prepared Zone transaction request. */
+      request: PrepareTransactionRequestReturnType<
+        chain,
+        account,
+        chainOverride,
+        accountOverride,
+        PrepareTransactionRequestRequest<chain, chainOverride> & {
+          calls: WithdrawalCalls
+        }
+      >
+      /** Recipient address on the parent Tempo chain. */
       to: Address
+      /** Token address or ID to withdraw. */
       token: TokenId.TokenIdOrAddress
-      totalFee: bigint
-      transactionFee?: bigint | undefined
-      withdrawalFee: bigint
     }>
 
-    export type ErrorType =
-      | EstimateGasErrorType
-      | GetGasPriceErrorType
-      | getWithdrawalFee.ErrorType
-      | BaseErrorType
+    export type ErrorType = PrepareTransactionRequestErrorType | BaseErrorType
   }
 }
 
@@ -2019,6 +2008,5 @@ function buildDepositHkdfInfo(
 }
 
 function ceilDiv(numerator: bigint, denominator: bigint) {
-  if (denominator <= 0n) throw new Error('`denominator` must be positive.')
   return (numerator + denominator - 1n) / denominator
 }

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -1476,13 +1476,13 @@ export namespace requestWithdrawal {
     const maxFee = ceilDiv(request.gas * feePerGas, 1_000_000_000_000n)
 
     return {
-      request,
-      maxFee,
       amount,
       callbackGas,
       data,
       fallbackRecipient: fallbackRecipient ?? to,
+      maxFee,
       memo,
+      request,
       to,
       token,
     } as never


### PR DESCRIPTION
Refactors `requestWithdrawal.prepare` around `prepareTransactionRequest`, returning the reusable request, normalized withdrawal details, and canonical maximum fee. Replaces bespoke fee estimation from https://github.com/wevm/viem/pull/4813.
