### PR TITLE
docs: remove tempo action recipes

### DIFF
--- a/site/pages/tempo/actions/accessKey.authorize.mdx
+++ b/site/pages/tempo/actions/accessKey.authorize.mdx
@@ -60,41 +60,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.authorize.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Authorize a Limited Session Key
-
-Use this pattern to authorize a limited session key.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { P256 } from 'viem/utils'
-import { Account } from 'viem/tempo'
-import { client } from './viem.config'
-
-const account = Account.fromSecp256k1('0x...')
-const accessKey = Account.fromP256(P256.randomPrivateKey(), {
-  access: account,
-})
-
-const { publicKey, receipt } = await client.accessKey.authorizeSync({
-  accessKey,
-  expiry: Math.floor((Date.now() + 30_000) / 1000),
-})
-
-console.log('Access key:', publicKey)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Access key: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.burnWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.burnWitness.mdx
@@ -45,33 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.burnWitness.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Cancel a Pending Key Authorization
-
-Use this pattern to cancel a pending key authorization.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { witness, receipt } = await client.accessKey.burnWitnessSync({
-  witness: '0x0000000000000000000000000000000000000000000000000000000000000001',
-})
-
-console.log('Burned witness:', witness)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Burned witness: 0x0000000000000000000000000000000000000000000000000000000000000001
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.getMetadata.mdx
+++ b/site/pages/tempo/actions/accessKey.getMetadata.mdx
@@ -25,31 +25,6 @@ console.log('Access key metadata:', metadata)
 
 :::
 
-## Recipes
-
-### Review Access Key Permissions
-
-Use this pattern to review access key permissions.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const metadata = await client.accessKey.getMetadata({
-  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Access key metadata:', metadata)
-// @log: Access key metadata: { address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', expiry: 1735689600n, isRevoked: false, keyType: 'secp256k1', spendPolicy: 'limited' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
+++ b/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
@@ -27,33 +27,6 @@ console.log('Remaining limit:', limit)
 
 :::
 
-## Recipes
-
-### Check an Access Key's Spending Budget
-
-Use this pattern to check an access key's spending budget.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const limit = await client.accessKey.getRemainingLimit({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
-  token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-})
-
-console.log('Remaining limit:', limit)
-// @log: Remaining limit: { periodEnd: 1735689600n, remaining: 1000000n }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.isAdmin.mdx
+++ b/site/pages/tempo/actions/accessKey.isAdmin.mdx
@@ -26,32 +26,6 @@ console.log('Is admin:', isAdmin)
 
 :::
 
-## Recipes
-
-### Check for Unrestricted Access
-
-Use this pattern to check for unrestricted access.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const isAdmin = await client.accessKey.isAdmin({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
-})
-
-console.log('Is admin:', isAdmin)
-// @log: Is admin: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
@@ -26,32 +26,6 @@ console.log('Is burned:', isBurned)
 
 :::
 
-## Recipes
-
-### Reject a Reused Authorization
-
-Use this pattern to reject a reused authorization.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const isBurned = await client.accessKey.isWitnessBurned({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  witness: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
-})
-
-console.log('Is burned:', isBurned)
-// @log: Is burned: false
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.revoke.mdx
+++ b/site/pages/tempo/actions/accessKey.revoke.mdx
@@ -45,33 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.revoke.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Remove a Compromised Access Key
-
-Use this pattern to remove a compromised access key.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { publicKey, receipt } = await client.accessKey.revokeSync({
-  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Revoked access key:', publicKey)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Revoked access key: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.signAuthorization.mdx
+++ b/site/pages/tempo/actions/accessKey.signAuthorization.mdx
@@ -35,39 +35,6 @@ console.log('Key authorization:', keyAuthorization)
 
 :::
 
-## Recipes
-
-### Prepare an Offline Key Authorization
-
-Use this pattern to prepare an offline key authorization.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { P256 } from 'viem/utils'
-import { Account } from 'viem/tempo'
-import { client } from './viem.config'
-
-const account = Account.fromSecp256k1('0x...')
-const accessKey = Account.fromP256(P256.randomPrivateKey(), {
-  access: account,
-})
-
-const keyAuthorization = await client.accessKey.signAuthorization({
-  accessKey,
-  expiry: Math.floor((Date.now() + 30_000) / 1000),
-})
-
-console.log('Key authorization:', keyAuthorization)
-// @log: Key authorization: { address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', chainId: 1337n, type: 'p256', ... }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.updateLimit.mdx
+++ b/site/pages/tempo/actions/accessKey.updateLimit.mdx
@@ -49,35 +49,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.updateLimit.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Refresh an Access Key's Spending Limit
-
-Use this pattern to refresh an access key's spending limit.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { limit, receipt } = await client.accessKey.updateLimitSync({
-  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  limit: 1000000000000000000n,
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('New limit:', limit)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: New limit: 1000000000000000000n
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.verifyHash.mdx
+++ b/site/pages/tempo/actions/accessKey.verifyHash.mdx
@@ -27,33 +27,6 @@ console.log('Valid:', valid)
 
 :::
 
-## Recipes
-
-### Verify an Access Key Signature
-
-Use this pattern to verify an access key signature.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const valid = await client.accessKey.verifyHash({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  hash: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
-  signature: '0x...',
-})
-
-console.log('Valid:', valid)
-// @log: Valid: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
+++ b/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchAdminAuthorized(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track New Admin Keys
-
-Use this pattern to track new admin keys.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.accessKey.watchAdminAuthorized()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', publicKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/accessKey.watchWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitness.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchWitness(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Submitted Key Authorizations
-
-Use this pattern to track submitted key authorizations.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.accessKey.watchWitness()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', witness: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchWitnessBurned(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Cancelled Key Authorizations
-
-Use this pattern to track cancelled key authorizations.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.accessKey.watchWitnessBurned()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', witness: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.burn.mdx
+++ b/site/pages/tempo/actions/amm.burn.mdx
@@ -50,33 +50,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.burn.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Remove Liquidity from a Fee Pool
-
-Use this pattern to remove liquidity from a fee pool.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, ...event } = await client.amm.burnSync({
-  liquidity: 500000n,
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  userToken: '0x20c0000000000000000000000000000000000001',
-  validatorToken: '0x20c0000000000000000000000000000000000002',
-})
-
-console.log('Burn:', event)
-// @log: Burn: { amountUserToken: 500000n, amountValidatorToken: 500000n, liquidity: 500000n, to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', userToken: '0x20c0000000000000000000000000000000000001', validatorToken: '0x20c0000000000000000000000000000000000002', sender: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.getLiquidityBalance.mdx
+++ b/site/pages/tempo/actions/amm.getLiquidityBalance.mdx
@@ -27,32 +27,6 @@ console.log('Liquidity balance:', balance)
 :::
 
 
-## Recipes
-
-### Show an Account's Liquidity Position
-
-Use this pattern to show an account's liquidity position.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const balance = await client.amm.getLiquidityBalance({
-  address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  userToken: '0x20c0000000000000000000000000000000000001',
-  validatorToken: '0x20c0000000000000000000000000000000000002',
-})
-
-console.log('Liquidity balance:', balance)
-// @log: Liquidity balance: 500000000n
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.getPool.mdx
+++ b/site/pages/tempo/actions/amm.getPool.mdx
@@ -26,31 +26,6 @@ console.log('Pool:', pool)
 :::
 
 
-## Recipes
-
-### Inspect Pool Reserves Before a Swap
-
-Use this pattern to inspect pool reserves before a swap.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const pool = await client.amm.getPool({
-  userToken: '0x20c0000000000000000000000000000000000001',
-  validatorToken: '0x20c0000000000000000000000000000000000002',
-})
-
-console.log('Pool:', pool)
-// @log: Pool: { reserveUserToken: 1000000000n, reserveValidatorToken: 1000000000n, totalSupply: 1000000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.mint.mdx
+++ b/site/pages/tempo/actions/amm.mint.mdx
@@ -57,40 +57,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.mint.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Add Liquidity to a Fee Pool
-
-Use this pattern to add liquidity to a fee pool.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, ...event } = await client.amm.mintSync({
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  userTokenAddress: '0x20c0000000000000000000000000000000000001',
-  validatorTokenAddress: '0x20c0000000000000000000000000000000000002',
-  validatorTokenAmount: 1000000n,
-})
-
-console.log('Mint:', event)
-// @log: Mint: {
-// @log:   sender: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-// @log:   to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-// @log:   userToken: '0x20c0000000000000000000000000000000000001',
-// @log:   validatorToken: '0x20c0000000000000000000000000000000000002',
-// @log:   amountValidatorToken: 1000000n,
-// @log:   liquidity: 1000000n,
-// @log: }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.rebalanceSwap.mdx
+++ b/site/pages/tempo/actions/amm.rebalanceSwap.mdx
@@ -52,33 +52,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.rebalanceSwap.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Rebalance Validator Fees into a User Token
-
-Use this pattern to rebalance validator fees into a user token.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, ...event } = await client.amm.rebalanceSwapSync({
-  amountOut: 1000000n,
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  userToken: '0x20c0000000000000000000000000000000000001',
-  validatorToken: '0x20c0000000000000000000000000000000000002',
-})
-
-console.log('Rebalance swap:', event)
-// @log: Rebalance swap: { userToken: '0x20c0000000000000000000000000000000000001', validatorToken: '0x20c0000000000000000000000000000000000002', swapper: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', amountIn: 1001000n, amountOut: 1000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.watchBurn.mdx
+++ b/site/pages/tempo/actions/amm.watchBurn.mdx
@@ -28,33 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchBurn(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Liquidity Removals
-
-Use this pattern to track liquidity removals.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.amm.watchBurn()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { sender: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', userToken: '0x20c0000000000000000000000000000000000001', validatorToken: '0x20c0000000000000000000000000000000000002' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.watchMint.mdx
+++ b/site/pages/tempo/actions/amm.watchMint.mdx
@@ -28,33 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchMint(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Liquidity Additions
-
-Use this pattern to track liquidity additions.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.amm.watchMint()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { sender: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', userToken: '0x20c0000000000000000000000000000000000001' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.watchRebalanceSwap.mdx
+++ b/site/pages/tempo/actions/amm.watchRebalanceSwap.mdx
@@ -28,33 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchRebalanceSwap(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Rebalance Activity
-
-Use this pattern to track rebalance activity.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.amm.watchRebalanceSwap()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { userToken: '0x20c0000000000000000000000000000000000001', validatorToken: '0x20c0000000000000000000000000000000000002', swapper: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/channel.close.mdx
+++ b/site/pages/tempo/actions/channel.close.mdx
@@ -70,43 +70,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.close.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Collect Final Payment and Close a Channel
-
-Use this pattern to collect final payment and close a channel.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const channel = {
-  authorizedSigner: '0x0000000000000000000000000000000000000000',
-  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-} as const
-
-const { receipt, ...closed } = await client.channel.closeSync({
-  captureAmount: 40000000n,
-  cumulativeAmount: 40000000n,
-  channel,
-  signature: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b',
-})
-
-console.log('Closed:', closed)
-// @log: Closed: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', settledToPayee: 40000000n, refundedToPayer: 60000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.getStates.mdx
+++ b/site/pages/tempo/actions/channel.getStates.mdx
@@ -25,30 +25,6 @@ console.log('Channel state:', state)
 :::
 
 
-## Recipes
-
-### Reconcile Channel Balances
-
-Use this pattern to reconcile channel balances.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const state = await client.channel.getStates({
-  channel: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-})
-
-console.log('Channel state:', state)
-// @log: Channel state: { closeRequestedAt: 0, deposit: 100000000n, settled: 40000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.open.mdx
+++ b/site/pages/tempo/actions/channel.open.mdx
@@ -50,34 +50,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.open.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Fund a New Payment Channel
-
-Use this pattern to fund a new payment channel.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, ...opened } = await client.channel.openSync({
-  deposit: 100000000n,
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Opened:', opened)
-// @log: Opened: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC', token: '0x20c0000000000000000000000000000000000001', authorizedSigner: '0x0000000000000000000000000000000000000000', salt: '0x0000000000000000000000000000000000000000000000000000000000000101', expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000', deposit: 100000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.requestClose.mdx
+++ b/site/pages/tempo/actions/channel.requestClose.mdx
@@ -64,40 +64,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.requestClose.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Start a Payer-Initiated Close
-
-Use this pattern to start a payer-initiated close.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const channel = {
-  authorizedSigner: '0x0000000000000000000000000000000000000000',
-  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-} as const
-
-const { receipt, ...requested } = await client.channel.requestCloseSync({
-  channel,
-})
-
-console.log('Close requested:', requested)
-// @log: Close requested: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', closeGraceEnd: 1780000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.settle.mdx
+++ b/site/pages/tempo/actions/channel.settle.mdx
@@ -68,42 +68,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.settle.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Redeem a Signed Payment Voucher
-
-Use this pattern to redeem a signed payment voucher.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const channel = {
-  authorizedSigner: '0x0000000000000000000000000000000000000000',
-  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-} as const
-
-const { receipt, ...settled } = await client.channel.settleSync({
-  cumulativeAmount: 40000000n,
-  channel,
-  signature: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b',
-})
-
-console.log('Settled:', settled)
-// @log: Settled: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', cumulativeAmount: 40000000n, deltaPaid: 40000000n, newSettled: 40000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.signVoucher.mdx
+++ b/site/pages/tempo/actions/channel.signVoucher.mdx
@@ -24,31 +24,6 @@ console.log('Signature:', signature)
 :::
 
 
-## Recipes
-
-### Create an Offchain Payment Voucher
-
-Use this pattern to create an offchain payment voucher.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const signature = await client.channel.signVoucher({
-  channel: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-  cumulativeAmount: 40000000n,
-})
-
-console.log('Signature:', signature)
-// @log: Signature: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.topUp.mdx
+++ b/site/pages/tempo/actions/channel.topUp.mdx
@@ -66,41 +66,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.topUp.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Extend Channel Spending Capacity
-
-Use this pattern to extend channel spending capacity.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const channel = {
-  authorizedSigner: '0x0000000000000000000000000000000000000000',
-  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-} as const
-
-const { receipt, ...topUp } = await client.channel.topUpSync({
-  additionalDeposit: 25000000n,
-  channel,
-})
-
-console.log('Top up:', topUp)
-// @log: Top up: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', additionalDeposit: 25000000n, newDeposit: 125000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.withdraw.mdx
+++ b/site/pages/tempo/actions/channel.withdraw.mdx
@@ -64,40 +64,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.withdraw.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Recover Funds After the Grace Period
-
-Use this pattern to recover funds after the grace period.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const channel = {
-  authorizedSigner: '0x0000000000000000000000000000000000000000',
-  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  operator: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-  payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
-  token: '0x20c0000000000000000000000000000000000001',
-} as const
-
-const { receipt, ...withdrawn } = await client.channel.withdrawSync({
-  channel,
-})
-
-console.log('Withdrawn:', withdrawn)
-// @log: Withdrawn: { channelId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', payee: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', settledToPayee: 40000000n, refundedToPayer: 60000000n }
-```
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.buy.mdx
+++ b/site/pages/tempo/actions/dex.buy.mdx
@@ -28,34 +28,6 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
-## Recipes
-
-### Buy an Exact Token Amount
-
-Use this pattern to buy an exact token amount.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.dex.buySync({
-  amountOut: 100000000n,
-  maxAmountIn: 150000000n,
-  tokenIn: '0x20c0000000000000000000000000000000000000',
-  tokenOut: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.cancel.mdx
+++ b/site/pages/tempo/actions/dex.cancel.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.cancel.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Remove an Open Limit Order
-
-Use this pattern to remove an open limit order.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { orderId } = await client.dex.cancelSync({
-  orderId: 123n,
-})
-
-console.log('Cancelled order:', orderId)
-// @log: Cancelled order: 123n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.cancelStale.mdx
+++ b/site/pages/tempo/actions/dex.cancelStale.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.cancelStale.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Clear an Expired Order
-
-Use this pattern to clear an expired order.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { orderId } = await client.dex.cancelStaleSync({
-  orderId: 123n,
-})
-
-console.log('Cancelled order:', orderId)
-// @log: Cancelled order: 123n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.createPair.mdx
+++ b/site/pages/tempo/actions/dex.createPair.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.createPair.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### List a Token Pair
-
-Use this pattern to list a token pair.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { base, key, quote } = await client.dex.createPairSync({
-  base: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Pair:', { base, quote, key })
-// @log: Pair: { base: '0x20c0000000000000000000000000000000000001', quote: '0x20c0000000000000000000000000000000000000', key: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getBalance.mdx
+++ b/site/pages/tempo/actions/dex.getBalance.mdx
@@ -26,32 +26,6 @@ console.log('DEX balance:', balance)
 
 :::
 
-## Recipes
-
-### Reconcile Funds Held on the DEX
-
-Use this pattern to reconcile funds held on the DEX.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const balance = await client.dex.getBalance({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('DEX balance:', balance)
-// @log: DEX balance: 100000000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getBuyQuote.mdx
+++ b/site/pages/tempo/actions/dex.getBuyQuote.mdx
@@ -27,33 +27,6 @@ console.log('Amount in:', amountIn)
 
 :::
 
-## Recipes
-
-### Budget for an Exact-Output Trade
-
-Use this pattern to budget for an exact-output trade.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const amountIn = await client.dex.getBuyQuote({
-  amountOut: 100000000n,
-  tokenIn: '0x20c0000000000000000000000000000000000000',
-  tokenOut: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Amount in:', amountIn)
-// @log: Amount in: 100100000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getOrder.mdx
+++ b/site/pages/tempo/actions/dex.getOrder.mdx
@@ -25,31 +25,6 @@ console.log('Order:', order)
 
 :::
 
-## Recipes
-
-### Check an Order's Status
-
-Use this pattern to check an order's status.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const order = await client.dex.getOrder({
-  orderId: 123n,
-})
-
-console.log('Order:', order)
-// @log: Order: { orderId: 123n, maker: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', bookKey: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', isBid: true, tick: 100, amount: 100000000n, remaining: 100000000n, prev: 0n, next: 0n, isFlip: false, flipTick: 0 }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getOrderbook.mdx
+++ b/site/pages/tempo/actions/dex.getOrderbook.mdx
@@ -26,32 +26,6 @@ console.log('Orderbook:', orderbook)
 
 :::
 
-## Recipes
-
-### Display the Best Bid and Ask
-
-Use this pattern to display the best bid and ask.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const orderbook = await client.dex.getOrderbook({
-  base: '0x20c0000000000000000000000000000000000001',
-  quote: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Orderbook:', orderbook)
-// @log: Orderbook: { base: '0x20c0000000000000000000000000000000000001', quote: '0x20c0000000000000000000000000000000000000', bestBidTick: -100, bestAskTick: 100 }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getSellQuote.mdx
+++ b/site/pages/tempo/actions/dex.getSellQuote.mdx
@@ -27,33 +27,6 @@ console.log('Amount out:', amountOut)
 
 :::
 
-## Recipes
-
-### Preview an Exact-Input Trade
-
-Use this pattern to preview an exact-input trade.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const amountOut = await client.dex.getSellQuote({
-  amountIn: 100000000n,
-  tokenIn: '0x20c0000000000000000000000000000000000001',
-  tokenOut: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Amount out:', amountOut)
-// @log: Amount out: 99900000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getTickLevel.mdx
+++ b/site/pages/tempo/actions/dex.getTickLevel.mdx
@@ -27,33 +27,6 @@ console.log('Tick level:', level)
 
 :::
 
-## Recipes
-
-### Inspect Liquidity at a Price
-
-Use this pattern to inspect liquidity at a price.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const level = await client.dex.getTickLevel({
-  base: '0x20c0000000000000000000000000000000000001',
-  isBid: true,
-  tick: 100,
-})
-
-console.log('Tick level:', level)
-// @log: Tick level: { head: 123n, tail: 124n, totalLiquidity: 200000000n }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.place.mdx
+++ b/site/pages/tempo/actions/dex.place.mdx
@@ -49,34 +49,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.place.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Post a Limit Order
-
-Use this pattern to post a limit order.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { amount, orderId, tick } = await client.dex.placeSync({
-  amount: 100000000n,
-  tick: 100,
-  token: '0x20c0000000000000000000000000000000000001',
-  type: 'buy',
-})
-
-console.log('Order:', { amount, orderId, tick })
-// @log: Order: { amount: 100000000n, orderId: 123n, tick: 100 }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.placeFlip.mdx
+++ b/site/pages/tempo/actions/dex.placeFlip.mdx
@@ -51,35 +51,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.placeFlip.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Maintain a Two-Sided Position
-
-Use this pattern to maintain a two-sided position.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { flipTick, isFlipOrder, orderId } = await client.dex.placeFlipSync({
-  amount: 100000000n,
-  flipTick: 200,
-  tick: 100,
-  token: '0x20c0000000000000000000000000000000000001',
-  type: 'buy',
-})
-
-console.log('Flip order:', { flipTick, isFlipOrder, orderId })
-// @log: Flip order: { flipTick: 200, isFlipOrder: true, orderId: 123n }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.sell.mdx
+++ b/site/pages/tempo/actions/dex.sell.mdx
@@ -28,34 +28,6 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
-## Recipes
-
-### Sell an Exact Token Amount
-
-Use this pattern to sell an exact token amount.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.dex.sellSync({
-  amountIn: 100000000n,
-  minAmountOut: 50000000n,
-  tokenIn: '0x20c0000000000000000000000000000000000001',
-  tokenOut: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.watchFlipOrderPlaced.mdx
+++ b/site/pages/tempo/actions/dex.watchFlipOrderPlaced.mdx
@@ -39,43 +39,6 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchFlipOrderPlaced(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Automatically Flipped Orders
-
-Use this pattern to track automatically flipped orders.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.dex.watchFlipOrderPlaced()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   orderId: 123n,
-  // @log:   maker: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   token: '0x20c0000000000000000000000000000000000001',
-  // @log:   amount: 100000000n,
-  // @log:   isBid: true,
-  // @log:   tick: 100,
-  // @log:   isFlipOrder: true,
-  // @log:   flipTick: 200,
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderCancelled.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderCancelled.mdx
@@ -30,36 +30,6 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderCancelled(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Keep an Order Interface in Sync
-
-Use this pattern to keep an order interface in sync.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.dex.watchOrderCancelled()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   orderId: 123n,
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderFilled.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderFilled.mdx
@@ -34,40 +34,6 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderFilled(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Trade Executions
-
-Use this pattern to track trade executions.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.dex.watchOrderFilled()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   orderId: 123n,
-  // @log:   maker: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   taker: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  // @log:   amountFilled: 100000000n,
-  // @log:   partialFill: false,
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderPlaced.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderPlaced.mdx
@@ -37,43 +37,6 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderPlaced(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Stream New Limit Orders
-
-Use this pattern to stream new limit orders.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.dex.watchOrderPlaced()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   orderId: 123n,
-  // @log:   maker: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   token: '0x20c0000000000000000000000000000000000001',
-  // @log:   amount: 100000000n,
-  // @log:   isBid: true,
-  // @log:   tick: 100,
-  // @log:   isFlipOrder: false,
-  // @log:   flipTick: 0,
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.withdraw.mdx
+++ b/site/pages/tempo/actions/dex.withdraw.mdx
@@ -26,32 +26,6 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
-## Recipes
-
-### Return Unused DEX Funds to a Wallet
-
-Use this pattern to return unused DEX funds to a wallet.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.dex.withdrawSync({
-  amount: 100000000n,
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
@@ -31,33 +31,6 @@ const { policy, receipts } = await client.earn.configureExitSafePolicy({
 
 :::
 
-## Recipes
-
-### Restrict New Share Holders Without Blocking Exits
-
-Use this pattern to restrict new share holders without blocking exits.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { policy, receipts } = await client.earn.configureExitSafePolicy({
-  accessAdministrator: '0x0000000000000000000000000000000000000002',
-  initialMembers: [
-    '0x0000000000000000000000000000000000000003',
-    '0x0000000000000000000000000000000000000004',
-  ],
-  shareToken: '0x20c0000000000000000000000000000000000001',
-})
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.deposit.mdx
+++ b/site/pages/tempo/actions/earn.deposit.mdx
@@ -80,38 +80,6 @@ const { args } = Actions.earn.deposit.extractEvent(receipt.logs, { vault })
 // @log: { assets: 100_000_000n, shares: 99_750_000n, ... }
 ```
 
-## Recipes
-
-### Invest Assets in an Earn Vault
-
-Use this pattern to invest assets in an Earn vault.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.depositSync({
-  assetAmount: 100_000_000n,
-  shareAmount: 99_900_000n,
-  slippageBps: 50,
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   assetAmount: 100_000_000n,
-//   caller: '0x...',
-//   receipt: { ... },
-//   recipient: '0x...',
-//   shareAmount: 99_500_500n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.depositShares.mdx
+++ b/site/pages/tempo/actions/earn.depositShares.mdx
@@ -54,40 +54,6 @@ const hash = await client.earn.depositShares({
 // @log: 0x1234...abcd
 ```
 
-## Recipes
-
-### Move Existing Venue Shares into Earn
-
-Use this pattern to move existing venue shares into Earn.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.depositSharesSync({
-  earnShareAmount: 499_000_000n,
-  slippageBps: 30,
-  vault: '0x0000000000000000000000000000000000000002',
-  venueShareAmount: 500_000_000n,
-  venueShareToken: '0x20c0000000000000000000000000000000000001',
-})
-// @log: {
-//   caller: '0x...',
-//   earnShareAmount: 498_750_000n,
-//   receipt: { ... },
-//   receivedVenueShareAmount: 500_000_000n,
-//   recipient: '0x...',
-//   venueShareAmount: 500_000_000n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getFeeState.mdx
+++ b/site/pages/tempo/actions/earn.getFeeState.mdx
@@ -52,36 +52,6 @@ const fees = await client.earn.getFeeState({
 
 :::
 
-## Recipes
-
-### Show Accrued Vault Fees
-
-Use this pattern to show accrued vault fees.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const fees = await client.earn.getFeeState({
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   config: { excess: { ... }, fixedFees: [...] },
-//   configId: 1n,
-//   feesActive: true,
-//   highWaterMark: 1_000_000_000_000_000_000n,
-//   preview: { totalFeeAssets: 10_000n, totalFeeShares: 9_950n, ... },
-//   targetBase: 1_000_000_000_000_000_000n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getPosition.mdx
+++ b/site/pages/tempo/actions/earn.getPosition.mdx
@@ -61,37 +61,6 @@ const position = await client.earn.getPosition({
 
 :::
 
-## Recipes
-
-### Display an Account's Earn Position
-
-Use this pattern to display an account's Earn position.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const position = await client.earn.getPosition({
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   assetAllowance: 0n,
-//   assetBalance: 250_000_000n,
-//   assetToken: '0x20c0...0001',
-//   shareAllowance: 0n,
-//   shareBalance: 99_500_000n,
-//   shareToken: '0x20c0...0002',
-//   value: 100_000_000n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getRedeemQuote.mdx
+++ b/site/pages/tempo/actions/earn.getRedeemQuote.mdx
@@ -24,30 +24,6 @@ const assetAmount = await client.earn.getRedeemQuote({
 
 :::
 
-## Recipes
-
-### Preview a Share Redemption
-
-Use this pattern to preview a share redemption.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const assetAmount = await client.earn.getRedeemQuote({
-  shareAmount: 100_000_000n,
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: 99_500_000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 `bigint`

--- a/site/pages/tempo/actions/earn.getVault.mdx
+++ b/site/pages/tempo/actions/earn.getVault.mdx
@@ -48,54 +48,6 @@ const vault = await client.earn.getVault({
 
 :::
 
-## Recipes
-
-### Inspect Vault Capabilities Before Depositing
-
-Use this pattern to inspect vault capabilities before depositing.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const vault = await client.earn.getVault({
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   assetToken: '0x20c0...0001',
-//   asyncJanitor: '0x0000...0000',
-//   capabilities: {
-//     asyncRedeem: false,
-//     exactWithdraw: true,
-//     inKindDeposit: true,
-//     syncRedeem: true,
-//   },
-//   depositsPaused: false,
-//   emergencyGuardian: '0x0000...0000',
-//   engine: {
-//     address: '0x0000...0002',
-//     name: 'Example Vault',
-//     symbol: 'evUSD',
-//     totalAssets: 1_000_000_000n,
-//   },
-//   engineMigrationMode: 'userOnly',
-//   engineShares: 1_000_000_000n,
-//   feesActive: true,
-//   isSynced: true,
-//   operator: '0x0000...0003',
-//   pendingRedeemCount: 0n,
-//   shareSupply: 995_000_000n,
-//   shareToken: '0x20c0...0002',
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getWithdrawQuote.mdx
+++ b/site/pages/tempo/actions/earn.getWithdrawQuote.mdx
@@ -24,30 +24,6 @@ const shareAmount = await client.earn.getWithdrawQuote({
 
 :::
 
-## Recipes
-
-### Calculate Shares for an Exact Withdrawal
-
-Use this pattern to calculate shares for an exact withdrawal.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const shareAmount = await client.earn.getWithdrawQuote({
-  assetAmount: 100_000_000n,
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: 100_500_000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 `bigint`

--- a/site/pages/tempo/actions/earn.privateDeposit.mdx
+++ b/site/pages/tempo/actions/earn.privateDeposit.mdx
@@ -93,43 +93,6 @@ const prepared = await parentClient.earn.privateDeposit.prepare({
 When `assetToken` is the vault asset, the action always requires the exact withdrawn `assetAmount`.
 For swap-routed deposits, omitting `vaultAssetAmountMin` preserves the zero minimum.
 
-## Recipes
-
-### Move Private Zone Assets into Earn
-
-Use this pattern to move private Zone assets into Earn.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client as parentClient } from './viem.config'
-import { client as zoneClient } from './zones.config'
-
-const prepared = await parentClient.earn.privateDeposit.prepare({
-  assetAmount: 100_000_000n,
-  gateway: '0x0000000000000000000000000000000000000001',
-  recipient: zoneClient.account.address,
-  recoveryRecipient: parentClient.account.address,
-  shareAmountMin: 99_500_000n,
-  vault: '0x0000000000000000000000000000000000000002',
-  zoneId: 7,
-})
-
-const { receipt, senderTag } = await zoneClient.earn.privateDepositSync(prepared)
-// @log: { transactionHash: '0x1234...abcd', ... }
-console.log('Sender tag:', senderTag)
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.privateRedeem.mdx
+++ b/site/pages/tempo/actions/earn.privateRedeem.mdx
@@ -68,43 +68,6 @@ const hash = await zoneClient.earn.privateRedeem(prepared)
 // @log: 0x1234...abcd
 ```
 
-## Recipes
-
-### Return Earn Assets to a Private Zone
-
-Use this pattern to return Earn assets to a private Zone.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client as parentClient } from './viem.config'
-import { client as zoneClient } from './zones.config'
-
-const prepared = await parentClient.earn.privateRedeem.prepare({
-  gateway: '0x0000000000000000000000000000000000000001',
-  recipient: zoneClient.account.address,
-  recoveryRecipient: parentClient.account.address,
-  shareAmount: 100_000_000n,
-  slippageBps: 50,
-  vault: '0x0000000000000000000000000000000000000002',
-  zoneId: 7,
-})
-
-const { receipt, senderTag } = await zoneClient.earn.privateRedeemSync(prepared)
-// @log: { transactionHash: '0x1234...abcd', ... }
-console.log('Sender tag:', senderTag)
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.redeem.mdx
+++ b/site/pages/tempo/actions/earn.redeem.mdx
@@ -75,37 +75,6 @@ const hash = await client.earn.redeem({
 // @log: 0x1234...abcd
 ```
 
-## Recipes
-
-### Exit an Earn Position by Shares
-
-Use this pattern to exit an Earn position by shares.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.redeemSync({
-  shareAmount: 100_000_000n,
-  slippageBps: 50,
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   assetAmount: 99_500_000n,
-//   caller: '0x...',
-//   receipt: { ... },
-//   recipient: '0x...',
-//   shareAmount: 100_000_000n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
@@ -37,39 +37,6 @@ await client.earn.validateExitSafePolicy({
 
 :::
 
-## Recipes
-
-### Verify That Earn Exits Remain Available
-
-Use this pattern to verify that Earn exits remain available.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-await client.earn.validateExitSafePolicy({
-  accessAdministrator: '0x0000000000000000000000000000000000000002',
-  policy: {
-    transferPolicyId: 3n,
-    senderPolicyId: 1n,
-    recipientPolicyId: 2n,
-    mintRecipientPolicyId: 2n,
-  },
-  requiredMembers: [
-    '0x0000000000000000000000000000000000000003',
-    '0x0000000000000000000000000000000000000004',
-  ],
-  shareToken: '0x20c0000000000000000000000000000000000001',
-})
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 `void`

--- a/site/pages/tempo/actions/earn.waitForPrivateDeposit.mdx
+++ b/site/pages/tempo/actions/earn.waitForPrivateDeposit.mdx
@@ -31,32 +31,6 @@ Use `tempoBlockNumber` from the result with
 [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) to confirm that the returned shares
 were imported by the Zone.
 
-## Recipes
-
-### Confirm a Cross-Zone Earn Deposit
-
-Use this pattern to confirm a cross-Zone Earn deposit.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.waitForPrivateDeposit({
-  actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
-  fromBlock: 123456n,
-  gateway: '0x0000000000000000000000000000000000000001',
-  vault: '0x0000000000000000000000000000000000000002',
-})
-// @log: { shares: 99_750_000n, tempoBlockNumber: 123457n, ... }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.waitForPrivateRedeem.mdx
+++ b/site/pages/tempo/actions/earn.waitForPrivateRedeem.mdx
@@ -31,32 +31,6 @@ Use `tempoBlockNumber` from the result with
 [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) to confirm that the returned assets
 were imported by the Zone.
 
-## Recipes
-
-### Confirm a Cross-Zone Earn Redemption
-
-Use this pattern to confirm a cross-Zone Earn redemption.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.waitForPrivateRedeem({
-  actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
-  fromBlock: 123456n,
-  gateway: '0x0000000000000000000000000000000000000001',
-  vault: '0x0000000000000000000000000000000000000002',
-})
-// @log: { outputAmount: 99_000_000n, tempoBlockNumber: 123457n, ... }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.withdrawExact.mdx
+++ b/site/pages/tempo/actions/earn.withdrawExact.mdx
@@ -74,37 +74,6 @@ const hash = await client.earn.withdrawExact({
 // @log: 0x1234...abcd
 ```
 
-## Recipes
-
-### Withdraw an Exact Asset Amount
-
-Use this pattern to withdraw an exact asset amount.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.earn.withdrawExactSync({
-  assetAmount: 40_000_000n,
-  slippageBps: 50,
-  vault: '0x0000000000000000000000000000000000000001',
-})
-// @log: {
-//   assetAmount: 40_000_000n,
-//   caller: '0x...',
-//   receipt: { ... },
-//   recipient: '0x...',
-//   shareAmount: 40_100_000n,
-// }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/faucet.fund.mdx
+++ b/site/pages/tempo/actions/faucet.fund.mdx
@@ -35,31 +35,6 @@ const hashes = await client.faucet.fund({
 })
 ```
 
-## Recipes
-
-### Fund a Local or Testnet Account
-
-Use this pattern to fund a local or testnet account.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const receipts = await client.faucet.fundSync({
-  account: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
-})
-
-console.log('Receipts:', receipts)
-// @log: Receipts: [{ status: 'success', transactionHash: '0x1234...' }]
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.getUserToken.mdx
+++ b/site/pages/tempo/actions/fee.getUserToken.mdx
@@ -25,29 +25,6 @@ console.log('Fee token:', token)
 
 :::
 
-## Recipes
-
-### Display an Account's Fee Currency
-
-Use this pattern to display an account's fee currency.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const token = await client.fee.getUserToken()
-
-console.log('Fee token:', token)
-// @log: Fee token: { address: '0x20c0000000000000000000000000000000000001', id: 1n }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.getValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.getValidatorToken.mdx
@@ -27,31 +27,6 @@ console.log('Fee token:', token)
 
 :::
 
-## Recipes
-
-### Select a Validator-Compatible Fee Token
-
-Use this pattern to select a validator-compatible fee token.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const token = await client.fee.getValidatorToken({
-  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Fee token:', token)
-// @log: Fee token: { address: '0x20c0000000000000000000000000000000000001', id: 1n }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.setUserToken.mdx
+++ b/site/pages/tempo/actions/fee.setUserToken.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.fee.setUserToken.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Make a Stablecoin the Default Fee Token
-
-Use this pattern to make a stablecoin the default fee token.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.fee.setUserTokenSync({
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.setValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.setValidatorToken.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.fee.setValidatorToken.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Advertise a Validator's Preferred Fee Token
-
-Use this pattern to advertise a validator's preferred fee token.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.fee.setValidatorTokenSync({
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.validateToken.mdx
+++ b/site/pages/tempo/actions/fee.validateToken.mdx
@@ -37,41 +37,6 @@ console.log('Fee token:', token)
 
 :::
 
-## Recipes
-
-### Check a Fee Token Before Sending
-
-Use this pattern to check a fee token before sending.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const token = await client.fee.validateToken({
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Fee token:', token)
-// @log: Fee token: {
-// @log:   address: '0x20c0000000000000000000000000000000000001',
-// @log:   id: 1n,
-// @log:   metadata: {
-// @log:     decimals: 6,
-// @log:     name: 'USD Token',
-// @log:     symbol: 'USD',
-// @log:     currency: 'USD',
-// @log:     paused: false,
-// @log:   },
-// @log: }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.watchSetUserToken.mdx
+++ b/site/pages/tempo/actions/fee.watchSetUserToken.mdx
@@ -31,37 +31,6 @@ watcher.off()
 
 Also callable standalone: `Actions.fee.watchSetUserToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Account Fee Token Changes
-
-Use this pattern to track account fee token changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.fee.watchSetUserToken()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   user: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   token: '0x20c0000000000000000000000000000000000001'
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
@@ -31,37 +31,6 @@ watcher.off()
 
 Also callable standalone: `Actions.fee.watchSetValidatorToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Validator Fee Token Changes
-
-Use this pattern to track validator fee token changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.fee.watchSetValidatorToken()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   validator: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   token: '0x20c0000000000000000000000000000000000001'
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/nonce.get.mdx
+++ b/site/pages/tempo/actions/nonce.get.mdx
@@ -27,31 +27,6 @@ console.log('Nonce:', nonce)
 
 :::
 
-## Recipes
-
-### Build a Transaction with a Parallel Nonce Key
-
-Use this pattern to build a transaction with a parallel nonce key.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const nonce = await client.nonce.get({
-  nonceKey: 1n,
-})
-
-console.log('Nonce:', nonce)
-// @log: Nonce: 42n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/nonce.watchIncremented.mdx
+++ b/site/pages/tempo/actions/nonce.watchIncremented.mdx
@@ -32,38 +32,6 @@ watcher.off()
 
 Also callable standalone: `Actions.nonce.watchIncremented(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Account Nonce Consumption
-
-Use this pattern to track account nonce consumption.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.nonce.watchIncremented()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   account: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   nonceKey: 1n,
-  // @log:   newNonce: 42n
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.create.mdx
+++ b/site/pages/tempo/actions/policy.create.mdx
@@ -48,33 +48,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.create.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Create a Whitelist Transfer Policy
-
-Use this pattern to create a whitelist transfer policy.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { policyId, receipt } = await client.policy.createSync({
-  type: 'whitelist',
-})
-
-console.log('Policy ID:', policyId)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Policy ID: 1n
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.getData.mdx
+++ b/site/pages/tempo/actions/policy.getData.mdx
@@ -25,31 +25,6 @@ console.log('Policy data:', data)
 
 :::
 
-## Recipes
-
-### Render Transfer Policy Rules
-
-Use this pattern to render transfer policy rules.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const data = await client.policy.getData({
-  policyId: 1n,
-})
-
-console.log('Policy data:', data)
-// @log: Policy data: { admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', type: 'whitelist' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.isAuthorized.mdx
+++ b/site/pages/tempo/actions/policy.isAuthorized.mdx
@@ -26,32 +26,6 @@ console.log('Authorized:', authorized)
 
 :::
 
-## Recipes
-
-### Check a Recipient Before Sending
-
-Use this pattern to check a recipient before sending.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const authorized = await client.policy.isAuthorized({
-  policyId: 1n,
-  user: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Authorized:', authorized)
-// @log: Authorized: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.modifyBlacklist.mdx
+++ b/site/pages/tempo/actions/policy.modifyBlacklist.mdx
@@ -49,35 +49,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.modifyBlacklist.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Block or Unblock an Address
-
-Use this pattern to block or unblock an address.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { restricted, receipt } = await client.policy.modifyBlacklistSync({
-  address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  policyId: 1n,
-  restricted: true,
-})
-
-console.log('Restricted:', restricted)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Restricted: true
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.modifyWhitelist.mdx
+++ b/site/pages/tempo/actions/policy.modifyWhitelist.mdx
@@ -49,35 +49,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.modifyWhitelist.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Grant or Remove Transfer Access
-
-Use this pattern to grant or remove transfer access.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { allowed, receipt } = await client.policy.modifyWhitelistSync({
-  address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  policyId: 1n,
-  allowed: true,
-})
-
-console.log('Allowed:', allowed)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Allowed: true
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.setAdmin.mdx
+++ b/site/pages/tempo/actions/policy.setAdmin.mdx
@@ -47,34 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.setAdmin.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Hand Off Policy Administration
-
-Use this pattern to hand off policy administration.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { admin, receipt } = await client.policy.setAdminSync({
-  admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  policyId: 1n,
-})
-
-console.log('Admin:', admin)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Admin: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.watchAdminUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchAdminUpdated.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchAdminUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Policy Administration Changes
-
-Use this pattern to track policy administration changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.policy.watchAdminUpdated()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { policyId: 1n, updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchBlacklistUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchBlacklistUpdated.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchBlacklistUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Blacklist Changes
-
-Use this pattern to track blacklist changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.policy.watchBlacklistUpdated()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { policyId: 1n, updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', restricted: true }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchCreate.mdx
+++ b/site/pages/tempo/actions/policy.watchCreate.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchCreate(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Discover New Transfer Policies
-
-Use this pattern to discover new transfer policies.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.policy.watchCreate()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { policyId: 1n, updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', policyType: 0 }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchWhitelistUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchWhitelistUpdated.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchWhitelistUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Whitelist Changes
-
-Use this pattern to track whitelist changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.policy.watchWhitelistUpdated()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { policyId: 1n, updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', allowed: true }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.burn.mdx
+++ b/site/pages/tempo/actions/receivePolicy.burn.mdx
@@ -45,33 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.burn.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Permanently Remove Blocked Funds
-
-Use this pattern to permanently remove blocked funds.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { amount, receipt } = await client.receivePolicy.burnSync({
-  receipt: '0x1234',
-})
-
-console.log('Amount:', amount)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Amount: 1000000n
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.claim.mdx
+++ b/site/pages/tempo/actions/receivePolicy.claim.mdx
@@ -47,34 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.claim.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Recover a Blocked Transfer
-
-Use this pattern to recover a blocked transfer.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { amount, receipt } = await client.receivePolicy.claimSync({
-  receipt: '0x1234',
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Amount:', amount)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Amount: 1000000n
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.get.mdx
+++ b/site/pages/tempo/actions/receivePolicy.get.mdx
@@ -25,31 +25,6 @@ console.log('Receive policy:', policy.hasReceivePolicy)
 
 :::
 
-## Recipes
-
-### Display an Account's Receive Policy
-
-Use this pattern to display an account's receive policy.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const policy = await client.receivePolicy.get({
-  account: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-})
-
-console.log('Receive policy:', policy.hasReceivePolicy)
-// @log: Receive policy: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
+++ b/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
@@ -25,31 +25,6 @@ console.log('Blocked balance:', balance)
 
 :::
 
-## Recipes
-
-### Show Funds Held by a Receipt
-
-Use this pattern to show funds held by a receipt.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const balance = await client.receivePolicy.getBlockedBalance({
-  receipt: '0x1234',
-})
-
-console.log('Blocked balance:', balance)
-// @log: Blocked balance: 1000000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.set.mdx
+++ b/site/pages/tempo/actions/receivePolicy.set.mdx
@@ -52,35 +52,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.set.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Require Transfers to Be Accepted
-
-Use this pattern to require transfers to be accepted.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { account, receipt } = await client.receivePolicy.setSync({
-  claimer: 'self',
-  senderPolicyId: 1n,
-  tokenPolicyId: 'allow-all',
-})
-
-console.log('Account:', account)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Account: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.validate.mdx
+++ b/site/pages/tempo/actions/receivePolicy.validate.mdx
@@ -27,33 +27,6 @@ console.log('Authorized:', result.authorized)
 
 :::
 
-## Recipes
-
-### Preflight a Transfer Against Recipient Rules
-
-Use this pattern to preflight a transfer against recipient rules.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.receivePolicy.validate({
-  receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  sender: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Authorized:', result.authorized)
-// @log: Authorized: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchBlocked(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Notify a Sender When Funds Are Blocked
-
-Use this pattern to notify a sender when funds are blocked.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.receivePolicy.watchBlocked()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { token: '0x20c0000000000000000000000000000000000001', receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', blockedNonce: 1n, amount: 1000000n, receiptVersion: 1, receipt: '0x1234' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchBurned(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Reconcile Burned Receipts
-
-Use this pattern to reconcile burned receipts.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.receivePolicy.watchBurned()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { token: '0x20c0000000000000000000000000000000000001', receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', blockedNonce: 1n, amount: 1000000n }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchClaimed(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Reconcile Claimed Receipts
-
-Use this pattern to reconcile claimed receipts.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.receivePolicy.watchClaimed()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { token: '0x20c0000000000000000000000000000000000001', receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', blockedNonce: 1n, to: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', amount: 1000000n }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
@@ -28,34 +28,6 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Refresh Receive Policy Settings
-
-Use this pattern to refresh receive policy settings.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.receivePolicy.watchUpdated()
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { account: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', senderPolicyId: 1n, tokenFilterId: 1n, recoveryAuthority: '0x0000000000000000000000000000000000000000' }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.approve.mdx
+++ b/site/pages/tempo/actions/token.approve.mdx
@@ -91,33 +91,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.approve.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Allow an App to Spend Tokens
-
-Use this pattern to allow an app to spend tokens.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.approveSync({
-  amount: { formatted: '10.5' },
-  spender: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.burn.mdx
+++ b/site/pages/tempo/actions/token.burn.mdx
@@ -87,32 +87,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.burn.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Reduce Token Supply from an Account Balance
-
-Use this pattern to reduce token supply from an account balance.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.burnSync({
-  amount: { formatted: '10.5' },
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.burnBlocked.mdx
+++ b/site/pages/tempo/actions/token.burnBlocked.mdx
@@ -91,33 +91,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.burnBlocked.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Enforce a Compliance Burn
-
-Use this pattern to enforce a compliance burn.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.burnBlockedSync({
-  amount: { formatted: '10.5' },
-  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.changeTransferPolicy.mdx
+++ b/site/pages/tempo/actions/token.changeTransferPolicy.mdx
@@ -45,32 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.changeTransferPolicy.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Move a Token to a New Transfer Policy
-
-Use this pattern to move a token to a new transfer policy.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.changeTransferPolicySync({
-  policyId: 1n,
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.create.mdx
+++ b/site/pages/tempo/actions/token.create.mdx
@@ -51,36 +51,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args: { token } } = Actions.token.create.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Issue a New Stablecoin
-
-Use this pattern to issue a new stablecoin.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { admin, receipt, token } = await client.token.createSync({
-  currency: 'USD',
-  logoURI: 'https://example.com/cusd.svg',
-  name: 'My Company USD',
-  symbol: 'CUSD',
-})
-
-console.log('Address:', token)
-// @log: Address: 0x20c0000000000000000000000000000000000004
-console.log('Admin:', admin)
-// @log: Admin: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getAllowance.mdx
+++ b/site/pages/tempo/actions/token.getAllowance.mdx
@@ -27,33 +27,6 @@ console.log('Allowance:', allowance)
 
 :::
 
-## Recipes
-
-### Check Delegated Spending Capacity
-
-Use this pattern to check delegated spending capacity.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const allowance = await client.token.getAllowance({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  spender: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Allowance:', allowance)
-// @log: Allowance: { amount: 10500000n, decimals: 6, formatted: '10.5' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getBalance.mdx
+++ b/site/pages/tempo/actions/token.getBalance.mdx
@@ -26,32 +26,6 @@ console.log('Balance:', balance)
 
 :::
 
-## Recipes
-
-### Show a Wallet's Token Balance
-
-Use this pattern to show a wallet's token balance.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const balance = await client.token.getBalance({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Balance:', balance)
-// @log: Balance: { amount: 10500000n, decimals: 6, formatted: '10.5' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getMetadata.mdx
+++ b/site/pages/tempo/actions/token.getMetadata.mdx
@@ -36,42 +36,6 @@ console.log(metadata)
 
 :::
 
-## Recipes
-
-### Render Token Details
-
-Use this pattern to render token details.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const metadata = await client.token.getMetadata({
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log(metadata)
-// @log: {
-// @log:   currency: 'USD',
-// @log:   decimals: 6,
-// @log:   logoURI: '',
-// @log:   name: 'AlphaUSD',
-// @log:   paused: false,
-// @log:   quoteToken: '0x20C0000000000000000000000000000000000000',
-// @log:   supplyCap: 340282366920938463463374607431768211455n,
-// @log:   symbol: 'AlphaUSD',
-// @log:   totalSupply: 202914184810805067765n,
-// @log:   transferPolicyId: 1n,
-// @log: }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getRoleAdmin.mdx
+++ b/site/pages/tempo/actions/token.getRoleAdmin.mdx
@@ -26,32 +26,6 @@ console.log('Admin role:', adminRole)
 
 :::
 
-## Recipes
-
-### Inspect Token Role Governance
-
-Use this pattern to inspect token role governance.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const adminRole = await client.token.getRoleAdmin({
-  role: 'issuer',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Admin role:', adminRole)
-// @log: Admin role: 0x0000000000000000000000000000000000000000000000000000000000000000
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getTotalSupply.mdx
+++ b/site/pages/tempo/actions/token.getTotalSupply.mdx
@@ -25,31 +25,6 @@ console.log('Total Supply:', totalSupply)
 
 :::
 
-## Recipes
-
-### Report Token Supply
-
-Use this pattern to report token supply.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const totalSupply = await client.token.getTotalSupply({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Total Supply:', totalSupply)
-// @log: Total Supply: { amount: 1000000000000000n, decimals: 6, formatted: '1000000000' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.grantRoles.mdx
+++ b/site/pages/tempo/actions/token.grantRoles.mdx
@@ -47,33 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.grantRoles.extractEvents(receipt.logs)
 ```
 
-## Recipes
-
-### Authorize a New Token Issuer
-
-Use this pattern to authorize a new token issuer.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, value } = await client.token.grantRolesSync({
-  roles: ['issuer'],
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Role granted:', value[0].hasRole)
-// @log: Role granted: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.hasRole.mdx
+++ b/site/pages/tempo/actions/token.hasRole.mdx
@@ -27,33 +27,6 @@ console.log('Has issuer role:', hasRole)
 
 :::
 
-## Recipes
-
-### Guard a Token Admin Operation
-
-Use this pattern to guard a token admin operation.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const hasRole = await client.token.hasRole({
-  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  role: 'issuer',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Has issuer role:', hasRole)
-// @log: Has issuer role: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.mint.mdx
+++ b/site/pages/tempo/actions/token.mint.mdx
@@ -91,33 +91,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.mint.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Issue Tokens to an Account
-
-Use this pattern to issue tokens to an account.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.mintSync({
-  amount: { formatted: '10.5' },
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.pause.mdx
+++ b/site/pages/tempo/actions/token.pause.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.pause.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Stop Transfers During an Incident
-
-Use this pattern to stop transfers during an incident.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { isPaused, receipt } = await client.token.pauseSync({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Is paused:', isPaused)
-// @log: Is paused: true
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.prepareUpdateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.prepareUpdateQuoteToken.mdx
@@ -47,32 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.prepareUpdateQuoteToken.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Stage a Quote Token Migration
-
-Use this pattern to stage a quote token migration.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { nextQuoteToken, receipt } = await client.token.prepareUpdateQuoteTokenSync({
-  quoteToken: '0x20c0000000000000000000000000000000000002',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Next quote token:', nextQuoteToken)
-// @log: Next quote token: 0x20C0000000000000000000000000000000000002
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.renounceRoles.mdx
+++ b/site/pages/tempo/actions/token.renounceRoles.mdx
@@ -45,32 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.renounceRoles.extractEvents(receipt.logs)
 ```
 
-## Recipes
-
-### Remove Your Own Token Privileges
-
-Use this pattern to remove your own token privileges.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, value } = await client.token.renounceRolesSync({
-  roles: ['issuer'],
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Roles renounced:', value.length)
-// @log: Roles renounced: 1
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.revokeRoles.mdx
+++ b/site/pages/tempo/actions/token.revokeRoles.mdx
@@ -47,33 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.revokeRoles.extractEvents(receipt.logs)
 ```
 
-## Recipes
-
-### Remove a Token Operator
-
-Use this pattern to remove a token operator.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt, value } = await client.token.revokeRolesSync({
-  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  roles: ['issuer'],
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Roles revoked:', value.length)
-// @log: Roles revoked: 1
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.setRoleAdmin.mdx
+++ b/site/pages/tempo/actions/token.setRoleAdmin.mdx
@@ -47,33 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.setRoleAdmin.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Delegate Token Role Management
-
-Use this pattern to delegate token role management.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.setRoleAdminSync({
-  adminRole: 'pause',
-  role: 'issuer',
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.setSupplyCap.mdx
+++ b/site/pages/tempo/actions/token.setSupplyCap.mdx
@@ -47,33 +47,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.setSupplyCap.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Limit Future Token Issuance
-
-Use this pattern to limit future token issuance.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { Value } from 'viem/utils'
-import { client } from './viem.config'
-
-const { newSupplyCap, receipt } = await client.token.setSupplyCapSync({
-  supplyCap: Value.from('1000000', 6),
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('New supply cap:', newSupplyCap)
-// @log: New supply cap: 1000000000000n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.transfer.mdx
+++ b/site/pages/tempo/actions/token.transfer.mdx
@@ -93,33 +93,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.transfer.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Send a Token Payment
-
-Use this pattern to send a token payment.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.token.transferSync({
-  amount: { formatted: '10.5' },
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.unpause.mdx
+++ b/site/pages/tempo/actions/token.unpause.mdx
@@ -43,31 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.unpause.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Resume Token Transfers
-
-Use this pattern to resume token transfers.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { isPaused, receipt } = await client.token.unpauseSync({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-console.log('Is paused:', isPaused)
-// @log: Is paused: false
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.updateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.updateQuoteToken.mdx
@@ -45,31 +45,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.updateQuoteToken.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Complete a Quote Token Migration
-
-Use this pattern to complete a quote token migration.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { newQuoteToken, receipt } = await client.token.updateQuoteTokenSync({
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('New quote token:', newQuoteToken)
-// @log: New quote token: 0x20C0000000000000000000000000000000000002
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.watchAdminRole.mdx
+++ b/site/pages/tempo/actions/token.watchAdminRole.mdx
@@ -34,40 +34,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchAdminRole(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Token Role Governance Changes
-
-Use this pattern to track token role governance changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchAdminRole({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   role: '0x114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa122',
-  // @log:   newAdminRole: '0x139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d',
-  // @log:   sender: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchApprove.mdx
+++ b/site/pages/tempo/actions/token.watchApprove.mdx
@@ -34,40 +34,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchApprove(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Delegated Token Spending
-
-Use this pattern to track delegated token spending.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchApprove({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   spender: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  // @log:   amount: 100000000n
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchBurn.mdx
+++ b/site/pages/tempo/actions/token.watchBurn.mdx
@@ -30,36 +30,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchBurn(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Token Supply Reductions
-
-Use this pattern to track token supply reductions.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchBurn({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { from: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', amount: 50000000n }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchCreate.mdx
+++ b/site/pages/tempo/actions/token.watchCreate.mdx
@@ -36,42 +36,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchCreate(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Discover Newly Created Tokens
-
-Use this pattern to discover newly created tokens.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchCreate({})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   token: '0x20c0000000000000000000000000000000000042',
-  // @log:   name: 'My Token',
-  // @log:   symbol: 'MYT',
-  // @log:   currency: 'USD',
-  // @log:   quoteToken: '0x20C0000000000000000000000000000000000000',
-  // @log:   admin: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   salt: '0x9d3a4e2f1b8c65d0a7e4f2c9b1d8360e5a2c7f41d9b06e8352c1a4f7e0b6d914'
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchMint.mdx
+++ b/site/pages/tempo/actions/token.watchMint.mdx
@@ -30,36 +30,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchMint(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track New Token Issuance
-
-Use this pattern to track new token issuance.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchMint({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: { to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', amount: 100000000n }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchRole.mdx
+++ b/site/pages/tempo/actions/token.watchRole.mdx
@@ -35,41 +35,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchRole(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Token Permission Changes
-
-Use this pattern to track token permission changes.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchRole({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   role: '0x114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa122',
-  // @log:   account: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  // @log:   sender: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   hasRole: true
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchTransfer.mdx
+++ b/site/pages/tempo/actions/token.watchTransfer.mdx
@@ -34,40 +34,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchTransfer(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Monitor Incoming Token Payments
-
-Use this pattern to monitor incoming token payments.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchTransfer({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.args)
-  // @log: {
-  // @log:   from: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  // @log:   amount: 100000000n
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchUpdateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.watchUpdateQuoteToken.mdx
@@ -33,39 +33,6 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchUpdateQuoteToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
-## Recipes
-
-### Track Quote Token Migrations
-
-Use this pattern to track quote token migrations.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const watcher = client.token.watchUpdateQuoteToken({
-  token: '0x20c0000000000000000000000000000000000000',
-})
-
-watcher.onLogs((logs) => {
-  for (const log of logs) console.log(log.eventName, log.args)
-  // @log: NextQuoteTokenSet {
-  // @log:   updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  // @log:   nextQuoteToken: '0x20C0000000000000000000000000000000000001'
-  // @log: }
-})
-
-// Later, tear down the watcher.
-watcher.off()
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/validator.add.mdx
+++ b/site/pages/tempo/actions/validator.add.mdx
@@ -51,35 +51,6 @@ const hash = await client.validator.add({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Onboard a New Validator
-
-Use this pattern to onboard a new validator.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.validator.addSync({
-  active: true,
-  inboundAddress: 'validator.example.com:9000',
-  newValidatorAddress: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  outboundAddress: '203.0.113.10:9000',
-  publicKey: '0x1111111111111111111111111111111111111111111111111111111111111111',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.changeOwner.mdx
+++ b/site/pages/tempo/actions/validator.changeOwner.mdx
@@ -40,31 +40,6 @@ const hash = await client.validator.changeOwner({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Transfer Validator Configuration Ownership
-
-Use this pattern to transfer validator configuration ownership.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.validator.changeOwnerSync({
-  newOwner: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.changeStatus.mdx
+++ b/site/pages/tempo/actions/validator.changeStatus.mdx
@@ -42,32 +42,6 @@ const hash = await client.validator.changeStatus({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Temporarily Deactivate a Validator
-
-Use this pattern to temporarily deactivate a validator.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.validator.changeStatusSync({
-  active: false,
-  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.get.mdx
+++ b/site/pages/tempo/actions/validator.get.mdx
@@ -25,31 +25,6 @@ console.log('Validator:', validator.validatorAddress)
 
 :::
 
-## Recipes
-
-### Display Validator Details
-
-Use this pattern to display validator details.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const validator = await client.validator.get({
-  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-})
-
-console.log('Validator:', validator.validatorAddress)
-// @log: Validator: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getByIndex.mdx
+++ b/site/pages/tempo/actions/validator.getByIndex.mdx
@@ -25,31 +25,6 @@ console.log('Validator:', validator)
 
 :::
 
-## Recipes
-
-### Look Up a Validator Address by Index
-
-Use this pattern to look up a validator address by index.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const validator = await client.validator.getByIndex({
-  index: 0n,
-})
-
-console.log('Validator:', validator)
-// @log: Validator: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getCount.mdx
+++ b/site/pages/tempo/actions/validator.getCount.mdx
@@ -23,29 +23,6 @@ console.log('Result:', result)
 
 :::
 
-## Recipes
-
-### Size a Validator List
-
-Use this pattern to size a validator list.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.validator.getCount()
-
-console.log('Result:', result)
-// @log: Result: 4n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getNextFullDkgCeremony.mdx
+++ b/site/pages/tempo/actions/validator.getNextFullDkgCeremony.mdx
@@ -23,29 +23,6 @@ console.log('Result:', result)
 
 :::
 
-## Recipes
-
-### Schedule Around the Next Full DKG Ceremony
-
-Use this pattern to schedule around the next full DKG ceremony.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.validator.getNextFullDkgCeremony()
-
-console.log('Result:', result)
-// @log: Result: 42n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getOwner.mdx
+++ b/site/pages/tempo/actions/validator.getOwner.mdx
@@ -23,29 +23,6 @@ console.log('Result:', result)
 
 :::
 
-## Recipes
-
-### Verify Validator Configuration Authority
-
-Use this pattern to verify validator configuration authority.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.validator.getOwner()
-
-console.log('Result:', result)
-// @log: Result: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.list.mdx
+++ b/site/pages/tempo/actions/validator.list.mdx
@@ -23,29 +23,6 @@ console.log('Result:', result.length)
 
 :::
 
-## Recipes
-
-### Build a Validator Directory
-
-Use this pattern to build a validator directory.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const result = await client.validator.list()
-
-console.log('Result:', result.length)
-// @log: Result: 4
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.setNextFullDkgCeremony.mdx
+++ b/site/pages/tempo/actions/validator.setNextFullDkgCeremony.mdx
@@ -40,31 +40,6 @@ const hash = await client.validator.setNextFullDkgCeremony({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Schedule a Full DKG Ceremony
-
-Use this pattern to schedule a full DKG ceremony.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.validator.setNextFullDkgCeremonySync({
-  epoch: 42n,
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.update.mdx
+++ b/site/pages/tempo/actions/validator.update.mdx
@@ -46,34 +46,6 @@ const hash = await client.validator.update({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Rotate Validator Network Details
-
-Use this pattern to rotate validator network details.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.validator.updateSync({
-  inboundAddress: 'validator.example.com:9000',
-  newValidatorAddress: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  outboundAddress: '203.0.113.10:9000',
-  publicKey: '0x1111111111111111111111111111111111111111111111111111111111111111',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.getMasterAddress.mdx
+++ b/site/pages/tempo/actions/virtualAddress.getMasterAddress.mdx
@@ -25,31 +25,6 @@ console.log('Address:', address)
 
 :::
 
-## Recipes
-
-### Recover a Master Address from Its ID
-
-Use this pattern to recover a master address from its id.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const address = await client.virtualAddress.getMasterAddress({
-  masterId: '0xdeadbeef',
-})
-
-console.log('Address:', address)
-// @log: Address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.registerMaster.mdx
+++ b/site/pages/tempo/actions/virtualAddress.registerMaster.mdx
@@ -43,33 +43,6 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.virtualAddress.registerMaster.extractEvent(receipt.logs)
 ```
 
-## Recipes
-
-### Create a Virtual Address Namespace
-
-Use this pattern to create a virtual address namespace.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { masterId, receipt } = await client.virtualAddress.registerMasterSync({
-  salt: '0x00000000000000000000000000000000000000000000000000000000abf52baf',
-})
-
-console.log('Master ID:', masterId)
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Master ID: 0x58e21090
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.resolve.mdx
+++ b/site/pages/tempo/actions/virtualAddress.resolve.mdx
@@ -25,31 +25,6 @@ console.log('Recipient:', recipient)
 
 :::
 
-## Recipes
-
-### Route Funds to a Virtual Address Owner
-
-Use this pattern to route funds to a virtual address owner.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const recipient = await client.virtualAddress.resolve({
-  address: '0x0000000000000000000000000000000000000001',
-})
-
-console.log('Recipient:', recipient)
-// @log: Recipient: 0x0000000000000000000000000000000000000001
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.deposit.mdx
+++ b/site/pages/tempo/actions/wallet.deposit.mdx
@@ -23,29 +23,6 @@ console.log('Receipts:', result?.receipts)
 // @log: Receipts: [{ status: 'success', transactionHash: '0x1234...' }]
 ```
 
-## Recipes
-
-### Prefill a Wallet Deposit
-
-Use this pattern to prefill a wallet deposit.
-
-```ts twoslash [example.ts]
-import { Client, custom } from 'viem/tempo'
-import 'viem/window'
-
-const client = Client.create({
-  transport: custom(window.ethereum!),
-})
-
-const result = await client.wallet.deposit({
-  amount: '1.5',
-  token: 'pathusd',
-})
-
-console.log('Receipts:', result?.receipts)
-// @log: Receipts: [{ status: 'success', transactionHash: '0x1234...' }]
-```
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.swap.mdx
+++ b/site/pages/tempo/actions/wallet.swap.mdx
@@ -24,30 +24,6 @@ console.log('Transaction hash:', receipt.transactionHash)
 // @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 ```
 
-## Recipes
-
-### Open a Preconfigured Wallet Swap
-
-Use this pattern to open a preconfigured wallet swap.
-
-```ts twoslash [example.ts]
-import { Client, custom } from 'viem/tempo'
-import 'viem/window'
-
-const client = Client.create({
-  transport: custom(window.ethereum!),
-})
-
-const { receipt } = await client.wallet.swap({
-  amount: '1.5',
-  token: '0x20c0000000000000000000000000000000000001',
-  type: 'sell',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.transfer.mdx
+++ b/site/pages/tempo/actions/wallet.transfer.mdx
@@ -43,30 +43,6 @@ const { receipt } = await client.wallet.transfer({
 })
 ```
 
-## Recipes
-
-### Send Tokens Through a Connected Wallet
-
-Use this pattern to send tokens through a connected wallet.
-
-```ts twoslash [example.ts]
-import { Client, custom } from 'viem/tempo'
-import 'viem/window'
-
-const client = Client.create({
-  transport: custom(window.ethereum!),
-})
-
-const { receipt } = await client.wallet.transfer({
-  amount: '1.5',
-  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
-  token: 'pathusd',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.deposit.mdx
+++ b/site/pages/tempo/actions/zone.deposit.mdx
@@ -46,33 +46,6 @@ const hash = await client.zone.deposit({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Bridge Tokens into a Zone
-
-Use this pattern to bridge tokens into a Zone.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.zone.depositSync({
-  amount: 100_000_000n,
-  token: '0x20c0000000000000000000000000000000000001',
-  zoneId: 7,
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.encryptedDeposit.mdx
+++ b/site/pages/tempo/actions/zone.encryptedDeposit.mdx
@@ -82,33 +82,6 @@ const { encrypted, keyIndex } =
 
 The helper returns the encrypted payload and its key index together with the parent chain ID, portal address, and zone ID.
 
-## Recipes
-
-### Send a Private Zone Deposit
-
-Use this pattern to send a private Zone deposit.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { receipt } = await client.zone.encryptedDepositSync({
-  amount: 100_000_000n,
-  token: '0x20c0000000000000000000000000000000000001',
-  zoneId: 7,
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getAuthorizationTokenInfo.mdx
+++ b/site/pages/tempo/actions/zone.getAuthorizationTokenInfo.mdx
@@ -23,31 +23,6 @@ console.log('Expires At:', info.expiresAt)
 
 :::
 
-## Recipes
-
-### Inspect the Current Zone Session
-
-Use this pattern to inspect the current Zone session.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const info = await client.zone.getAuthorizationTokenInfo()
-
-console.log('Account:', info.account)
-console.log('Expires At:', info.expiresAt)
-// @log: Account: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
-// @log: Expires At: 1717027200n
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getEncryptionKey.mdx
+++ b/site/pages/tempo/actions/zone.getEncryptionKey.mdx
@@ -25,33 +25,6 @@ console.log('Public key:', publicKey)
 
 :::
 
-## Recipes
-
-### Encrypt Data for the Active Sequencer
-
-Use this pattern to encrypt data for the active sequencer.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { keyIndex, publicKey } = await client.zone.getEncryptionKey({
-  zoneId: 7,
-})
-
-console.log('Key index:', keyIndex)
-console.log('Public key:', publicKey)
-// @log: Key index: 0n
-// @log: Public key: { prefix: 3, x: '0x57e8a1e347b0c8e8c14290499e1281f84eae5d1cdd10cc5eb4d92aca17c5c1d4' }
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
+++ b/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
@@ -33,29 +33,6 @@ const fee = await client.zone.getWithdrawalFee({
 })
 ```
 
-## Recipes
-
-### Quote a Zone Withdrawal
-
-Use this pattern to quote a Zone withdrawal.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './zones.config'
-
-const fee = await client.zone.getWithdrawalFee()
-
-console.log('Fee:', fee)
-// @log: Fee: 0n
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getZoneInfo.mdx
+++ b/site/pages/tempo/actions/zone.getZoneInfo.mdx
@@ -27,35 +27,6 @@ console.log('Tempo block number:', info.tempoBlockNumber)
 
 :::
 
-## Recipes
-
-### Display Zone Status
-
-Use this pattern to display Zone status.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './zones.config'
-
-const info = await client.zone.getZoneInfo()
-
-console.log('Zone ID:', info.zoneId)
-console.log('Chain ID:', info.chainId)
-console.log('Sequencers:', info.sequencers)
-console.log('Tempo block number:', info.tempoBlockNumber)
-// @log: Zone ID: 7
-// @log: Chain ID: 1337
-// @log: Sequencers: ['0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb']
-// @log: Tempo block number: 1234n
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
@@ -56,39 +56,6 @@ const hash = await client.zone.requestVerifiableWithdrawal({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
-## Recipes
-
-### Withdraw with Selective Identity Disclosure
-
-Use this pattern to withdraw with selective identity disclosure.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { PublicKey, Secp256k1 } from 'viem/utils'
-import { client } from './zones.config'
-
-// Generate a keypair for decrypting the sender identity later.
-// Store the private key securely: the holder can reveal the sender.
-const { publicKey } = Secp256k1.createKeyPair()
-const revealTo = PublicKey.toHex(PublicKey.compress(publicKey))
-
-const { receipt } = await client.zone.requestVerifiableWithdrawalSync({
-  amount: 100_000_000n,
-  revealTo,
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.requestWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestWithdrawal.mdx
@@ -83,34 +83,6 @@ type PreparedWithdrawal = {
 }
 ```
 
-## Recipes
-
-### Bridge Tokens Back to Tempo
-
-Use this pattern to bridge tokens back to Tempo.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './zones.config'
-
-const { receipt, senderTag } = await client.zone.requestWithdrawalSync({
-  amount: 100_000_000n,
-  token: '0x20c0000000000000000000000000000000000001',
-})
-
-console.log('Transaction hash:', receipt.transactionHash)
-// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-console.log('Withdrawal sender tag:', senderTag)
-// @log: Withdrawal sender tag: 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.signAuthorizationToken.mdx
+++ b/site/pages/tempo/actions/zone.signAuthorizationToken.mdx
@@ -21,29 +21,6 @@ console.log('Token:', token)
 
 :::
 
-## Recipes
-
-### Authenticate Zone RPC Requests
-
-Use this pattern to authenticate Zone RPC requests.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './viem.config'
-
-const { token } = await client.zone.signAuthorizationToken()
-
-console.log('Token:', token)
-// @log: Token: 0x...
-```
-
-```ts twoslash [viem.config.ts] filename="viem.config.ts"
-// [!include ~/snippets/tempo/viem.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.waitForTempoBlock.mdx
+++ b/site/pages/tempo/actions/zone.waitForTempoBlock.mdx
@@ -26,31 +26,6 @@ console.log('Imported Tempo block:', info.tempoBlockNumber)
 The action polls [`zone.getZoneInfo`](/tempo/actions/zone.getZoneInfo) and resolves when the zone's
 `tempoBlockNumber` reaches the requested block.
 
-## Recipes
-
-### Wait for Zone State to Catch Up
-
-Use this pattern to wait for Zone state to catch up.
-
-:::code-group
-
-```ts twoslash [example.ts]
-import { client } from './zones.config'
-
-const info = await client.zone.waitForTempoBlock({
-  tempoBlockNumber: 123456n,
-})
-
-console.log('Imported Tempo block:', info.tempoBlockNumber)
-// @log: Imported Tempo block: 123456n
-```
-
-```ts twoslash [zones.config.ts] filename="zones.config.ts"
-// [!include ~/snippets/tempo/zones.config.ts:setup]
-```
-
-:::
-
 ## Return Value
 
 `Actions.zone.getZoneInfo.ReturnType`


### PR DESCRIPTION
Removes the `## Recipes` sections from all Tempo Action reference pages because these pages should remain focused on action usage and API details.