### PR TITLE
ci: re-enable wagmi

### DIFF
--- a/.github/actions/setup-wagmi/action.yml
+++ b/.github/actions/setup-wagmi/action.yml
@@ -11,7 +11,14 @@ runs:
     - name: Set up pnpm
       uses: pnpm/action-setup@v4
       with:
+        dest: ~/setup-pnpm-wagmi
         package_json_file: ./wagmi/package.json
+
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        cache: pnpm
+        cache-dependency-path: ./wagmi/pnpm-lock.yaml
 
     - name: Build viem
       shell: bash

--- a/.github/actions/setup-wagmi/action.yml
+++ b/.github/actions/setup-wagmi/action.yml
@@ -16,6 +16,8 @@ runs:
 
     - name: Set up node
       uses: actions/setup-node@v4
+      env:
+        NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS: 'false'
       with:
         cache: pnpm
         cache-dependency-path: ./wagmi/pnpm-lock.yaml

--- a/.github/actions/setup-wagmi/action.yml
+++ b/.github/actions/setup-wagmi/action.yml
@@ -13,12 +13,6 @@ runs:
       with:
         package_json_file: ./wagmi/package.json
 
-    - name: Set up node
-      uses: actions/setup-node@v4
-      with:
-        cache: pnpm
-        cache-dependency-path: ./wagmi/pnpm-lock.yaml
-
     - name: Build viem
       shell: bash
       run: pnpm build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -340,8 +340,6 @@ jobs:
   wagmi:
     name: Wagmi
     continue-on-error: true
-    # TODO: Re-enable Wagmi verification.
-    if: ${{ false }}
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
Re-enables the Wagmi downstream verification job now that Wagmi uses the released `viem@2.55.7`.

This restores the Viem build and Wagmi type checks across the TypeScript version matrix.