### PR TITLE
fix(tempo): support T8 and T9 zones

### DIFF
--- a/.changeset/swift-zone-sequencers.md
+++ b/.changeset/swift-zone-sequencers.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Replaced `zone.getZoneInfo.sequencer` with `sequencers`.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -203,11 +203,23 @@ jobs:
           VITE_TEMPO_TAG: sha-6d831c2
 
   test-tempo-zones:
-    name: Test Local Tempo Zones
+    name: Test Local Tempo Zones (${{ matrix.version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: T8
+            tempo-tag: sha-e828ab7
+            zone-tag: sha-aae82c4
+            zone-xtask-tag: ''
+          - version: T9
+            tempo-tag: sha256:290c7c1843cc8fbc8c0e5e37025c5373050d21004e4d22f4b00f978dfbee4c47
+            zone-tag: sha256:2cb2d54c6d5b0473c1d0fc112d806fcb80a21516b660d4ab6e1bb0bcc7a97896
+            zone-xtask-tag: sha256:57bdf58caf4654eef2615260b19c1b65d8823af150e95643d0619a97dcbba3bd
 
     steps:
       - name: Clone repository
@@ -230,10 +242,10 @@ jobs:
         env:
           CI: true
           VITE_TEMPO_ENV: localnet
-          # TODO: Restore latest tags once Tempo includes the ZoneFactory contract.
-          VITE_TEMPO_TAG: sha-e828ab7
+          VITE_TEMPO_TAG: ${{ matrix.tempo-tag }}
           VITE_TEMPO_ZONES: 'true'
-          VITE_TEMPO_ZONE_TAG: sha-aae82c4
+          VITE_TEMPO_ZONE_TAG: ${{ matrix.zone-tag }}
+          VITE_TEMPO_ZONE_XTASK_TAG: ${{ matrix.zone-xtask-tag }}
 
   test-envs:
     name: Test Environments

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: pnpm test --bail=1 --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
+          command: pnpm test --bail=1 --project core --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
         env:
           CI: true
           VITE_ANVIL_FORK_URL: ${{ secrets.VITE_ANVIL_FORK_URL }}
@@ -134,8 +134,6 @@ jobs:
           VITE_BATCH_MULTICALL: ${{ matrix.multicall }}
           VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}
           VITE_SHARD_ID: ${{ matrix.shard }}
-          VITE_TEMPO_ENV: localnet
-          VITE_TEMPO_TAG: latest
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
@@ -202,16 +200,24 @@ jobs:
           VITE_TEMPO_MULTISIG: 'true'
           VITE_TEMPO_TAG: sha-6d831c2
 
-  test-tempo-zones:
-    name: Test Local Tempo Zones (${{ matrix.version }})
+  test-tempo:
+    name: Test Local Tempo (${{ matrix.version }}, ${{ matrix.shard }}/${{ matrix.total-shards }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
+        version: [T7, T8, T9]
+        shard: [1, 2, 3]
+        total-shards: [3]
         include:
+          - version: T7
+            tempo-tag: sha-f56f173
+            zone-tag: sha-aae82c4
+            zone-xtask-tag: ''
           - version: T8
             tempo-tag: sha-e828ab7
             zone-tag: sha-aae82c4
@@ -233,12 +239,12 @@ jobs:
       - name: Build contracts
         run: pnpm contracts:build
 
-      - name: Run tests
+      - name: Test Local Tempo
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: pnpm test --run --bail=1 --project tempo src/tempo/actions/zone.test.ts
+          command: pnpm test --run --bail=1 --project tempo --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
         env:
           CI: true
           VITE_TEMPO_ENV: localnet

--- a/site/pages/tempo/actions/zone.getZoneInfo.mdx
+++ b/site/pages/tempo/actions/zone.getZoneInfo.mdx
@@ -14,11 +14,11 @@ const info = await client.zone.getZoneInfo()
 
 console.log('Zone ID:', info.zoneId)
 console.log('Chain ID:', info.chainId)
-console.log('Sequencer:', info.sequencer)
+console.log('Sequencers:', info.sequencers)
 console.log('Tempo block number:', info.tempoBlockNumber)
 // @log: Zone ID: 7
 // @log: Chain ID: 1337
-// @log: Sequencer: 0x...
+// @log: Sequencers: ['0x...']
 // @log: Tempo block number: 1234n
 ```
 
@@ -34,9 +34,9 @@ console.log('Tempo block number:', info.tempoBlockNumber)
 ```ts
 type ReturnType = {
   chainId: number
-  sequencer: Address
+  sequencers: readonly Address[]
   tempoBlockNumber: bigint
   zoneId: number
-  zoneTokens: Address[]
+  zoneTokens: readonly Address[]
 }
 ```

--- a/site/pages/tempo/actions/zone.requestWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestWithdrawal.mdx
@@ -137,6 +137,7 @@ Gas limit reserved for the withdrawal callback on the parent chain.
 ### gas (optional)
 
 - **Type:** `bigint`
+- **Default:** `10_000_000n`
 
 Transaction gas limit on the Zone chain.
 

--- a/site/pages/tempo/guides/zones/connect.mdx
+++ b/site/pages/tempo/guides/zones/connect.mdx
@@ -83,7 +83,7 @@ const { token } = await client.zone.signAuthorizationToken()
 ### Use Zone Actions
 
 Once authenticated, use [Zone Actions](/tempo/actions) to interact with your zone, such as
-[`zone.getZoneInfo`](/tempo/actions/zone.getZoneInfo) to read the zone's id, chain id, and sequencer.
+[`zone.getZoneInfo`](/tempo/actions/zone.getZoneInfo) to read the zone's id, chain id, and sequencers.
 
 :::code-group
 

--- a/src/tempo/actions/simulate.test.ts
+++ b/src/tempo/actions/simulate.test.ts
@@ -544,7 +544,7 @@ describe('simulateCalls', () => {
     expect(recipientBaseAfter.amount - recipientBaseBefore.amount).toBe(
       buyAmount,
     )
-  })
+  }, 30_000)
 
   test('behavior: multiple getBalance reads', async () => {
     const result = await actions.simulate.simulateCalls(client, {

--- a/src/tempo/actions/simulate.test.ts
+++ b/src/tempo/actions/simulate.test.ts
@@ -34,7 +34,12 @@ describe('simulateBlocks', () => {
     })
 
     const call = result.blocks[0].calls[0]
-    const { data: _data, result: _result, ...callWithoutDynamic } = call
+    const {
+      data: _data,
+      gasUsed,
+      result: _result,
+      ...callWithoutDynamic
+    } = call
 
     expect({
       calls: [callWithoutDynamic],
@@ -43,7 +48,6 @@ describe('simulateBlocks', () => {
       {
         "calls": [
           {
-            "gasUsed": 271644n,
             "logs": [],
             "status": "success",
           },
@@ -59,6 +63,8 @@ describe('simulateBlocks', () => {
     `)
 
     expect(call.data).toBeTypeOf('string')
+    expect(gasUsed).toBeTypeOf('bigint')
+    expect(gasUsed).toBeGreaterThan(0n)
     expect(call.result).toBeTypeOf('bigint')
   })
 
@@ -78,17 +84,16 @@ describe('simulateBlocks', () => {
     })
 
     const call = result.blocks[0].calls[0]
-    const { data: _, ...callWithoutData } = call
+    const { data: _, gasUsed, ...callWithoutDynamic } = call
     const log = call.logs![0]
 
     expect({
-      ...callWithoutData,
-      logs: callWithoutData.logs?.map(
+      ...callWithoutDynamic,
+      logs: callWithoutDynamic.logs?.map(
         ({ blockHash, blockNumber, blockTimestamp, ...l }) => l,
       ),
     }).toMatchInlineSnapshot(`
       {
-        "gasUsed": 539270n,
         "logs": [
           {
             "address": "0x20c0000000000000000000000000000000000001",
@@ -109,6 +114,8 @@ describe('simulateBlocks', () => {
       }
     `)
 
+    expect(gasUsed).toBeTypeOf('bigint')
+    expect(gasUsed).toBeGreaterThan(0n)
     expect(log.blockHash).toBeDefined()
     expect(log.blockNumber).toBeTypeOf('bigint')
     expect(log.blockTimestamp).toBeTypeOf('bigint')

--- a/src/tempo/actions/zone.test-d.ts
+++ b/src/tempo/actions/zone.test-d.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'viem'
 import { expectTypeOf, test } from 'vitest'
 import { sendTransaction } from '../../actions/wallet/sendTransaction.js'
 import { tempoModerato } from '../../chains/index.js'
@@ -127,9 +128,10 @@ test('getEncryptionKey returns the active key and index', async () => {
   })
 })
 
-test('getZoneInfo returns the imported Tempo block number', async () => {
+test('getZoneInfo returns sequencers and the imported Tempo block number', async () => {
   const info = await zoneActions.getZoneInfo(zoneClient)
 
+  expectTypeOf(info.sequencers).toEqualTypeOf<readonly Address[]>()
   expectTypeOf(info.tempoBlockNumber).toEqualTypeOf<bigint>()
 })
 

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -7,6 +7,7 @@ import {
   decodeFunctionData,
   encodeFunctionData,
   type Hash,
+  isAddressEqual,
   parseEventLogs,
   zeroHash,
 } from 'viem'
@@ -22,13 +23,14 @@ import { parseUnits } from 'viem/utils'
 import { describe, expect, test } from 'vitest'
 import { accounts } from '~test/constants.js'
 import { chain, http, nodeEnv } from '~test/tempo/config.js'
-import { defineZone } from '~test/tempo/prool.js'
+import { defineZone, zoneAdminKey } from '~test/tempo/prool.js'
 import {
   factoryAddress,
   getClient as getZoneClient,
   portalAddress,
   zoneId,
 } from '~test/tempo/zones.js'
+import { createHttpServer } from '~test/utils.js'
 import * as Storage from '../Storage.js'
 import * as ZoneAbis from '../zones/Abis.js'
 import { getPortalAddress } from '../zones/zone.js'
@@ -36,8 +38,15 @@ import * as tokenActions from './token.js'
 import * as zoneActions from './zone.js'
 
 const account = privateKeyToAccount(accounts[0].privateKey)
+const portalAdmin = privateKeyToAccount(zoneAdminKey)
 const mainnetClient = createClient({
   account,
+  chain,
+  pollingInterval: 100,
+  transport: http(),
+})
+const portalAdminClient = createClient({
+  account: portalAdmin,
   chain,
   pollingInterval: 100,
   transport: http(),
@@ -104,35 +113,60 @@ async function ensureZoneBalance(zoneToken: Address, minimumBalance: bigint) {
 async function createUnconfiguredZone() {
   if (!factoryAddress) throw new Error('ZoneFactory is unavailable.')
 
-  const verifier = await readContract(mainnetClient, {
-    address: factoryAddress,
-    abi: ZoneAbis.zoneFactory,
-    functionName: 'verifier',
-  })
-  const genesisTempoBlockNumber = BigInt(
-    await mainnetClient.request({ method: 'eth_blockNumber' }),
-  )
-  const hash = await writeContract(mainnetClient, {
-    account,
-    address: factoryAddress,
-    abi: ZoneAbis.zoneFactory,
-    functionName: 'createZone',
-    args: [
-      {
-        initialToken: parentToken,
-        admin: account.address,
-        sequencer: account.address,
-        verifier,
-        zoneParams: {
-          genesisBlockHash: zeroHash,
-          genesisTempoBlockHash: zeroHash,
-          genesisTempoBlockNumber,
-        },
-        rpcUrl: 'http://127.0.0.1:0',
-      },
-    ],
-    gas: 20_000_000n,
-  })
+  const info = await zoneClient.request<{
+    Method: 'zone_getZoneInfo'
+    Parameters: []
+    ReturnType: zoneActions.getZoneInfo.RpcReturnType
+  }>({ method: 'zone_getZoneInfo', params: [] })
+  const hash =
+    'sequencers' in info
+      ? await writeContract(portalAdminClient, {
+          account: portalAdmin,
+          address: factoryAddress,
+          abi: ZoneAbis.zoneFactory,
+          functionName: 'createZone',
+          args: [
+            {
+              initialToken: parentToken,
+              admin: account.address,
+              sequencers: [account.address],
+              threshold: 1,
+              rpcUrl: 'http://127.0.0.1:0',
+            },
+          ],
+          gas: 20_000_000n,
+        })
+      : await (async () => {
+          const verifier = await readContract(mainnetClient, {
+            address: factoryAddress,
+            abi: ZoneAbis.zoneFactory,
+            functionName: 'verifier',
+          })
+          const genesisTempoBlockNumber = BigInt(
+            await mainnetClient.request({ method: 'eth_blockNumber' }),
+          )
+          return writeContract(mainnetClient, {
+            account,
+            address: factoryAddress,
+            abi: ZoneAbis.zoneFactory,
+            functionName: 'createZone',
+            args: [
+              {
+                initialToken: parentToken,
+                admin: account.address,
+                sequencer: account.address,
+                verifier,
+                zoneParams: {
+                  genesisBlockHash: zeroHash,
+                  genesisTempoBlockHash: zeroHash,
+                  genesisTempoBlockNumber,
+                },
+                rpcUrl: 'http://127.0.0.1:0',
+              },
+            ],
+            gas: 20_000_000n,
+          })
+        })()
   const receipt = await waitForTransactionReceipt(mainnetClient, { hash })
   const [event] = parseEventLogs({
     abi: ZoneAbis.zoneFactory,
@@ -161,10 +195,7 @@ describe('zone instance', () => {
     async () => {
       if (!factoryAddress) throw new Error('ZoneFactory is unavailable.')
 
-      const secondary = defineZone({
-        factoryAddress,
-        key: accounts[2].privateKey,
-      })
+      const secondary = defineZone({ factoryAddress })
 
       try {
         const [zone_, sameZone] = await Promise.all([
@@ -264,9 +295,59 @@ describe('getZoneInfo', () => {
 
     expect(info.zoneId).toBe(zoneId)
     expect(info.chainId).toBe(zoneClient.chain.id)
-    expect(info.sequencer).toBeDefined()
+    expect(info.sequencers).toHaveLength(1)
+    expect(isAddressEqual(info.sequencers[0]!, portalAdmin.address)).toBe(true)
     expect(info.tempoBlockNumber).toBeGreaterThanOrEqual(0n)
     expect(info.zoneTokens).toBeDefined()
+  })
+
+  test('behavior: normalizes a response without a block number', async () => {
+    const server = await createHttpServer(async (req, res) => {
+      let body = ''
+      req.setEncoding('utf8')
+      for await (const chunk of req) body += chunk
+      const request = JSON.parse(body)
+      const result =
+        request.method === 'zone_getZoneInfo'
+          ? {
+              chainId: '0x1922a1a1',
+              sequencer: account.address,
+              zoneId: '0x1',
+              zoneTokens: [parentToken],
+            }
+          : { zoneProcessedThrough: '0x1' }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          id: request.id,
+          jsonrpc: '2.0',
+          result,
+        }),
+      )
+    })
+
+    try {
+      const client = createClient({ transport: http(server.url) })
+
+      const info = await zoneActions.getZoneInfo(client)
+
+      expect(info).toMatchInlineSnapshot(`
+        {
+          "chainId": 421700001,
+          "sequencers": [
+            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          ],
+          "tempoBlockNumber": 1n,
+          "zoneId": 1,
+          "zoneTokens": [
+            "0x20c0000000000000000000000000000000000000",
+          ],
+        }
+      `)
+    } finally {
+      await server.close()
+    }
   })
 })
 
@@ -722,7 +803,7 @@ describe('requestWithdrawal', () => {
     })
     expect(prepared.request.calls).toHaveLength(2)
     expect(prepared.request.type).toBe('tempo')
-    expect(prepared.request.gas).toBeGreaterThan(0n)
+    expect(prepared.request.gas).toBe(10_000_000n)
     const denominator = 1_000_000_000_000n
     expect(prepared.maxFee).toBe(
       (prepared.request.gas * prepared.request.maxFeePerGas +

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -56,6 +56,8 @@ import type { TransactionReceipt } from '../Transaction.js'
 import * as ZoneAbis from '../zones/Abis.js'
 import { getPortalAddress } from '../zones/zone.js'
 
+const defaultWithdrawalGas = 10_000_000n
+
 export type EncryptedPayload = {
   ciphertext: Hex.Hex
   ephemeralPubkeyX: Hex.Hex
@@ -1029,11 +1031,23 @@ export async function getZoneInfo<
     method: 'zone_getZoneInfo',
     params: [],
   })
+  const tempoBlockNumber =
+    info.tempoBlockNumber ??
+    (
+      await client.request<{
+        Method: 'zone_getDepositStatus'
+        Parameters: [Hex.Hex]
+        ReturnType: { zoneProcessedThrough: Hex.Hex }
+      }>({
+        method: 'zone_getDepositStatus',
+        params: ['0x0'],
+      })
+    ).zoneProcessedThrough
 
   return {
     chainId: Hex.toNumber(info.chainId),
-    sequencer: info.sequencer,
-    tempoBlockNumber: Hex.toBigInt(info.tempoBlockNumber),
+    sequencers: 'sequencers' in info ? info.sequencers : [info.sequencer],
+    tempoBlockNumber: Hex.toBigInt(tempoBlockNumber),
     zoneId: Hex.toNumber(info.zoneId),
     zoneTokens: info.zoneTokens,
   }
@@ -1041,18 +1055,35 @@ export async function getZoneInfo<
 
 export namespace getZoneInfo {
   export type RpcReturnType = {
+    /** Zone chain ID. */
     chainId: Hex.Hex
-    sequencer: Address
-    tempoBlockNumber: Hex.Hex
+    /** Latest Tempo block imported by the zone. */
+    tempoBlockNumber?: Hex.Hex | undefined
+    /** Zone ID. */
     zoneId: Hex.Hex
+    /** Enabled zone token addresses. */
     zoneTokens: readonly Address[]
-  }
+  } & (
+    | {
+        /** Active sequencer addresses. */
+        sequencers: readonly Address[]
+      }
+    | {
+        /** Active sequencer address. */
+        sequencer: Address
+      }
+  )
 
   export type ReturnType = {
+    /** Zone chain ID. */
     chainId: number
-    sequencer: Address
+    /** Active sequencer addresses. */
+    sequencers: readonly Address[]
+    /** Latest Tempo block imported by the zone. */
     tempoBlockNumber: bigint
+    /** Zone ID. */
     zoneId: number
+    /** Enabled zone token addresses. */
     zoneTokens: readonly Address[]
   }
 
@@ -1207,6 +1238,7 @@ export async function requestWithdrawal<
   return sendTransaction(client, {
     ...pickWriteParameters(parameters as never),
     calls: requestWithdrawal.calls(args),
+    gas: parameters.gas ?? defaultWithdrawalGas,
   } as never) as never
 }
 
@@ -1358,6 +1390,7 @@ export namespace requestWithdrawal {
         to,
         token,
       }),
+      gas: transactionRequest.gas ?? defaultWithdrawalGas,
     } as never)
     const feePerGas = request.maxFeePerGas ?? request.gasPrice
     if (typeof request.gas !== 'bigint' || typeof feePerGas !== 'bigint')
@@ -1489,6 +1522,7 @@ export async function requestWithdrawalSync<
     ...pickWriteParameters(parameters as never),
     ...pickWriteSyncParameters(parameters as never),
     calls: requestWithdrawal.calls(args),
+    gas: parameters.gas ?? defaultWithdrawalGas,
     throwOnReceiptRevert,
   } as never)
   return { receipt }
@@ -1562,6 +1596,7 @@ export async function requestVerifiableWithdrawal<
   return sendTransaction(client, {
     ...pickWriteParameters(parameters as never),
     calls: requestVerifiableWithdrawal.calls(args),
+    gas: parameters.gas ?? defaultWithdrawalGas,
   } as never) as never
 }
 
@@ -1676,6 +1711,7 @@ export async function requestVerifiableWithdrawalSync<
     ...pickWriteParameters(parameters as never),
     ...pickWriteSyncParameters(parameters as never),
     calls: requestVerifiableWithdrawal.calls(args),
+    gas: parameters.gas ?? defaultWithdrawalGas,
     throwOnReceiptRevert,
   } as never)
   return { receipt }

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -1,0 +1,40 @@
+import { encodeFunctionData, type Hex, zeroAddress, zeroHash } from 'viem'
+import { Abis } from 'viem/tempo/zones'
+import { expectTypeOf, test } from 'vitest'
+
+test('zoneFactory supports both parameter shapes', () => {
+  const sequencerSet = encodeFunctionData({
+    abi: Abis.zoneFactory,
+    functionName: 'createZone',
+    args: [
+      {
+        initialToken: zeroAddress,
+        admin: zeroAddress,
+        sequencers: [zeroAddress],
+        threshold: 1,
+        rpcUrl: '',
+      },
+    ],
+  })
+  const sequencer = encodeFunctionData({
+    abi: Abis.zoneFactory,
+    functionName: 'createZone',
+    args: [
+      {
+        initialToken: zeroAddress,
+        admin: zeroAddress,
+        sequencer: zeroAddress,
+        verifier: zeroAddress,
+        zoneParams: {
+          genesisBlockHash: zeroHash,
+          genesisTempoBlockHash: zeroHash,
+          genesisTempoBlockNumber: 0n,
+        },
+        rpcUrl: '',
+      },
+    ],
+  })
+
+  expectTypeOf(sequencerSet).toEqualTypeOf<Hex>()
+  expectTypeOf(sequencer).toEqualTypeOf<Hex>()
+})

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -5,6 +5,19 @@ export const zoneFactory = [
     inputs: [
       { name: 'zoneId', type: 'uint32', indexed: true },
       { name: 'portal', type: 'address', indexed: true },
+      { name: 'initialToken', type: 'address', indexed: false },
+      { name: 'admin', type: 'address', indexed: false },
+      { name: 'sequencers', type: 'address[]', indexed: false },
+      { name: 'threshold', type: 'uint8', indexed: false },
+      { name: 'verifier', type: 'address', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'ZoneCreated',
+    inputs: [
+      { name: 'zoneId', type: 'uint32', indexed: true },
+      { name: 'portal', type: 'address', indexed: true },
       { name: 'messenger', type: 'address', indexed: true },
       { name: 'initialToken', type: 'address', indexed: false },
       { name: 'admin', type: 'address', indexed: false },
@@ -17,6 +30,28 @@ export const zoneFactory = [
         type: 'uint64',
         indexed: false,
       },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'createZone',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'params',
+        type: 'tuple',
+        components: [
+          { name: 'initialToken', type: 'address' },
+          { name: 'admin', type: 'address' },
+          { name: 'sequencers', type: 'address[]' },
+          { name: 'threshold', type: 'uint8' },
+          { name: 'rpcUrl', type: 'string' },
+        ],
+      },
+    ],
+    outputs: [
+      { name: 'zoneId', type: 'uint32' },
+      { name: 'portal', type: 'address' },
     ],
   },
   {

--- a/test/src/tempo/prool.tmp.ts
+++ b/test/src/tempo/prool.tmp.ts
@@ -1,0 +1,279 @@
+// TODO: Remove after https://github.com/tempoxyz/tempo/pull/6916 and
+// https://github.com/tempoxyz/zones/pull/767 merge.
+import { execFileSync } from 'node:child_process'
+import { AbiParameters, Address, Hash, Hex, Secp256k1 } from 'ox'
+import { Instance } from 'prool'
+import {
+  GenericContainer,
+  PullPolicy,
+  type StartedTestContainer,
+  Wait,
+} from 'testcontainers'
+import { pathUsd } from '../../../src/tempo/Addresses.js'
+
+const zoneFactory = {
+  address: '0x5aF2000000000000000000000000000000000000',
+  code: '0xef',
+} as const
+
+const zoneMessenger = {
+  address: '0x5A4D000000000000000000000000000000000000',
+  artifact: 'ZoneMessenger',
+} as const
+
+const zonePortal = {
+  address: '0x5AD1000000000000000000000000000000000000',
+  artifact: 'ZonePortal',
+} as const
+
+const zoneVerifier = {
+  address: '0x5A56000000000000000000000000000000000000',
+  artifact: 'Verifier',
+} as const
+
+// Zone settlement reads Tempo block hashes from the canonical EIP-2935 account.
+const historyStorage = {
+  address: '0x0000f90827f1c53a10cb7a02335b175320002935',
+  code: '0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500',
+} as const
+
+const tip403Registry = {
+  address: '0x403c000000000000000000000000000000000000',
+  storage: {
+    [Hash.keccak256(
+      AbiParameters.encode(AbiParameters.from('address, uint256'), [
+        pathUsd,
+        4n,
+      ]),
+    )]: Hex.fromNumber((1n << 64n) | 1n, { size: 32 }),
+  },
+} as const
+
+type Genesis = {
+  alloc: Record<
+    string,
+    {
+      balance?: string | undefined
+      code?: string | undefined
+      nonce?: string | undefined
+      storage?: Record<string, string> | undefined
+    }
+  >
+}
+
+type ZoneArtifacts = {
+  messenger: string
+  portal: string
+  verifier: string
+}
+
+type Parameters = {
+  artifactsImage: string
+  blockTime: string
+  image: string
+  log?: Instance.tempo.Parameters['log'] | undefined
+  ownerKey: `0x${string}`
+  port: number
+}
+
+export function createTempo(parameters: Parameters) {
+  return tempo({
+    ...parameters,
+    genesisContent: buildZoneGenesis(parameters),
+  })
+}
+
+function buildZoneGenesis(options: {
+  artifactsImage: string
+  image: string
+  ownerKey: `0x${string}`
+}) {
+  const dumped = execFileSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '--platform',
+      'linux/amd64',
+      '--entrypoint',
+      '/usr/local/bin/tempo',
+      options.image,
+      '-q',
+      'dump-genesis',
+      '--chain',
+      'dev',
+    ],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  )
+  const genesis = JSON.parse(dumped) as Genesis
+  const artifacts = JSON.parse(
+    execFileSync(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '--platform',
+        'linux/amd64',
+        '--entrypoint',
+        '/usr/bin/jq',
+        options.artifactsImage,
+        '-n',
+        '--slurpfile',
+        'portal',
+        `/app/specs/ref-impls/out/${zonePortal.artifact}.sol/${zonePortal.artifact}.json`,
+        '--slurpfile',
+        'messenger',
+        `/app/specs/ref-impls/out/${zoneMessenger.artifact}.sol/${zoneMessenger.artifact}.json`,
+        '--slurpfile',
+        'verifier',
+        `/app/specs/ref-impls/out/${zoneVerifier.artifact}.sol/${zoneVerifier.artifact}.json`,
+        '{portal:$portal[0].deployedBytecode.object,messenger:$messenger[0].deployedBytecode.object,verifier:$verifier[0].deployedBytecode.object}',
+      ],
+      { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+    ),
+  ) as ZoneArtifacts
+  const owner = Address.fromPublicKey(
+    Secp256k1.getPublicKey({ privateKey: options.ownerKey }),
+  )
+  genesis.alloc[zoneFactory.address] = {
+    balance: '0x0',
+    code: zoneFactory.code,
+    storage: {
+      // Slot 0 packs the owner and next Zone ID.
+      [Hex.fromNumber(0n, { size: 32 })]: Hex.fromNumber(
+        (Hex.toBigInt(owner) << 32n) | 1n,
+        { size: 32 },
+      ),
+    },
+  }
+  genesis.alloc[zoneMessenger.address] = {
+    balance: '0x0',
+    code: artifacts.messenger,
+    nonce: '0x1',
+  }
+  genesis.alloc[zonePortal.address] = {
+    balance: '0x0',
+    code: artifacts.portal,
+    nonce: '0x1',
+  }
+  genesis.alloc[zoneVerifier.address] = {
+    balance: '0x0',
+    code: artifacts.verifier,
+    nonce: '0x1',
+  }
+  genesis.alloc[historyStorage.address] = {
+    balance: '0x0',
+    code: historyStorage.code,
+    nonce: '0x1',
+  }
+  const registry = genesis.alloc[tip403Registry.address]
+  if (!registry) throw new Error('TIP-403 registry is unavailable.')
+  registry.storage = { ...registry.storage, ...tip403Registry.storage }
+  return `${JSON.stringify(genesis)}\n`
+}
+
+const tempoContainerPort = 8545
+
+const tempo = Instance.define(
+  (parameters: {
+    blockTime: string
+    genesisContent: string
+    image: string
+    log?: Instance.tempo.Parameters['log'] | undefined
+    port: number
+  }) => {
+    const log = parameters.log
+    const rustLog = log && typeof log !== 'boolean' ? log : ''
+    let container: StartedTestContainer | undefined
+
+    return {
+      _internal: {},
+      host: 'localhost',
+      name: 'tempo',
+      port: parameters.port,
+      async start(_, { emitter, setEndpoint }) {
+        const genesisPath = '/tmp/tempo-dev-eip2935.json'
+        const container_ = await new GenericContainer(parameters.image)
+          .withPullPolicy(PullPolicy.alwaysPull())
+          .withPlatform('linux/amd64')
+          .withExposedPorts(tempoContainerPort)
+          .withExtraHosts([
+            { host: 'host.docker.internal', ipAddress: 'host-gateway' },
+          ])
+          .withName(`tempo.${crypto.randomUUID()}`)
+          .withEnvironment({ RUST_LOG: rustLog })
+          .withCopyContentToContainer([
+            { content: parameters.genesisContent, target: genesisPath },
+          ])
+          .withCommand([
+            'node',
+            '--authrpc.port',
+            '8551',
+            '--datadir',
+            '/tmp/prool-tempo',
+            '--dev',
+            '--dev.block-time',
+            parameters.blockTime,
+            '--engine.disable-precompile-cache',
+            '--engine.legacy-state-root',
+            '--faucet.address',
+            '0x20c0000000000000000000000000000000000000',
+            '0x20c0000000000000000000000000000000000001',
+            '0x20c0000000000000000000000000000000000002',
+            '0x20c0000000000000000000000000000000000003',
+            '--faucet.amount',
+            '1000000000000',
+            '--faucet.enabled',
+            '--faucet.private-key',
+            '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+            '--faucet.node-address',
+            `http://localhost:${tempoContainerPort}`,
+            '--http.addr',
+            '0.0.0.0',
+            '--http.api',
+            'all',
+            '--http.corsdomain',
+            '*',
+            '--http.port',
+            String(tempoContainerPort),
+            '--port',
+            '30303',
+            '--ws',
+            '--ws.addr',
+            '0.0.0.0',
+            '--ws.api',
+            'all',
+            '--ws.port',
+            String(tempoContainerPort),
+            '--chain',
+            genesisPath,
+          ])
+          .withWaitStrategy(Wait.forListeningPorts())
+          .withLogConsumer((stream) => {
+            stream.on('data', (data) => {
+              const message = data.toString()
+              emitter.emit('message', message)
+              emitter.emit('stdout', message)
+              if (log) process.stdout.write(message)
+            })
+            stream.on('error', (error) => {
+              emitter.emit('message', error.message)
+              emitter.emit('stderr', error.message)
+              if (log) process.stderr.write(`${error.message}\n`)
+            })
+          })
+          .withStartupTimeout(120_000)
+          .start()
+        container = container_
+        setEndpoint?.({
+          host: container_.getHost(),
+          port: container_.getMappedPort(tempoContainerPort),
+        })
+      },
+      async stop() {
+        await container?.stop()
+        container = undefined
+      },
+    }
+  },
+)

--- a/test/src/tempo/prool.ts
+++ b/test/src/tempo/prool.ts
@@ -12,8 +12,13 @@ import { pathUsd } from '../../../src/tempo/Addresses.js'
 import * as actions from '../../../src/tempo/actions/index.js'
 import { withRetry } from '../../../src/utils/promise/withRetry.js'
 import { accounts, nodeEnv } from './config.js'
+import { createTempo } from './prool.tmp.js'
 
 export const port = 9545
+
+/** Dev key used to provision and administer local Zones. */
+export const zoneAdminKey =
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
 
 export const rpcUrl = (() => {
   // Explicit override (e.g. a custom devnet) wins over env presets. Useful for
@@ -49,23 +54,31 @@ export async function createServer() {
     return `sha-${sha}`
   })()
 
+  const zones = import.meta.env.VITE_TEMPO_ZONES === 'true'
   const args = {
     // Match Tempo's production cadence when Zone consumes every L1 block.
-    blockTime:
-      import.meta.env.VITE_TEMPO_ZONES === 'true'
-        ? '500ms'
-        : process.env.CI
-          ? '50ms'
-          : '2ms',
+    blockTime: zones ? '500ms' : process.env.CI ? '50ms' : '2ms',
     log: import.meta.env.VITE_TEMPO_LOG,
     port,
   } satisfies Instance.tempo.Parameters
+  const image = tag?.startsWith('sha256:')
+    ? `ghcr.io/tempoxyz/tempo@${tag}`
+    : `ghcr.io/tempoxyz/tempo:${tag ?? 'latest'}`
+  const artifactsTag = import.meta.env.VITE_TEMPO_ZONE_XTASK_TAG
+  const instance =
+    zones && artifactsTag
+      ? createTempo({
+          ...args,
+          artifactsImage: artifactsTag.startsWith('sha256:')
+            ? `ghcr.io/tempoxyz/tempo-zone-xtask@${artifactsTag}`
+            : `ghcr.io/tempoxyz/tempo-zone-xtask:${artifactsTag}`,
+          image,
+          ownerKey: zoneAdminKey,
+        })
+      : TestContainers.Instance.tempo({ ...args, image })
 
   return Server.create({
-    instance: TestContainers.Instance.tempo({
-      ...args,
-      image: `ghcr.io/tempoxyz/tempo:${tag ?? 'latest'}`,
-    }),
+    instance,
     port,
   })
 }
@@ -92,8 +105,6 @@ type StartedZone = Zone & {
 export type DefineZoneParameters = {
   /** Existing factory to reuse for unique zone IDs. */
   factoryAddress?: `0x${string}` | undefined
-  /** L1 provisioning key. Use distinct keys for concurrent instances. */
-  key?: `0x${string}` | undefined
 }
 
 export type ZoneInstance = {
@@ -152,6 +163,9 @@ async function startZone(
     throw new Error('Local zones require `VITE_TEMPO_ENV=localnet`.')
 
   const tag = import.meta.env.VITE_TEMPO_ZONE_TAG ?? 'latest'
+  const image = tag.startsWith('sha256:')
+    ? `ghcr.io/tempoxyz/tempo-zone@${tag}`
+    : `ghcr.io/tempoxyz/tempo-zone:${tag}`
 
   // The zone container reaches this worker's L1 through the prool server
   // (`host.docker.internal` resolves to the host; the server proxies WS).
@@ -162,13 +176,10 @@ async function startZone(
 
   const instance = TestContainers.Instance.tempoZone({
     dev: {
-      // anvil #1; the default dev key is anvil #0 (= `accounts[0]`), which
-      // would race nonces with test transactions.
-      key:
-        parameters.key ??
-        '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+      // Anvil #1 owns the native factory and avoids test-account nonce races.
+      key: zoneAdminKey,
     },
-    image: `ghcr.io/tempoxyz/tempo-zone:${tag}`,
+    image,
     l1: {
       factoryAddress: parameters.factoryAddress,
       rpcUrl: l1RpcUrl,

--- a/test/src/tempo/zones.ts
+++ b/test/src/tempo/zones.ts
@@ -3,7 +3,6 @@ import {
   type Address,
   type ClientConfig,
   createClient,
-  createTransport,
   defineChain,
   type Transport,
   type Account as viem_Account,
@@ -56,43 +55,11 @@ export const zone = local
 
 export const rpcUrl = zone.rpcUrls.default.http[0]!
 
-export const http = (url = rpcUrl, config: ZoneHttpConfig = {}) => {
-  const transport = zoneHttp(url, {
+export const http = (url = rpcUrl, config: ZoneHttpConfig = {}) =>
+  zoneHttp(url, {
     ...debugOptions({ rpcUrl: url }),
     ...config,
   })
-  if (nodeEnv !== 'localnet') return transport
-
-  // TODO: Remove this compatibility transport once `tempo-zone dev` supports Tempo's native TIP-1091 ZoneFactory and the pinned Zone image exposes `tempoBlockNumber`.
-  return ((parameters) => {
-    const { config: transportConfig, value } = transport(parameters)
-    return createTransport(
-      {
-        ...transportConfig,
-        async request(args) {
-          const info = await transportConfig.request(args)
-          if (
-            args.method !== 'zone_getZoneInfo' ||
-            typeof info !== 'object' ||
-            info === null ||
-            'tempoBlockNumber' in info
-          )
-            return info as never
-
-          const status = (await transportConfig.request({
-            method: 'zone_getDepositStatus',
-            params: ['0x0'],
-          })) as { zoneProcessedThrough: string }
-          return {
-            ...info,
-            tempoBlockNumber: status.zoneProcessedThrough,
-          } as never
-        },
-      },
-      value,
-    )
-  }) satisfies Transport
-}
 
 export function getClient<
   accountOrAddress extends viem_Account | Address | undefined = undefined,


### PR DESCRIPTION
Supports both T8 and T9 Zone nodes while moving T9-only local provisioning into a removable harness. Keeps local CI compatible until https://github.com/tempoxyz/tempo/pull/6916 and https://github.com/tempoxyz/zones/pull/767 land.
