### PR TITLE
chore: update frog action-only setup

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -17,11 +17,11 @@ Do not maintain an index here. This directory is the index.
 ## Logging Friction
 
 ```sh
-frog list    # what is already known
-frog log     # add one
+pnpx frog list    # what is already known
+pnpx frog log     # add one
 ```
 
-`frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+`pnpx frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
 the directory reads oldest-first.
 
 Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
@@ -29,10 +29,10 @@ write-up. The next reader runs the reproduction instead of rebuilding it.
 
 ## For Agents
 
-Add this to `AGENTS.md` under the appropriate section:
+Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
 
-- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`.
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
 - Do not add global, system, or internal friction.
-- Run `frog list` first to see what is already known.
+- Run `pnpx frog list` first to see what is already known.
 
 Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,3 +1,6 @@
 {
-  "$schema": "https://unpkg.com/frog/schema.json"
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": true
+  }
 }

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -16,7 +16,9 @@ permissions: {}
 jobs:
   friction-log:
     name: Friction Log
-    if: github.event_name != 'push' || github.ref_name == github.event.repository.default_branch
+    if: >-
+      (github.event_name != 'push' || github.ref_name == github.event.repository.default_branch) &&
+      (github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,7 +30,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
 
       - name: Report and reconcile frictions
         uses: wevm/frog/action@v1
+        with:
+          issue-author: github-actions[bot]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ This document contains guidelines for AI agents working on the Viem codebase.
 
 ## Friction Logging
 
-- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`.
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
 - Do not add global, system, or internal friction.
-- Run `frog list` first to see what is already known.
+- Run `pnpx frog list` first to see what is already known.
 
 ## Documentation (Site)
 


### PR DESCRIPTION
Updates Frog’s pnpm runner guidance, enables inbound reports, and hardens Action-only automation to process bot-authored issues from the triggering commit.