### PR TITLE
Fix EIP-7702 authorization yParity of 0 serialization

### DIFF
--- a/.changeset/eip7702-yparity-zero.md
+++ b/.changeset/eip7702-yparity-zero.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `formatUserOperationRequest` encoding an EIP-7702 authorization `yParity` of `0` as a 32-byte zero value instead of `0x00`.

--- a/src/account-abstraction/utils/formatters/userOperationRequest.test.ts
+++ b/src/account-abstraction/utils/formatters/userOperationRequest.test.ts
@@ -70,3 +70,62 @@ test('default', () => {
     }
   `)
 })
+
+test('behavior: eip7702 authorization (yParity: 0)', () => {
+  const request = formatUserOperationRequest({
+    callData: '0xdeadbeef',
+    callGasLimit: 69420n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 10n,
+    nonce: 69n,
+    preVerificationGas: 69420n,
+    verificationGasLimit: 69420n,
+    sender: '0x0000000000000000000000000000000000000000',
+    signature: '0xdeadbeef',
+    authorization: {
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 1,
+      nonce: 0,
+      r: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      s: '0x0000000000000000000000000000000000000000000000000000000000000002',
+      yParity: 0,
+    },
+  })
+
+  // `yParity` of `0` must be encoded as the 1-byte `0x00`, not a 32-byte zero.
+  expect(request.eip7702Auth?.yParity).toBe('0x00')
+  expect(request.eip7702Auth).toMatchInlineSnapshot(`
+    {
+      "address": "0x0000000000000000000000000000000000000000",
+      "chainId": "0x1",
+      "nonce": "0x0",
+      "r": "0x0000000000000000000000000000000000000000000000000000000000000001",
+      "s": "0x0000000000000000000000000000000000000000000000000000000000000002",
+      "yParity": "0x00",
+    }
+  `)
+})
+
+test('behavior: eip7702 authorization (yParity: 1)', () => {
+  const request = formatUserOperationRequest({
+    callData: '0xdeadbeef',
+    callGasLimit: 69420n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 10n,
+    nonce: 69n,
+    preVerificationGas: 69420n,
+    verificationGasLimit: 69420n,
+    sender: '0x0000000000000000000000000000000000000000',
+    signature: '0xdeadbeef',
+    authorization: {
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 1,
+      nonce: 0,
+      r: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      s: '0x0000000000000000000000000000000000000000000000000000000000000002',
+      yParity: 1,
+    },
+  })
+
+  expect(request.eip7702Auth?.yParity).toBe('0x01')
+})

--- a/src/account-abstraction/utils/formatters/userOperationRequest.ts
+++ b/src/account-abstraction/utils/formatters/userOperationRequest.ts
@@ -69,8 +69,9 @@ function formatAuthorization(authorization: SignedAuthorization) {
     s: authorization.s
       ? numberToHex(BigInt(authorization.s), { size: 32 })
       : pad('0x', { size: 32 }),
-    yParity: authorization.yParity
-      ? numberToHex(authorization.yParity, { size: 1 })
-      : pad('0x', { size: 32 }),
+    yParity:
+      typeof authorization.yParity !== 'undefined'
+        ? numberToHex(authorization.yParity, { size: 1 })
+        : pad('0x', { size: 32 }),
   }
 }


### PR DESCRIPTION
### Summary

Fixes #4897.

`formatUserOperationRequest` (`src/account-abstraction/utils/formatters/userOperationRequest.ts`) serialized an EIP-7702 authorization `yParity` of `0` as a **32-byte** zero value instead of the single byte `0x00`.

The guard used a truthiness check:

```ts
yParity: authorization.yParity
  ? numberToHex(authorization.yParity, { size: 1 })
  : pad('0x', { size: 32 }),
```

`yParity` is a valid ECDSA recovery id and can legitimately be `0`, but the truthy check treats `0` as "not provided" and falls through to the 32-byte pad. Since roughly half of signed authorizations have `yParity === 0`, this intermittently produces a malformed `eip7702Auth` in `eth_sendUserOperation` / `pm_getPaymasterData`, which bundlers reject with a signature error (observed as `AA24` via Pimlico).

### Fix

Use a presence check so a `yParity` of `0` is encoded as `0x00`:

```ts
yParity:
  typeof authorization.yParity !== 'undefined'
    ? numberToHex(authorization.yParity, { size: 1 })
    : pad('0x', { size: 32 }),
```

### Tests

Added regression tests asserting the `eip7702Auth.yParity` output for `yParity: 0` (`0x00`) and `yParity: 1` (`0x01`), covering the previously untested authorization path.


### Note on the `undefined` fallback

I deliberately left the existing `pad('0x', { size: 32 })` fallback (used when `yParity` is `undefined`, e.g. a legacy `v`-only `SignedAuthorization`) unchanged, to keep this PR scoped to the reported bug. Happy to tighten that branch in this PR if you'd prefer — though the "correct" value there is arguably derived from `v` rather than a zero pad, which felt out of scope for a targeted fix.
