### PR TITLE
fix: fee-payer check must run before shouldAttempt gate

### DIFF
--- a/.changeset/tempo-fee-payer-parameters-gap.md
+++ b/.changeset/tempo-fee-payer-parameters-gap.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Ensured `prepareTransactionRequest` fetched Tempo fee payer signatures when the caller's `parameters` option omitted `fees`/`gas`.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -383,26 +383,37 @@ export async function prepareTransactionRequest<
     // Do not attempt if `eth_fillTransaction` is not supported.
     if (supportsFillTransaction.get(client.uid) === false) return false
 
+    // Always attempt if the caller explicitly requested a non-empty set of
+    // `parameters` and a fee payer signature is being requested (e.g. Tempo
+    // sponsorship via `feePayer: true`/`Account`) and has not already been
+    // filled. The fee payer signature can only be obtained as a side effect
+    // of `eth_fillTransaction` (the relay co-signs the returned transaction),
+    // so it must be called even when nonce/gas/fees are already fully
+    // populated, or when the caller's `parameters` option omits `'fees'`/
+    // `'gas'` entirely — otherwise the transaction silently ends up without
+    // a fee payer signature. This check intentionally runs before the
+    // `shouldAttempt` gate below, since fee-payer sponsorship is independent
+    // of which parameters the caller opted into filling.
+    //
+    // The `parameters.length > 0` guard excludes internal micro-prepare calls
+    // that explicitly pass an empty `parameters` array (e.g. `estimateGas`'s
+    // internal `prepareTransactionRequest` call for local accounts) — those
+    // are deliberately scoped to fill nothing, and should not independently
+    // re-attempt `eth_fillTransaction` for fee-payer sponsorship.
+    if (
+      parameters.length > 0 &&
+      'feePayer' in request &&
+      (request as any).feePayer &&
+      !('feePayerSignature' in request && (request as any).feePayerSignature)
+    )
+      return true
+
     // Should attempt `eth_fillTransaction` if "fees" or "gas" are required to be populated,
     // otherwise, can just use the other individual calls.
     const shouldAttempt = ['fees', 'gas'].some((parameter) =>
       parameters.includes(parameter as PrepareTransactionRequestParameterType),
     )
     if (!shouldAttempt) return false
-
-    // Always attempt if a fee payer signature is being requested (e.g. Tempo
-    // sponsorship via `feePayer: true`/`Account`) and has not already been
-    // filled. The fee payer signature can only be obtained as a side effect
-    // of `eth_fillTransaction` (the relay co-signs the returned transaction),
-    // so it must be called even when nonce/gas/fees are already fully
-    // populated — otherwise the transaction silently ends up without a
-    // fee payer signature.
-    if (
-      'feePayer' in request &&
-      (request as any).feePayer &&
-      !('feePayerSignature' in request && (request as any).feePayerSignature)
-    )
-      return true
 
     // Check if `eth_fillTransaction` needs to be called.
     if (parameters.includes('chainId') && typeof request.chainId !== 'number')

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -173,6 +173,70 @@ describe('withRelay', () => {
       })
     })
 
+    test('behavior: sendTransaction still gets sponsored via feePayer: true when the caller restricts `parameters` to omit fees/gas, even with a fully-populated envelope', async () => {
+      const account = privateKeyToAccount(
+        '0xecc3fe55647412647e5c6b657c496803b08ef956f927b7a821da298cfbdd9666',
+      )
+
+      // The feePayer check must run *before* the `shouldAttempt` gate, which
+      // only fires `eth_fillTransaction` when the caller's `parameters`
+      // option includes `'fees'` or `'gas'`. A caller who restricts
+      // `parameters` to omit both (e.g. only wants `nonce`/`type` filled)
+      // must still get a fee-payer signature -- sponsorship is independent
+      // of which parameters the caller opted into filling.
+      const nonce = await prepareTransactionRequest(client, {
+        account,
+        parameters: ['nonce'],
+        to: '0x0000000000000000000000000000000000000000',
+      }).then((request) => request.nonce)
+
+      const receipt = await sendTransactionSync(client, {
+        account,
+        chainId: chain.id,
+        feePayer: true,
+        gas: 100_000n,
+        maxFeePerGas: 10_000_000_000n,
+        maxPriorityFeePerGas: 1_000_000_000n,
+        nonce,
+        parameters: ['nonce', 'type'],
+        to: '0x0000000000000000000000000000000000000000',
+      })
+
+      expect(receipt.status).toBe('success')
+      expect(receipt.feePayer).toBe(accounts[0].address.toLowerCase())
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: expect.any(Array),
+      })
+    })
+
+    test('behavior: sendTransaction still gets sponsored via feePayer: true when the caller restricts `parameters` to omit fees/gas on a minimal (unpopulated) envelope', async () => {
+      const account = privateKeyToAccount(
+        '0xecc3fe55647412647e5c6b657c496803b08ef956f927b7a821da298cfbdd9666',
+      )
+
+      // Same as above, but with no envelope fields pre-populated at all --
+      // confirms the fix isn't accidentally coupled to "fields already set".
+      // Uses `prepareTransactionRequest` directly (rather than a full send)
+      // since restricting `parameters` to omit `'gas'`/`'fees'` on an
+      // otherwise-empty envelope intentionally leaves the transaction
+      // incomplete for broadcast -- what's under test is that the fill is
+      // still *attempted* (this mock relay only attaches the fee-payer
+      // signature at raw-transaction send time, not at fill time, so it
+      // can't be asserted on the prepared result here).
+      await prepareTransactionRequest(client, {
+        account,
+        feePayer: true,
+        parameters: ['nonce', 'type'],
+        to: '0x0000000000000000000000000000000000000000',
+      })
+
+      expect(relayRequests).toContainEqual({
+        method: 'eth_fillTransaction',
+        params: expect.any(Array),
+      })
+    })
+
     test('behavior: eth_fillTransaction with feePayer: true', async () => {
       await client.request({
         method: 'eth_fillTransaction',


### PR DESCRIPTION
## Summary

Follow-up to #4866. That PR added a fee-payer check to `attemptFill` in `prepareTransactionRequest`, but placed it *after* the `shouldAttempt` gate:

```ts
if (!shouldAttempt) return false
// feePayer check never reached if shouldAttempt is false
```

`shouldAttempt` only becomes `true` when the caller's `parameters` option includes `'fees'` or `'gas'`. A caller who restricts `parameters` to omit both (e.g. `parameters: ['nonce', 'type']`) — even on a fully-populated envelope — still returns `false` before the fee-payer check runs, silently dropping the fee-payer signature. This reproduces the original bug #4866 set out to fix, just for a narrower trigger condition.

Confirmed live against the Tempo mainnet relay (`sponsor.tempo.xyz`) that this scenario still results in `feePayerSignature: ABSENT` with #4866 applied.

- Move the fee-payer check before the `shouldAttempt` gate
- Guard it on `parameters.length > 0` so internal micro-prepare calls (e.g. `estimateGas`'s nested `prepareTransactionRequest` call with `parameters: []`) don't trigger a redundant extra `eth_fillTransaction`
- Add two regression tests in `src/tempo/Transport.test.ts` covering the restricted-`parameters` gap on both populated and minimal envelopes

## Test plan

- [x] `src/tempo/Transport.test.ts` — 26 passed, 1 skipped
- [x] Verified the two new tests fail without this fix and pass with it
- [x] `src/actions/wallet/prepareTransactionRequest.test.ts` has 15 pre-existing failures on this branch unrelated to this change (confirmed via `git stash` — same failures occur without this diff applied)