### PR TITLE
fix: update vulnerable transitive dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ overrides:
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0
   postcss@<8.5.10: 8.5.10
-  protobufjs@<=7.6.2: 7.6.3
-  protobufjs@>=8.0.0 <8.6.0: 8.6.0
+  protobufjs@<=7.6.4: 7.6.5
+  protobufjs@>=8.0.0 <8.6.6: 8.6.6
   '@protobufjs/utf8@<=1.1.0': 1.1.1
   '@opentelemetry/sdk-node@<0.217.0': 0.217.0
   find-my-way@>=5.5.0 <8.2.2: ^8.2.2
@@ -68,7 +68,7 @@ overrides:
   serialize-javascript@<7.0.5: 7.0.5
   serve-static@<1.16.0: ^1.16.0
   smol-toml@<1.6.1: 1.6.1
-  tar: '>=7.5.16'
+  tar: '>=7.5.19'
   tar-fs@>=3.0.0 <3.1.1: '>=3.1.1'
   tmp: '>=0.2.7'
   undici@>=7.0.0 <7.28.0: 7.28.0
@@ -79,7 +79,8 @@ overrides:
   ws@>=7.0.0 <7.5.10: ^7.5.10
   ws@>=8.0.0 <8.21.0: ^8.21.0
   yauzl@<3.2.1: 3.2.1
-  js-yaml: '>=4.2.0'
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=5.0.0 <=5.2.0: 5.2.1
   '@changesets/read>@changesets/parse': 0.4.3
   '@manypkg/get-packages>read-yaml-file': 2.1.0
   next@>=16.0.1 <16.1.7: 16.1.7
@@ -89,7 +90,7 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   srvx@<0.11.13: 0.11.13
-  brace-expansion@>=4.0.0 <5.0.6: 5.0.6
+  brace-expansion@>=4.0.0 <5.0.7: 5.0.7
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
   next@>=16.0.0-beta.0 <16.2.6: 16.2.6
@@ -2179,9 +2180,6 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
@@ -3568,8 +3566,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4844,12 +4842,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5869,12 +5867,12 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
-  protobufjs@7.6.3:
-    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.6.0:
-    resolution: {integrity: sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==}
+  protobufjs@8.6.6:
+    resolution: {integrity: sha512-RkLIhE+Tdc2Kpq1F4Uw6OnpAXPca7B+GSDov/GqGCqNBpVyDskQ9yReZfgM+C7xw9AAix873iQZXbBWXj6NzYQ==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -6551,8 +6549,8 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
     engines: {node: '>=18'}
 
   tdigest@0.1.2:
@@ -7651,7 +7649,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -7997,14 +7995,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.3
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.1)':
@@ -8687,7 +8685,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.7.0)
-      protobufjs: 8.6.0
+      protobufjs: 8.6.6
 
   '@opentelemetry/otlp-transformer@0.52.1(@opentelemetry/api@1.7.0)':
     dependencies:
@@ -8698,7 +8696,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.52.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.7.0)
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.7.0)':
     dependencies:
@@ -8995,8 +8993,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -10532,7 +10528,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.3
 
@@ -10779,7 +10775,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 5.2.0
+      js-yaml: 5.2.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -10890,7 +10886,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.13
       docker-modem: 5.0.6
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       tar-fs: 2.1.4
       uuid: 14.0.0
     transitivePeerDependencies:
@@ -11948,11 +11944,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -11998,7 +11994,7 @@ snapshots:
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimist: 1.2.8
       oxc-resolver: 11.8.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
@@ -12688,7 +12684,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -13295,7 +13291,7 @@ snapshots:
       execa: 9.6.1
       get-port: 7.1.0
       http-proxy: 1.18.1
-      tar: 7.5.16
+      tar: 7.5.20
     optionalDependencies:
       '@pimlico/alto': 0.0.18(typescript@5.9.3)
       testcontainers: 11.10.0
@@ -13314,7 +13310,7 @@ snapshots:
 
   property-information@7.2.0: {}
 
-  protobufjs@7.6.3:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -13322,14 +13318,13 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
       '@types/node': 24.13.2
       long: 5.3.2
 
-  protobufjs@8.6.0:
+  protobufjs@8.6.6:
     dependencies:
       long: 5.3.2
 
@@ -13448,7 +13443,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       strip-bom: 4.0.0
 
   readable-stream@2.3.8:
@@ -14228,7 +14223,7 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.23.0
 
-  tar@7.5.16:
+  tar@7.5.20:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,8 +61,8 @@ overrides:
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0
   postcss@<8.5.10: 8.5.10
-  protobufjs@<=7.6.2: 7.6.3
-  protobufjs@>=8.0.0 <8.6.0: 8.6.0
+  protobufjs@<=7.6.4: 7.6.5
+  protobufjs@>=8.0.0 <8.6.6: 8.6.6
   '@protobufjs/utf8@<=1.1.0': 1.1.1
   '@opentelemetry/sdk-node@<0.217.0': 0.217.0
   find-my-way@>=5.5.0 <8.2.2: ^8.2.2
@@ -86,7 +86,7 @@ overrides:
   serialize-javascript@<7.0.5: 7.0.5
   serve-static@<1.16.0: ^1.16.0
   smol-toml@<1.6.1: 1.6.1
-  tar: '>=7.5.16'
+  tar: '>=7.5.19'
   tar-fs@>=3.0.0 <3.1.1: '>=3.1.1'
   tmp: '>=0.2.7'
   undici@>=7.0.0 <7.28.0: 7.28.0
@@ -97,7 +97,8 @@ overrides:
   ws@>=7.0.0 <7.5.10: ^7.5.10
   ws@>=8.0.0 <8.21.0: ^8.21.0
   yauzl@<3.2.1: 3.2.1
-  js-yaml: '>=4.2.0'
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=5.0.0 <=5.2.0: 5.2.1
   '@changesets/read>@changesets/parse': 0.4.3
   '@manypkg/get-packages>read-yaml-file': 2.1.0
   next@>=16.0.1 <16.1.7: 16.1.7
@@ -107,7 +108,7 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   srvx@<0.11.13: 0.11.13
-  brace-expansion@>=4.0.0 <5.0.6: 5.0.6
+  brace-expansion@>=4.0.0 <5.0.7: 5.0.7
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
   next@>=16.0.0-beta.0 <16.2.6: 16.2.6


### PR DESCRIPTION
Updates transitive dependency overrides and the lockfile for patched `tar`, `brace-expansion`, `js-yaml`, and `protobufjs` releases. Clears newly disclosed advisories that blocked the `Verify / Check` workflow.
