### PR TITLE
Update EDU Chain mainnet and testnet

### DIFF
--- a/.changeset/lovely-meals-tickle.md
+++ b/.changeset/lovely-meals-tickle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated EDU Chain and EDU Chain Testnet RPC URLs, block explorer URLs, and added multicall3 contract to EDU Chain mainnet

--- a/src/chains/definitions/eduChain.ts
+++ b/src/chains/definitions/eduChain.ts
@@ -10,13 +10,19 @@ export const eduChain = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.edu-chain.raas.gelato.cloud'],
+      http: ['https://rpc.educhain.xyz'],
     },
   },
   blockExplorers: {
     default: {
       name: 'EDU Chain Explorer',
-      url: 'https://educhain.blockscout.com/',
+      url: 'https://explorer.educhain.xyz/',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 16410660,
     },
   },
   testnet: false,

--- a/src/chains/definitions/eduChain.ts
+++ b/src/chains/definitions/eduChain.ts
@@ -11,6 +11,7 @@ export const eduChain = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://rpc.educhain.xyz'],
+      webSocket: ['wss://ws.rpc.educhain.xyz'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/eduChain.ts
+++ b/src/chains/definitions/eduChain.ts
@@ -11,7 +11,7 @@ export const eduChain = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://rpc.educhain.xyz'],
-      webSocket: ['wss://ws.rpc.educhain.xyz'],
+      webSocket: ['wss://rpc.educhain.xyz'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/eduChainTestnet.ts
+++ b/src/chains/definitions/eduChainTestnet.ts
@@ -11,7 +11,7 @@ export const eduChainTestnet = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://rpc.testnet.educhain.xyz'],
-      webSocket: ['wss://ws.rpc.testnet.educhain.xyz'],
+      webSocket: ['wss://rpc.testnet.educhain.xyz'],
     },
   },
   blockExplorers: {

--- a/src/chains/definitions/eduChainTestnet.ts
+++ b/src/chains/definitions/eduChainTestnet.ts
@@ -10,15 +10,14 @@ export const eduChainTestnet = /*#__PURE__*/ defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.open-campus-codex.gelato.digital/'],
-      webSocket: ['wss://ws.open-campus-codex.gelato.digital'],
+      http: ['https://rpc.testnet.educhain.xyz'],
+      webSocket: ['wss://ws.rpc.testnet.educhain.xyz'],
     },
   },
   blockExplorers: {
     default: {
       name: 'EDU Chain Testnet Explorer',
-      url: 'https://opencampus-codex.blockscout.com',
-      apiUrl: 'https://opencampus-codex.blockscout.com/api',
+      url: 'https://explorer.testnet.educhain.xyz/',
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Updated RPC and block explorer URLs for EDU Chain mainnet and testnet. Also added multicall3 contract details for mainnet.

References:
- https://opencampus-xyz.notion.site/edu-chain-rpc-updates
- https://x.com/educhain_xyz/status/2077013359862632840
- https://www.multicall3.com/deployments (search "EDU")

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

