### PR TITLE
fix: decode sized bytes without padding

### DIFF
--- a/.changeset/frombytes-size-scaling.md
+++ b/.changeset/frombytes-size-scaling.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `bytesToBigInt` and `bytesToNumber` (and `fromBytes` with `to: "bigint" | "number"`) scaling the decoded value when a `size` larger than the input byte length was provided.

--- a/src/utils/encoding/fromBytes.test.ts
+++ b/src/utils/encoding/fromBytes.test.ts
@@ -41,6 +41,7 @@ describe('converts bytes to number', () => {
         size: 32,
       }),
     ).toEqual(420)
+    expect(bytesToNumber(new Uint8Array([1, 164]), { size: 32 })).toEqual(420)
   })
 
   test('error: size overflow', () => {
@@ -99,6 +100,7 @@ describe('converts bytes to bigint', () => {
         size: 32,
       }),
     ).toEqual(420n)
+    expect(bytesToBigInt(new Uint8Array([1, 164]), { size: 32 })).toEqual(420n)
   })
 
   test('error: size overflow', () => {

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -118,7 +118,7 @@ export function bytesToBigInt(
   opts: BytesToBigIntOpts = {},
 ): bigint {
   if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
-  const hex = bytesToHex(bytes, opts)
+  const hex = bytesToHex(bytes)
   return hexToBigInt(hex, opts)
 }
 
@@ -186,7 +186,7 @@ export function bytesToNumber(
   opts: BytesToNumberOpts = {},
 ): number {
   if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
-  const hex = bytesToHex(bytes, opts)
+  const hex = bytesToHex(bytes)
   return hexToNumber(hex, opts)
 }
 


### PR DESCRIPTION
Decode numeric byte values without right-padding them to the asserted `size`, preventing scaled results for short inputs. Reimplements https://github.com/wevm/viem/pull/4885 on a maintainer-controlled branch.
