### PR TITLE
Fix 0G Testnet native currency and explorer names

### DIFF
--- a/.changeset/nine-doors-yell.md
+++ b/.changeset/nine-doors-yell.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated 0G Testnet native currency to `0G` and 0G explorer names, per [ethereum-lists/chains](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-16602.json).

--- a/src/chains/definitions/0gMainnet.ts
+++ b/src/chains/definitions/0gMainnet.ts
@@ -11,7 +11,7 @@ export const zeroGMainnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: '0G BlockChain Explorer',
+      name: '0G Chainscan',
       url: 'https://chainscan.0g.ai',
     },
   },

--- a/src/chains/definitions/0gTestnet.ts
+++ b/src/chains/definitions/0gTestnet.ts
@@ -3,7 +3,7 @@ import { defineChain } from '../../utils/chain/defineChain.js'
 export const zeroGTestnet = /*#__PURE__*/ defineChain({
   id: 16_602,
   name: '0G Galileo Testnet',
-  nativeCurrency: { name: 'A0GI', symbol: 'A0GI', decimals: 18 },
+  nativeCurrency: { name: '0G', symbol: '0G', decimals: 18 },
   rpcUrls: {
     default: {
       http: ['https://evmrpc-testnet.0g.ai'],
@@ -11,7 +11,7 @@ export const zeroGTestnet = /*#__PURE__*/ defineChain({
   },
   blockExplorers: {
     default: {
-      name: '0G BlockChain Explorer',
+      name: '0G Chainscan',
       url: 'https://chainscan-galileo.0g.ai',
     },
   },


### PR DESCRIPTION
### Description

Corrects 0G chain metadata to match the canonical [ethereum-lists/chains](https://github.com/ethereum-lists/chains) data:

- **`zeroGTestnet` (16602): native currency `A0GI` → `0G`** ([eip155-16602.json](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-16602.json)). The 0G token was renamed from A0GI to 0G; the current Galileo testnet uses `0G`. (The deprecated Newton `16600` and old Galileo `16601` definitions correctly keep `A0GI` and are untouched.)
- `zeroGTestnet` (16602) and `zeroGMainnet` (16661): block explorer name `0G BlockChain Explorer` → `0G Chainscan`, matching the explorer name in the canonical data ([eip155-16661.json](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-16661.json)).