### PR TITLE
fix: accept `Token.from` results omitting optional metadata in `Client.create({ tokens })`

### DIFF
--- a/.changeset/token-from-optional-metadata.md
+++ b/.changeset/token-from-optional-metadata.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `Token.from` results omitting optional metadata being rejected by `Client.create({ tokens })` in consumer tsconfigs without `exactOptionalPropertyTypes`.

--- a/environments/tsc/index.ts
+++ b/environments/tsc/index.ts
@@ -1,9 +1,18 @@
-import { Client, http, publicActions, webSocket } from 'viem'
+import { Client, http, publicActions, Token, webSocket } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// Minimal token (no optional metadata): must satisfy `tokens` without
+// `exactOptionalPropertyTypes`, unlike Viem's own tsconfig.
+const usdc = Token.from({
+  addresses: { 1: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' },
+  decimals: 6,
+  symbol: 'usdc',
+})
 
 ;(async () => {
   const client = Client.create({
     chain: mainnet,
+    tokens: [usdc],
     transport: http('https://ethereum-rpc.publicnode.com'),
   }).extend(publicActions())
 

--- a/src/core/Token.test-d.ts
+++ b/src/core/Token.test-d.ts
@@ -1,0 +1,46 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import { Account, Actions, Client, http, Token } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const account = Account.fromPrivateKey(
+  '0x0000000000000000000000000000000000000000000000000000000000000001',
+)
+
+describe('minimal token: addresses + decimals + symbol only', () => {
+  const usdc = Token.from({
+    addresses: { 1: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' },
+    decimals: 6,
+    symbol: 'usdc',
+  })
+
+  test('assignable to `Token.Tokens`', () => {
+    expectTypeOf(usdc).toMatchTypeOf<Token.Token>()
+    expectTypeOf([usdc] as const).toMatchTypeOf<Token.Tokens>()
+    expectTypeOf(usdc.currency).toEqualTypeOf<undefined>()
+    expectTypeOf(usdc.symbol).toEqualTypeOf<'usdc'>()
+  })
+
+  test('optional metadata on the default `Token` accepts undefined', () => {
+    expectTypeOf<Token.Token['currency']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<Token.Token['name']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<Token.Token['popular']>().toEqualTypeOf<boolean | undefined>()
+    expectTypeOf<Token.Token['symbol']>().toEqualTypeOf<string | undefined>()
+  })
+
+  test('declared on `Client.create`: `token` narrows to declared symbols', () => {
+    const client = Client.create({
+      account,
+      chain: mainnet,
+      tokens: [usdc],
+      transport: http(),
+    })
+    Actions.token.getBalance(client, { account: '0x', token: 'usdc' })
+    Actions.token.getBalance(client, { account: '0x', token: '0x' })
+    Actions.token.transferSync(client, { amount: 1n, to: '0x', token: 'usdc' })
+    // @ts-expect-error - 'dai' is neither declared on the client nor an address
+    Actions.token.getBalance(client, { account: '0x', token: 'dai' })
+    // @ts-expect-error - 'dai' is neither declared on the client nor an address
+    Actions.token.transferSync(client, { amount: 1n, to: '0x', token: 'dai' })
+  })
+})

--- a/src/core/Token.ts
+++ b/src/core/Token.ts
@@ -84,7 +84,7 @@ export declare namespace from {
   type ParameterValue<
     token extends Parameters,
     key extends keyof Parameters,
-  > = token extends { [_ in key]?: infer value } ? value : undefined
+  > = key extends keyof token ? token[key] : undefined
 
   type Parameters<
     addresses extends Record<number, Address.Address> = Record<


### PR DESCRIPTION
Resolved `Token.from` metadata types via indexed access instead of optional-property `infer`, which strips `| undefined` without `exactOptionalPropertyTypes` and made `Client.create({ tokens })` reject tokens omitting optional metadata.
