### PR TITLE
fix: sponsored access key gas estimation

### DIFF
--- a/.changeset/fair-plants-fill.md
+++ b/.changeset/fair-plants-fill.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+`viem/tempo`: Fixed gas estimation for sponsored access key transactions prepared without gas.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -89,6 +89,33 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBeUndefined()
   })
 
+  test('behavior: does not set gas when gas is not prepared', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: accounts.at(0)!,
+    })
+    const request = await prepareTransactionRequest(client, {
+      account: accessKey,
+      feePayer: true,
+      parameters: [],
+    })
+
+    expect(request.gas).toBeUndefined()
+  })
+
+  test('behavior: bumps prepared gas for sponsored access keys', async () => {
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: accounts.at(0)!,
+    })
+    const request = await prepareTransactionRequest(client, {
+      account: accessKey,
+      feePayer: true,
+      gas: 33_000n,
+      parameters: [],
+    })
+
+    expect(request.gas).toBe(43_000n)
+  })
+
   test('behavior: nonceKey expiring uses expiring nonces', async () => {
     const now = Math.floor(Date.now() / 1000)
     const request = await prepareTransactionRequest(client, {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -68,7 +68,11 @@ export const chainConfig = {
       // Actual tx has larger keychain/webAuthn sigs + real fee payer sig, costing more intrinsic gas.
       if (phase === 'afterFillParameters') {
         // Fee payer signature covers the gas limit, so the relay must set it before signing and Viem must not change it afterward.
-        if (request.feePayer && !request.feePayerSignature) {
+        if (
+          typeof request.gas !== 'undefined' &&
+          request.feePayer &&
+          !request.feePayerSignature
+        ) {
           if (request.keyAuthorization?.signature.type === 'webAuthn')
             request.gas = (request.gas ?? 0n) + 20_000n
           else if (request.account?.source === 'accessKey')


### PR DESCRIPTION
`prepareTransactionRequest` still runs Tempo's `afterFillParameters` hook when callers pass `parameters: []`. The hook currently turns missing gas into a 10,000 or 20,000 placeholder, so a later `eth_fillTransaction` treats that placeholder as an explicit gas limit instead of estimating gas.

Only apply the existing access-key/WebAuthn buffer when gas has already been filled. This preserves the original buffers and the relay-signed gas behavior.

Regression coverage verifies that:

- missing gas remains missing for a sponsored access-key micro-prepare
- an existing 33,000 gas estimate still receives the 10,000 access-key buffer

Live verification reproduced the failure as a 20,000 gas limit for a transaction requiring 43,828, then completed the same OpenClaw payment with HTTP 200 after applying this guard.

Validation:

- focused regression tests: 2 passed
- `pnpm build:esm`
- Biome check on changed source and tests