### PR TITLE
test(tempo): enable zone tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -171,6 +171,38 @@ jobs:
           VITE_TEMPO_CREDENTIALS: ${{ secrets.VITE_TEMPO_CREDENTIALS }}
           VITE_TEMPO_ENV: ${{ matrix.node-env }}
 
+  test-tempo-zones:
+    name: Test Local Tempo Zones
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Build contracts
+        run: pnpm contracts:build
+
+      - name: Run tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: pnpm test --run --bail=1 --project tempo src/tempo/actions/zone.test.ts
+        env:
+          CI: true
+          VITE_TEMPO_ENV: localnet
+          VITE_TEMPO_TAG: latest
+          VITE_TEMPO_ZONES: 'true'
+          VITE_TEMPO_ZONE_TAG: latest
+
   test-envs:
     name: Test Environments
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "micro-eth-signer": "^0.14.0",
     "ox": "0.14.30",
     "permissionless": "^0.2.57",
-    "prool": "~0.2.7",
+    "prool": "~0.2.8",
     "publint": "^0.2.12",
     "sherif": "^0.8.4",
     "simple-git-hooks": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,8 +159,8 @@ importers:
         specifier: ^0.2.57
         version: 0.2.57(ox@0.14.30(typescript@5.9.3)(zod@4.4.3))
       prool:
-        specifier: ~0.2.7
-        version: 0.2.7(@pimlico/alto@0.0.18(typescript@5.9.3))(testcontainers@11.10.0)
+        specifier: ~0.2.8
+        version: 0.2.8(@pimlico/alto@0.0.18(typescript@5.9.3))(testcontainers@11.10.0)
       publint:
         specifier: ^0.2.12
         version: 0.2.12
@@ -5839,8 +5839,8 @@ packages:
     resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
     engines: {node: '>=10'}
 
-  prool@0.2.7:
-    resolution: {integrity: sha512-j59JXGPs6cvib2hM9PFcXSP6U6ZoVYE+OaYt1G+15J08Tc3knV7RidPCim7KabtPSe8oB0wj014MWr2tcWBI9w==}
+  prool@0.2.8:
+    resolution: {integrity: sha512-VJXscto4WK/pISa5QvvXE0DEbbOA3vDuEXa2I27gGyqwUQZt3KnfkuzxqJ2sLqR7qm6vXg3NS2sZCXJRkmqfqQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@pimlico/alto': '*'
@@ -13280,7 +13280,7 @@ snapshots:
     dependencies:
       tdigest: 0.1.2
 
-  prool@0.2.7(@pimlico/alto@0.0.18(typescript@5.9.3))(testcontainers@11.10.0):
+  prool@0.2.8(@pimlico/alto@0.0.18(typescript@5.9.3))(testcontainers@11.10.0):
     dependencies:
       change-case: 5.4.4
       eventemitter3: 5.0.4

--- a/test/src/tempo/prool.ts
+++ b/test/src/tempo/prool.ts
@@ -48,7 +48,8 @@ export async function createServer() {
   })()
 
   const args = {
-    blockTime: '2ms',
+    // Match Tempo's production cadence when Zone consumes every L1 block.
+    blockTime: import.meta.env.VITE_TEMPO_ZONES === 'true' ? '500ms' : '2ms',
     log: import.meta.env.VITE_TEMPO_LOG,
     port,
   } satisfies Instance.tempo.Parameters
@@ -143,8 +144,7 @@ async function startZone(
   if (nodeEnv !== 'localnet')
     throw new Error('Local zones require `VITE_TEMPO_ENV=localnet`.')
 
-  // TODO: default to `latest` once tempoxyz/zones#610 merges.
-  const tag = import.meta.env.VITE_TEMPO_ZONE_TAG ?? 'sha-aae82c4'
+  const tag = import.meta.env.VITE_TEMPO_ZONE_TAG ?? 'latest'
 
   // The zone container reaches this worker's L1 through the prool server
   // (`host.docker.internal` resolves to the host; the server proxies WS).


### PR DESCRIPTION
Runs Tempo Zone tests in dedicated CI with the public image and compatible L1 cadence, backed by `prool` 0.2.8 container readiness.
