### PR TITLE
fix: handle odd-length hex in signed hexToBigInt / hexToNumber

### DIFF
--- a/.changeset/signed-odd-length-hex.md
+++ b/.changeset/signed-odd-length-hex.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed `hexToBigInt` and `hexToNumber` throwing `RangeError: The number 1.5 cannot be converted to a BigInt` when `signed: true` is used with an odd-length hex value (e.g. the documented example `hexToBigInt('0x1a4', { signed: true })`, or minimal-encoded RPC quantities such as `0x0`). The byte size of the value is now rounded up.
+Fixed signed `hexToBigInt` and `hexToNumber` calls with odd-length hex values.

--- a/.changeset/signed-odd-length-hex.md
+++ b/.changeset/signed-odd-length-hex.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `hexToBigInt` and `hexToNumber` throwing `RangeError: The number 1.5 cannot be converted to a BigInt` when `signed: true` is used with an odd-length hex value (e.g. the documented example `hexToBigInt('0x1a4', { signed: true })`, or minimal-encoded RPC quantities such as `0x0`). The byte size of the value is now rounded up.

--- a/src/utils/encoding/fromHex.test.ts
+++ b/src/utils/encoding/fromHex.test.ts
@@ -46,6 +46,10 @@ describe('converts hex to number', () => {
     expect(hexToNumber('0x00027760a62ec2ac', { signed: true })).toBe(
       694206942069420,
     )
+
+    // odd-length hex
+    expect(hexToNumber('0x0', { signed: true })).toBe(0)
+    expect(hexToNumber('0x1a4', { signed: true })).toBe(420)
   })
 
   test('args: size', () => {
@@ -129,6 +133,11 @@ describe('converts hex to bigint', () => {
         { signed: true },
       ),
     ).toBe(-12312312312312312412n)
+
+    // odd-length hex
+    expect(hexToBigInt('0x0', { signed: true })).toBe(0n)
+    expect(hexToBigInt('0xf', { signed: true })).toBe(15n)
+    expect(hexToBigInt('0x1a4', { signed: true })).toBe(420n)
   })
 
   test('args: size', () => {

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -137,7 +137,7 @@ export function hexToBigInt(hex: Hex, opts: HexToBigIntOpts = {}): bigint {
   const value = BigInt(hex)
   if (!signed) return value
 
-  const size = (hex.length - 2) / 2
+  const size = Math.ceil((hex.length - 2) / 2)
   const max = (1n << (BigInt(size) * 8n - 1n)) - 1n
   if (value <= max) return value
 


### PR DESCRIPTION
### Summary

`hexToBigInt` (and `hexToNumber`) with `signed: true` crash on any odd-length hex value:

```ts
import { hexToBigInt } from 'viem'

hexToBigInt('0x1a4', { signed: true })
// RangeError: The number 1.5 cannot be converted to a BigInt because it is not an integer
```

This is the function's own `@example` (`src/utils/encoding/fromHex.ts:124` documents it returning `420n`). It also hits minimal-encoded JSON-RPC quantities, which are odd-length whenever the leading nibble is dropped (`0x0`, `0xf`, `0x1a4`, ...).

### Root cause

`src/utils/encoding/fromHex.ts:140`:

```ts
const size = (hex.length - 2) / 2
```

For odd-length hex the byte size is fractional (`'0x1a4'` → `1.5`), and the subsequent `BigInt(size)` throws. The unsigned path is unaffected — `size` is only used to compute the signed two's-complement bound.

### Fix

Round the byte size up:

```ts
const size = Math.ceil((hex.length - 2) / 2)
```

An odd-length value is interpreted at its minimal byte width (`0x1a4` ≙ `0x01a4`, 2 bytes), so `hexToBigInt('0x1a4', { signed: true })` now returns `420n` as documented. Even-length inputs take the exact same path as before.

### Test

Extended the `args: signed` tests in `fromHex.test.ts` with odd-length cases (`0x0`, `0xf`, `0x1a4`) for both `hexToBigInt` and `hexToNumber`. They fail on `main` with the `RangeError` above and pass with the fix.
