### PR TITLE
fix: update ethereum rpc

### DIFF
--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -7,7 +7,7 @@ export const mainnet = /*#__PURE__*/ defineChain({
   blockTime: 12_000,
   rpcUrls: {
     default: {
-      http: ['https://ethereum-rpc.publicnode.com'],
+      http: ['https://ethereum.reth.rs/rpc'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Sets Ethereum mainnet’s default RPC to `https://ethereum.reth.rs/rpc`, replacing PublicNode with the preferred Reth endpoint.