### PR TITLE
fix(unit): delegate parse/format unit utils to Ox's Value module

### DIFF
--- a/.changeset/unit-utils-ox-value.md
+++ b/.changeset/unit-utils-ox-value.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Fixed `parseUnits` mis-rounding long fractional tails by delegating the unit utilities (`parseUnits`, `formatUnits`, `parseEther`, `parseGwei`, `formatEther`, `formatGwei`) to Ox's `Value` module, which rounds exactly in decimal space instead of via `Math.round(Number(...))`.

--- a/.changeset/unit-utils-ox-value.md
+++ b/.changeset/unit-utils-ox-value.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `parseUnits` mis-rounding long fractional tails by delegating the unit utilities (`parseUnits`, `formatUnits`, `parseEther`, `parseGwei`, `formatEther`, `formatGwei`) to Ox's `Value` module, which rounds exactly in decimal space instead of via `Math.round(Number(...))`.

--- a/src/utils/unit/formatEther.ts
+++ b/src/utils/unit/formatEther.ts
@@ -1,6 +1,6 @@
-import { etherUnits } from '../../constants/unit.js'
+import * as Value from 'ox/Value'
 
-import { type FormatUnitsErrorType, formatUnits } from './formatUnits.js'
+import type { FormatUnitsErrorType } from './formatUnits.js'
 
 export type FormatEtherErrorType = FormatUnitsErrorType
 
@@ -16,5 +16,5 @@ export type FormatEtherErrorType = FormatUnitsErrorType
  * // '1'
  */
 export function formatEther(wei: bigint, unit: 'wei' | 'gwei' = 'wei') {
-  return formatUnits(wei, etherUnits[unit])
+  return Value.formatEther(wei, unit)
 }

--- a/src/utils/unit/formatGwei.ts
+++ b/src/utils/unit/formatGwei.ts
@@ -1,6 +1,6 @@
-import { gweiUnits } from '../../constants/unit.js'
+import * as Value from 'ox/Value'
 
-import { type FormatUnitsErrorType, formatUnits } from './formatUnits.js'
+import type { FormatUnitsErrorType } from './formatUnits.js'
 
 export type FormatGweiErrorType = FormatUnitsErrorType
 
@@ -16,5 +16,5 @@ export type FormatGweiErrorType = FormatUnitsErrorType
  * // '1'
  */
 export function formatGwei(wei: bigint, unit: 'wei' = 'wei') {
-  return formatUnits(wei, gweiUnits[unit])
+  return Value.formatGwei(wei, unit)
 }

--- a/src/utils/unit/formatUnits.ts
+++ b/src/utils/unit/formatUnits.ts
@@ -1,3 +1,5 @@
+import * as Value from 'ox/Value'
+
 import type { ErrorType } from '../../errors/utils.js'
 
 export type FormatUnitsErrorType = ErrorType
@@ -14,19 +16,5 @@ export type FormatUnitsErrorType = ErrorType
  * // '420'
  */
 export function formatUnits(value: bigint, decimals: number) {
-  let display = value.toString()
-
-  const negative = display.startsWith('-')
-  if (negative) display = display.slice(1)
-
-  display = display.padStart(decimals, '0')
-
-  let [integer, fraction] = [
-    display.slice(0, display.length - decimals),
-    display.slice(display.length - decimals),
-  ]
-  fraction = fraction.replace(/(0+)$/, '')
-  return `${negative ? '-' : ''}${integer || '0'}${
-    fraction ? `.${fraction}` : ''
-  }`
+  return Value.format(value, decimals)
 }

--- a/src/utils/unit/parseEther.ts
+++ b/src/utils/unit/parseEther.ts
@@ -1,7 +1,8 @@
-import { etherUnits } from '../../constants/unit.js'
+import * as Value from 'ox/Value'
+
 import type { ErrorType } from '../../errors/utils.js'
 
-import { type ParseUnitsErrorType, parseUnits } from './parseUnits.js'
+import type { ParseUnitsErrorType } from './parseUnits.js'
 
 export type ParseEtherErrorType = ParseUnitsErrorType | ErrorType
 
@@ -17,5 +18,5 @@ export type ParseEtherErrorType = ParseUnitsErrorType | ErrorType
  * // 420000000000000000000n
  */
 export function parseEther(ether: string, unit: 'wei' | 'gwei' = 'wei') {
-  return parseUnits(ether, etherUnits[unit])
+  return Value.fromEther(ether, unit)
 }

--- a/src/utils/unit/parseGwei.ts
+++ b/src/utils/unit/parseGwei.ts
@@ -1,7 +1,8 @@
-import { gweiUnits } from '../../constants/unit.js'
+import * as Value from 'ox/Value'
+
 import type { ErrorType } from '../../errors/utils.js'
 
-import { type ParseUnitsErrorType, parseUnits } from './parseUnits.js'
+import type { ParseUnitsErrorType } from './parseUnits.js'
 
 export type ParseGweiErrorType = ParseUnitsErrorType | ErrorType
 
@@ -17,5 +18,5 @@ export type ParseGweiErrorType = ParseUnitsErrorType | ErrorType
  * // 420000000000n
  */
 export function parseGwei(ether: string, unit: 'wei' = 'wei') {
-  return parseUnits(ether, gweiUnits[unit])
+  return Value.fromGwei(ether, unit)
 }

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -100,3 +100,10 @@ test('decimals < fraction length', () => {
   expect(parseUnits('69.59000000059', 9)).toMatchInlineSnapshot('69590000001n')
   expect(parseUnits('69.59000002359', 9)).toMatchInlineSnapshot('69590000024n')
 })
+
+test('rounds long fractional tails exactly (https://github.com/wevm/viem/issues/4855)', () => {
+  // `Math.round(Number(...))` used to mis-round these because IEEE-754 is not
+  // exact for long fractional tails. Rounding must be exact in decimal space.
+  expect(parseUnits('1.4499999999999999999', 1)).toMatchInlineSnapshot('14n')
+  expect(parseUnits('1.14999999999999999', 1)).toMatchInlineSnapshot('11n')
+})

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -1,4 +1,5 @@
-import { InvalidDecimalNumberError } from '../../errors/unit.js'
+import * as Value from 'ox/Value'
+
 import type { ErrorType } from '../../errors/utils.js'
 
 export type ParseUnitsErrorType = ErrorType
@@ -15,43 +16,5 @@ export type ParseUnitsErrorType = ErrorType
  * // 420000000000n
  */
 export function parseUnits(value: string, decimals: number) {
-  if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(value))
-    throw new InvalidDecimalNumberError({ value })
-
-  let [integer, fraction = '0'] = value.split('.')
-
-  const negative = integer.startsWith('-')
-  if (negative) integer = integer.slice(1)
-
-  // trim trailing zeros.
-  fraction = fraction.replace(/(0+)$/, '')
-
-  // round off if the fraction is larger than the number of decimals.
-  if (decimals === 0) {
-    if (Math.round(Number(`.${fraction}`)) === 1)
-      integer = `${BigInt(integer) + 1n}`
-    fraction = ''
-  } else if (fraction.length > decimals) {
-    const [left, unit, right] = [
-      fraction.slice(0, decimals - 1),
-      fraction.slice(decimals - 1, decimals),
-      fraction.slice(decimals),
-    ]
-
-    const rounded = Math.round(Number(`${unit}.${right}`))
-    if (rounded > 9)
-      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(left.length + 1, '0')
-    else fraction = `${left}${rounded}`
-
-    if (fraction.length > decimals) {
-      fraction = fraction.slice(1)
-      integer = `${BigInt(integer) + 1n}`
-    }
-
-    fraction = fraction.slice(0, decimals)
-  } else {
-    fraction = fraction.padEnd(decimals, '0')
-  }
-
-  return BigInt(`${negative ? '-' : ''}${integer}${fraction}`)
+  return Value.from(value, decimals)
 }


### PR DESCRIPTION
Fixes #4855. `parseUnits` rounded long fractional tails with
`Math.round(Number(...))`, which is not exact for IEEE-754 doubles and
could round the wrong way (e.g. parseUnits('1.4499999999999999999', 1)
returned 15n instead of 14n).

Reuses Ox's `Value` module (`from`/`format`/`fromEther`/`fromGwei`/
`formatEther`/`formatGwei`), which rounds exactly in decimal space, and
adds regression tests for the reported cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y5AhB5FfyPaJLykDnV8Eqi