### PR TITLE
fix: don't misread a 0x80 data byte as the fromBlobs terminator

### DIFF
--- a/.changeset/fromblobs-full-blob-terminator.md
+++ b/.changeset/fromblobs-full-blob-terminator.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `fromBlobs` dropping data (and skipping subsequent blobs) when a completely-full blob's final data byte was `0x80`, which was misread as the blob terminator.

--- a/src/utils/blob/fromBlobs.test.ts
+++ b/src/utils/blob/fromBlobs.test.ts
@@ -32,3 +32,20 @@ test('https://github.com/wevm/viem/issues/1986', () => {
   const blobs = toBlobs({ data })
   expect(fromBlobs({ blobs: blobs })).toEqual(data)
 })
+
+test('round-trip: full blob ending in a 0x80 data byte', () => {
+  // one blob's data capacity: `fieldElementsPerBlob * (bytesPerFieldElement - 1)`.
+  const size = 4096 * 31
+  const data = new Uint8Array(size).fill(1)
+  data[size - 1] = 0x80
+  const blobs = toBlobs({ data })
+  expect(fromBlobs({ blobs })).toEqual(data)
+})
+
+test('round-trip: full blob ending in a 0x80 data byte, then another blob', () => {
+  const size = 4096 * 31
+  const data = new Uint8Array(size + 100).fill(1)
+  data[size - 1] = 0x80
+  const blobs = toBlobs({ data })
+  expect(fromBlobs({ blobs })).toEqual(data)
+})

--- a/src/utils/blob/fromBlobs.ts
+++ b/src/utils/blob/fromBlobs.ts
@@ -45,8 +45,13 @@ export function fromBlobs<
   const data = createCursor(new Uint8Array(length))
   let active = true
 
-  for (const blob of blobs) {
+  for (const [index, blob] of blobs.entries()) {
     const cursor = createCursor(blob)
+    // The terminator byte (`0x80` followed by zero-padding) is only ever
+    // written to the last blob – every preceding blob is completely filled
+    // with data. Only look for the terminator in the last blob, otherwise a
+    // `0x80` data byte at the end of a full blob is misread as the terminator.
+    const isLastBlob = index === blobs.length - 1
     while (active && cursor.position < blob.length) {
       // First byte will be a zero 0x00 byte – we can skip.
       cursor.incrementPosition(1)
@@ -58,7 +63,9 @@ export function fromBlobs<
       for (const _ in Array.from({ length: consume })) {
         const byte = cursor.readByte()
         const isTerminator =
-          byte === 0x80 && !cursor.inspectBytes(cursor.remaining).includes(0x80)
+          isLastBlob &&
+          byte === 0x80 &&
+          !cursor.inspectBytes(cursor.remaining).includes(0x80)
         if (isTerminator) {
           active = false
           break


### PR DESCRIPTION
`toBlobs` marks the end of the encoded data with a `0x80` terminator byte. That terminator is only ever written to the **last** blob: every preceding blob is completely filled with data (a terminator is only emitted when a data segment shorter than 31 bytes is reached, which ends encoding).

`fromBlobs`, however, scanned for the terminator in *every* blob, disambiguating it from a genuine `0x80` data byte by checking that no other `0x80` followed it within the same blob. When a completely-full blob's final data byte happens to be `0x80`, there are no bytes left in that blob, so the check passes and the byte is misclassified as the terminator: it is dropped and every subsequent blob is skipped.

This breaks the round-trip `fromBlobs(toBlobs(data)) === data`:

```ts
// one blob's data capacity: fieldElementsPerBlob * (bytesPerFieldElement - 1) = 4096 * 31
const data = new Uint8Array(4096 * 31).fill(1)
data[data.length - 1] = 0x80

fromBlobs({ blobs: toBlobs({ data }) })
// ❌ returns data with the trailing 0x80 dropped (and, with more data, the
//    entire following blob missing)
```

**Fix:** only look for the terminator in the last blob, since that is the only blob `toBlobs` ever writes it to.

**Tests:** added two round-trip regressions (full blob ending in `0x80`; and the same followed by another blob). Both fail on `main` and pass with this change. Existing `fromBlobs`/`toBlobs` tests (including the #1986 regression) still pass.
