### PR TITLE
feat(tempo): add Zone E contracts

### DIFF
--- a/.changeset/fresh-zones-connect.md
+++ b/.changeset/fresh-zones-connect.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Added Zone E metadata, address registries, and source-chain Portal and Messenger contracts.
+`viem/tempo`: Added Zone E metadata, address registries, and Portal and Messenger contracts.

--- a/.changeset/fresh-zones-connect.md
+++ b/.changeset/fresh-zones-connect.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Added Zone E metadata, address registries, and source-chain Portal and Messenger contracts.

--- a/.changeset/portal-addresses-retire.md
+++ b/.changeset/portal-addresses-retire.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+**Breaking(viem/tempo)**: Removed `portalAddresses`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.7: 5.0.7
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
-  next@>=16.0.0-beta.0 <16.2.6: 16.2.6
+  next@>=16.0.0-beta.0 <16.2.11: 16.2.11
   react-server-dom-webpack@>=19.2.0 <19.2.6: 19.2.6
   basic-ftp@<=5.3.0: 5.3.1
   fast-uri@<=3.1.3: 3.1.4
@@ -195,8 +195,8 @@ importers:
   environments/next:
     dependencies:
       next:
-        specifier: 16.2.6
-        version: 16.2.6(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 16.2.11
+        version: 16.2.11(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19
         version: 19.2.3
@@ -656,7 +656,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3)
       vocs:
         specifier: https://pkg.pr.new/vocs@35ebd0c
-        version: https://pkg.pr.new/vocs@35ebd0c(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(rolldown@1.0.3)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(waku@1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.28.1))
+        version: https://pkg.pr.new/vocs@35ebd0c(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(rolldown@1.0.3)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(waku@1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.28.1))
       waku:
         specifier: ^1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -1596,57 +1596,57 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.6':
-    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
-  '@next/swc-darwin-arm64@16.2.6':
-    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.6':
-    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
-    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.6':
-    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.6':
-    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.6':
-    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
-    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.6':
-    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3549,11 +3549,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.10.8:
-    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
@@ -3654,9 +3649,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001769:
-    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -5431,8 +5423,8 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  next@16.2.6:
-    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5502,7 +5494,7 @@ packages:
     peerDependencies:
       '@remix-run/react': '>=2'
       '@tanstack/react-router': ^1
-      next: 16.2.6
+      next: 16.2.11
       react: '>=18.2.0 || ^19.0.0-0'
       react-router: 7.12.0
       react-router-dom: ^5 || ^6 || ^7
@@ -8347,30 +8339,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.6': {}
+  '@next/env@16.2.11': {}
 
-  '@next/swc-darwin-arm64@16.2.6':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.6':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.6':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.6':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.6':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.6':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -10477,8 +10469,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.40: {}
 
-  baseline-browser-mapping@2.10.8: {}
-
   basic-ftp@5.3.1: {}
 
   bcrypt-pbkdf@1.0.2:
@@ -10598,8 +10588,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001769: {}
 
   caniuse-lite@1.0.30001799: {}
 
@@ -12743,25 +12731,25 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.2.6
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.8
-      caniuse-lite: 1.0.30001769
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
       postcss: 8.5.10
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.7.0
       '@playwright/test': 1.59.1
       sharp: 0.35.0
@@ -12770,25 +12758,25 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  next@16.2.6(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.11(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.2.6
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.8
-      caniuse-lite: 1.0.30001769
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
       postcss: 8.5.10
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.7.0
       '@playwright/test': 1.59.1
       sharp: 0.35.0
@@ -12839,12 +12827,12 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nuqs@2.8.9(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  nuqs@2.8.9(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   object-assign@4.1.1: {}
 
@@ -14649,7 +14637,7 @@ snapshots:
       - tsx
       - yaml
 
-  vocs@https://pkg.pr.new/vocs@35ebd0c(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(rolldown@1.0.3)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(waku@1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.28.1)):
+  vocs@https://pkg.pr.new/vocs@35ebd0c(@cfworker/json-schema@4.1.1)(@types/react@19.0.8)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(rolldown@1.0.3)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(waku@1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.0.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -14700,7 +14688,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-extension-gfm: 3.0.0
       minisearch: 7.2.0
-      nuqs: 2.8.9(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      nuqs: 2.8.9(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.7.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-error-boundary: 6.1.2(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -115,7 +115,7 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.7: 5.0.7
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
-  next@>=16.0.0-beta.0 <16.2.6: 16.2.6
+  next@>=16.0.0-beta.0 <16.2.11: 16.2.11
   react-server-dom-webpack@>=19.2.0 <19.2.6: 19.2.6
   basic-ftp@<=5.3.0: 5.3.1
   fast-uri@<=3.1.3: 3.1.4

--- a/src/tempo/zones/Addresses.ts
+++ b/src/tempo/zones/Addresses.ts
@@ -1,0 +1,15 @@
+import { tempoModerato } from '../../chains/definitions/tempoModerato.js'
+
+export const messenger = {
+  [tempoModerato.id]: {
+    1: '0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7',
+  },
+} as const satisfies Record<number, Record<number, `0x${string}`>>
+
+export const portal = {
+  [tempoModerato.id]: {
+    1: '0x59831A17340EE14FE136d751EfbeA8b630470fD2',
+    6: '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23',
+    7: '0x3F5296303400B56271b476F5A0B9cBF74350D6Ac',
+  },
+} as const satisfies Record<number, Record<number, `0x${string}`>>

--- a/src/tempo/zones/index.ts
+++ b/src/tempo/zones/index.ts
@@ -1,11 +1,10 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export * as Abis from './Abis.js'
+export * as Addresses from './Addresses.js'
 export { http, type ZoneHttpConfig } from './transport.js'
 export {
   from,
   getPortalAddress,
-  messengerAddresses,
-  portalAddresses,
   zone,
   zoneModerato,
 } from './zone.js'

--- a/src/tempo/zones/index.ts
+++ b/src/tempo/zones/index.ts
@@ -4,6 +4,7 @@ export { http, type ZoneHttpConfig } from './transport.js'
 export {
   from,
   getPortalAddress,
+  messengerAddresses,
   portalAddresses,
   zone,
   zoneModerato,

--- a/src/tempo/zones/zone.test-d.ts
+++ b/src/tempo/zones/zone.test-d.ts
@@ -1,14 +1,14 @@
 import { tempoModerato } from 'viem/chains'
-import { messengerAddresses, zoneModerato } from 'viem/tempo/zones'
+import { Addresses, zoneModerato } from 'viem/tempo/zones'
 import { expectTypeOf, test } from 'vitest'
 
 test('exposes Zone E contracts', () => {
   const contracts = zoneModerato(1).contracts
 
   expectTypeOf(
-    messengerAddresses[tempoModerato.id][1],
+    Addresses.messenger[tempoModerato.id][1],
   ).toEqualTypeOf<'0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7'>()
-  expectTypeOf(contracts?.messenger[tempoModerato.id]?.address).toEqualTypeOf<
+  expectTypeOf(contracts?.messenger.address).toEqualTypeOf<
     `0x${string}` | undefined
   >()
   expectTypeOf(contracts?.portal[tempoModerato.id]?.address).toEqualTypeOf<

--- a/src/tempo/zones/zone.test-d.ts
+++ b/src/tempo/zones/zone.test-d.ts
@@ -1,0 +1,17 @@
+import { tempoModerato } from 'viem/chains'
+import { messengerAddresses, zoneModerato } from 'viem/tempo/zones'
+import { expectTypeOf, test } from 'vitest'
+
+test('exposes Zone E contracts', () => {
+  const contracts = zoneModerato(1).contracts
+
+  expectTypeOf(
+    messengerAddresses[tempoModerato.id][1],
+  ).toEqualTypeOf<'0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7'>()
+  expectTypeOf(contracts?.messenger[tempoModerato.id]?.address).toEqualTypeOf<
+    `0x${string}` | undefined
+  >()
+  expectTypeOf(contracts?.portal[tempoModerato.id]?.address).toEqualTypeOf<
+    `0x${string}` | undefined
+  >()
+})

--- a/src/tempo/zones/zone.test-d.ts
+++ b/src/tempo/zones/zone.test-d.ts
@@ -8,7 +8,7 @@ test('exposes Zone E contracts', () => {
   expectTypeOf(
     Addresses.messenger[tempoModerato.id][1],
   ).toEqualTypeOf<'0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7'>()
-  expectTypeOf(contracts?.messenger.address).toEqualTypeOf<
+  expectTypeOf(contracts?.messenger[tempoModerato.id]?.address).toEqualTypeOf<
     `0x${string}` | undefined
   >()
   expectTypeOf(contracts?.portal[tempoModerato.id]?.address).toEqualTypeOf<

--- a/src/tempo/zones/zone.test.ts
+++ b/src/tempo/zones/zone.test.ts
@@ -1,19 +1,13 @@
 import { ZoneId } from 'ox/tempo'
 import { tempo, tempoModerato } from 'viem/chains'
+import { Addresses } from 'viem/tempo/zones'
 import { describe, expect, test } from 'vitest'
-import {
-  from,
-  getPortalAddress,
-  messengerAddresses,
-  portalAddresses,
-  zone,
-  zoneModerato,
-} from './zone.js'
+import { from, getPortalAddress, zone, zoneModerato } from './zone.js'
 
 describe('getPortalAddress', () => {
   test('returns a configured portal address', () => {
     expect(getPortalAddress(tempoModerato.id, 1)).toBe(
-      portalAddresses[tempoModerato.id][1],
+      Addresses.portal[tempoModerato.id][1],
     )
   })
 
@@ -29,13 +23,11 @@ describe('from', () => {
     expect(zoneModerato(1)).toMatchObject({
       contracts: {
         messenger: {
-          [tempoModerato.id]: {
-            address: messengerAddresses[tempoModerato.id][1],
-          },
+          address: Addresses.messenger[tempoModerato.id][1],
         },
         portal: {
           [tempoModerato.id]: {
-            address: portalAddresses[tempoModerato.id][1],
+            address: Addresses.portal[tempoModerato.id][1],
           },
         },
       },

--- a/src/tempo/zones/zone.test.ts
+++ b/src/tempo/zones/zone.test.ts
@@ -23,7 +23,9 @@ describe('from', () => {
     expect(zoneModerato(1)).toMatchObject({
       contracts: {
         messenger: {
-          address: Addresses.messenger[tempoModerato.id][1],
+          [tempoModerato.id]: {
+            address: Addresses.messenger[tempoModerato.id][1],
+          },
         },
         portal: {
           [tempoModerato.id]: {

--- a/src/tempo/zones/zone.test.ts
+++ b/src/tempo/zones/zone.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import {
   from,
   getPortalAddress,
+  messengerAddresses,
   portalAddresses,
   zone,
   zoneModerato,
@@ -11,8 +12,8 @@ import {
 
 describe('getPortalAddress', () => {
   test('returns a configured portal address', () => {
-    expect(getPortalAddress(tempoModerato.id, 7)).toBe(
-      portalAddresses[tempoModerato.id][7],
+    expect(getPortalAddress(tempoModerato.id, 1)).toBe(
+      portalAddresses[tempoModerato.id][1],
     )
   })
 
@@ -25,6 +26,27 @@ describe('getPortalAddress', () => {
 
 describe('from', () => {
   test('uses zone metadata overrides', () => {
+    expect(zoneModerato(1)).toMatchObject({
+      contracts: {
+        messenger: {
+          [tempoModerato.id]: {
+            address: messengerAddresses[tempoModerato.id][1],
+          },
+        },
+        portal: {
+          [tempoModerato.id]: {
+            address: portalAddresses[tempoModerato.id][1],
+          },
+        },
+      },
+      id: ZoneId.toChainId(1),
+      name: 'Zone E',
+      rpcUrls: {
+        default: { http: ['https://rpc-zone-e.testnet.tempo.xyz'] },
+      },
+      sourceId: tempoModerato.id,
+      supportsTransactionReplacementDetection: false,
+    })
     expect(zoneModerato(6)).toMatchObject({
       id: ZoneId.toChainId(6),
       name: 'Zone A',
@@ -37,11 +59,11 @@ describe('from', () => {
   })
 
   test('builds default zone metadata', () => {
-    expect(zone(8)).toMatchObject({
-      id: ZoneId.toChainId(8),
-      name: 'Tempo Zone 008',
+    expect(zone(1)).toMatchObject({
+      id: ZoneId.toChainId(1),
+      name: 'Tempo Zone 001',
       rpcUrls: {
-        default: { http: ['https://rpc-zone-008.tempo.xyz'] },
+        default: { http: ['https://rpc-zone-001.tempo.xyz'] },
       },
       sourceId: tempo.id,
       supportsTransactionReplacementDetection: false,
@@ -49,11 +71,11 @@ describe('from', () => {
   })
 
   test('builds a custom zone factory', () => {
-    expect(from({ rpcHost: 'example.com', sourceId: 1 })(123)).toMatchObject({
-      id: ZoneId.toChainId(123),
-      name: 'Tempo Zone 123',
+    expect(from({ rpcHost: 'example.com', sourceId: 1 })(6)).toMatchObject({
+      id: ZoneId.toChainId(6),
+      name: 'Tempo Zone 006',
       rpcUrls: {
-        default: { http: ['https://rpc-zone-123.example.com'] },
+        default: { http: ['https://rpc-zone-006.example.com'] },
       },
       sourceId: 1,
       supportsTransactionReplacementDetection: false,

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -3,29 +3,14 @@ import { tempo } from '../../chains/definitions/tempo.js'
 import { tempoModerato } from '../../chains/definitions/tempoModerato.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../chainConfig.js'
-
-/** Messenger addresses keyed by parent chain ID and Zone ID. */
-export const messengerAddresses = {
-  [tempoModerato.id]: {
-    1: '0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7',
-  },
-} as const satisfies Record<number, Record<number, `0x${string}`>>
-
-/** Portal addresses keyed by parent chain ID and Zone ID. */
-export const portalAddresses = {
-  [tempoModerato.id]: {
-    1: '0x59831A17340EE14FE136d751EfbeA8b630470fD2',
-    6: '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23',
-    7: '0x3F5296303400B56271b476F5A0B9cBF74350D6Ac',
-  },
-} as const satisfies Record<number, Record<number, `0x${string}`>>
+import * as Addresses from './Addresses.js'
 
 export function getPortalAddress(
   chainId: number,
   zoneId: number,
 ): `0x${string}` {
   const address = (
-    portalAddresses as Record<number, Record<number, `0x${string}`>>
+    Addresses.portal as Record<number, Record<number, `0x${string}`>>
   )[chainId]?.[zoneId]
   if (!address)
     throw new Error(
@@ -35,7 +20,7 @@ export function getPortalAddress(
 }
 
 type ZoneContracts = {
-  messenger: Record<number, { address: `0x${string}` } | undefined>
+  messenger: { address: `0x${string}` }
   portal: Record<number, { address: `0x${string}` } | undefined>
 }
 
@@ -50,13 +35,11 @@ const overrides = {
     1: {
       contracts: {
         messenger: {
-          [tempoModerato.id]: {
-            address: messengerAddresses[tempoModerato.id][1],
-          },
+          address: Addresses.messenger[tempoModerato.id][1],
         },
         portal: {
           [tempoModerato.id]: {
-            address: portalAddresses[tempoModerato.id][1],
+            address: Addresses.portal[tempoModerato.id][1],
           },
         },
       },

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -20,7 +20,7 @@ export function getPortalAddress(
 }
 
 type ZoneContracts = {
-  messenger: { address: `0x${string}` }
+  messenger: Record<number, { address: `0x${string}` } | undefined>
   portal: Record<number, { address: `0x${string}` } | undefined>
 }
 
@@ -35,7 +35,9 @@ const overrides = {
     1: {
       contracts: {
         messenger: {
-          address: Addresses.messenger[tempoModerato.id][1],
+          [tempoModerato.id]: {
+            address: Addresses.messenger[tempoModerato.id][1],
+          },
         },
         portal: {
           [tempoModerato.id]: {

--- a/src/tempo/zones/zone.ts
+++ b/src/tempo/zones/zone.ts
@@ -4,8 +4,17 @@ import { tempoModerato } from '../../chains/definitions/tempoModerato.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 import { chainConfig } from '../chainConfig.js'
 
+/** Messenger addresses keyed by parent chain ID and Zone ID. */
+export const messengerAddresses = {
+  [tempoModerato.id]: {
+    1: '0x254356112cCf6f32fAd84F16CC5E0A0cCA17Beb7',
+  },
+} as const satisfies Record<number, Record<number, `0x${string}`>>
+
+/** Portal addresses keyed by parent chain ID and Zone ID. */
 export const portalAddresses = {
   [tempoModerato.id]: {
+    1: '0x59831A17340EE14FE136d751EfbeA8b630470fD2',
     6: '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23',
     7: '0x3F5296303400B56271b476F5A0B9cBF74350D6Ac',
   },
@@ -25,21 +34,45 @@ export function getPortalAddress(
   return address
 }
 
+type ZoneContracts = {
+  messenger: Record<number, { address: `0x${string}` } | undefined>
+  portal: Record<number, { address: `0x${string}` } | undefined>
+}
+
 type Override = {
+  contracts?: ZoneContracts | undefined
   name: string
   rpcUrl: string
 }
 
 const overrides = {
-  6: {
-    name: 'Zone A',
-    rpcUrl: 'https://rpc-zone-a.testnet.tempo.xyz',
+  [tempoModerato.id]: {
+    1: {
+      contracts: {
+        messenger: {
+          [tempoModerato.id]: {
+            address: messengerAddresses[tempoModerato.id][1],
+          },
+        },
+        portal: {
+          [tempoModerato.id]: {
+            address: portalAddresses[tempoModerato.id][1],
+          },
+        },
+      },
+      name: 'Zone E',
+      rpcUrl: 'https://rpc-zone-e.testnet.tempo.xyz',
+    },
+    6: {
+      name: 'Zone A',
+      rpcUrl: 'https://rpc-zone-a.testnet.tempo.xyz',
+    },
+    7: {
+      name: 'Zone B',
+      rpcUrl: 'https://rpc-zone-b.testnet.tempo.xyz',
+    },
   },
-  7: {
-    name: 'Zone B',
-    rpcUrl: 'https://rpc-zone-b.testnet.tempo.xyz',
-  },
-} as const satisfies Record<number, Override>
+} as const satisfies Record<number, Record<number, Override>>
 
 export const zone = /*#__PURE__*/ from({
   sourceId: tempo.id,
@@ -57,10 +90,13 @@ export function from(options: from.Options) {
     const chainId = ZoneId.toChainId(id)
     const paddedId = String(id).padStart(3, '0')
 
-    const override = (overrides as Record<number, Override>)[id]
+    const override = (overrides as Record<number, Record<number, Override>>)[
+      options.sourceId
+    ]?.[id]
 
     return defineChain({
       ...chainConfig,
+      ...(override?.contracts ? { contracts: override.contracts } : {}),
       id: chainId,
       name: override?.name ?? `Tempo Zone ${paddedId}`,
       nativeCurrency: {


### PR DESCRIPTION
Adds Zone E metadata and RPC configuration, with Portal and Messenger addresses exposed through shared registries and derived into the chain contract configuration for downstream Zone clients.