### PR TITLE
perf: batch concurrent `multicall` actions

### DIFF
--- a/.changeset/flat-multicalls-batch.md
+++ b/.changeset/flat-multicalls-batch.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Batched compatible concurrent `multicall` actions into one aggregate call.

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -73,6 +73,166 @@ test('default', async () => {
   expect(spy).toHaveBeenCalledOnce()
 })
 
+test('batches concurrent multicalls', async () => {
+  const client = anvilMainnet.getClient({
+    batch: { multicall: true },
+  })
+  const spy = vi.spyOn(readContract, 'readContract')
+
+  const [token, nft] = await Promise.all([
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...usdcContractConfig,
+          functionName: 'totalSupply',
+        },
+        {
+          ...usdcContractConfig,
+          functionName: 'balanceOf',
+          args: [address.vitalik],
+        },
+      ],
+    }),
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...baycContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+  ])
+
+  expect(token).toMatchInlineSnapshot(`
+    [
+      {
+        "result": 39507977228957576n,
+        "status": "success",
+      },
+      {
+        "result": 123223706565n,
+        "status": "success",
+      },
+    ]
+  `)
+  expect(nft).toMatchInlineSnapshot(`
+    [
+      {
+        "result": 10000n,
+        "status": "success",
+      },
+    ]
+  `)
+  expect(spy).toHaveBeenCalledOnce()
+})
+
+test('does not batch incompatible concurrent multicalls', async () => {
+  const client = anvilMainnet.getClient({
+    batch: { multicall: { deployless: true } },
+  })
+  const spy = vi.spyOn(readContract, 'readContract')
+
+  await Promise.all([
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...usdcContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+    multicall(client, {
+      blockTag: 'latest',
+      contracts: [
+        {
+          ...baycContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+  ])
+
+  expect(spy).toHaveBeenCalledTimes(2)
+})
+
+test('preserves concurrent failure boundaries', async () => {
+  const client = anvilMainnet.getClient({
+    batch: { multicall: { deployless: true } },
+  })
+  const spy = vi.spyOn(readContract, 'readContract')
+
+  const [failed, successful] = await Promise.allSettled([
+    multicall(client, {
+      allowFailure: false,
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...usdcContractConfig,
+          address: '0x0000000000000000000000000000000000000000',
+          functionName: 'balanceOf',
+          args: [address.vitalik],
+        },
+      ],
+    }),
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...baycContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+  ])
+
+  expect(failed.status).toBe('rejected')
+  expect(successful).toMatchInlineSnapshot(`
+    {
+      "status": "fulfilled",
+      "value": [
+        {
+          "result": 10000n,
+          "status": "success",
+        },
+      ],
+    }
+  `)
+  expect(spy).toHaveBeenCalledOnce()
+})
+
+test('respects batch size across concurrent multicalls', async () => {
+  const client = anvilMainnet.getClient({
+    batch: { multicall: { batchSize: 4, deployless: true } },
+  })
+  const spy = vi.spyOn(readContract, 'readContract')
+
+  await Promise.all([
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...usdcContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+    multicall(client, {
+      blockNumber: anvilMainnet.forkBlockNumber,
+      contracts: [
+        {
+          ...baycContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+    }),
+  ])
+
+  expect(spy).toHaveBeenCalledTimes(2)
+})
+
 test('args: blockHash', async () => {
   const address = '0x0000000000000000000000000000000000000421'
   const block = await getBlock(client)

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -32,6 +32,11 @@ import {
   getContractError,
 } from '../../utils/errors/getContractError.js'
 import { getAction } from '../../utils/getAction.js'
+import {
+  type CreateBatchSchedulerErrorType,
+  createBatchScheduler,
+} from '../../utils/promise/createBatchScheduler.js'
+import { stringify } from '../../utils/stringify.js'
 import type { CallParameters } from './call.js'
 import { type ReadContractErrorType, readContract } from './readContract.js'
 
@@ -82,12 +87,21 @@ export type MulticallReturnType<
 >
 
 export type MulticallErrorType =
+  | CreateBatchSchedulerErrorType
   | GetChainContractAddressErrorType
   | ReadContractErrorType
   | GetContractErrorReturnType<
       EncodeFunctionDataErrorType | DecodeFunctionResultErrorType
     >
   | ErrorType
+
+type Aggregate3Call = {
+  allowFailure: boolean
+  callData: Hex
+  target: Address
+}
+
+type Aggregate3Calls = Aggregate3Call[]
 
 /**
  * Similar to [`readContract`](https://viem.sh/docs/contract/readContract), but batches up multiple functions on a contract in a single RPC call via the [`multicall3` contract](https://github.com/mds1/multicall).
@@ -169,12 +183,6 @@ export async function multicall<
     )
   })()
 
-  type Aggregate3Calls = {
-    allowFailure: boolean
-    callData: Hex
-    target: Address
-  }[]
-
   const chunkedCalls: Aggregate3Calls[] = [[]]
   let currentChunk = 0
   let currentChunkSize = 0
@@ -227,9 +235,27 @@ export async function multicall<
     }
   }
 
+  const batching = Boolean(client.batch?.multicall)
+  const batches = batching
+    ? chunkedCalls.flatMap((calls) => calls.map((call) => [call]))
+    : chunkedCalls
   const aggregate3Results = await Promise.allSettled(
-    chunkedCalls.map((calls) =>
-      getAction(
+    batches.map((calls) => {
+      if (batching)
+        return scheduleMulticall(client, {
+          account,
+          authorizationList,
+          batchSize,
+          blockHash,
+          blockNumber,
+          blockOverrides,
+          blockTag,
+          call: calls[0]!,
+          multicallAddress,
+          requireCanonical,
+          stateOverride,
+        }).then((result) => [result])
+      return getAction(
         client,
         readContract,
         'readContract',
@@ -248,8 +274,8 @@ export async function multicall<
         functionName: 'aggregate3',
         requireCanonical,
         stateOverride,
-      }),
-    ),
+      })
+    }),
   )
 
   const results = []
@@ -260,7 +286,7 @@ export async function multicall<
     // then append the failure reason to each contract result.
     if (result.status === 'rejected') {
       if (!allowFailure) throw result.reason
-      for (let j = 0; j < chunkedCalls[i].length; j++) {
+      for (let j = 0; j < batches[i].length; j++) {
         results.push({
           status: 'failure',
           error: result.reason,
@@ -277,7 +303,7 @@ export async function multicall<
       const { returnData, success } = aggregate3Result[j]
 
       // Extract the request call data from the original call.
-      const { callData } = chunkedCalls[i][j]
+      const { callData } = batches[i][j]
 
       // Extract the contract config for this call from the `contracts` argument
       // for decoding.
@@ -312,4 +338,58 @@ export async function multicall<
   if (results.length !== contracts.length)
     throw new BaseError('multicall results mismatch')
   return results as MulticallReturnType<contracts, allowFailure>
+}
+
+type ScheduleMulticallParameters = Pick<
+  MulticallParameters,
+  | 'account'
+  | 'authorizationList'
+  | 'blockHash'
+  | 'blockNumber'
+  | 'blockOverrides'
+  | 'blockTag'
+  | 'requireCanonical'
+  | 'stateOverride'
+> & {
+  batchSize: number
+  call: Aggregate3Call
+  multicallAddress: Address | null
+}
+
+async function scheduleMulticall(
+  client: Client<Transport>,
+  parameters: ScheduleMulticallParameters,
+) {
+  const { batchSize, call, multicallAddress, ...rest } = parameters
+  const { wait = 0 } =
+    typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
+  const { schedule } = createBatchScheduler({
+    id: stringify(['multicall', client.uid, batchSize, multicallAddress, rest]),
+    wait,
+    shouldSplitBatch(calls: Aggregate3Calls) {
+      if (batchSize === 0) return false
+      const size = calls.reduce(
+        (size, { callData }) => size + (callData.length - 2) / 2,
+        0,
+      )
+      return size > batchSize
+    },
+    fn: (calls: Aggregate3Calls) =>
+      getAction(
+        client,
+        readContract,
+        'readContract',
+      )({
+        ...(multicallAddress === null
+          ? { code: multicall3Bytecode }
+          : { address: multicallAddress }),
+        ...rest,
+        abi: multicall3Abi,
+        args: [calls],
+        functionName: 'aggregate3',
+      }),
+  })
+
+  const [result] = await schedule(call)
+  return result
 }


### PR DESCRIPTION
Batches compatible concurrent `multicall` actions into one Aggregate3 request. This reduces RPC round trips while preserving execution context, failure isolation, deployment mode, and batch-size limits.
