### PR TITLE
fix: bind `prepareRecipient` helper

### DIFF
--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -350,9 +350,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Binds an action function to a `client`, returning a parameter-only version
  * along with any helpers the action exposes. Helpers that need a client
  * (`.call`, `.calls`, `.callWithPeriod`, `.estimateGas`, `.prepare`,
- * `.simulate`) are bound to `client`; pure helpers (`.extractEvent`,
- * `.extractEvents`) are copied as-is. Used by decorators that attach
- * namespaced actions to a Client.
+ * `.prepareRecipient`, `.simulate`) are bound to `client`; pure helpers
+ * (`.extractEvent`, `.extractEvents`) are copied as-is. Used by decorators
+ * that attach namespaced actions to a Client.
  * @internal
  */
 export function bindActionDecorators(
@@ -366,6 +366,7 @@ export function bindActionDecorators(
     'callWithPeriod',
     'estimateGas',
     'prepare',
+    'prepareRecipient',
     'simulate',
   ] as const)
     if (Object.hasOwn(action, key)) {


### PR DESCRIPTION
Bind `prepareRecipient` alongside other client-aware action helpers. The Tempo decorator now exposes the runtime function already promised by its type instead of returning `undefined`.
