### PR TITLE
docs: align crypto benchmark values

### DIFF
--- a/site/pages/docs/benchmarks.mdx
+++ b/site/pages/docs/benchmarks.mdx
@@ -31,11 +31,11 @@ row is bold.
 | Generate Random Private Key | `Secp256k1.randomPrivateKey` | 1.61 µs | **1.47 µs** | 1.51 µs | 1.54 µs | 1.1× faster |
 | Get Personal Message Sign Payload | `PersonalMessage.getSignPayload` | 4.9 µs | 3.4 µs | 3.4 µs | **1.0 µs** | 4.8× faster |
 | Get Transaction Sign Payload | `TxEnvelope.getSignPayload` | 5.6 µs | 3.9 µs | 4.0 µs | **1.5 µs** | 3.6× faster |
-| Hash 32-byte Payload | `Hash.keccak256` | N/A | 2.62 µs | n/a | **278 ns** | 9.44× faster |
+| Hash 32-byte Payload | `Hash.keccak256` | 3.55 µs | 2.59 µs | 2.60 µs | **343 ns** | 10.4× faster |
 | Hash Typed Data | `TypedData.getSignPayload` | 70.3 µs | 52.0 µs | 52.5 µs | **20.0 µs** | 3.5× faster |
-| Recover Secp256k1 Public Key | `Secp256k1.recoverPublicKey` (32 B) | N/A | 1.15 ms | n/a | **36.62 µs** | 31.40× faster |
-| Sign Secp256k1 Message | `Secp256k1.sign` (32 B message) | N/A | 183.76 µs | n/a | **25.03 µs** | 7.34× faster |
-| Verify Secp256k1 Signature | `Secp256k1.verify` (32 B message) | N/A | 1.03 ms | n/a | **31.50 µs** | 32.80× faster |
+| Recover Secp256k1 Public Key | `Secp256k1.recoverPublicKey` (32 B) | 1.05 ms | 1.10 ms | 1.10 ms | **36.6 µs** | 28.8× faster |
+| Sign Secp256k1 Message | `Secp256k1.sign` (32 B message) | 178.6 µs | 172.6 µs | 171.9 µs | **24.2 µs** | 7.4× faster |
+| Verify Secp256k1 Signature | `Secp256k1.verify` (32 B message) | 1.83 ms | 963.1 µs | 965.0 µs | **31.3 µs** | 58.3× faster |
 
 </div>
 


### PR DESCRIPTION
Updates the four crypto benchmark rows to match Ox's latest v0, core, Node.js, and WASM measurements and recalculates each displayed speedup.