### PR TITLE
fix(tempo): stabilize local tests against latest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,10 @@ When encountering situations that require judgment:
 
 Tests should be co-located with actions in `*action-name*.test.ts` files. Reference contract tests in `test/tempo/crates/precompiles/` for expected behavior. 
 
+- Local Tempo tests intentionally run against `VITE_TEMPO_TAG=latest`. Before submitting fixture
+  transactions with expiring nonces, wait until `getBlock` returns a nonzero timestamp; the node's
+  startup signal can arrive before the first canonical block is available through RPC.
+
 See `src/tempo/actions/token.test.ts` for a comprehensive example of test patterns and structure.
 
 #### Test Structure

--- a/src/tempo/actions/policy.test.ts
+++ b/src/tempo/actions/policy.test.ts
@@ -404,6 +404,7 @@ describe('watchAdminUpdated', () => {
 
     const logs: any[] = []
     const unwatch = actions.policy.watchAdminUpdated(client, {
+      args: { admin: account2.address, policyId },
       onAdminUpdated: (args, log) => {
         logs.push({ args, log })
       },

--- a/src/tempo/actions/simulate.test.ts
+++ b/src/tempo/actions/simulate.test.ts
@@ -43,7 +43,7 @@ describe('simulateBlocks', () => {
       {
         "calls": [
           {
-            "gasUsed": 22080n,
+            "gasUsed": 271644n,
             "logs": [],
             "status": "success",
           },
@@ -88,7 +88,7 @@ describe('simulateBlocks', () => {
       ),
     }).toMatchInlineSnapshot(`
       {
-        "gasUsed": 287170n,
+        "gasUsed": 539270n,
         "logs": [
           {
             "address": "0x20c0000000000000000000000000000000000001",
@@ -100,7 +100,7 @@ describe('simulateBlocks', () => {
               "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "0x0000000000000000000000008c8d35429f74ec245f8ef2f4fd1e551cff97d650",
             ],
-            "transactionHash": "0x1cf44b23d9c272c374ae0e2539b96673f0bf2e07a17afc696e4e3a4e256b7cef",
+            "transactionHash": "0x9f28dc5a4f517fd897be777b9d825503afc02f0d778e934c9560e4143d47ff2e",
             "transactionIndex": 0,
           },
         ],

--- a/test/src/tempo/prool.ts
+++ b/test/src/tempo/prool.ts
@@ -220,18 +220,23 @@ async function startZone(
 export async function restart(client: Client<Transport, Chain>) {
   if (nodeEnv !== 'localnet') return
   await fetch(`${client.chain.rpcUrls.default.http[0]}/restart`)
+  await setup(client)
+}
+
+async function waitForBlock(client: Client<Transport, Chain>) {
   await withRetry(
     async () => {
       const block = await getBlock(client)
       if (block.timestamp === 0n)
-        throw new Error('Tempo has not produced a block after restart.')
+        throw new Error('Tempo has not produced a block.')
     },
     { delay: 50, retryCount: 100 },
   )
-  await setup(client)
 }
 
 export async function setup(client: Client<Transport, Chain>) {
+  await waitForBlock(client)
+
   // Mint liquidity for fee tokens.
   await Promise.all(
     [1n, 2n, 3n].map((id) =>


### PR DESCRIPTION
## Summary

Stabilized local Tempo tests against `tempo:latest` by waiting for the first canonical block before submitting fixture transactions and refreshing latest-compatible assertions.

## Motivation

The release workflow was blocked because fixture transactions used expiring nonces while the node still reported block timestamp `0`. Current `tempo:latest` also changed simulation gas accounting, and an event watcher could consume the policy creation event instead of the intended admin update.

## Changes

- Waited for a nonzero block timestamp before initial and restarted localnet fixture setup.
- Filtered the policy admin watcher to the expected policy and new admin.
- Updated simulation snapshots for the current `tempo:latest` behavior.
- Documented the local Tempo readiness invariant.

## Testing

- `CI=true VITE_TEMPO_ENV=localnet VITE_TEMPO_TAG=latest VITE_BATCH_MULTICALL=false VITE_NETWORK_TRANSPORT_MODE=http pnpm test --project tempo --run` — 29 files passed, 1 skipped; 526 tests passed, 24 skipped.
- `pnpm exec biome check AGENTS.md src/tempo/actions/policy.test.ts src/tempo/actions/simulate.test.ts test/src/tempo/prool.ts`