### PR TITLE
fix(abi): do not trim leading zero bytes when decoding strings

### DIFF
--- a/.changeset/decode-string-leading-zero-bytes.md
+++ b/.changeset/decode-string-leading-zero-bytes.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `decodeAbiParameters` silently corrupting `string` values whose UTF-8 payload begins with one or more NUL (`0x00`) bytes. The dynamic `string` decoder was left-trimming the payload, dropping leading zero bytes; since the ABI length prefix is authoritative, the payload is now decoded as-is. This also makes `string` decoding consistent with `bytes`.

--- a/.changeset/decode-string-leading-zero-bytes.md
+++ b/.changeset/decode-string-leading-zero-bytes.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Fixed `decodeAbiParameters` silently corrupting `string` values whose UTF-8 payload begins with one or more NUL (`0x00`) bytes. The dynamic `string` decoder was left-trimming the payload, dropping leading zero bytes; since the ABI length prefix is authoritative, the payload is now decoded as-is. This also makes `string` decoding consistent with `bytes`.
+Fixed `decodeAbiParameters` to preserve leading NUL bytes when decoding `string` values.

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -466,6 +466,28 @@ describe('dynamic', () => {
       `,
       )
     })
+
+    test('leading zero bytes (round-trip)', () => {
+      // The ABI length prefix is authoritative, so leading NUL (0x00) bytes
+      // of a string payload must be preserved, not trimmed.
+      for (const value of ['\x00ab', '\x00\x00x', 'a\x00b', '\x00']) {
+        expect(
+          decodeAbiParameters(
+            parseAbiParameters('string'),
+            encodeAbiParameters(parseAbiParameters('string'), [value]),
+          ),
+        ).toEqual([value])
+      }
+    })
+
+    test('leading zero bytes (hand-crafted)', () => {
+      // offset 0x20, length 3, payload 0x00 'a' 'b' right-padded.
+      const result = decodeAbiParameters(
+        parseAbiParameters('string'),
+        '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030061620000000000000000000000000000000000000000000000000000000000',
+      )
+      expect(result).toEqual(['\x00ab'])
+    })
   })
 
   describe('string,uint,bool', () => {

--- a/src/utils/abi/decodeAbiParameters.ts
+++ b/src/utils/abi/decodeAbiParameters.ts
@@ -22,7 +22,6 @@ import {
 } from '../cursor.js'
 import { type SizeErrorType, size } from '../data/size.js'
 import { type SliceBytesErrorType, sliceBytes } from '../data/slice.js'
-import type { TrimErrorType } from '../data/trim.js'
 import {
   type BytesToBigIntErrorType,
   type BytesToBoolErrorType,
@@ -355,7 +354,6 @@ function decodeTuple(
 type DecodeStringErrorType =
   | BytesToNumberErrorType
   | BytesToStringErrorType
-  | TrimErrorType
   | ErrorType
 
 function decodeString(

--- a/src/utils/abi/decodeAbiParameters.ts
+++ b/src/utils/abi/decodeAbiParameters.ts
@@ -22,7 +22,7 @@ import {
 } from '../cursor.js'
 import { type SizeErrorType, size } from '../data/size.js'
 import { type SliceBytesErrorType, sliceBytes } from '../data/slice.js'
-import { type TrimErrorType, trim } from '../data/trim.js'
+import type { TrimErrorType } from '../data/trim.js'
 import {
   type BytesToBigIntErrorType,
   type BytesToBoolErrorType,
@@ -378,7 +378,7 @@ function decodeString(
   }
 
   const data = cursor.readBytes(length, 32)
-  const value = bytesToString(trim(data))
+  const value = bytesToString(data)
 
   // As we have gone wondering, restore to the original position + next slot.
   cursor.setPosition(staticPosition + 32)


### PR DESCRIPTION
### Summary

The dynamic `string` decoder in `decodeAbiParameters` silently corrupts any decoded `string` whose UTF-8 encoding begins with one or more NUL (`0x00`) bytes.

In `decodeString` (`src/utils/abi/decodeAbiParameters.ts`), the payload is read with:

```ts
const data = cursor.readBytes(length, 32)   // exactly `length` UTF-8 bytes, no left padding
const value = bytesToString(trim(data))
```

`trim` defaults to `dir: 'left'`, so it strips leading `0x00` bytes from `data`. Since the ABI length prefix is authoritative and the payload has no left padding, this trim is unnecessary and drops the leading NUL byte(s) with no error. The corruption propagates through `decodeFunctionResult`, `readContract`, event/error decoding, etc.

Dynamic `bytes` (`decodeBytes`, same file) does **not** trim, so `string` and `bytes` decode inconsistently for identical payloads.

### Failing scenario

Decoding the ABI encoding of the `string` value `"\x00ab"` (payload bytes `00 61 62`; head/tail = offset `0x20`, length `3`, data word `0061620000…`) returns `"ab"` instead of `"\x00ab"`. Likewise `"\x00\x00x"` decodes to `"x"`. Round-tripping `encodeAbiParameters` -> `decodeAbiParameters` fails for these leading-NUL strings.

Interior NULs (`"a\x00b"`), a lone `"\x00"`, and all normal ASCII strings are unaffected, which is why no existing test vector caught this.

### Fix

Decode the payload as-is; the length prefix already delimits it exactly:

```ts
const value = bytesToString(data)
```

This preserves leading NUL bytes and makes `string` decoding consistent with `bytes`. The now-unused runtime `trim` import is dropped (the `TrimErrorType` type is still referenced by `DecodeStringErrorType`).

### Tests

Adds a regression test in `decodeAbiParameters.test.ts`: a round-trip over `["\x00ab", "\x00\x00x", "a\x00b", "\x00"]` and a hand-crafted hex decode asserting `"\x00ab"`. Both fail on the current code and pass with the fix; the existing ASCII string tests are unchanged.
