### PR TITLE
docs: add benchmarks page

### DIFF
--- a/site/pages/_root.css
+++ b/site/pages/_root.css
@@ -395,6 +395,10 @@ body > div:has(> div > .twoslash-completion-list) {
   text-decoration: none;
 }
 
+.benchmark-table :is(th, td) {
+  white-space: nowrap;
+}
+
 /* Keep light-dark() aligned with Vocs's inline color-scheme toggle. */
 html[style*='color-scheme: light'] {
   --lightningcss-light: initial;

--- a/site/pages/docs/benchmarks.mdx
+++ b/site/pages/docs/benchmarks.mdx
@@ -1,0 +1,48 @@
+---
+description: Compare Viem implementations and engine provider performance.
+---
+
+# Benchmarks
+
+These benchmarks compare high-level operations that power Viem across
+versions and engine providers. Lower timings are better.
+
+The following results are single-call durations from an Apple M4 Max running
+macOS 26.5.2 and Node.js 25.9.0. The comparison represents Viem 3.0.0-next.2
+with Ox 1.2.0 and Viem 2.55.10 with Ox 0.14.33. The fastest result in each
+row is bold.
+
+<div className="benchmark-table">
+
+| Task | Operation | Viem v2 | Viem v3 | `viem/node` | `viem/wasm` | Fastest speedup |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Calculate Swap Input Amount | `getAmountIn` (bigint) | 484.0 ns | 526.4 ns | 480.0 ns | **479.6 ns** | 1.0× faster |
+| Calculate Swap Output Amount | `getAmountOut` (bigint) | 186.7 ns | **184.4 ns** | 191.3 ns | 184.7 ns | 1.0× faster |
+| Decode RLP Struct | `Rlp.toBytes` | **146.8 ns** | 149.9 ns | 150.7 ns | 161.0 ns | Baseline |
+| Decrypt JSON Keystore | `Keystore.decrypt` | 5.9 µs | 4.7 µs | 5.2 µs | **2.4 µs** | 2.5× faster |
+| Derive CREATE2 Contract Address | `ContractAddress.fromCreate2` | 14.7 µs | 11.4 µs | 11.6 µs | **6.8 µs** | 2.2× faster |
+| Derive Mnemonic Private Key | `Mnemonic.toPrivateKey` | 7.26 ms | 7.34 ms | **1.82 ms** | 3.04 ms | 4.0× faster |
+| Encode Event Topics | `AbiEvent.encode` | 4.5 µs | 3.3 µs | 3.3 µs | **1.0 µs** | 4.7× faster |
+| Encode RLP Struct | `Rlp.fromBytes` | 257.0 ns | 118.5 ns | 118.9 ns | **117.6 ns** | 2.2× faster |
+| Encode Seaport Fulfill Order | `AbiFunction.encodeData` (cached) | 13.4 µs | 7.4 µs | 7.3 µs | **7.2 µs** | 1.9× faster |
+| Encode Seaport Fulfill Order | `AbiFunction.encodeData` (dynamic) | 39.5 µs | 29.3 µs | 28.4 µs | **24.1 µs** | 1.6× faster |
+| Encode Uniswap V2 Swap | `AbiFunction.encodeData` (cached) | 1.72 µs | 1.08 µs | **1.07 µs** | 1.19 µs | 1.6× faster |
+| Encode Uniswap V2 Swap | `AbiFunction.encodeData` (dynamic) | 8.8 µs | 6.9 µs | 6.7 µs | **4.2 µs** | 2.1× faster |
+| Generate Random Private Key | `Secp256k1.randomPrivateKey` | 1.61 µs | **1.47 µs** | 1.51 µs | 1.54 µs | 1.1× faster |
+| Get Personal Message Sign Payload | `PersonalMessage.getSignPayload` | 4.9 µs | 3.4 µs | 3.4 µs | **1.0 µs** | 4.8× faster |
+| Get Transaction Sign Payload | `TxEnvelope.getSignPayload` | 5.6 µs | 3.9 µs | 4.0 µs | **1.5 µs** | 3.6× faster |
+| Hash 32-byte Payload | `Hash.keccak256` | N/A | 2.62 µs | n/a | **278 ns** | 9.44× faster |
+| Hash Typed Data | `TypedData.getSignPayload` | 70.3 µs | 52.0 µs | 52.5 µs | **20.0 µs** | 3.5× faster |
+| Recover Secp256k1 Public Key | `Secp256k1.recoverPublicKey` (32 B) | N/A | 1.15 ms | n/a | **36.62 µs** | 31.40× faster |
+| Sign Secp256k1 Message | `Secp256k1.sign` (32 B message) | N/A | 183.76 µs | n/a | **25.03 µs** | 7.34× faster |
+| Verify Secp256k1 Signature | `Secp256k1.verify` (32 B message) | N/A | 1.03 ms | n/a | **31.50 µs** | 32.80× faster |
+
+</div>
+
+## Method
+
+Run the comparison from the [Ox repository](https://github.com/wevm/ox):
+
+```sh
+pnpm bench:comparison --run
+```

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -656,6 +656,7 @@ export default defineConfig({
           { text: 'Platform Compatibility', link: '/docs/compatibility' },
           { text: 'AI Agents', link: '/docs/agents' },
           { text: 'FAQ', link: '/docs/faq' },
+          { text: 'Benchmarks', link: '/docs/benchmarks' },
           { text: 'Migrating from v2', link: '/docs/v2-migration' },
         ],
       },


### PR DESCRIPTION
Adds a benchmark page comparing Viem v2, Viem v3, `viem/node`, and `viem/wasm`, with Ox measurements and a horizontally scrollable table for clear provider comparisons.