### PR TITLE
fix: parseUnits rounding for long fractional values

### DIFF
--- a/.changeset/fix-parse-units-rounding.md
+++ b/.changeset/fix-parse-units-rounding.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `parseUnits` rounding for long fractional values near half boundaries.

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -53,6 +53,7 @@ test('decimals === 0', () => {
   expect(parseUnits('99999999999999999999999.5', 0)).toMatchInlineSnapshot(
     '100000000000000000000000n',
   )
+  expect(parseUnits('1.49999999999999999999', 0)).toMatchInlineSnapshot('1n')
 })
 
 test('decimals < fraction length', () => {
@@ -99,4 +100,7 @@ test('decimals < fraction length', () => {
   expect(parseUnits('69.00000000059', 9)).toMatchInlineSnapshot('69000000001n')
   expect(parseUnits('69.59000000059', 9)).toMatchInlineSnapshot('69590000001n')
   expect(parseUnits('69.59000002359', 9)).toMatchInlineSnapshot('69590000024n')
+  expect(parseUnits('1.14999999999999999', 1)).toMatchInlineSnapshot('11n')
+  expect(parseUnits('1.4499999999999999999', 1)).toMatchInlineSnapshot('14n')
+  expect(parseUnits('-1.4499999999999999999', 1)).toMatchInlineSnapshot('-14n')
 })

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -28,20 +28,17 @@ export function parseUnits(value: string, decimals: number) {
 
   // round off if the fraction is larger than the number of decimals.
   if (decimals === 0) {
-    if (Math.round(Number(`.${fraction}`)) === 1)
-      integer = `${BigInt(integer) + 1n}`
+    if (fraction[0] && fraction[0] >= '5') integer = `${BigInt(integer) + 1n}`
     fraction = ''
   } else if (fraction.length > decimals) {
-    const [left, unit, right] = [
-      fraction.slice(0, decimals - 1),
-      fraction.slice(decimals - 1, decimals),
+    const [left, right] = [
+      fraction.slice(0, decimals),
       fraction.slice(decimals),
     ]
 
-    const rounded = Math.round(Number(`${unit}.${right}`))
-    if (rounded > 9)
-      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(left.length + 1, '0')
-    else fraction = `${left}${rounded}`
+    if ((right[0] ?? '0') >= '5')
+      fraction = `${BigInt(left) + 1n}`.padStart(left.length, '0')
+    else fraction = left
 
     if (fraction.length > decimals) {
       fraction = fraction.slice(1)


### PR DESCRIPTION
Fixes #4855

This PR fixes `parseUnits` rounding for long fractional values near half boundaries.

Previously, `parseUnits` used `Number(...)` and `Math.round(...)` when the fractional part exceeded the requested decimal precision. For long decimal strings, JavaScript floating-point conversion can round values like `.49999999999999999999` to `0.5`, causing `parseUnits` to round up incorrectly.

This changes rounding to stay in decimal string/`BigInt` space by checking the first discarded fractional digit and carrying manually.