### PR TITLE
fix: decode bytesToNumber/bytesToBigInt independent of size

### DIFF
--- a/.changeset/frombytes-size-scaling.md
+++ b/.changeset/frombytes-size-scaling.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `bytesToBigInt` and `bytesToNumber` (and `fromBytes` with `to: "bigint" | "number"`) scaling the decoded value when a `size` larger than the input byte length was provided.

--- a/src/utils/encoding/fromBytes.test.ts
+++ b/src/utils/encoding/fromBytes.test.ts
@@ -41,6 +41,9 @@ describe('converts bytes to number', () => {
         size: 32,
       }),
     ).toEqual(420)
+    // an input shorter than `size` must decode to the same value (size is an
+    // assertion, not left/right padding of the underlying number).
+    expect(bytesToNumber(new Uint8Array([1, 164]), { size: 32 })).toEqual(420)
   })
 
   test('error: size overflow', () => {
@@ -99,6 +102,9 @@ describe('converts bytes to bigint', () => {
         size: 32,
       }),
     ).toEqual(420n)
+    // an input shorter than `size` must decode to the same value (size is an
+    // assertion, not left/right padding of the underlying number).
+    expect(bytesToBigInt(new Uint8Array([1, 164]), { size: 32 })).toEqual(420n)
   })
 
   test('error: size overflow', () => {

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -118,7 +118,7 @@ export function bytesToBigInt(
   opts: BytesToBigIntOpts = {},
 ): bigint {
   if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
-  const hex = bytesToHex(bytes, opts)
+  const hex = bytesToHex(bytes)
   return hexToBigInt(hex, opts)
 }
 
@@ -186,7 +186,7 @@ export function bytesToNumber(
   opts: BytesToNumberOpts = {},
 ): number {
   if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
-  const hex = bytesToHex(bytes, opts)
+  const hex = bytesToHex(bytes)
   return hexToNumber(hex, opts)
 }
 


### PR DESCRIPTION
`bytesToBigInt` / `bytesToNumber` (and `fromBytes` with `to: "bigint" | "number"`) passed the full `opts` — including `size` — into `bytesToHex`. `bytesToHex` with a `size` **right-pads** the hex, appending low-order zero bytes, which multiplies the decoded integer by `256^(size - len)` whenever the input is shorter than `size`.

`assertSize` only enforces an upper bound (a value larger than `size` throws), so shorter inputs are deliberately allowed through — and then silently corrupted.

```ts
fromBytes(Uint8Array.from([1, 164]), { to: 'bigint', size: 32 })
// actual:   420n * 2n ** 240n
// expected: 420n
```

This also disagrees with the equivalent hex path, which only asserts the size and never pads the value:

```ts
fromHex('0x01a4', { to: 'bigint', size: 32 }) // 420n  ✅
```

**Fix:** convert the bytes to hex without `size`, so the decoded value is independent of the padding width. The `size` assertion (`assertSize`) is unchanged, and full-length inputs are unaffected (the right-pad was a no-op there, which is why existing tests passed).

**Test:** added a shorter-than-`size` case to the existing `args: size` blocks for both `bytesToNumber` and `bytesToBigInt`. They fail on `main` and pass with this change.
