### PR TITLE
fix(tempo): preserve relay fee payer signatures

### DIFF
--- a/.changeset/quick-relays-sign.md
+++ b/.changeset/quick-relays-sign.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Tempo access key transactions failing by preserving the gas limit covered by fee payer signatures returned from `eth_fillTransaction`.

--- a/src/tempo/Transport.test.ts
+++ b/src/tempo/Transport.test.ts
@@ -1,8 +1,8 @@
 import * as Http from 'node:http'
 import { createRequestListener } from '@remix-run/node-fetch-server'
-import { Hex, RpcRequest, RpcResponse } from 'ox'
-import { MultisigConfig } from 'ox/tempo'
-import { privateKeyToAccount } from 'viem/accounts'
+import { Hex, RpcRequest, RpcResponse, Signature } from 'ox'
+import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import {
   getCallsStatus,
   prepareTransactionRequest,
@@ -11,13 +11,20 @@ import {
   sendTransactionSync,
   signTransaction,
 } from 'viem/actions'
-import { Account, Transaction } from 'viem/tempo'
+import { Account, Actions, Transaction } from 'viem/tempo'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
-import { accounts, chain, getClient, http } from '~test/tempo/config.js'
+import {
+  accounts,
+  chain,
+  feeToken,
+  getClient,
+  http,
+} from '~test/tempo/config.js'
 import { walletNamespaceCompat, withFeePayer, withRelay } from './Transport.js'
 
 describe('withRelay', () => {
   let server: Http.Server
+  let sponsorFills = false
   let relayRequests: Array<{
     method: string
     params: readonly unknown[] | undefined
@@ -40,6 +47,41 @@ describe('withRelay', () => {
         })
 
         if (request.method === 'eth_fillTransaction') {
+          if (sponsorFills) {
+            const result = await feePayerClient.request({
+              method: 'eth_fillTransaction',
+              params: request.params as never,
+            })
+            const transaction = {
+              ...Transaction.deserialize(result.raw as `0x76${string}`),
+              feeToken,
+            }
+            const sender = (request.params?.[0] as { from: `0x${string}` }).from
+            const feePayerSignature = Signature.from(
+              await accounts[0].sign({
+                hash: TxEnvelopeTempo.getFeePayerSignPayload(
+                  TxEnvelopeTempo.from(transaction as never),
+                  { sender },
+                ),
+              }),
+            )
+
+            return Response.json(
+              RpcResponse.from({
+                id: request.id,
+                jsonrpc: request.jsonrpc,
+                result: {
+                  ...result,
+                  tx: {
+                    ...result.tx,
+                    feePayerSignature: Signature.toRpc(feePayerSignature),
+                    feeToken,
+                  },
+                },
+              }),
+            )
+          }
+
           return Response.json(
             RpcResponse.from({
               id: request.id,
@@ -103,6 +145,7 @@ describe('withRelay', () => {
   })
 
   beforeEach(() => {
+    sponsorFills = false
     relayRequests = []
   })
 
@@ -133,6 +176,30 @@ describe('withRelay', () => {
         method: 'eth_signRawTransaction',
         params: expect.any(Array),
       })
+    })
+
+    test('behavior: access key preserves fill-time sponsorship', async () => {
+      sponsorFills = true
+      const account = Account.fromSecp256k1(generatePrivateKey())
+      const accessKey = Account.fromSecp256k1(generatePrivateKey(), {
+        access: account,
+      })
+      const keyAuthorization = await Actions.accessKey.signAuthorization(
+        client,
+        { account, accessKey },
+      )
+
+      const receipt = await sendTransactionSync(client, {
+        account: accessKey,
+        feePayer: true,
+        keyAuthorization,
+        to: '0x0000000000000000000000000000000000000000',
+      })
+
+      expect(receipt.status).toBe('success')
+      expect(relayRequests.map(({ method }) => method)).toEqual([
+        'eth_fillTransaction',
+      ])
     })
 
     test('behavior: sendTransaction still gets sponsored via feePayer: true when nonce/gas/fees are pre-populated', async () => {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -58,6 +58,7 @@ export const chainConfig = {
               feeToken?: TokenId.TokenIdOrAddress | undefined
             })
           | undefined
+        feePayerSignature?: Transaction.TransactionSerializableTempo['feePayerSignature']
         from?: Address | undefined
         multisig?: MultisigConfig.Config | undefined
         signatures?: readonly unknown[] | undefined
@@ -66,7 +67,8 @@ export const chainConfig = {
       // FIXME: node estimates gas with secp256k1 dummy sig + null feePayerSignature.
       // Actual tx has larger keychain/webAuthn sigs + real fee payer sig, costing more intrinsic gas.
       if (phase === 'afterFillParameters') {
-        if (request.feePayer) {
+        // Fee payer signature covers the gas limit, so the relay must set it before signing and Viem must not change it afterward.
+        if (request.feePayer && !request.feePayerSignature) {
           if (request.keyAuthorization?.signature.type === 'webAuthn')
             request.gas = (request.gas ?? 0n) + 20_000n
           else if (request.account?.source === 'accessKey')


### PR DESCRIPTION
Preserves relay-provided fee payer signatures by avoiding post-signature gas padding for Tempo access key transactions.