### PR TITLE
feat(tempo): add withdrawal sender tag helper

### DIFF
--- a/.changeset/quiet-zones-hash.md
+++ b/.changeset/quiet-zones-hash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `getWithdrawalSenderTag` for computing authenticated Tempo Zone withdrawal sender tags.

--- a/src/tempo/zones/getWithdrawalSenderTag.test.ts
+++ b/src/tempo/zones/getWithdrawalSenderTag.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { getWithdrawalSenderTag } from './getWithdrawalSenderTag.js'
+
+test('default', () => {
+  expect(
+    getWithdrawalSenderTag({
+      sender: '0x0000000000000000000000000000000000000001',
+      transactionHash:
+        '0x2222222222222222222222222222222222222222222222222222222222222222',
+    }),
+  ).toBe('0x1180de90ed8e66ef4e3771194b0197494aefe21754c9c2117efe146c2b4d9237')
+})

--- a/src/tempo/zones/getWithdrawalSenderTag.ts
+++ b/src/tempo/zones/getWithdrawalSenderTag.ts
@@ -1,0 +1,36 @@
+import type { Address } from 'abitype'
+import type { Hash } from '../../types/misc.js'
+import { concatHex } from '../../utils/data/concat.js'
+import { keccak256 } from '../../utils/hash/keccak256.js'
+
+export type GetWithdrawalSenderTagParameters = {
+  /** Address that requested the withdrawal on the zone. */
+  sender: Address
+  /** Hash of the zone transaction that requested the withdrawal. */
+  transactionHash: Hash
+}
+
+export type GetWithdrawalSenderTagReturnType = Hash
+
+/**
+ * Computes the authenticated sender tag for a Tempo Zone withdrawal.
+ *
+ * @example
+ * ```ts
+ * import { getWithdrawalSenderTag } from 'viem/tempo/zones'
+ *
+ * const senderTag = getWithdrawalSenderTag({
+ *   sender: '0x0000000000000000000000000000000000000001',
+ *   transactionHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+ * })
+ * ```
+ *
+ * @param parameters - Withdrawal sender and zone transaction hash.
+ * @returns The withdrawal sender tag.
+ */
+export function getWithdrawalSenderTag({
+  sender,
+  transactionHash,
+}: GetWithdrawalSenderTagParameters): GetWithdrawalSenderTagReturnType {
+  return keccak256(concatHex([sender, transactionHash]))
+}

--- a/src/tempo/zones/index.ts
+++ b/src/tempo/zones/index.ts
@@ -1,5 +1,10 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export * as Abis from './Abis.js'
+export {
+  type GetWithdrawalSenderTagParameters,
+  type GetWithdrawalSenderTagReturnType,
+  getWithdrawalSenderTag,
+} from './getWithdrawalSenderTag.js'
 export { http, type ZoneHttpConfig } from './transport.js'
 export {
   from,


### PR DESCRIPTION
## Summary

- add `getWithdrawalSenderTag` to `viem/tempo/zones`
- compute the protocol commitment from the packed sender address and Zone transaction hash
- cover the helper with a cross-language vector matching the Tempo Zones Rust implementation

## Motivation

Viem exposes verifiable Zone withdrawals, but consumers currently need to reproduce the sender-tag encoding themselves. Providing the protocol-specific computation avoids reversed inputs and ABI-padding mismatches when reconstructing or verifying a withdrawal sender tag.

## Testing

- `pnpm exec vitest run src/tempo/zones/getWithdrawalSenderTag.test.ts`
- `pnpm check:types`
- `pnpm check`

cc @struong
