### PR TITLE
feat(tempo): add Earn exit-safe policy actions

### DIFF
--- a/.changeset/tidy-vaults-exit.md
+++ b/.changeset/tidy-vaults-exit.md
@@ -1,0 +1,5 @@
+---
+'viem': minor
+---
+
+Added Tempo Earn exit-safe TIP-403 policy configuration and validation actions.

--- a/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
@@ -1,0 +1,83 @@
+# `earn.configureExitSafePolicy`
+
+Creates and attaches an admission-only TIP-403 policy to an Earn vault share token. Existing
+holders can continue sending shares, while recipients and mint recipients must belong to the same
+whitelist.
+
+The action submits three or four sequential transactions and is not atomic. Use
+[`earn.validateExitSafePolicy`](/tempo/actions/earn.validateExitSafePolicy) to verify the final
+onchain state before publishing a protected deployment.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { policy, receipts } = await client.earn.configureExitSafePolicy({
+  accessAdministrator: '0x0000000000000000000000000000000000000002',
+  initialMembers: [
+    '0x0000000000000000000000000000000000000003',
+    '0x0000000000000000000000000000000000000004',
+  ],
+  shareToken: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Value
+
+```ts
+type ReturnValue = {
+  policy: {
+    transferPolicyId: bigint
+    senderPolicyId: bigint
+    recipientPolicyId: bigint
+    mintRecipientPolicyId: bigint
+  }
+  receipts: {
+    eligibilityPolicy: TransactionReceipt
+    compoundPolicy: TransactionReceipt
+    tokenPolicy: TransactionReceipt
+    policyAdmin?: TransactionReceipt
+  }
+}
+```
+
+`senderPolicyId` is the always-allow policy. `recipientPolicyId` and
+`mintRecipientPolicyId` identify the same whitelist.
+
+## Parameters
+
+### accessAdministrator
+
+- **Type:** `Address`
+
+Address that will administer recipient eligibility. The admin-transfer transaction is skipped when
+this is the calling account.
+
+### initialMembers
+
+- **Type:** `readonly Address[]`
+
+Addresses initially eligible to receive transfers and mints. Duplicate addresses are removed. At
+least one member is required.
+
+### shareToken
+
+- **Type:** `Address`
+
+Earn vault share token. The calling account must be authorized to change its transfer policy.
+
+### account (optional)
+
+- **Type:** `Account | Address`
+- **Default:** `client.account`
+
+Account that creates the policies and changes the share token transfer policy.

--- a/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
@@ -1,0 +1,71 @@
+import ReadParameters from '../../../snippets/tempo/read-parameters.mdx'
+
+# `earn.validateExitSafePolicy`
+
+Verifies that an Earn vault share token uses an expected exit-safe TIP-403 policy and that every
+required member can receive transfers and mints.
+
+The action throws when the token policy, compound components, whitelist administrator, or member
+authorization does not match the expected configuration.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+await client.earn.validateExitSafePolicy({
+  accessAdministrator: '0x0000000000000000000000000000000000000002',
+  policy: {
+    transferPolicyId: 3n,
+    senderPolicyId: 1n,
+    recipientPolicyId: 2n,
+    mintRecipientPolicyId: 2n,
+  },
+  requiredMembers: [
+    '0x0000000000000000000000000000000000000003',
+    '0x0000000000000000000000000000000000000004',
+  ],
+  shareToken: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+## Return Value
+
+`void`
+
+## Parameters
+
+### accessAdministrator
+
+- **Type:** `Address`
+
+Expected whitelist administrator.
+
+### policy
+
+- **Type:** `ExitSafePolicy`
+
+Expected compound and component policy IDs. The sender policy must be the always-allow policy, and
+the recipient and mint-recipient policy IDs must match.
+
+### requiredMembers
+
+- **Type:** `readonly Address[]`
+
+Addresses that must be authorized as recipients and mint recipients.
+
+### shareToken
+
+- **Type:** `Address`
+
+Earn vault share token expected to use the compound transfer policy.
+
+<ReadParameters />

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -1745,6 +1745,26 @@ type DecoratorBase<
   }
   earn: {
     /**
+     * Creates and attaches an admission-only TIP-403 policy to an Earn vault
+     * share token. Existing holders remain able to send shares while
+     * recipients and mint recipients must belong to the same whitelist.
+     *
+     * @example
+     * ```ts
+     * const { policy } = await client.earn.configureExitSafePolicy({
+     *   accessAdministrator: '0x...',
+     *   initialMembers: ['0x...', '0x...'],
+     *   shareToken: '0x...',
+     * })
+     * ```
+     *
+     * @param parameters - Share token, administrator, and initial members.
+     * @returns The configured policy IDs and transaction receipts.
+     */
+    configureExitSafePolicy: (
+      parameters: earnActions.configureExitSafePolicy.Parameters<account>,
+    ) => Promise<earnActions.configureExitSafePolicy.ReturnValue>
+    /**
      * Deposits assets into a vault and mints vault shares to `recipient`. The
      * transaction includes the required asset approval.
      *
@@ -2167,6 +2187,27 @@ type DecoratorBase<
     waitForPrivateRedeem: (
       parameters: earnActions.waitForPrivateRedeem.Parameters,
     ) => Promise<earnActions.waitForPrivateRedeem.ReturnType>
+    /**
+     * Verifies that an Earn vault share token uses the expected exit-safe
+     * TIP-403 policy and that every required member can receive transfers and
+     * mints.
+     *
+     * @example
+     * ```ts
+     * await client.earn.validateExitSafePolicy({
+     *   accessAdministrator: '0x...',
+     *   policy,
+     *   requiredMembers: ['0x...', '0x...'],
+     *   shareToken: '0x...',
+     * })
+     * ```
+     *
+     * @param parameters - Expected policy, administrator, and required members.
+     * @returns Nothing when the policy is valid.
+     */
+    validateExitSafePolicy: (
+      parameters: earnActions.validateExitSafePolicy.Parameters,
+    ) => Promise<earnActions.validateExitSafePolicy.ReturnValue>
     /**
      * Withdraws an exact asset amount to `recipient`, up to the specified
      * vault share limit. The transaction includes the required vault share
@@ -5871,6 +5912,7 @@ export function decorator() {
         'watchOrderPlaced',
       ]),
       earn: bindActions(client, earnActions, [
+        'configureExitSafePolicy',
         'deposit',
         'depositSync',
         'depositShares',
@@ -5888,6 +5930,7 @@ export function decorator() {
         'privateRedeemSync',
         'waitForPrivateDeposit',
         'waitForPrivateRedeem',
+        'validateExitSafePolicy',
         'withdrawExact',
         'withdrawExactSync',
       ]),

--- a/src/tempo/actions/earn.test-d.ts
+++ b/src/tempo/actions/earn.test-d.ts
@@ -37,6 +37,46 @@ const zoneClientWithAccount = createClient({
 })
 const decoratedZoneClient = zoneClientWithAccount.extend(decorator())
 
+test('exit-safe policy actions preserve account and result types', async () => {
+  const parameters = {
+    accessAdministrator: address,
+    initialMembers: [address],
+    shareToken: address,
+  } as const
+
+  // @ts-expect-error account required when the client has none
+  await earnActions.configureExitSafePolicy(client, parameters)
+  await earnActions.configureExitSafePolicy(client, {
+    ...parameters,
+    account: address,
+  })
+  const result = await earnActions.configureExitSafePolicy(
+    clientWithAccount,
+    parameters,
+  )
+  expectTypeOf(result.policy).toEqualTypeOf<earnActions.ExitSafePolicy>()
+  expectTypeOf(result.policy.transferPolicyId).toEqualTypeOf<bigint>()
+  expectTypeOf(
+    result.receipts,
+  ).toEqualTypeOf<earnActions.ExitSafePolicyReceipts>()
+  expectTypeOf(earnActions.alwaysAllowPolicyId).toEqualTypeOf<bigint>()
+
+  const decorated =
+    await decoratedClient.earn.configureExitSafePolicy(parameters)
+  expectTypeOf(
+    decorated,
+  ).toEqualTypeOf<earnActions.configureExitSafePolicy.ReturnValue>()
+
+  expectTypeOf(
+    await decoratedClient.earn.validateExitSafePolicy({
+      accessAdministrator: address,
+      policy: result.policy,
+      requiredMembers: [address],
+      shareToken: address,
+    }),
+  ).toEqualTypeOf<void>()
+})
+
 test('getVault narrows union and nested fields', async () => {
   const vault = await earnActions.getVault(client, { vault: address })
 

--- a/src/tempo/actions/earn.test.ts
+++ b/src/tempo/actions/earn.test.ts
@@ -123,6 +123,61 @@ describe('deployEarnStack', () => {
   })
 })
 
+describe('configureExitSafePolicy', () => {
+  test('default', async () => {
+    const stack = await setupStack()
+    const accessAdministrator = accounts[2].address
+    const initialMembers = [stack.adapter, accounts[1].address]
+
+    const { policy, receipts } = await Actions.earn.configureExitSafePolicy(
+      client,
+      {
+        accessAdministrator,
+        initialMembers: [...initialMembers, accounts[1].address],
+        shareToken: stack.shareToken,
+      },
+    )
+
+    expect(policy.senderPolicyId).toBe(Actions.earn.alwaysAllowPolicyId)
+    expect(policy.mintRecipientPolicyId).toBe(policy.recipientPolicyId)
+    expect(policy.transferPolicyId).not.toBe(policy.recipientPolicyId)
+    expect(receipts.eligibilityPolicy.status).toBe('success')
+    expect(receipts.compoundPolicy.status).toBe('success')
+    expect(receipts.tokenPolicy.status).toBe('success')
+    expect(receipts.policyAdmin?.status).toBe('success')
+
+    await expect(
+      Actions.earn.validateExitSafePolicy(client, {
+        accessAdministrator,
+        policy,
+        requiredMembers: initialMembers,
+        shareToken: stack.shareToken,
+      }),
+    ).resolves.toBeUndefined()
+
+    await expect(
+      Actions.earn.validateExitSafePolicy(client, {
+        accessAdministrator,
+        policy,
+        requiredMembers: [accounts[3].address],
+        shareToken: stack.shareToken,
+      }),
+    ).rejects.toThrow(
+      `Required TIP-403 member is unauthorized: ${accounts[3].address}`,
+    )
+  })
+
+  test('behavior: requires an initial member', async () => {
+    await expect(
+      Actions.earn.configureExitSafePolicy(client, {
+        accessAdministrator: account.address,
+        initialMembers: [],
+        shareToken: account.address,
+      }),
+    ).rejects.toThrow('At least one initial policy member is required.')
+  })
+})
+
 describe('deposit', () => {
   test('default', async () => {
     const stack = await setupStack()

--- a/src/tempo/actions/earn.ts
+++ b/src/tempo/actions/earn.ts
@@ -21,6 +21,7 @@ import {
   sendTransaction,
 } from '../../actions/wallet/sendTransaction.js'
 import { sendTransactionSync } from '../../actions/wallet/sendTransactionSync.js'
+import { writeContractSync } from '../../actions/wallet/writeContractSync.js'
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
@@ -31,12 +32,14 @@ import type { Compute, OneOf } from '../../types/utils.js'
 import { encodeAbiParameters } from '../../utils/abi/encodeAbiParameters.js'
 import { getAbiItem } from '../../utils/abi/getAbiItem.js'
 import { parseEventLogs } from '../../utils/abi/parseEventLogs.js'
+import { getAddress } from '../../utils/address/getAddress.js'
 import { isAddressEqual } from '../../utils/address/isAddressEqual.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
 import { withResolvers } from '../../utils/promise/withResolvers.js'
 import { stringify } from '../../utils/stringify.js'
 import * as Abis from '../Abis.js'
+import * as Addresses from '../Addresses.js'
 import {
   GetVaultEngineChangedError,
   type GetVaultEngineChangedErrorType,
@@ -59,7 +62,291 @@ import {
   resolveTokenWithDecimals,
 } from '../internal/utils.js'
 import type { TransactionReceipt } from '../Transaction.js'
+import * as policyActions from './policy.js'
+import * as tokenActions from './token.js'
 import * as zoneActions from './zone.js'
+
+/** TIP-403 policy ID that allows every sender, recipient, and mint recipient. */
+export const alwaysAllowPolicyId = 1n
+
+/** Admission-only TIP-403 policy attached to an Earn vault share token. */
+export type ExitSafePolicy = {
+  /** Compound policy attached to the vault share token. */
+  transferPolicyId: bigint
+  /** Sender policy. Must be {@link alwaysAllowPolicyId} so holders can exit. */
+  senderPolicyId: bigint
+  /** Recipient eligibility policy. */
+  recipientPolicyId: bigint
+  /** Mint-recipient eligibility policy. Must match `recipientPolicyId`. */
+  mintRecipientPolicyId: bigint
+}
+
+/** Receipts produced while configuring an exit-safe Earn policy. */
+export type ExitSafePolicyReceipts = {
+  /** Whitelist policy creation receipt. */
+  eligibilityPolicy: TransactionReceipt
+  /** Compound policy creation receipt. */
+  compoundPolicy: TransactionReceipt
+  /** Vault share token policy update receipt. */
+  tokenPolicy: TransactionReceipt
+  /** Eligibility policy admin transfer receipt, when an administrator is provided. */
+  policyAdmin?: TransactionReceipt | undefined
+}
+
+/**
+ * Creates and attaches an admission-only TIP-403 policy to an Earn vault share
+ * token. Existing holders remain able to send shares while recipients and mint
+ * recipients must belong to the same whitelist.
+ *
+ * The action submits three or four sequential transactions and is not atomic.
+ * Use {@link validateExitSafePolicy} to verify the final state.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const account = privateKeyToAccount('0x...')
+ * const client = createClient({
+ *   account,
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ *
+ * const { policy, receipts } =
+ *   await Actions.earn.configureExitSafePolicy(client, {
+ *     accessAdministrator: '0x...',
+ *     initialMembers: ['0x...', '0x...'],
+ *     shareToken: '0x...',
+ *   })
+ * ```
+ *
+ * @param client - Client authorized to change the vault share token policy.
+ * @param parameters - Share token, administrator, and initial members.
+ * @returns The configured policy IDs and transaction receipts.
+ */
+export async function configureExitSafePolicy<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: configureExitSafePolicy.Parameters<account>,
+): Promise<configureExitSafePolicy.ReturnValue> {
+  const account_ = parameters.account ?? client.account
+  if (!account_) throw new AccountNotFoundError()
+  const account = parseAccount(account_)
+  const initialMembers = [
+    ...new Set(parameters.initialMembers.map((member) => getAddress(member))),
+  ]
+  if (initialMembers.length === 0)
+    throw new Error('At least one initial policy member is required.')
+
+  const eligibility = await policyActions.createSync(client, {
+    account,
+    addresses: initialMembers,
+    chain: client.chain,
+    type: 'whitelist',
+  } as never)
+  const compoundPolicy = await writeContractSync(client, {
+    account,
+    abi: Abis.tip403Registry,
+    address: Addresses.tip403Registry,
+    args: [alwaysAllowPolicyId, eligibility.policyId, eligibility.policyId],
+    chain: client.chain,
+    functionName: 'createCompoundPolicy',
+    throwOnReceiptRevert: true,
+  } as never)
+  const [compoundEvent] = parseEventLogs({
+    abi: Abis.tip403Registry,
+    eventName: 'CompoundPolicyCreated',
+    logs: compoundPolicy.logs,
+    strict: true,
+  })
+  if (!compoundEvent)
+    throw new Error('`CompoundPolicyCreated` event not found.')
+
+  const tokenPolicy = await tokenActions.changeTransferPolicySync(client, {
+    account,
+    chain: client.chain,
+    policyId: compoundEvent.args.policyId,
+    token: parameters.shareToken,
+  } as never)
+  const policyAdmin = isAddressEqual(
+    parameters.accessAdministrator,
+    account.address,
+  )
+    ? undefined
+    : await policyActions.setAdminSync(client, {
+        account,
+        admin: parameters.accessAdministrator,
+        chain: client.chain,
+        policyId: eligibility.policyId,
+      } as never)
+
+  return {
+    policy: {
+      transferPolicyId: compoundEvent.args.policyId,
+      senderPolicyId: alwaysAllowPolicyId,
+      recipientPolicyId: eligibility.policyId,
+      mintRecipientPolicyId: eligibility.policyId,
+    },
+    receipts: {
+      eligibilityPolicy: eligibility.receipt,
+      compoundPolicy,
+      tokenPolicy: tokenPolicy.receipt,
+      policyAdmin: policyAdmin?.receipt,
+    },
+  }
+}
+
+export namespace configureExitSafePolicy {
+  export type Args = {
+    /** Address that will administer recipient eligibility. */
+    accessAdministrator: Address
+    /** Addresses initially eligible to receive or be minted vault shares. */
+    initialMembers: readonly Address[]
+    /** Earn vault share token. */
+    shareToken: Address
+  }
+  export type Parameters<
+    account extends Account | undefined = Account | undefined,
+  > = GetAccountParameter<account> & Args
+  export type ReturnValue = Compute<{
+    /** Configured onchain policy IDs. */
+    policy: ExitSafePolicy
+    /** Receipts for each configuration transaction. */
+    receipts: ExitSafePolicyReceipts
+  }>
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+/**
+ * Verifies that an Earn vault share token uses the expected exit-safe TIP-403
+ * policy and that every required member can receive transfers and mints.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ *
+ * await Actions.earn.validateExitSafePolicy(client, {
+ *   accessAdministrator: '0x...',
+ *   policy: {
+ *     transferPolicyId: 3n,
+ *     senderPolicyId: 1n,
+ *     recipientPolicyId: 2n,
+ *     mintRecipientPolicyId: 2n,
+ *   },
+ *   requiredMembers: ['0x...', '0x...'],
+ *   shareToken: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Expected policy, administrator, and required members.
+ * @returns Nothing when the policy is valid.
+ */
+export async function validateExitSafePolicy<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  parameters: validateExitSafePolicy.Parameters,
+): Promise<validateExitSafePolicy.ReturnValue> {
+  const { accessAdministrator, policy, requiredMembers, shareToken, ...rest } =
+    parameters
+  const [tokenPolicyId, compound, simplePolicy, memberResults] =
+    await Promise.all([
+      readContract(client, {
+        ...rest,
+        abi: Abis.tip20,
+        address: shareToken,
+        functionName: 'transferPolicyId',
+      }),
+      readContract(client, {
+        ...rest,
+        abi: Abis.tip403Registry,
+        address: Addresses.tip403Registry,
+        args: [policy.transferPolicyId],
+        functionName: 'compoundPolicyData',
+      }),
+      readContract(client, {
+        ...rest,
+        abi: Abis.tip403Registry,
+        address: Addresses.tip403Registry,
+        args: [policy.recipientPolicyId],
+        functionName: 'policyData',
+      }),
+      Promise.all(
+        requiredMembers.map(async (member) => {
+          const [recipient, mintRecipient] = await Promise.all([
+            readContract(client, {
+              ...rest,
+              abi: Abis.tip403Registry,
+              address: Addresses.tip403Registry,
+              args: [policy.transferPolicyId, member],
+              functionName: 'isAuthorizedRecipient',
+            }),
+            readContract(client, {
+              ...rest,
+              abi: Abis.tip403Registry,
+              address: Addresses.tip403Registry,
+              args: [policy.transferPolicyId, member],
+              functionName: 'isAuthorizedMintRecipient',
+            }),
+          ])
+          return { member, mintRecipient, recipient }
+        }),
+      ),
+    ])
+
+  if (tokenPolicyId !== policy.transferPolicyId)
+    throw new Error('Earn vault share token transfer policy mismatch.')
+  if (
+    compound[0] !== policy.senderPolicyId ||
+    compound[1] !== policy.recipientPolicyId ||
+    compound[2] !== policy.mintRecipientPolicyId
+  )
+    throw new Error('TIP-403 compound policy components mismatch.')
+  if (policy.senderPolicyId !== alwaysAllowPolicyId)
+    throw new Error('TIP-403 sender policy is not always allow.')
+  if (policy.recipientPolicyId !== policy.mintRecipientPolicyId)
+    throw new Error('TIP-403 recipient and mint-recipient policies must match.')
+  if (simplePolicy[0] !== 0)
+    throw new Error('TIP-403 eligibility policy is not a whitelist.')
+  if (!isAddressEqual(simplePolicy[1], accessAdministrator))
+    throw new Error('TIP-403 access administrator mismatch.')
+  const unauthorized = memberResults.find(
+    (result) => !result.recipient || !result.mintRecipient,
+  )
+  if (unauthorized)
+    throw new Error(
+      `Required TIP-403 member is unauthorized: ${unauthorized.member}`,
+    )
+}
+
+export namespace validateExitSafePolicy {
+  export type Args = {
+    /** Expected eligibility policy administrator. */
+    accessAdministrator: Address
+    /** Expected exit-safe policy IDs. */
+    policy: ExitSafePolicy
+    /** Addresses that must be eligible to receive or be minted vault shares. */
+    requiredMembers: readonly Address[]
+    /** Earn vault share token. */
+    shareToken: Address
+  }
+  export type Parameters = Omit<ReadParameters, 'account'> & Args
+  export type ReturnValue = void
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
 
 /**
  * Deposits assets into a vault and mints vault shares to `recipient`. The


### PR DESCRIPTION
## Summary

Added Viem-native actions for configuring and validating the exit-safe TIP-403 policy used by Earn vault share tokens. Exposed both actions through the Tempo decorator with runtime tests, type tests, API documentation, and a changeset.

## Motivation

The Earn SDK still owned policy orchestration that belongs in Viem, which prevented `tempoxyz/earn` from consuming the upstream Earn action surface directly. Moving the onchain configuration and validation into Viem leaves only deployment-registry serialization in the application.

## Changes

- Added `configureExitSafePolicy` to create the eligibility whitelist, compose the always-allow sender policy, attach it to the share token, and hand off policy administration.
- Added `validateExitSafePolicy` to verify token policy wiring, compound policy components, whitelist administration, and required member authorization.
- Added decorator bindings, local Tempo coverage, public type assertions, action documentation, and a minor changeset.
- Documented that configuration submits three or four sequential transactions and requires post-configuration validation because it is not atomic.

## Testing

- `pnpm test --run src/tempo/actions/earn.test.ts` (68 tests passed)
- `pnpm build:types`
- `pnpm check:types`
- `pnpm exec biome check` on the seven changed files
- `pnpm docs:build` compiled the documentation through the client build; the final AI search indexing step requires `CLOUDFLARE_ACCOUNT_ID`, which is unavailable locally.