### PR TITLE
docs: add circle sponsor

### DIFF
--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -26,7 +26,10 @@ export const sponsors = {
     { name: 'Paradigm', url: 'https://paradigm.xyz' },
     { name: 'Tempo', url: 'https://tempo.xyz' },
   ],
-  largeEnterprise: [{ name: 'Stripe', url: 'https://www.stripe.com' }],
+  largeEnterprise: [
+    { name: 'Stripe', url: 'https://www.stripe.com' },
+    { name: 'Circle', url: 'https://www.circle.com' },
+  ],
   smallEnterprise: [
     { name: 'Family', url: 'https://twitter.com/family' },
     { name: 'Context', url: 'https://twitter.com/context' },


### PR DESCRIPTION
Adds Circle to Viem’s large-enterprise sponsors, matching the wevm.dev sponsor update.

Requires `circle-light.svg` and `circle-dark.svg` in `wevm/.github` before merge.

Related: https://github.com/wevm/wevm.dev/pull/3