### PR TITLE
fix(tempo): randomize expiring nonce hashes

### DIFF
--- a/.changeset/random-lions-smile.md
+++ b/.changeset/random-lions-smile.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Randomize `validAfter` for Tempo expiring-nonce transactions to prevent otherwise-identical transactions from sharing a nonce hash.

--- a/.changeset/random-lions-smile.md
+++ b/.changeset/random-lions-smile.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Randomize `validAfter` for Tempo expiring-nonce transactions to prevent otherwise-identical transactions from sharing a nonce hash.
+Defaulted omitted `validAfter` values to random past timestamps for Tempo expiring-nonce transactions, preventing otherwise-identical transactions from sharing a nonce hash.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -1,4 +1,3 @@
-import * as Hex from 'ox/Hex'
 import { MultisigConfig } from 'ox/tempo'
 import { describe, expect, test, vi } from 'vitest'
 import { accounts, feeToken, getClient } from '~test/tempo/config.js'
@@ -32,10 +31,6 @@ const maxUint256 = 2n ** 256n - 1n
 
 describe('prepareTransactionRequest', () => {
   test('behavior: expiring nonces for feePayer transactions', async () => {
-    vi.spyOn(Hex, 'random')
-      .mockReturnValueOnce('0x0000000000000001')
-      .mockReturnValueOnce('0x0000000000000002')
-      .mockReturnValueOnce('0x0000000000000003')
     const now = Math.floor(Date.now() / 1000)
     const requests = await Promise.all([
       prepareTransactionRequest(client, { feePayer: true }),
@@ -53,8 +48,10 @@ describe('prepareTransactionRequest', () => {
     expect(requests[1]?.nonce).toBe(0)
     expect(requests[2]?.nonce).toBe(0)
 
-    // Identical expiring transactions receive distinct nonce hashes.
-    expect(requests.map((request) => request.validAfter)).toEqual([1, 2, 3])
+    // All should be immediately valid
+    expect(requests[0]?.validAfter).toBeLessThan(now)
+    expect(requests[1]?.validAfter).toBeLessThan(now)
+    expect(requests[2]?.validAfter).toBeLessThan(now)
 
     // All should have validBefore set within 30 seconds
     expect(requests[0]?.validBefore).toBeGreaterThanOrEqual(now)
@@ -103,13 +100,16 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBeLessThanOrEqual(now + 31)
   })
 
-  test('behavior: explicit validBefore is preserved', async () => {
+  test('behavior: explicit validity window is preserved', async () => {
+    const customValidAfter = Math.floor(Date.now() / 1000) - 15
     const customValidBefore = Math.floor(Date.now() / 1000) + 15
     const request = await prepareTransactionRequest(client, {
       feePayer: true,
+      validAfter: customValidAfter,
       validBefore: customValidBefore,
     })
     expect(request?.nonceKey).toBe(maxUint256)
+    expect(request?.validAfter).toBe(customValidAfter)
     expect(request?.validBefore).toBe(customValidBefore)
   })
 

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -1,3 +1,4 @@
+import * as Hex from 'ox/Hex'
 import { MultisigConfig } from 'ox/tempo'
 import { describe, expect, test, vi } from 'vitest'
 import { accounts, feeToken, getClient } from '~test/tempo/config.js'
@@ -31,6 +32,10 @@ const maxUint256 = 2n ** 256n - 1n
 
 describe('prepareTransactionRequest', () => {
   test('behavior: expiring nonces for feePayer transactions', async () => {
+    vi.spyOn(Hex, 'random')
+      .mockReturnValueOnce('0x0000000000000001')
+      .mockReturnValueOnce('0x0000000000000002')
+      .mockReturnValueOnce('0x0000000000000003')
     const now = Math.floor(Date.now() / 1000)
     const requests = await Promise.all([
       prepareTransactionRequest(client, { feePayer: true }),
@@ -47,6 +52,9 @@ describe('prepareTransactionRequest', () => {
     expect(requests[0]?.nonce).toBe(0)
     expect(requests[1]?.nonce).toBe(0)
     expect(requests[2]?.nonce).toBe(0)
+
+    // Identical expiring transactions receive distinct nonce hashes.
+    expect(requests.map((request) => request.validAfter)).toEqual([1, 2, 3])
 
     // All should have validBefore set within 30 seconds
     expect(requests[0]?.validBefore).toBeGreaterThanOrEqual(now)

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -22,6 +22,14 @@ import * as Transaction from './Transaction.js'
 
 const maxExpirySecs = 25
 
+/** Returns random past seconds to distinguish otherwise-identical expiring transactions. */
+function randomValidAfter(): number {
+  const now = BigInt(Math.floor(Date.now() / 1_000))
+  const latest = now - 60n
+  if (latest <= 0n) return 0
+  return Number(BigInt(Hex.random(8)) % latest)
+}
+
 export const chainConfig = {
   blockTime: 1_000,
   extendSchema: extendSchema<{
@@ -160,6 +168,8 @@ export const chainConfig = {
       if (useExpiringNonce) {
         request.nonceKey = maxUint256
         request.nonce = 0
+        if (typeof request.validAfter === 'undefined')
+          request.validAfter = randomValidAfter()
         if (typeof request.validBefore === 'undefined')
           request.validBefore = Math.floor(Date.now() / 1000) + maxExpirySecs
       } else if (typeof request.nonceKey !== 'undefined') {

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -369,6 +369,7 @@ describe('sendTransaction', () => {
       nonceKey,
       signature,
       transactionIndex,
+      validAfter,
       validBefore,
       ...transaction
     } = await getTransaction(client, { hash })
@@ -387,6 +388,7 @@ describe('sendTransaction', () => {
     expect(nonceKey).toBeDefined()
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
+    expect(validAfter).toBeTypeOf('number')
     expect(validBefore).toBeTypeOf('number')
     expect(transaction).toMatchInlineSnapshot(`
       {
@@ -405,7 +407,6 @@ describe('sendTransaction', () => {
         "type": "tempo",
         "typeHex": "0x76",
         "v": undefined,
-        "validAfter": null,
         "value": 0n,
         "yParity": undefined,
       }
@@ -658,6 +659,7 @@ describe('sendTransaction', () => {
         nonceKey,
         signature,
         transactionIndex,
+        validAfter,
         validBefore,
         ...transaction
       } = await getTransaction(client, { hash })
@@ -676,6 +678,7 @@ describe('sendTransaction', () => {
       expect(nonceKey).toBeDefined()
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
+      expect(validAfter).toBeTypeOf('number')
       expect(validBefore).toBeTypeOf('number')
       expect(transaction).toMatchInlineSnapshot(`
         {
@@ -694,7 +697,6 @@ describe('sendTransaction', () => {
           "type": "tempo",
           "typeHex": "0x76",
           "v": undefined,
-          "validAfter": null,
           "value": 0n,
           "yParity": undefined,
         }
@@ -1164,6 +1166,7 @@ describe('sendTransaction', () => {
         nonceKey,
         signature,
         transactionIndex,
+        validAfter,
         validBefore,
         ...transaction
       } = await getTransaction(client, { hash })
@@ -1182,6 +1185,7 @@ describe('sendTransaction', () => {
       expect(nonceKey).toBeDefined()
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
+      expect(validAfter).toBeTypeOf('number')
       expect(validBefore).toBeTypeOf('number')
       expect(transaction).toMatchInlineSnapshot(`
         {
@@ -1200,7 +1204,6 @@ describe('sendTransaction', () => {
           "type": "tempo",
           "typeHex": "0x76",
           "v": undefined,
-          "validAfter": null,
           "value": 0n,
           "yParity": undefined,
         }
@@ -1377,6 +1380,7 @@ describe('signTransaction', () => {
       nonceKey,
       signature,
       transactionIndex,
+      validAfter,
       validBefore,
       ...transaction2
     } = await getTransaction(client, { hash })
@@ -1395,6 +1399,7 @@ describe('signTransaction', () => {
     expect(nonceKey).toBeDefined()
     expect(signature).toBeDefined()
     expect(transactionIndex).toBeDefined()
+    expect(validAfter).toBeTypeOf('number')
     expect(validBefore).toBeTypeOf('number')
     expect(transaction2).toMatchInlineSnapshot(`
       {
@@ -1413,7 +1418,6 @@ describe('signTransaction', () => {
         "type": "tempo",
         "typeHex": "0x76",
         "v": undefined,
-        "validAfter": null,
         "value": 0n,
         "yParity": undefined,
       }
@@ -1552,6 +1556,7 @@ describe('relay', () => {
         nonceKey,
         signature,
         transactionIndex,
+        validAfter,
         validBefore,
         ...transaction
       } = await getTransaction(client, { hash: receipt.transactionHash })
@@ -1571,6 +1576,7 @@ describe('relay', () => {
       expect(nonceKey).toBeDefined()
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
+      expect(validAfter).toBeTypeOf('number')
       expect(validBefore).toBeTypeOf('number')
       expect(transaction).toMatchInlineSnapshot(`
         {
@@ -1582,7 +1588,6 @@ describe('relay', () => {
           "type": "tempo",
           "typeHex": "0x76",
           "v": undefined,
-          "validAfter": null,
           "value": 0n,
           "yParity": undefined,
         }
@@ -1613,6 +1618,31 @@ describe('relay', () => {
         }),
       ])
 
+      expect(receipts.every((receipt) => receipt.status === 'success')).toBe(
+        true,
+      )
+    })
+
+    test('behavior: identical sponsored transactions', async () => {
+      const account = privateKeyToAccount(
+        // unfunded PK
+        '0xecc3fe55647412647e5c6b657c496803b08ef956f927b7a821da298cfbdd9666',
+      )
+      const hashes = await Promise.all(
+        Array.from({ length: 3 }, () =>
+          sendTransaction(client, {
+            account,
+            feePayer: true,
+            to: '0x0000000000000000000000000000000000000000',
+          }),
+        ),
+      )
+
+      expect(new Set(hashes).size).toBe(hashes.length)
+
+      const receipts = await Promise.all(
+        hashes.map((hash) => waitForTransactionReceipt(client, { hash })),
+      )
       expect(receipts.every((receipt) => receipt.status === 'success')).toBe(
         true,
       )
@@ -1675,6 +1705,7 @@ describe('relay', () => {
         nonceKey,
         signature,
         transactionIndex,
+        validAfter,
         validBefore,
         ...transaction
       } = await getTransaction(client, { hash: receipt.transactionHash })
@@ -1694,6 +1725,7 @@ describe('relay', () => {
       expect(nonceKey).toBeDefined()
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
+      expect(validAfter).toBeTypeOf('number')
       expect(validBefore).toBeTypeOf('number')
       expect(transaction).toMatchInlineSnapshot(`
         {
@@ -1705,7 +1737,6 @@ describe('relay', () => {
           "type": "tempo",
           "typeHex": "0x76",
           "v": undefined,
-          "validAfter": null,
           "value": 0n,
           "yParity": undefined,
         }
@@ -1771,6 +1802,7 @@ describe('relay', () => {
         nonceKey,
         signature,
         transactionIndex,
+        validAfter,
         validBefore,
         ...transaction
       } = await getTransaction(client, { hash: receipt.transactionHash })
@@ -1790,6 +1822,7 @@ describe('relay', () => {
       expect(nonceKey).toBeDefined()
       expect(signature).toBeDefined()
       expect(transactionIndex).toBeDefined()
+      expect(validAfter).toBeTypeOf('number')
       expect(validBefore).toBeTypeOf('number')
       expect(transaction).toMatchInlineSnapshot(`
         {
@@ -1801,7 +1834,6 @@ describe('relay', () => {
           "type": "tempo",
           "typeHex": "0x76",
           "v": undefined,
-          "validAfter": null,
           "value": 0n,
           "yParity": undefined,
         }


### PR DESCRIPTION
Tempo expiring transactions currently default to the same `nonceKey`, `nonce`, `validAfter`, and `validBefore`. Identical calldata prepared within the same second therefore produces the same expiring nonce hash, which can leave subsequent sponsored requests blocked behind an in-flight transaction.

This sets a random, already-valid `validAfter` when Viem selects an expiring nonce, while preserving an explicitly supplied value. The regression test uses deterministic randomness to verify otherwise-identical sponsored requests receive distinct values.

Validation:
- `biome check src/tempo/chainConfig.ts src/tempo/chainConfig.test.ts .changeset/random-lions-smile.md`
- Targeted Vitest execution was unavailable from the GitHub source archive because its `ox` submodule build is not included; CI will exercise the regression test in the complete checkout.

Prompted by: @jxom