### PR TITLE
chore: add friction log workflow

### DIFF
--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,34 @@
+name: Friction Log
+on:
+  push:
+  issues:
+    types: [closed, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  friction-log:
+    name: Friction Log
+    if: github.event_name != 'push' || github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Report and reconcile frictions
+        uses: wevm/frog/action@v1


### PR DESCRIPTION
Adds an Action-only workflow that reports and reconciles the repository friction log after default-branch updates, issue changes, manual runs, and a daily schedule.