### PR TITLE
fix(ci): pin Tempo Zone images

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -199,9 +199,10 @@ jobs:
         env:
           CI: true
           VITE_TEMPO_ENV: localnet
-          VITE_TEMPO_TAG: latest
+          # TODO: Restore latest tags once Tempo includes the ZoneFactory contract.
+          VITE_TEMPO_TAG: sha-e828ab7
           VITE_TEMPO_ZONES: 'true'
-          VITE_TEMPO_ZONE_TAG: latest
+          VITE_TEMPO_ZONE_TAG: sha-aae82c4
 
   test-envs:
     name: Test Environments


### PR DESCRIPTION
Pins compatible Tempo and Tempo Zone images for local zone tests. The current `latest` pair omits `ZoneFactory`, preventing the test container from starting.
