### PR TITLE
fix: always call eth_fillTransaction when a fee payer signature is requested

### DIFF
--- a/.changeset/tempo-fee-payer-signature.md
+++ b/.changeset/tempo-fee-payer-signature.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Ensured `prepareTransactionRequest` fetched Tempo fee payer signatures for fully specified transactions.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -390,6 +390,20 @@ export async function prepareTransactionRequest<
     )
     if (!shouldAttempt) return false
 
+    // Always attempt if a fee payer signature is being requested (e.g. Tempo
+    // sponsorship via `feePayer: true`/`Account`) and has not already been
+    // filled. The fee payer signature can only be obtained as a side effect
+    // of `eth_fillTransaction` (the relay co-signs the returned transaction),
+    // so it must be called even when nonce/gas/fees are already fully
+    // populated — otherwise the transaction silently ends up without a
+    // fee payer signature.
+    if (
+      'feePayer' in request &&
+      (request as any).feePayer &&
+      !('feePayerSignature' in request && (request as any).feePayerSignature)
+    )
+      return true
+
     // Check if `eth_fillTransaction` needs to be called.
     if (parameters.includes('chainId') && typeof request.chainId !== 'number')
       return true

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -135,6 +135,44 @@ describe('withRelay', () => {
       })
     })
 
+    test('behavior: sendTransaction still gets sponsored via feePayer: true when nonce/gas/fees are pre-populated', async () => {
+      const account = privateKeyToAccount(
+        '0xecc3fe55647412647e5c6b657c496803b08ef956f927b7a821da298cfbdd9666',
+      )
+
+      // Pre-populate nonce/gas/fees, simulating a caller that has already
+      // fully filled out the transaction envelope before calling
+      // `prepareTransactionRequest` (e.g. because a wallet SDK filled them
+      // in separately). Historically this caused `prepareTransactionRequest`
+      // to skip the `eth_fillTransaction` call entirely (its heuristic
+      // assumes nothing is left to fill), which meant the fee-payer
+      // signature -- only obtainable as a side effect of that call -- was
+      // silently never attached, even though `feePayer: true` was set.
+      const nonce = await prepareTransactionRequest(client, {
+        account,
+        parameters: ['nonce'],
+        to: '0x0000000000000000000000000000000000000000',
+      }).then((request) => request.nonce)
+
+      const receipt = await sendTransactionSync(client, {
+        account,
+        chainId: chain.id,
+        feePayer: true,
+        gas: 100_000n,
+        maxFeePerGas: 10_000_000_000n,
+        maxPriorityFeePerGas: 1_000_000_000n,
+        nonce,
+        to: '0x0000000000000000000000000000000000000000',
+      })
+
+      expect(receipt.status).toBe('success')
+      expect(receipt.feePayer).toBe(accounts[0].address.toLowerCase())
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: expect.any(Array),
+      })
+    })
+
     test('behavior: eth_fillTransaction with feePayer: true', async () => {
       await client.request({
         method: 'eth_fillTransaction',


### PR DESCRIPTION
## Summary

Fixes a bug in Tempo's fee-payer (gas sponsorship) support where `prepareTransactionRequest` silently drops the fee-payer signature when the caller has already populated `nonce`/`gas`/fee fields. Feedback welcome, especially on whether the check should be broader (e.g. detecting "sponsorship requested" more generically) or narrower.

**Root cause:** `prepareTransactionRequest` (`src/actions/wallet/prepareTransactionRequest.ts`) has a heuristic (`attemptFill`) that skips calling `eth_fillTransaction` once the caller has already supplied `nonce`, `gas`, and fee (`maxFeePerGas`/`maxPriorityFeePerGas`) parameters — the assumption being "if everything is already filled in, there's nothing left to fill."

That assumption breaks down for Tempo's fee-payer sponsorship model. A relay can co-sign a transaction to cover gas on the caller's behalf (`feePayer: true`/`Account`), but the resulting `feePayerSignature` is only obtainable as a *side effect* of the `eth_fillTransaction` call (`withRelay` in `src/tempo/Transport.ts` routes that RPC method to the relay transport, which co-signs and returns the signature inline on the transaction). If the caller has already populated nonce/gas/fees (e.g. because a wallet SDK or app pre-fills the envelope), `eth_fillTransaction` was never called, so the transaction silently ended up with **no fee-payer signature** — no error, no warning, just an incomplete/unsponsored transaction that looks superficially fine.

**Live-relay evidence:** We reproduced this against the live Tempo mainnet fee-payer relay (`https://sponsor.tempo.xyz`). Calling `eth_fillTransaction` directly (bypassing `prepareTransactionRequest`'s skip logic, e.g. via viem's standalone `fillTransaction` action) with a transaction that had `nonce`, `nonceKey` (expiring-nonce sentinel), `validBefore`, `gas`, `maxFeePerGas`, and `maxPriorityFeePerGas` **all** pre-set — mirroring a real customer's exact failing payload — the relay happily returned a valid `feePayerSignature`. So this is purely a viem-side skip-detection bug; the relay is fully willing to sign a fully-specified transaction, viem just never asked it to.

**Customer impact:** An app integrating a wallet provider with Tempo gas sponsorship pre-populated (redundantly) the tx envelope fields. Their sponsored transactions silently never got a fee-payer signature attached.

## Fix

In the `attemptFill` heuristic in `prepareTransactionRequest.ts`, add an explicit, independent trigger: if `feePayer` is set on the request and no `feePayerSignature` is present yet, always attempt `eth_fillTransaction`, regardless of whether nonce/gas/fees are already populated.

```ts
// Always attempt if a fee payer signature is being requested (e.g. Tempo
// sponsorship via `feePayer: true`/`Account`) and has not already been
// filled. The fee payer signature can only be obtained as a side effect
// of `eth_fillTransaction` (the relay co-signs the returned transaction),
// so it must be called even when nonce/gas/fees are already fully
// populated — otherwise the transaction silently ends up without a
// fee payer signature.
if (
  'feePayer' in request &&
  (request as any).feePayer &&
  !('feePayerSignature' in request && (request as any).feePayerSignature)
)
  return true
```

This is intentionally minimal and not Tempo-specific in the core action — it keys off the generic `feePayer`/`feePayerSignature` request fields that Tempo's chain config populates, so it doesn't require special-casing `type === 'tempo'` in core.

## Testing

Added a regression test in `src/tempo/Transport.test.ts` (`behavior: sendTransaction still gets sponsored via feePayer: true when nonce/gas/fees are pre-populated`) using the existing local mock fee-payer relay harness. The test pre-populates `chainId`, `nonce`, `gas`, `maxFeePerGas`, and `maxPriorityFeePerGas` before calling `sendTransactionSync` with `feePayer: true`, and asserts:
- `eth_fillTransaction` is still called
- the transaction receipt shows the expected `feePayer`

Verified this test fails without the fix (only `eth_signRawTransaction` shows up in the relay call log, `eth_fillTransaction` is never reached) and passes with it.

## Test plan

- [x] `biome check` passes on both changed files
- [x] `tsc -b` shows no new errors introduced by this change (pre-existing unrelated errors in the repo require a contracts build that isn't relevant here)
- [x] `vitest run -c ./test/vitest.config.ts src/tempo/Transport.test.ts` — 24 passed, 1 skipped (multisig-gated)
- [x] Confirmed pre-existing failures in `src/actions/wallet/prepareTransactionRequest.test.ts` are present on `upstream-main` without this change too (unrelated environment issue, not caused by this PR)
