### PR TITLE
fix: accept partial logs in event extractors

### DIFF
--- a/.changeset/extract-event-log-shape.md
+++ b/.changeset/extract-event-log-shape.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Allowed `extractEvent`/`extractEvents` and the OP Stack log extractors to decode partial logs, so EIP-5792 call receipts can be passed without a cast. Return types stay generic over the log passed in, so full logs keep their block and transaction metadata.

--- a/.changeset/extract-event-log-shape.md
+++ b/.changeset/extract-event-log-shape.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Allowed `extractEvent`/`extractEvents` and the OP Stack log extractors to decode partial logs, so EIP-5792 call receipts can be passed without a cast. Return types stay generic over the log passed in, so full logs keep their block and transaction metadata.
+Allowed `extractEvent`/`extractEvents` and the OP Stack log extractors to decode partial EIP-5792 call receipt logs without casts while preserving the input logs' block and transaction metadata in their return types.

--- a/src/core/actions/token/approve.ts
+++ b/src/core/actions/token/approve.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../Account.js'
 import type * as Chain from '../../Chain.js'
@@ -169,7 +169,9 @@ export namespace approve {
    * @param logs - The logs.
    * @returns The `Approval` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(erc20Abi, logs, {
       eventName: 'Approval',
       strict: true,

--- a/src/core/actions/token/transfer.test-d.ts
+++ b/src/core/actions/token/transfer.test-d.ts
@@ -1,9 +1,11 @@
-import { describe, test } from 'vitest'
+import type { Address, Hex, Log } from 'ox'
+import { describe, expectTypeOf, test } from 'vitest'
 
 import { Account, Client, http } from 'viem'
 import { mainnet, zora } from 'viem/chains'
 import { usdc } from 'viem/tokens'
 
+import type { getCallsStatus } from '../wallet/getCallsStatus.js'
 import { transfer } from './transfer.js'
 import { transferSync } from './transferSync.js'
 
@@ -72,6 +74,43 @@ describe('transfer: token selector', () => {
     })
     // @ts-expect-error - the client declares no `tokens`, so symbols are unavailable
     transfer(client, { amount: { formatted: '1' }, to: '0x', token: 'usdc' })
+  })
+})
+
+describe('transfer.extractEvent: log shape', () => {
+  test('accepts EIP-5792 call receipt logs', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    const log = transfer.extractEvent(logs)
+
+    expectTypeOf(log.eventName).toEqualTypeOf<'Transfer'>()
+    expectTypeOf(log.args).toEqualTypeOf<{
+      from: Address.Address
+      to: Address.Address
+      value: bigint
+    }>()
+  })
+
+  test('does not invent metadata the input never carried', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    const log = transfer.extractEvent(logs)
+
+    expectTypeOf(log).not.toHaveProperty('blockNumber')
+    expectTypeOf(log).not.toHaveProperty('transactionHash')
+    expectTypeOf(log.address).toEqualTypeOf<Address.Address>()
+    expectTypeOf(log.data).toEqualTypeOf<Hex.Hex>()
+  })
+
+  test('preserves metadata for full logs', () => {
+    const logs: readonly Log.Log[] = []
+    const log = transfer.extractEvent(logs)
+
+    expectTypeOf(log.blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(log.transactionHash).toEqualTypeOf<Hex.Hex>()
+  })
+
+  test('rejects logs without topics', () => {
+    // @ts-expect-error - `topics` is the one field decoding cannot do without
+    transfer.extractEvent([{ address: '0x', data: '0x' }])
   })
 })
 

--- a/src/core/actions/token/transfer.test.ts
+++ b/src/core/actions/token/transfer.test.ts
@@ -221,3 +221,28 @@ describe('transfer: from (allowance)', () => {
     expect(after.amount - before.amount).toMatchInlineSnapshot(`2000000000n`)
   })
 })
+
+describe('transfer.extractEvent', () => {
+  test('decodes an EIP-5792 call receipt log', () => {
+    const log = transfer.extractEvent([
+      {
+        address: usdc,
+        data: '0x000000000000000000000000000000000000000000000000000000003b9aca00',
+        topics: [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+          '0x0000000000000000000000005414d89a8bf7e99d732bc52f3e6a3ef461c0c078',
+          '0x0000000000000000000000009965507d1a55bcc2695c58ba16fb37d819b0a4dc',
+        ],
+      },
+    ])
+
+    expect(log.eventName).toMatchInlineSnapshot(`"Transfer"`)
+    expect(log.args).toMatchInlineSnapshot(`
+      {
+        "from": "0x5414d89a8bF7E99d732BC52f3e6A3Ef461c0C078",
+        "to": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+        "value": 1000000000n,
+      }
+    `)
+  })
+})

--- a/src/core/actions/token/transfer.ts
+++ b/src/core/actions/token/transfer.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../Account.js'
 import type * as Chain from '../../Chain.js'
@@ -189,7 +189,9 @@ export namespace transfer {
    * @param logs - The logs.
    * @returns The `Transfer` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(erc20Abi, logs, {
       eventName: 'Transfer',
       strict: true,

--- a/src/op-stack/Deposit.test-d.ts
+++ b/src/op-stack/Deposit.test-d.ts
@@ -1,0 +1,39 @@
+import type { Hex, Log } from 'ox'
+import { describe, expectTypeOf, test } from 'vitest'
+
+import type { getCallsStatus } from '../core/actions/wallet/getCallsStatus.js'
+import * as Deposit from './Deposit.js'
+
+describe('extractTransactionDepositedLogs: log shape', () => {
+  test('accepts EIP-5792 call receipt logs', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    const [log] = Deposit.extractTransactionDepositedLogs({ logs })
+
+    expectTypeOf(log!.eventName).toEqualTypeOf<'TransactionDeposited'>()
+    expectTypeOf(log!.args.opaqueData).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(log!).not.toHaveProperty('blockHash')
+  })
+
+  test('preserves metadata for full logs', () => {
+    const logs: readonly Log.Log[] = []
+    const [log] = Deposit.extractTransactionDepositedLogs({ logs })
+
+    expectTypeOf(log!.blockHash).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(log!.logIndex).toEqualTypeOf<number>()
+  })
+})
+
+describe('getL2TransactionHashes: log shape', () => {
+  test('rejects EIP-5792 call receipt logs', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    // @ts-expect-error - partial logs cannot produce a source hash
+    Deposit.getL2TransactionHashes({ logs })
+  })
+
+  test('accepts full logs', () => {
+    const logs: readonly Log.Log[] = []
+    expectTypeOf(Deposit.getL2TransactionHashes({ logs })).toEqualTypeOf<
+      readonly Hex.Hex[]
+    >()
+  })
+})

--- a/src/op-stack/Deposit.ts
+++ b/src/op-stack/Deposit.ts
@@ -32,19 +32,23 @@ export type Request = {
 )
 
 /** A decoded `TransactionDeposited` log. */
-export type TransactionDepositedLog = AbiEvent.extractLogs.ReturnType<
+export type TransactionDepositedLog<
+  log extends AbiEvent.extractLogs.Log = Log.Log,
+> = AbiEvent.extractLogs.ReturnType<
   AbiEvent.extractLogs.ExtractEvent<
     typeof Abis.portalAbi,
     'TransactionDeposited'
   >,
-  Log.Log,
+  log,
   true
 >
 
 /** Extracts `TransactionDeposited` events from L1 logs. */
-export function extractTransactionDepositedLogs(
-  options: extractTransactionDepositedLogs.Options,
-): extractTransactionDepositedLogs.ReturnType {
+export function extractTransactionDepositedLogs<
+  const log extends AbiEvent.extractLogs.Log,
+>(
+  options: extractTransactionDepositedLogs.Options<log>,
+): extractTransactionDepositedLogs.ReturnType<log> {
   return AbiEvent.extractLogs(Abis.portalAbi, options.logs, {
     eventName: 'TransactionDeposited',
     strict: true,
@@ -53,13 +57,14 @@ export function extractTransactionDepositedLogs(
 
 export declare namespace extractTransactionDepositedLogs {
   /** Options for {@link extractTransactionDepositedLogs}. */
-  type Options = {
+  type Options<log extends AbiEvent.extractLogs.Log = Log.Log> = {
     /** L1 logs to inspect. */
-    logs: readonly Log.Log[]
+    logs: readonly log[]
   }
 
   /** Return type of {@link extractTransactionDepositedLogs}. */
-  type ReturnType = readonly TransactionDepositedLog[]
+  type ReturnType<log extends AbiEvent.extractLogs.Log = Log.Log> =
+    readonly TransactionDepositedLog<log>[]
 
   /** Errors thrown by {@link extractTransactionDepositedLogs}. */
   type ErrorType = AbiEvent.extractLogs.ErrorType | Errors.GlobalErrorType
@@ -124,7 +129,7 @@ export function getL2TransactionHashes(
 
 export declare namespace getL2TransactionHashes {
   /** Options for {@link getL2TransactionHashes}. */
-  type Options = extractTransactionDepositedLogs.Options
+  type Options = extractTransactionDepositedLogs.Options<Log.Log>
 
   /** Return type of {@link getL2TransactionHashes}. */
   type ReturnType = readonly Hex.Hex[]

--- a/src/op-stack/Withdrawal.test-d.ts
+++ b/src/op-stack/Withdrawal.test-d.ts
@@ -1,0 +1,34 @@
+import type { Hex, Log } from 'ox'
+import { describe, expectTypeOf, test } from 'vitest'
+
+import type { getCallsStatus } from '../core/actions/wallet/getCallsStatus.js'
+import * as Withdrawal from './Withdrawal.js'
+
+describe('extractWithdrawalMessageLogs: log shape', () => {
+  test('accepts EIP-5792 call receipt logs', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    const [log] = Withdrawal.extractWithdrawalMessageLogs({ logs })
+
+    expectTypeOf(log!.eventName).toEqualTypeOf<'MessagePassed'>()
+    expectTypeOf(log!.args.withdrawalHash).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(log!).not.toHaveProperty('blockHash')
+  })
+
+  test('preserves metadata for full logs', () => {
+    const logs: readonly Log.Log[] = []
+    const [log] = Withdrawal.extractWithdrawalMessageLogs({ logs })
+
+    expectTypeOf(log!.blockHash).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(log!.logIndex).toEqualTypeOf<number>()
+  })
+})
+
+describe('getWithdrawals: log shape', () => {
+  // Withdrawals are built from decoded args alone, so partial logs are fine.
+  test('accepts EIP-5792 call receipt logs', () => {
+    const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+    expectTypeOf(Withdrawal.getWithdrawals({ logs })).toEqualTypeOf<
+      readonly Withdrawal.Withdrawal[]
+    >()
+  })
+})

--- a/src/op-stack/Withdrawal.ts
+++ b/src/op-stack/Withdrawal.ts
@@ -35,19 +35,22 @@ export type Withdrawal = {
 }
 
 /** A decoded `MessagePassed` log. */
-export type MessagePassedLog = AbiEvent.extractLogs.ReturnType<
-  AbiEvent.extractLogs.ExtractEvent<
-    typeof Abis.l2ToL1MessagePasserAbi,
-    'MessagePassed'
-  >,
-  Log.Log,
-  true
->
+export type MessagePassedLog<log extends AbiEvent.extractLogs.Log = Log.Log> =
+  AbiEvent.extractLogs.ReturnType<
+    AbiEvent.extractLogs.ExtractEvent<
+      typeof Abis.l2ToL1MessagePasserAbi,
+      'MessagePassed'
+    >,
+    log,
+    true
+  >
 
 /** Extracts `MessagePassed` events from L2 logs. */
-export function extractWithdrawalMessageLogs(
-  options: extractWithdrawalMessageLogs.Options,
-): extractWithdrawalMessageLogs.ReturnType {
+export function extractWithdrawalMessageLogs<
+  const log extends AbiEvent.extractLogs.Log,
+>(
+  options: extractWithdrawalMessageLogs.Options<log>,
+): extractWithdrawalMessageLogs.ReturnType<log> {
   return AbiEvent.extractLogs(Abis.l2ToL1MessagePasserAbi, options.logs, {
     eventName: 'MessagePassed',
     strict: true,
@@ -56,13 +59,14 @@ export function extractWithdrawalMessageLogs(
 
 export declare namespace extractWithdrawalMessageLogs {
   /** Options for {@link extractWithdrawalMessageLogs}. */
-  type Options = {
+  type Options<log extends AbiEvent.extractLogs.Log = Log.Log> = {
     /** L2 logs to inspect. */
-    logs: readonly Log.Log[]
+    logs: readonly log[]
   }
 
   /** Return type of {@link extractWithdrawalMessageLogs}. */
-  type ReturnType = readonly MessagePassedLog[]
+  type ReturnType<log extends AbiEvent.extractLogs.Log = Log.Log> =
+    readonly MessagePassedLog<log>[]
 
   /** Errors thrown by {@link extractWithdrawalMessageLogs}. */
   type ErrorType = AbiEvent.extractLogs.ErrorType | Errors.GlobalErrorType
@@ -97,15 +101,16 @@ export declare namespace getWithdrawalHashStorageSlot {
 }
 
 /** Extracts withdrawals from L2 receipt logs. */
-export function getWithdrawals(
-  options: getWithdrawals.Options,
+export function getWithdrawals<const log extends AbiEvent.extractLogs.Log>(
+  options: getWithdrawals.Options<log>,
 ): getWithdrawals.ReturnType {
   return extractWithdrawalMessageLogs(options).map((log) => log.args)
 }
 
 export declare namespace getWithdrawals {
   /** Options for {@link getWithdrawals}. */
-  type Options = extractWithdrawalMessageLogs.Options
+  type Options<log extends AbiEvent.extractLogs.Log = Log.Log> =
+    extractWithdrawalMessageLogs.Options<log>
 
   /** Return type of {@link getWithdrawals}. */
   type ReturnType = readonly Withdrawal[]

--- a/src/tempo/actions/accessKey/authorize.ts
+++ b/src/tempo/actions/accessKey/authorize.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import * as CoreAccount from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -101,7 +101,9 @@ export namespace authorize {
   }
 
   /** Extracts the `KeyAuthorized` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.accountKeychain, logs, {
       eventName: 'KeyAuthorized',
       strict: true,

--- a/src/tempo/actions/accessKey/burnWitness.ts
+++ b/src/tempo/actions/accessKey/burnWitness.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -128,7 +128,9 @@ export namespace burnWitness {
   }
 
   /** Extracts the `KeyAuthorizationWitnessBurned` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.accountKeychain, logs, {
       eventName: 'KeyAuthorizationWitnessBurned',
       strict: true,

--- a/src/tempo/actions/accessKey/revoke.ts
+++ b/src/tempo/actions/accessKey/revoke.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -120,7 +120,9 @@ export namespace revoke {
   }
 
   /** Extracts the `KeyRevoked` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.accountKeychain, logs, {
       eventName: 'KeyRevoked',
       strict: true,

--- a/src/tempo/actions/accessKey/updateLimit.ts
+++ b/src/tempo/actions/accessKey/updateLimit.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -129,7 +129,9 @@ export namespace updateLimit {
   }
 
   /** Extracts the `SpendingLimitUpdated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.accountKeychain, logs, {
       eventName: 'SpendingLimitUpdated',
       strict: true,

--- a/src/tempo/actions/amm/burn.ts
+++ b/src/tempo/actions/amm/burn.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -128,7 +128,9 @@ export namespace burn {
   }
 
   /** Extracts the `Burn` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.feeAmm, logs, {
       eventName: 'Burn',
       strict: true,

--- a/src/tempo/actions/amm/mint.ts
+++ b/src/tempo/actions/amm/mint.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -138,7 +138,9 @@ export namespace mint {
   }
 
   /** Extracts the `Mint` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.feeAmm, logs, {
       eventName: 'Mint',
       strict: true,

--- a/src/tempo/actions/amm/rebalanceSwap.ts
+++ b/src/tempo/actions/amm/rebalanceSwap.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -128,7 +128,9 @@ export namespace rebalanceSwap {
   }
 
   /** Extracts the `RebalanceSwap` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.feeAmm, logs, {
       eventName: 'RebalanceSwap',
       strict: true,

--- a/src/tempo/actions/channel/close.ts
+++ b/src/tempo/actions/channel/close.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 import { Channel } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -143,7 +143,9 @@ export namespace close {
   }
 
   /** Extracts the `ChannelClosed` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'ChannelClosed',
       strict: true,

--- a/src/tempo/actions/channel/open.ts
+++ b/src/tempo/actions/channel/open.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Hex } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -121,7 +121,9 @@ export namespace open {
   }
 
   /** Extracts the `ChannelOpened` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'ChannelOpened',
       strict: true,

--- a/src/tempo/actions/channel/requestClose.ts
+++ b/src/tempo/actions/channel/requestClose.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 import { Channel } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -105,7 +105,9 @@ export namespace requestClose {
   }
 
   /** Extracts the `CloseRequested` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'CloseRequested',
       strict: true,

--- a/src/tempo/actions/channel/settle.ts
+++ b/src/tempo/actions/channel/settle.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 import { Channel } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -116,7 +116,9 @@ export namespace settle {
   }
 
   /** Extracts the `Settled` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'Settled',
       strict: true,

--- a/src/tempo/actions/channel/topUp.ts
+++ b/src/tempo/actions/channel/topUp.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 import { Channel } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -107,7 +107,9 @@ export namespace topUp {
   }
 
   /** Extracts the `TopUp` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'TopUp',
       strict: true,

--- a/src/tempo/actions/channel/withdraw.ts
+++ b/src/tempo/actions/channel/withdraw.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 import { Channel } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -105,7 +105,9 @@ export namespace withdraw {
   }
 
   /** Extracts the `ChannelClosed` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20ChannelReserve, logs, {
       eventName: 'ChannelClosed',
       strict: true,

--- a/src/tempo/actions/dex/cancel.ts
+++ b/src/tempo/actions/dex/cancel.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -145,7 +145,9 @@ export namespace cancel {
    * @param logs - The logs.
    * @returns The `OrderCancelled` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.stablecoinDex, logs, {
       eventName: 'OrderCancelled',
       strict: true,

--- a/src/tempo/actions/dex/cancelStale.ts
+++ b/src/tempo/actions/dex/cancelStale.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -150,7 +150,9 @@ export namespace cancelStale {
    * @param logs - The logs.
    * @returns The `OrderCancelled` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.stablecoinDex, logs, {
       eventName: 'OrderCancelled',
       strict: true,

--- a/src/tempo/actions/dex/createPair.ts
+++ b/src/tempo/actions/dex/createPair.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -147,7 +147,9 @@ export namespace createPair {
    * @param logs - The logs.
    * @returns The `PairCreated` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.stablecoinDex, logs, {
       eventName: 'PairCreated',
       strict: true,

--- a/src/tempo/actions/dex/place.ts
+++ b/src/tempo/actions/dex/place.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -154,7 +154,9 @@ export namespace place {
    * @param logs - The logs.
    * @returns The `OrderPlaced` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.stablecoinDex, logs, {
       eventName: 'OrderPlaced',
       strict: true,

--- a/src/tempo/actions/dex/placeFlip.ts
+++ b/src/tempo/actions/dex/placeFlip.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -158,7 +158,9 @@ export namespace placeFlip {
    * @param logs - The logs.
    * @returns The `OrderPlaced` event for a flip order.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const logs_ = AbiEvent.extractLogs(Abis.stablecoinDex, logs, {
       eventName: 'OrderPlaced',
       strict: true,

--- a/src/tempo/actions/earn.test-d.ts
+++ b/src/tempo/actions/earn.test-d.ts
@@ -1,9 +1,11 @@
-import type { Address, Hex, TransactionReceipt } from 'ox'
+import type { Address, Hex, Log, TransactionReceipt } from 'ox'
 import { expectTypeOf, test } from 'vitest'
 
 import { tempoLocalnet } from 'viem/chains'
 import { Account, Actions, Client, EarnShares, http } from 'viem/tempo'
 import { zoneModerato } from 'viem/tempo/zones'
+
+import type { getCallsStatus } from '../../core/actions/wallet/getCallsStatus.js'
 
 const account = Account.fromSecp256k1(
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
@@ -826,4 +828,21 @@ test('decorated zone earn actions preserve helpers and results', async () => {
       vault: privatePreparation.vault,
     }),
   ).toEqualTypeOf<Actions.earn.waitForPrivateRedeem.ReturnType>()
+})
+
+test('deposit.extractEvent: accepts EIP-5792 call receipt logs', () => {
+  const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+  const log = Actions.earn.deposit.extractEvent(logs, { vault: address })
+
+  expectTypeOf(log.eventName).toEqualTypeOf<'Deposited'>()
+  expectTypeOf(log).not.toHaveProperty('blockNumber')
+})
+
+test('deposit.extractEvent: preserves metadata for full logs', () => {
+  const logs: readonly Log.Log[] = []
+  const log = Actions.earn.deposit.extractEvent(logs, { vault: address })
+
+  expectTypeOf(log.blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(log.logIndex).toEqualTypeOf<number>()
+  expectTypeOf(log.transactionHash).toEqualTypeOf<Hex.Hex>()
 })

--- a/src/tempo/actions/earn.test-d.ts
+++ b/src/tempo/actions/earn.test-d.ts
@@ -846,3 +846,40 @@ test('deposit.extractEvent: preserves metadata for full logs', () => {
   expectTypeOf(log.logIndex).toEqualTypeOf<number>()
   expectTypeOf(log.transactionHash).toEqualTypeOf<Hex.Hex>()
 })
+
+test('deployment extractEvent helpers accept EIP-5792 call receipt logs', () => {
+  const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+  const engine = Actions.earn.createErc4626Engine.extractEvent(logs, {
+    factory: address,
+  })
+  const stack = Actions.earn.createStack.extractEvent(logs, {
+    factory: address,
+  })
+  const binding = Actions.earn.bindErc4626Engine.extractEvent(logs, {
+    engine: address,
+  })
+
+  expectTypeOf(engine.eventName).toEqualTypeOf<'ERC4626EngineDeployed'>()
+  expectTypeOf(stack.eventName).toEqualTypeOf<'EarnStackDeployed'>()
+  expectTypeOf(binding.eventName).toEqualTypeOf<'EarnVaultInitialized'>()
+  expectTypeOf(engine).not.toHaveProperty('blockNumber')
+  expectTypeOf(stack).not.toHaveProperty('blockNumber')
+  expectTypeOf(binding).not.toHaveProperty('blockNumber')
+})
+
+test('deployment extractEvent helpers preserve metadata for full logs', () => {
+  const logs: readonly Log.Log[] = []
+  const engine = Actions.earn.createErc4626Engine.extractEvent(logs, {
+    factory: address,
+  })
+  const stack = Actions.earn.createStack.extractEvent(logs, {
+    factory: address,
+  })
+  const binding = Actions.earn.bindErc4626Engine.extractEvent(logs, {
+    engine: address,
+  })
+
+  expectTypeOf(engine.blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(stack.blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(binding.blockNumber).toEqualTypeOf<bigint>()
+})

--- a/src/tempo/actions/earn.ts
+++ b/src/tempo/actions/earn.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, AbiParameters, Address, Hex } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 import { EarnShares } from 'ox/tempo'
 
 import * as Account from '../../core/Account.js'
@@ -500,16 +500,19 @@ export namespace deposit {
    * @param options - Options.
    * @returns The `Deposited` event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    options: { vault: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, options: { vault: Address.Address }) {
     const { vault } = options
     // Earn contracts are user-deployed: several adapters can emit the same
     // signature in one receipt, so filter by emitting address before decode.
     const [log] = AbiEvent.extractLogs(
       Abis.earnVault,
-      logs.filter((log) => Address.isEqual(log.address, vault)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, vault),
+      ),
       { eventName: 'Deposited', strict: true },
     )
     if (!log) throw new Error('`Deposited` event not found.')
@@ -789,16 +792,19 @@ export namespace depositShares {
    * @param options - Options.
    * @returns The `VenueSharesDeposited` event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    options: { vault: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, options: { vault: Address.Address }) {
     const { vault } = options
     // Earn contracts are user-deployed: several adapters can emit the same
     // signature in one receipt, so filter by emitting address before decode.
     const [log] = AbiEvent.extractLogs(
       Abis.earnVault,
-      logs.filter((log) => Address.isEqual(log.address, vault)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, vault),
+      ),
       { eventName: 'VenueSharesDeposited', strict: true },
     )
     if (!log) throw new Error('`VenueSharesDeposited` event not found.')
@@ -2152,16 +2158,19 @@ export namespace redeem {
    * @param options - Options.
    * @returns The `Redeemed` event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    options: { vault: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, options: { vault: Address.Address }) {
     const { vault } = options
     // Earn contracts are user-deployed: several adapters can emit the same
     // signature in one receipt, so filter by emitting address before decode.
     const [log] = AbiEvent.extractLogs(
       Abis.earnVault,
-      logs.filter((log) => Address.isEqual(log.address, vault)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, vault),
+      ),
       { eventName: 'Redeemed', strict: true },
     )
     if (!log) throw new Error('`Redeemed` event not found.')
@@ -2791,16 +2800,19 @@ export namespace withdrawExact {
    * @param options - Options.
    * @returns The `WithdrewExact` event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    options: { vault: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, options: { vault: Address.Address }) {
     const { vault } = options
     // Earn contracts are user-deployed: several adapters can emit the same
     // signature in one receipt, so filter by emitting address before decode.
     const [log] = AbiEvent.extractLogs(
       Abis.earnVault,
-      logs.filter((log) => Address.isEqual(log.address, vault)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, vault),
+      ),
       { eventName: 'WithdrewExact', strict: true },
     )
     if (!log) throw new Error('`WithdrewExact` event not found.')

--- a/src/tempo/actions/earn/deployment.ts
+++ b/src/tempo/actions/earn/deployment.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Address, Hex } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -274,13 +274,16 @@ export namespace createErc4626Engine {
    * @param parameters - Factory address used to filter the logs.
    * @returns The deployment event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    parameters: { factory: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, parameters: { factory: Address.Address }) {
     const [log] = AbiEvent.extractLogs(
       Abis.erc4626EngineFactory,
-      logs.filter((log) => Address.isEqual(log.address, parameters.factory)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, parameters.factory),
+      ),
       {
         eventName: 'ERC4626EngineDeployed',
         strict: true,
@@ -531,13 +534,16 @@ export namespace createStack {
    * @param parameters - Factory address used to filter the logs.
    * @returns The deployment event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    parameters: { factory: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, parameters: { factory: Address.Address }) {
     const [log] = AbiEvent.extractLogs(
       Abis.earnFactory,
-      logs.filter((log) => Address.isEqual(log.address, parameters.factory)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, parameters.factory),
+      ),
       {
         eventName: 'EarnStackDeployed',
         strict: true,
@@ -710,13 +716,16 @@ export namespace bindErc4626Engine {
    * @param parameters - Engine address used to filter the logs.
    * @returns The initialization event.
    */
-  export function extractEvent(
-    logs: readonly Log.Log[],
-    parameters: { engine: Address.Address },
-  ) {
+  export function extractEvent<
+    const logs extends readonly (AbiEvent.extractLogs.Log & {
+      address: Address.Address
+    })[],
+  >(logs: logs, parameters: { engine: Address.Address }) {
     const [log] = AbiEvent.extractLogs(
       Abis.erc4626Engine,
-      logs.filter((log) => Address.isEqual(log.address, parameters.engine)),
+      logs.filter((log): log is logs[number] =>
+        Address.isEqual(log.address, parameters.engine),
+      ),
       {
         eventName: 'EarnVaultInitialized',
         strict: true,

--- a/src/tempo/actions/fee/setUserToken.ts
+++ b/src/tempo/actions/fee/setUserToken.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -100,7 +100,9 @@ export namespace setUserToken {
    * @param logs - The logs.
    * @returns The `UserTokenSet` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.feeManager, logs, {
       eventName: 'UserTokenSet',
       strict: true,

--- a/src/tempo/actions/fee/setValidatorToken.ts
+++ b/src/tempo/actions/fee/setValidatorToken.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -100,7 +100,9 @@ export namespace setValidatorToken {
    * @param logs - The logs.
    * @returns The `ValidatorTokenSet` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.feeManager, logs, {
       eventName: 'ValidatorTokenSet',
       strict: true,

--- a/src/tempo/actions/policy/create.ts
+++ b/src/tempo/actions/policy/create.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -149,7 +149,9 @@ export namespace create {
   }
 
   /** Extracts the `PolicyCreated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip403Registry, logs, {
       eventName: 'PolicyCreated',
       strict: true,

--- a/src/tempo/actions/policy/modifyBlacklist.ts
+++ b/src/tempo/actions/policy/modifyBlacklist.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -105,7 +105,9 @@ export namespace modifyBlacklist {
   }
 
   /** Extracts the `BlacklistUpdated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip403Registry, logs, {
       eventName: 'BlacklistUpdated',
       strict: true,

--- a/src/tempo/actions/policy/modifyWhitelist.ts
+++ b/src/tempo/actions/policy/modifyWhitelist.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -105,7 +105,9 @@ export namespace modifyWhitelist {
   }
 
   /** Extracts the `WhitelistUpdated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip403Registry, logs, {
       eventName: 'WhitelistUpdated',
       strict: true,

--- a/src/tempo/actions/policy/setAdmin.ts
+++ b/src/tempo/actions/policy/setAdmin.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -100,7 +100,9 @@ export namespace setAdmin {
   }
 
   /** Extracts the `PolicyAdminUpdated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip403Registry, logs, {
       eventName: 'PolicyAdminUpdated',
       strict: true,

--- a/src/tempo/actions/receivePolicy/burn.ts
+++ b/src/tempo/actions/receivePolicy/burn.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -102,7 +102,9 @@ export namespace burn {
   }
 
   /** Extracts the `ReceiptBurned` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.receivePolicyGuard, logs, {
       eventName: 'ReceiptBurned',
       strict: true,

--- a/src/tempo/actions/receivePolicy/claim.ts
+++ b/src/tempo/actions/receivePolicy/claim.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Hex, Log } from 'ox'
+import type { Address, Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -101,7 +101,9 @@ export namespace claim {
   }
 
   /** Extracts the `ReceiptClaimed` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.receivePolicyGuard, logs, {
       eventName: 'ReceiptClaimed',
       strict: true,

--- a/src/tempo/actions/receivePolicy/set.ts
+++ b/src/tempo/actions/receivePolicy/set.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Address as Address_ } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 import { VirtualAddress } from 'ox/tempo'
 
 import * as Account from '../../../core/Account.js'
@@ -153,7 +153,9 @@ export namespace set {
   }
 
   /** Extracts the `ReceivePolicyUpdated` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip403Registry, logs, {
       eventName: 'ReceivePolicyUpdated',
       strict: true,

--- a/src/tempo/actions/token/approve.ts
+++ b/src/tempo/actions/token/approve.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -157,7 +157,9 @@ export namespace approve {
    * @param logs - The logs.
    * @returns The `Approval` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'Approval',
       strict: true,

--- a/src/tempo/actions/token/burn.ts
+++ b/src/tempo/actions/token/burn.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Hex as Hex_ } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -165,7 +165,9 @@ export namespace burn {
    * @param logs - The logs.
    * @returns The `Burn` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'Burn',
       strict: true,

--- a/src/tempo/actions/token/burnBlocked.ts
+++ b/src/tempo/actions/token/burnBlocked.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -158,7 +158,9 @@ export namespace burnBlocked {
    * @param logs - The logs.
    * @returns The `BurnBlocked` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'BurnBlocked',
       strict: true,

--- a/src/tempo/actions/token/changeTransferPolicy.ts
+++ b/src/tempo/actions/token/changeTransferPolicy.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -150,7 +150,9 @@ export namespace changeTransferPolicy {
    * @param logs - The logs.
    * @returns The `TransferPolicyUpdate` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'TransferPolicyUpdate',
       strict: true,

--- a/src/tempo/actions/token/create.ts
+++ b/src/tempo/actions/token/create.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Hex } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -199,7 +199,9 @@ export namespace create {
    * @param logs - The logs.
    * @returns The `TokenCreated` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20Factory, logs, {
       eventName: 'TokenCreated',
       strict: true,

--- a/src/tempo/actions/token/grantRoles.ts
+++ b/src/tempo/actions/token/grantRoles.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, AbiFunction } from 'ox'
-import type { Address, Errors, Hex, Log } from 'ox'
+import type { Address, Errors, Hex } from 'ox'
 import { TokenRole } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -121,7 +121,9 @@ export namespace grantRoles {
    * @param logs - The logs.
    * @returns The `RoleMembershipUpdated` events.
    */
-  export function extractEvents(logs: readonly Log.Log[]) {
+  export function extractEvents<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const events = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'RoleMembershipUpdated',
       strict: true,

--- a/src/tempo/actions/token/mint.ts
+++ b/src/tempo/actions/token/mint.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Hex as Hex_ } from 'ox'
-import type { Address, Errors, Hex, Log } from 'ox'
+import type { Address, Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -137,7 +137,9 @@ export namespace mint {
   }
 
   /** Extracts the `Mint` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'Mint',
       strict: true,

--- a/src/tempo/actions/token/pause.ts
+++ b/src/tempo/actions/token/pause.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -114,7 +114,9 @@ export namespace pause {
   }
 
   /** Extracts the `PauseStateUpdate` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'PauseStateUpdate',
       strict: true,

--- a/src/tempo/actions/token/prepareUpdateQuoteToken.ts
+++ b/src/tempo/actions/token/prepareUpdateQuoteToken.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -145,7 +145,9 @@ export namespace prepareUpdateQuoteToken {
    * @param logs - The logs.
    * @returns The `NextQuoteTokenSet` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'NextQuoteTokenSet',
       strict: true,

--- a/src/tempo/actions/token/renounceRoles.ts
+++ b/src/tempo/actions/token/renounceRoles.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, AbiFunction } from 'ox'
-import type { Address, Errors, Hex, Log } from 'ox'
+import type { Address, Errors, Hex } from 'ox'
 import { TokenRole } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -118,7 +118,9 @@ export namespace renounceRoles {
    * @param logs - The logs.
    * @returns The `RoleMembershipUpdated` events.
    */
-  export function extractEvents(logs: readonly Log.Log[]) {
+  export function extractEvents<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const events = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'RoleMembershipUpdated',
       strict: true,

--- a/src/tempo/actions/token/revokeRoles.ts
+++ b/src/tempo/actions/token/revokeRoles.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, AbiFunction } from 'ox'
-import type { Address, Errors, Hex, Log } from 'ox'
+import type { Address, Errors, Hex } from 'ox'
 import { TokenRole } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -121,7 +121,9 @@ export namespace revokeRoles {
    * @param logs - The logs.
    * @returns The `RoleMembershipUpdated` events.
    */
-  export function extractEvents(logs: readonly Log.Log[]) {
+  export function extractEvents<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const events = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'RoleMembershipUpdated',
       strict: true,

--- a/src/tempo/actions/token/setRoleAdmin.ts
+++ b/src/tempo/actions/token/setRoleAdmin.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 import { TokenRole } from 'ox/tempo'
 
 import type * as Account from '../../../core/Account.js'
@@ -152,7 +152,9 @@ export namespace setRoleAdmin {
    * @param logs - The logs.
    * @returns The `RoleAdminUpdated` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'RoleAdminUpdated',
       strict: true,

--- a/src/tempo/actions/token/setSupplyCap.ts
+++ b/src/tempo/actions/token/setSupplyCap.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -146,7 +146,9 @@ export namespace setSupplyCap {
    * @param logs - The logs.
    * @returns The `SupplyCapUpdate` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'SupplyCapUpdate',
       strict: true,

--- a/src/tempo/actions/token/transfer.ts
+++ b/src/tempo/actions/token/transfer.ts
@@ -1,5 +1,5 @@
 import { AbiEvent, Hex } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -192,7 +192,9 @@ export namespace transfer {
    * @param logs - The logs.
    * @returns The `Transfer` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'Transfer',
       strict: true,

--- a/src/tempo/actions/token/unpause.ts
+++ b/src/tempo/actions/token/unpause.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Log } from 'ox'
+import type { Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -145,7 +145,9 @@ export namespace unpause {
    * @param logs - The logs.
    * @returns The `PauseStateUpdate` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'PauseStateUpdate',
       strict: true,

--- a/src/tempo/actions/token/updateQuoteToken.ts
+++ b/src/tempo/actions/token/updateQuoteToken.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Address, Errors, Log } from 'ox'
+import type { Address, Errors } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -141,7 +141,9 @@ export namespace updateQuoteToken {
    * @param logs - The logs.
    * @returns The `QuoteTokenUpdate` event.
    */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.tip20, logs, {
       eventName: 'QuoteTokenUpdate',
       strict: true,

--- a/src/tempo/actions/virtualAddress/registerMaster.ts
+++ b/src/tempo/actions/virtualAddress/registerMaster.ts
@@ -1,5 +1,5 @@
 import { AbiEvent } from 'ox'
-import type { Errors, Hex, Log } from 'ox'
+import type { Errors, Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -122,7 +122,9 @@ export namespace registerMaster {
   }
 
   /** Extracts the `MasterRegistered` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(Abis.addressRegistry, logs, {
       eventName: 'MasterRegistered',
       strict: true,

--- a/src/tempo/actions/zone/requestWithdrawal.ts
+++ b/src/tempo/actions/zone/requestWithdrawal.ts
@@ -1,4 +1,4 @@
-import { AbiEvent, type Address, type Errors, type Hex, type Log } from 'ox'
+import { AbiEvent, type Address, type Errors, type Hex } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -140,7 +140,9 @@ export namespace requestWithdrawal {
   }
 
   /** Extracts the `WithdrawalRequested` event from logs. */
-  export function extractEvent(logs: readonly Log.Log[]) {
+  export function extractEvent<
+    const logs extends readonly AbiEvent.extractLogs.Log[],
+  >(logs: logs) {
     const [log] = AbiEvent.extractLogs(ZoneAbis.zoneOutbox, logs, {
       eventName: 'WithdrawalRequested',
       strict: true,

--- a/src/tempo/actions/zone/zone.test-d.ts
+++ b/src/tempo/actions/zone/zone.test-d.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex } from 'ox'
+import type { Address, Hex, Log } from 'ox'
 import { describe, expectTypeOf, test } from 'vitest'
 
 import { Actions as CoreActions } from 'viem'
@@ -6,6 +6,7 @@ import { tempoLocalnet } from 'viem/chains'
 import { Account, Actions, Client, http } from 'viem/tempo'
 import { zoneModerato } from 'viem/tempo/zones'
 
+import type { getCallsStatus } from '../../../core/actions/wallet/getCallsStatus.js'
 import { deposit } from './deposit.js'
 import { depositSync } from './depositSync.js'
 import { encryptedDeposit } from './encryptedDeposit.js'
@@ -35,6 +36,23 @@ const zoneClient = Client.create({
 const publicZoneClient = Client.create({
   chain: zoneModerato(7),
   transport: http(),
+})
+
+test('requestWithdrawal.extractEvent accepts EIP-5792 call receipt logs', () => {
+  const logs: getCallsStatus.ReturnType['receipts'][number]['logs'] = []
+  const log = Actions.zone.requestWithdrawal.extractEvent(logs)
+
+  expectTypeOf(log.eventName).toEqualTypeOf<'WithdrawalRequested'>()
+  expectTypeOf(log).not.toHaveProperty('blockNumber')
+})
+
+test('requestWithdrawal.extractEvent preserves metadata for full logs', () => {
+  const logs: readonly Log.Log[] = []
+  const log = Actions.zone.requestWithdrawal.extractEvent(logs)
+
+  expectTypeOf(log.blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(log.logIndex).toEqualTypeOf<number>()
+  expectTypeOf(log.transactionHash).toEqualTypeOf<Hex.Hex>()
 })
 
 describe('zone action types', () => {


### PR DESCRIPTION

## Problem

EIP-5792 call receipts expose logs as `{ address, data, topics }`, without block or transaction metadata. That is the shape `getCallsStatus` returns:

```ts
// src/core/actions/wallet/getCallsStatus.ts
type Receipt = {
  logs: readonly {
    address: Hex.Hex
    data: Hex.Hex
    topics: readonly Hex.Hex[]
  }[]
  // …
}
```

`AbiEvent.extractLogs` already accepts that shape. `extractLogs.Log` has every metadata field optional, and its return is `Compute<log & { args, eventName }>`, generic over the input log. 

But every viem wrapper around it declared `logs: readonly Log.Log[]`, the full ox log. So the two halves of viem's own batched-call flow do not connect:

```ts
const { receipts } = await Actions.wallet.waitForCallsStatus(client, { id })
Actions.token.transfer.extractEvent(receipts[0].logs)
//                                  ^^^^^^^^^^^^^^^^
// Argument of type 'readonly { address; data; topics: readonly Hex[] }[]' is not
// assignable to parameter of type 'readonly Log.Log[]'.
//   Type '{ address; data; topics }' is missing the following properties from
//   type 'Log': blockHash, blockNumber, logIndex, transactionHash, and 2 more.
```

The gap is type-level only. 
Decoding works on a 3-field log at runtime, so today the workaround is `logs as unknown as Log.Log[]`.

## Change

Make the wrappers generic over the logs passed in, constrained to `AbiEvent.extractLogs.Log`:

```diff
-export function extractEvent(logs: readonly Log.Log[]) {
+export function extractEvent<
+  const logs extends readonly AbiEvent.extractLogs.Log[],
+>(logs: logs) {
```

Applied to `extractEvent`/`extractEvents` helpers across `core/actions/token` and `tempo/actions/**`, plus the OP Stack extractors. The change is type-level throughout; emitted JS is unchanged.

Because the return stays generic over the input, this is additive:

| input | `log.blockNumber` |
| --- | --- |
| `readonly Log.Log[]` | `bigint`, unchanged |
| EIP-5792 receipt logs | property absent |

A non-generic widening would also compile, but it would degrade every existing caller's return to `bigint \| Hex \| null \| undefined`. Both are sound; the generic avoids the breaking type change.

## Notes

- `Deposit.getL2TransactionHashes` stays pinned to full logs on purpose. Its source hash needs `blockHash` & `logIndex`, and a `@ts-expect-error` test covers that. `Withdrawal.getWithdrawals` is widened; it only maps args.
- `tempo/actions/earn.ts` needs the closest look. It filters by emitting address, so its constraint requires `address` and its `filter` needs a type predicate. Dropping the predicate blurs metadata for full-log callers with no error at the definition, so only the test catches it.
- `op-stack/{Deposit,Withdrawal}.ts` declare decoded-log types up front, so `TransactionDepositedLog` / `MessagePassedLog` and their `Options`/`ReturnType` gained a log type parameter defaulting to `Log.Log`, source-compatible for the bare names.
- Same gap exists in v2, but it needs a `parseEventLogs` return-type change there; v3 only needed wiring on top of ox.