### PR TITLE
fix: preserve blob-boundary `0x80` bytes

### DIFF
--- a/.changeset/fromblobs-full-blob-terminator.md
+++ b/.changeset/fromblobs-full-blob-terminator.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `fromBlobs` misreading a `0x80` data byte at a blob boundary as the terminator.

--- a/src/utils/blob/fromBlobs.test.ts
+++ b/src/utils/blob/fromBlobs.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from 'vitest'
 import { blobData } from '~test/kzg.js'
+import {
+  bytesPerFieldElement,
+  fieldElementsPerBlob,
+} from '../../constants/blob.js'
 import { stringToHex } from '../encoding/toHex.js'
 import { fromBlobs } from './fromBlobs.js'
 import { toBlobs } from './toBlobs.js'
+
+const dataBytesPerBlob = fieldElementsPerBlob * (bytesPerFieldElement - 1)
 
 test('default', () => {
   const data = stringToHex('we are all gonna make it'.repeat(5))
@@ -31,4 +37,18 @@ test('https://github.com/wevm/viem/issues/1986', () => {
   const data = new Uint8Array([1, 2, 128, 3, 4, 5, 6, 7, 8, 9, 10])
   const blobs = toBlobs({ data })
   expect(fromBlobs({ blobs: blobs })).toEqual(data)
+})
+
+test('round-trip: full blob ending in a 0x80 data byte', () => {
+  const data = new Uint8Array(dataBytesPerBlob).fill(1)
+  data[dataBytesPerBlob - 1] = 0x80
+  const blobs = toBlobs({ data })
+  expect(fromBlobs({ blobs })).toEqual(data)
+})
+
+test('round-trip: full blob ending in a 0x80 data byte, then another blob', () => {
+  const data = new Uint8Array(dataBytesPerBlob + 100).fill(1)
+  data[dataBytesPerBlob - 1] = 0x80
+  const blobs = toBlobs({ data })
+  expect(fromBlobs({ blobs })).toEqual(data)
 })

--- a/src/utils/blob/fromBlobs.ts
+++ b/src/utils/blob/fromBlobs.ts
@@ -45,8 +45,10 @@ export function fromBlobs<
   const data = createCursor(new Uint8Array(length))
   let active = true
 
-  for (const blob of blobs) {
+  for (const [index, blob] of blobs.entries()) {
     const cursor = createCursor(blob)
+    // Only the final blob contains a terminator; preceding blobs contain only data.
+    const isLastBlob = index === blobs.length - 1
     while (active && cursor.position < blob.length) {
       // First byte will be a zero 0x00 byte – we can skip.
       cursor.incrementPosition(1)
@@ -58,7 +60,9 @@ export function fromBlobs<
       for (const _ in Array.from({ length: consume })) {
         const byte = cursor.readByte()
         const isTerminator =
-          byte === 0x80 && !cursor.inspectBytes(cursor.remaining).includes(0x80)
+          isLastBlob &&
+          byte === 0x80 &&
+          !cursor.inspectBytes(cursor.remaining).includes(0x80)
         if (isTerminator) {
           active = false
           break


### PR DESCRIPTION
Decode terminators only in the final blob, preserving boundary `0x80` data and all following blobs. Reimplements https://github.com/wevm/viem/pull/4886 on a maintainer-controlled branch.
