### PR TITLE
docs: add tempo action recipes

### DIFF
--- a/site/pages/tempo/actions/accessKey.authorize.mdx
+++ b/site/pages/tempo/actions/accessKey.authorize.mdx
@@ -60,6 +60,125 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.authorize.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Issue a Checkout Access Key with Least Privilege
+
+Combine `expiry`, `limits`, and `scopes` so a browser access key can only pay the merchant, up to a cap, until checkout expires.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256, Value } from 'viem/utils'
+import { Account, Expiry } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const merchant = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const { receipt } = await client.accessKey.authorizeSync({
+  accessKey,
+  expiry: Expiry.hours(1), // [!code focus]
+  limits: [ // [!code focus]
+    { // [!code focus]
+      limit: Value.from('50', 6), // [!code focus]
+      token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+    }, // [!code focus]
+  ], // [!code focus]
+  scopes: [ // [!code focus]
+    { // [!code focus]
+      address: '0x20c0000000000000000000000000000000000000', // [!code focus]
+      recipients: [merchant], // [!code focus]
+      selector: 'transfer(address,uint256)', // [!code focus]
+    }, // [!code focus]
+  ], // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Grant a Server Agent a Recurring Budget
+
+Pass a `period` on a limit to give a server-side agent a budget that resets monthly, and an `expiry` to bound the key's lifetime.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256, Value } from 'viem/utils'
+import { Account, Expiry } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const agentKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const { receipt } = await client.accessKey.authorizeSync({
+  accessKey: agentKey,
+  expiry: Expiry.days(90), // [!code focus]
+  limits: [
+    {
+      limit: Value.from('5000', 6),
+      period: 30 * 24 * 60 * 60, // resets every 30 days // [!code focus]
+      token: '0x20c0000000000000000000000000000000000000',
+    },
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Delegate Key Management to an Admin Key
+
+Pass `admin: true` to authorize an unrestricted admin key, then use it as the sending `account` to manage other keys while the root key stays offline.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account, Expiry } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+
+// 1. Authorize an unrestricted admin key for the ops service.
+const adminKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+await client.accessKey.authorizeSync({
+  accessKey: adminKey,
+  admin: true, // [!code focus]
+})
+
+// 2. The admin key authorizes scoped keys without the root key.
+const workerKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+const { receipt } = await client.accessKey.authorizeSync({
+  account: adminKey, // [!code focus]
+  accessKey: workerKey,
+  expiry: Expiry.days(1),
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.burnWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.burnWitness.mdx
@@ -45,6 +45,68 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.burnWitness.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Cancel an Issued Authorization Before First Use
+
+Combine a `witness` signed via [`accessKey.signAuthorization`](/tempo/actions/accessKey.signAuthorization) with `burnWitness` to cancel an authorization you handed out before it is submitted onchain.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+// Issue a revocable authorization bound to a witness.
+const witness =
+  '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+const keyAuthorization = await client.accessKey.signAuthorization({
+  accessKey,
+  witness, // [!code focus]
+})
+
+// The user abandons checkout: burn the witness so the
+// authorization can never activate.
+const { receipt } = await client.accessKey.burnWitnessSync({
+  witness, // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Make a Cancel Endpoint Idempotent
+
+Check [`accessKey.isWitnessBurned`](/tempo/actions/accessKey.isWitnessBurned) first so repeated cancel requests skip the transaction once the witness is burned.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const witness =
+  '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+
+const burned = await client.accessKey.isWitnessBurned({ witness }) // [!code focus]
+if (!burned) // [!code focus]
+  await client.accessKey.burnWitnessSync({ witness }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.getMetadata.mdx
+++ b/site/pages/tempo/actions/accessKey.getMetadata.mdx
@@ -25,6 +25,64 @@ console.log('Access key metadata:', metadata)
 
 :::
 
+## Recipes
+
+### Confirm a Billing Key Before Charging
+
+Check `isRevoked` and `expiry` on a stored key before a server-side charge, and re-authorize instead of submitting a transaction that will revert.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const metadata = await client.accessKey.getMetadata({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // subscriber
+  accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // billing key
+})
+
+const now = BigInt(Math.floor(Date.now() / 1000))
+if (metadata.isRevoked || metadata.expiry <= now) // [!code focus]
+  throw new Error('billing key inactive: re-authorize before charging') // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Flag Keys Without Spending Limits
+
+Use `spendPolicy` to surface active keys that have no spending cap during a periodic security review.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const keys = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+const flagged = []
+for (const accessKey of keys) {
+  const metadata = await client.accessKey.getMetadata({ accessKey })
+  if (metadata.spendPolicy === 'unlimited' && !metadata.isRevoked) // [!code focus]
+    flagged.push(metadata.address) // [!code focus]
+}
+
+console.log('Keys without limits:', flagged)
+// @log: Keys without limits: ['0x8ba1f109551bD432803012645Ac136ddd64DBA72']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
+++ b/site/pages/tempo/actions/accessKey.getRemainingLimit.mdx
@@ -27,6 +27,68 @@ console.log('Remaining limit:', limit)
 
 :::
 
+## Recipes
+
+### Gate a Subscription Charge on Remaining Budget
+
+Compare `remaining` with the charge amount before submitting a [`token.transfer`](/tempo/actions/token.transfer), and use `periodEnd` to schedule the retry when the cap resets.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const charge = Value.from('49.99', 6)
+
+const { remaining, periodEnd } = await client.accessKey.getRemainingLimit({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // subscriber
+  accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // billing key
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+if (remaining < charge) // [!code focus]
+  console.log('Budget exhausted, retry at:', periodEnd) // [!code focus]
+// @log: Budget exhausted, retry at: 1735689600n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Monitor an Agent's Budgets Across Tokens
+
+Query each token an agent key can spend to build a treasury dashboard of remaining budgets.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const tokens = [
+  '0x20c0000000000000000000000000000000000000', // pathUSD
+  '0x20c0000000000000000000000000000000000001', // alphaUsd
+] as const
+
+const budgets = await Promise.all(
+  tokens.map(async (token) => ({
+    token,
+    ...(await client.accessKey.getRemainingLimit({ // [!code focus]
+      accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+      token, // [!code focus]
+    })), // [!code focus]
+  })),
+)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.isAdmin.mdx
+++ b/site/pages/tempo/actions/accessKey.isAdmin.mdx
@@ -26,6 +26,71 @@ console.log('Is admin:', isAdmin)
 
 :::
 
+## Recipes
+
+### Verify an Admin Key Before Delegated Management
+
+Confirm the operator's key still has admin rights before signing key management like [`accessKey.revoke`](/tempo/actions/accessKey.revoke) with it.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+
+// Admin key held by your ops service, authorized with `admin: true`.
+const adminKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const isAdmin = await client.accessKey.isAdmin({ accessKey: adminKey }) // [!code focus]
+if (!isAdmin) throw new Error('admin key was revoked') // [!code focus]
+
+const { receipt } = await client.accessKey.revokeSync({
+  account: adminKey,
+  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Audit the Account's Admin Keys
+
+Check each known key so you can keep the number of active admin keys small.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const keys = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+const admins = []
+for (const accessKey of keys) {
+  if (await client.accessKey.isAdmin({ accessKey })) // [!code focus]
+    admins.push(accessKey) // [!code focus]
+}
+
+console.log('Admin keys:', admins)
+// @log: Admin keys: ['0x8ba1f109551bD432803012645Ac136ddd64DBA72']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.isWitnessBurned.mdx
@@ -26,6 +26,38 @@ console.log('Is burned:', isBurned)
 
 :::
 
+## Recipes
+
+### Validate a Stored Authorization Before Submitting
+
+Check the witness before attaching a stored authorization from [`accessKey.signAuthorization`](/tempo/actions/accessKey.signAuthorization) to a transaction, since a burned witness makes it revert.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Witness bound into a signed authorization held in your database.
+const witness =
+  '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+
+const burned = await client.accessKey.isWitnessBurned({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // authorizing account
+  witness,
+})
+
+if (burned) // [!code focus]
+  throw new Error('authorization cancelled: request a new one') // [!code focus]
+
+// Safe to attach the stored authorization via `keyAuthorization`.
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.revoke.mdx
+++ b/site/pages/tempo/actions/accessKey.revoke.mdx
@@ -45,6 +45,72 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.revoke.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Rotate an Access Key
+
+Combine [`accessKey.authorize`](/tempo/actions/accessKey.authorize) with `revoke` to bring a replacement key live before retiring the old one, avoiding a signing gap.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account, Expiry } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+
+// 1. Authorize the replacement key.
+const nextKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+await client.accessKey.authorizeSync({ // [!code focus]
+  accessKey: nextKey, // [!code focus]
+  expiry: Expiry.days(30), // [!code focus]
+}) // [!code focus]
+
+// 2. Retire the outgoing key.
+const { receipt } = await client.accessKey.revokeSync({ // [!code focus]
+  accessKey: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Revoke a Compromised Key with an Admin Key
+
+Pass an admin key as `account` so your incident response service can revoke keys while the root key stays offline.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+
+// Admin key previously authorized with `admin: true`.
+const adminKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+const { receipt } = await client.accessKey.revokeSync({
+  account: adminKey, // [!code focus]
+  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.signAuthorization.mdx
+++ b/site/pages/tempo/actions/accessKey.signAuthorization.mdx
@@ -35,6 +35,77 @@ console.log('Key authorization:', keyAuthorization)
 
 :::
 
+## Recipes
+
+### Provision the Key with the User's First Payment
+
+Attach the signed authorization to a [`token.transfer`](/tempo/actions/token.transfer) via `keyAuthorization`, so provisioning lands with the first payment instead of a standalone transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+// Sign the authorization offchain: no transaction is sent yet.
+const keyAuthorization = await client.accessKey.signAuthorization({
+  accessKey,
+})
+
+// The authorization is provisioned with the first payment the key signs.
+const { receipt } = await client.token.transferSync({
+  account: accessKey, // [!code focus]
+  amount: { formatted: '49.99' },
+  keyAuthorization, // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Bind the Authorization to a Server Challenge
+
+Pass a server-issued challenge as `witness` to tie the authorization to a single session, and cancel it with [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness) before it lands.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { P256 } from 'viem/utils'
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = Account.fromSecp256k1('0x...')
+const accessKey = Account.fromP256(P256.randomPrivateKey(), {
+  access: account,
+})
+
+// Single-use challenge issued by your server for this session.
+const challenge =
+  '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+
+const keyAuthorization = await client.accessKey.signAuthorization({
+  accessKey,
+  witness: challenge, // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.updateLimit.mdx
+++ b/site/pages/tempo/actions/accessKey.updateLimit.mdx
@@ -49,6 +49,63 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.accessKey.updateLimit.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Freeze a Key Without Revoking It
+
+Set `limit` to `0n` to stop a key from spending during an investigation, keeping the option to restore it later, unlike [`accessKey.revoke`](/tempo/actions/accessKey.revoke).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.accessKey.updateLimitSync({
+  accessKey: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  limit: 0n, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Top Up a Budget When It Runs Low
+
+Combine [`accessKey.getRemainingLimit`](/tempo/actions/accessKey.getRemainingLimit) with `updateLimit` to raise an agent's cap only when its remaining budget drops below a threshold.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const accessKey = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+const token = '0x20c0000000000000000000000000000000000000'
+
+const { remaining } = await client.accessKey.getRemainingLimit({ // [!code focus]
+  accessKey, // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+if (remaining < Value.from('100', 6)) {
+  await client.accessKey.updateLimitSync({
+    accessKey,
+    limit: Value.from('1000', 6), // [!code focus]
+    token,
+  })
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.verifyHash.mdx
+++ b/site/pages/tempo/actions/accessKey.verifyHash.mdx
@@ -27,6 +27,44 @@ console.log('Valid:', valid)
 
 :::
 
+## Recipes
+
+### Tier Endpoint Access by Signer Privilege
+
+Use the default admin check for sensitive operations and `admin: false` for routine access key traffic, so one signature check enforces two permission tiers.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const account = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+const hash =
+  '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+const signature = '0x...'
+
+// Any active access key may read order history.
+const isAccessKey = await client.accessKey.verifyHash({
+  account,
+  admin: false, // [!code focus]
+  hash,
+  signature,
+})
+
+// Only the root key or an admin key may change payout settings.
+const isOwner = await client.accessKey.verifyHash({
+  account,
+  hash,
+  signature,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
+++ b/site/pages/tempo/actions/accessKey.watchAdminAuthorized.mdx
@@ -28,6 +28,41 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchAdminAuthorized(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Auto-Revoke Unexpected Admin Grants
+
+Filter `args` to your account and revoke any admin key you did not provision with [`accessKey.revoke`](/tempo/actions/accessKey.revoke).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Admin keys provisioned through your ops workflow.
+const expected = new Set<string>([
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+])
+
+const watcher = client.accessKey.watchAdminAuthorized({
+  args: { account: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs(async (logs) => {
+  for (const log of logs) {
+    if (expected.has(log.args.publicKey)) continue
+    // Unexpected admin grant: revoke immediately.
+    await client.accessKey.revokeSync({ accessKey: log.args.publicKey }) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/accessKey.watchWitness.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitness.mdx
@@ -28,6 +28,75 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchWitness(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Activate Checkout Sessions When Their Witness Lands Onchain
+
+Filter `args.witness` to the witnesses you issued via [`accessKey.signAuthorization`](/tempo/actions/accessKey.signAuthorization) to mark each checkout session active once its authorization lands.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Witnesses issued with pending checkout sessions.
+const pending = new Map<`0x${string}`, string>([
+  [
+    '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658',
+    'order_1024',
+  ],
+])
+
+const watcher = client.accessKey.watchWitness({
+  args: { witness: [...pending.keys()] }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const order = pending.get(log.args.witness) // [!code focus]
+    if (!order) continue
+    pending.delete(log.args.witness)
+    console.log('Checkout active for:', order)
+    // @log: Checkout active for: order_1024
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Backfill Missed Authorizations After a Restart
+
+Pass `fromBlock` so a restarted service replays witness events emitted while it was offline.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Last block the service processed before restarting.
+const lastProcessed = 1_204_320n
+
+const watcher = client.accessKey.watchWitness({
+  fromBlock: lastProcessed + 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    console.log(log.blockNumber, log.args.witness)
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
+++ b/site/pages/tempo/actions/accessKey.watchWitnessBurned.mdx
@@ -28,6 +28,36 @@ watcher.off()
 
 Also callable standalone: `Actions.accessKey.watchWitnessBurned(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Purge Cancelled Authorizations from Storage
+
+Filter `args` to your account and delete stored authorizations when their witness is burned via [`accessKey.burnWitness`](/tempo/actions/accessKey.burnWitness).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.accessKey.watchWitnessBurned({
+  args: { account: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Delete the stored authorization bound to this witness
+    // so it is never attached to a transaction.
+    console.log('Cancelled witness:', log.args.witness) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.burn.mdx
+++ b/site/pages/tempo/actions/amm.burn.mdx
@@ -50,6 +50,80 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.burn.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Exit a Pool Completely
+
+Combine [`amm.getLiquidityBalance`](/tempo/actions/amm.getLiquidityBalance) with `burnSync` to withdraw a full position, for example when winding down a treasury's allocation to a pool.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const userToken = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+
+const liquidity = await client.amm.getLiquidityBalance({ // [!code focus]
+  address: client.account.address, // [!code focus]
+  userToken, // [!code focus]
+  validatorToken, // [!code focus]
+}) // [!code focus]
+
+const { amountUserToken, amountValidatorToken } = await client.amm.burnSync({
+  liquidity, // [!code focus]
+  to: client.account.address,
+  userToken,
+  validatorToken,
+})
+
+console.log('Withdrawn:', amountUserToken, amountValidatorToken)
+// @log: Withdrawn: 500000n 500000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Preview the Tokens a Burn Returns
+
+Use [`amm.getPool`](/tempo/actions/amm.getPool) to compute the pro-rata share a burn will return, so a withdrawal report shows expected amounts before execution.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const userToken = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+const liquidity = 500_000n
+
+const pool = await client.amm.getPool({ userToken, validatorToken }) // [!code focus]
+
+const expectedUserToken = // [!code focus]
+  (liquidity * pool.reserveUserToken) / pool.totalSupply // [!code focus]
+const expectedValidatorToken = // [!code focus]
+  (liquidity * pool.reserveValidatorToken) / pool.totalSupply // [!code focus]
+
+console.log('Expected:', expectedUserToken, expectedValidatorToken)
+// @log: Expected: 500000n 500000n
+
+await client.amm.burnSync({
+  liquidity,
+  to: client.account.address,
+  userToken,
+  validatorToken,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.getLiquidityBalance.mdx
+++ b/site/pages/tempo/actions/amm.getLiquidityBalance.mdx
@@ -27,6 +27,63 @@ console.log('Liquidity balance:', balance)
 :::
 
 
+## Recipes
+
+### Monitor Your Share of a Pool
+
+Combine the LP balance with [`amm.getPool`](/tempo/actions/amm.getPool) to compute your ownership share, for example to enforce a treasury concentration limit per pool.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const userToken = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+
+const balance = await client.amm.getLiquidityBalance({
+  address: client.account.address,
+  userToken,
+  validatorToken,
+})
+const pool = await client.amm.getPool({ userToken, validatorToken }) // [!code focus]
+
+const shareBps = (balance * 10_000n) / pool.totalSupply // [!code focus]
+
+console.log('Pool share:', `${Number(shareBps) / 100}%`)
+// @log: Pool share: 25%
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Look Up a Position by Pool ID
+
+Pass `poolId` when your tooling already tracks pools by id, for example rows ingested from an indexer, instead of re-deriving token pairs.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const balance = await client.amm.getLiquidityBalance({
+  address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  poolId: '0xcfa2fc65dd0637cd912c7d689aa434a91d3456c723019921fe1f4a9018beab08', // [!code focus]
+})
+
+console.log('LP balance:', balance)
+// @log: LP balance: 500000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.getPool.mdx
+++ b/site/pages/tempo/actions/amm.getPool.mdx
@@ -26,6 +26,61 @@ console.log('Pool:', pool)
 :::
 
 
+## Recipes
+
+### Check Pool Depth Before Adopting a Fee Token
+
+Check the validator token reserve before saving a default with [`fee.setUserToken`](/tempo/actions/fee.setUserToken): fee payments in a token only settle while its pool holds validator tokens.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const pool = await client.amm.getPool({
+  userToken: alphaUsd,
+  validatorToken: '0x20c0000000000000000000000000000000000002',
+})
+
+if (pool.reserveValidatorToken >= 10_000_000000n) // [!code focus]
+  await client.fee.setUserTokenSync({ token: alphaUsd }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Detect a Pool Worth Rebalancing
+
+Compare the reserves to spot user token buildup, then act with [`amm.rebalanceSwap`](/tempo/actions/amm.rebalanceSwap) when the surplus is worth the swap.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pool = await client.amm.getPool({
+  userToken: '0x20c0000000000000000000000000000000000001',
+  validatorToken: '0x20c0000000000000000000000000000000000002',
+})
+
+const surplus = pool.reserveUserToken - pool.reserveValidatorToken // [!code focus]
+
+if (surplus > 1_000_000000n) // [!code focus]
+  console.log('Rebalance opportunity:', surplus)
+// @log: Rebalance opportunity: 2500000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.mint.mdx
+++ b/site/pages/tempo/actions/amm.mint.mdx
@@ -57,6 +57,69 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.mint.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Seed a Pool for a New Fee Token
+
+Combine [`amm.getPool`](/tempo/actions/amm.getPool) with `mintSync` to confirm a pool is empty before seeding it, so fees paid in a newly issued stablecoin can settle.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+
+const pool = await client.amm.getPool({ // [!code focus]
+  userToken: alphaUsd, // [!code focus]
+  validatorToken, // [!code focus]
+}) // [!code focus]
+
+if (pool.totalSupply === 0n) { // [!code focus]
+  await client.amm.mintSync({
+    to: client.account.address,
+    userTokenAddress: alphaUsd,
+    validatorTokenAddress: validatorToken,
+    validatorTokenAmount: 10_000_000000n,
+  })
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Custody LP Shares in a Treasury Account
+
+Pass a treasury address as `to` when an operator wallet funds the pool: LP shares belong to `to`, and only that address can [`burn`](/tempo/actions/amm.burn) them.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const treasury = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const { liquidity } = await client.amm.mintSync({
+  to: treasury, // [!code focus]
+  userTokenAddress: '0x20c0000000000000000000000000000000000001',
+  validatorTokenAddress: '0x20c0000000000000000000000000000000000002',
+  validatorTokenAmount: 1_000_000000n,
+})
+
+console.log('LP shares minted to treasury:', liquidity)
+// @log: LP shares minted to treasury: 1000000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.rebalanceSwap.mdx
+++ b/site/pages/tempo/actions/amm.rebalanceSwap.mdx
@@ -52,6 +52,69 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.amm.rebalanceSwap.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Size a Rebalance from Pool Reserves
+
+Combine [`amm.getPool`](/tempo/actions/amm.getPool) with `rebalanceSwapSync` to withdraw the user tokens that fee flows accumulated and restore the pool's validator reserve.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const userToken = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+
+const pool = await client.amm.getPool({ userToken, validatorToken }) // [!code focus]
+
+// Half the reserve gap restores parity: the swap adds validator
+// tokens and removes user tokens in roughly equal measure.
+const amountOut = // [!code focus]
+  (pool.reserveUserToken - pool.reserveValidatorToken) / 2n // [!code focus]
+
+if (amountOut > 0n) {
+  await client.amm.rebalanceSwapSync({
+    amountOut, // [!code focus]
+    to: client.account.address,
+    userToken,
+    validatorToken,
+  })
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Record the Cost of a Rebalance
+
+Read `amountIn` from the result to book the validator tokens the swap pulled against the user tokens received.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { amountIn, amountOut } = await client.amm.rebalanceSwapSync({ // [!code focus]
+  amountOut: 1_000_000000n,
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  userToken: '0x20c0000000000000000000000000000000000001',
+  validatorToken: '0x20c0000000000000000000000000000000000002',
+})
+
+console.log('Spent:', amountIn, 'Received:', amountOut) // [!code focus]
+// @log: Spent: 1001000000n Received: 1000000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/amm.watchBurn.mdx
+++ b/site/pages/tempo/actions/amm.watchBurn.mdx
@@ -28,6 +28,62 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchBurn(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Alert on Large Exits from Your Token's Pool
+
+Filter `args.userToken` to the stablecoin you issue and flag large withdrawals early: fee payments in that token stall once its pool drains.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const watcher = client.amm.watchBurn({
+  args: { userToken: alphaUsd }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (log.args.amountUserToken > 10_000_000000n) // [!code focus]
+      console.log('Large exit:', log.args.sender, log.args.amountUserToken) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Record Your Own Withdrawals in Order
+
+Consume the watcher as an async iterator to record your own burns sequentially, so each ledger write completes before the next batch is handled.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.amm.watchBurn({
+  args: { sender: client.account.address }, // [!code focus]
+})
+
+for await (const { logs } of watcher) { // [!code focus]
+  for (const log of logs)
+    console.log('Recorded:', log.args.liquidity, log.args.amountUserToken)
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.watchMint.mdx
+++ b/site/pages/tempo/actions/amm.watchMint.mdx
@@ -28,6 +28,61 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchMint(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Confirm Treasury LP Deposits
+
+Filter `args.to` to the treasury when several operator wallets fund pools, so a dashboard only processes deposits that credit the treasury.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.amm.watchMint({
+  args: { to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log('Deposit:', log.args.sender, log.args.liquidity)
+  // @log: Deposit: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 1000000n
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Resume Watching from the Last Processed Block
+
+Pass `fromBlock` when an indexer restarts, so mints emitted while it was offline are replayed before live events.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Last block the indexer processed, loaded from its store.
+const lastProcessedBlock = 1_204_320n
+
+const watcher = client.amm.watchMint({
+  fromBlock: lastProcessedBlock + 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log(log.blockNumber, log.args.liquidity)
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/amm.watchRebalanceSwap.mdx
+++ b/site/pages/tempo/actions/amm.watchRebalanceSwap.mdx
@@ -28,6 +28,65 @@ watcher.off()
 
 Also callable standalone: `Actions.amm.watchRebalanceSwap(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Monitor Arbitrage Flow Through a Pool
+
+Filter `args.userToken` and `args.validatorToken` to a pool you provide liquidity for, so you can track each rebalance and who performed it.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.amm.watchRebalanceSwap({
+  args: { // [!code focus]
+    userToken: '0x20c0000000000000000000000000000000000001', // [!code focus]
+    validatorToken: '0x20c0000000000000000000000000000000000002', // [!code focus]
+  }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log('Rebalance:', log.args.swapper, log.args.amountIn)
+  // @log: Rebalance: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 1001000n
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Refresh Reserve Metrics on Each Rebalance
+
+Combine the watcher with [`amm.getPool`](/tempo/actions/amm.getPool) to re-read reserves whenever a swap lands, keeping reserve metrics current without polling.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const userToken = '0x20c0000000000000000000000000000000000001'
+const validatorToken = '0x20c0000000000000000000000000000000000002'
+
+const watcher = client.amm.watchRebalanceSwap({
+  args: { userToken, validatorToken },
+})
+
+watcher.onLogs(async () => { // [!code focus]
+  const pool = await client.amm.getPool({ userToken, validatorToken }) // [!code focus]
+  console.log('Reserves:', pool.reserveUserToken, pool.reserveValidatorToken) // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/channel.close.mdx
+++ b/site/pages/tempo/actions/channel.close.mdx
@@ -70,6 +70,81 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.close.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Capture Only the Unsettled Remainder
+
+Combine [`channel.getStates`](/tempo/actions/channel.getStates) with `captureAmount` to take what earlier settlements have not yet paid out when closing on the final voucher.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: client.account.address,
+  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Final voucher received from the payer.
+const cumulativeAmount = 75_000000n
+
+const state = await client.channel.getStates({ channel }) // [!code focus]
+
+await client.channel.closeSync({
+  captureAmount: cumulativeAmount - state.settled, // [!code focus]
+  cumulativeAmount,
+  channel,
+  signature: '0x...',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Refund Part of a Tab at Close
+
+Pass a `captureAmount` below the voucher's `cumulativeAmount` to return the difference to the payer, resolving a dispute or refund without a separate transfer.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+// Channel opened with a 100 pathUSD deposit.
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: client.account.address,
+  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+const { settledToPayee, refundedToPayer } = await client.channel.closeSync({
+  captureAmount: 65_000000n, // [!code focus]
+  cumulativeAmount: 80_000000n, // [!code focus]
+  channel,
+  signature: '0x...',
+})
+
+console.log({ settledToPayee, refundedToPayer })
+// @log: { settledToPayee: 65000000n, refundedToPayer: 35000000n }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.getStates.mdx
+++ b/site/pages/tempo/actions/channel.getStates.mdx
@@ -24,6 +24,61 @@ console.log('Channel state:', state)
 
 :::
 
+## Recipes
+
+### Audit Capacity Across Many Channels
+
+Pass a list of channel IDs to read every state in one call, then compare deposits against settled amounts to find channels that need a top-up.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const states = await client.channel.getStates({
+  channel: [ // [!code focus]
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', // [!code focus]
+    '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890', // [!code focus]
+  ], // [!code focus]
+})
+
+const remaining = states.map((state) => state.deposit - state.settled) // [!code focus]
+
+console.log('Remaining capacity:', remaining)
+// @log: Remaining capacity: [60000000n, 25000000n]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Alert the Payee When a Close Is Requested
+
+Poll `closeRequestedAt` to detect a payer's close request; a non-zero value starts the window to settle the final voucher with [`channel.settle`](/tempo/actions/channel.settle).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const state = await client.channel.getStates({
+  channel: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+})
+
+if (state.closeRequestedAt > 0) { // [!code focus]
+  const deadline = BigInt(state.closeRequestedAt) + Channel.closeGracePeriod // [!code focus]
+  console.log('Settle vouchers before:', new Date(Number(deadline) * 1000))
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
 
 ## Return Value
 

--- a/site/pages/tempo/actions/channel.open.mdx
+++ b/site/pages/tempo/actions/channel.open.mdx
@@ -50,6 +50,84 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.open.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Open a Channel and Sign the First Voucher
+
+Combine `channel.openSync` with [`channel.signVoucher`](/tempo/actions/channel.signVoucher) to start paying for a metered service the moment the channel exists.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { channelId } = await client.channel.openSync({ // [!code focus]
+  deposit: 100_000000n,
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+const signature = await client.channel.signVoucher({ // [!code focus]
+  channel: channelId, // [!code focus]
+  cumulativeAmount: 1_000000n, // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Delegate Voucher Signing to a Hot Key
+
+Pass `authorizedSigner` when a dedicated service key signs vouchers through [`channel.signVoucher`](/tempo/actions/channel.signVoucher)'s `account` option, keeping the treasury key that funded the channel offline.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+await client.channel.openSync({
+  authorizedSigner: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  deposit: 500_000000n,
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Run a Channel per Project with Deterministic Salts
+
+Derive `salt` from an internal identifier to keep several channels open to the same payee and token, one per project, with reproducible channel identities.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Hex } from 'viem/utils'
+import { client } from './viem.config'
+
+const projectId = 'project-atlas'
+
+const { channelId } = await client.channel.openSync({
+  deposit: 100_000000n,
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  salt: Hex.fromString(projectId, { size: 32 }), // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.requestClose.mdx
+++ b/site/pages/tempo/actions/channel.requestClose.mdx
@@ -64,6 +64,89 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.requestClose.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Reclaim Deposit from an Unresponsive Payee
+
+Combine `channel.requestCloseSync` with [`channel.withdraw`](/tempo/actions/channel.withdraw) to recover funds unilaterally; the returned `closeGraceEnd` tells you when withdrawal unlocks.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: client.account.address,
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+const { closeGraceEnd } = await client.channel.requestCloseSync({ channel }) // [!code focus]
+
+const delay = closeGraceEnd * 1000n - BigInt(Date.now()) // [!code focus]
+setTimeout(async () => { // [!code focus]
+  await client.channel.withdrawSync({ channel }) // [!code focus]
+}, Number(delay)) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Give the Payee Notice to Settle
+
+The close request doubles as on-chain notice: the payee detects it with [`channel.getStates`](/tempo/actions/channel.getStates) and settles the final voucher via [`channel.settle`](/tempo/actions/channel.settle) before withdrawal unlocks.
+
+:::code-group
+
+```ts twoslash [payer.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+await client.channel.requestCloseSync({ channel }) // [!code focus]
+```
+
+```ts twoslash [payee.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+const state = await client.channel.getStates({ channel }) // [!code focus]
+
+if (state.closeRequestedAt > 0) // [!code focus]
+  await client.channel.settleSync({ // [!code focus]
+    cumulativeAmount: 40_000000n, // [!code focus]
+    channel, // [!code focus]
+    signature: '0x...', // [!code focus]
+  }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.settle.mdx
+++ b/site/pages/tempo/actions/channel.settle.mdx
@@ -68,6 +68,79 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.settle.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Settle Before the Deposit Cap Is Reached
+
+Combine [`channel.getStates`](/tempo/actions/channel.getStates) with a capacity check to capture what you are owed before signed vouchers approach the channel's deposit cap.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: client.account.address,
+  payer: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Latest voucher received from the payer.
+const voucher = { cumulativeAmount: 90_000000n, signature: '0x...' } as const
+
+const state = await client.channel.getStates({ channel }) // [!code focus]
+
+if (voucher.cumulativeAmount >= (state.deposit * 8n) / 10n) // [!code focus]
+  await client.channel.settleSync({ // [!code focus]
+    cumulativeAmount: voucher.cumulativeAmount, // [!code focus]
+    channel, // [!code focus]
+    signature: voucher.signature, // [!code focus]
+  }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Settle for a Merchant as the Channel Operator
+
+Use an operator account, set through [`channel.open`](/tempo/actions/channel.open)'s `operator` option, to submit settlements for payees that do not transact themselves.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+// This client is the platform backend acting as the channel's operator.
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  operator: client.account.address, // [!code focus]
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Voucher forwarded by the merchant (the payee).
+const { newSettled } = await client.channel.settleSync({
+  cumulativeAmount: 40_000000n,
+  channel,
+  signature: '0x...',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.signVoucher.mdx
+++ b/site/pages/tempo/actions/channel.signVoucher.mdx
@@ -23,6 +23,61 @@ console.log('Signature:', signature)
 
 :::
 
+## Recipes
+
+### Meter Usage with a Running Cumulative Total
+
+Sign a voucher for the new running total after each unit of usage; each voucher supersedes the last, so the payee only keeps the latest one.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pricePerRequest = 10_000n
+let cumulativeAmount = 0n
+
+async function payForRequest() {
+  cumulativeAmount += pricePerRequest // [!code focus]
+  const signature = await client.channel.signVoucher({
+    channel: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    cumulativeAmount, // [!code focus]
+  })
+  // Hand the voucher to the payee off-chain.
+  return { cumulativeAmount, signature } // [!code focus]
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sign with a Delegated Hot Key
+
+Pass `account` to sign with the channel's authorized signer instead of the client account, as configured through [`channel.open`](/tempo/actions/channel.open)'s `authorizedSigner` option.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const hotKey = Account.fromSecp256k1('0x...') // [!code focus]
+
+const signature = await client.channel.signVoucher({
+  account: hotKey, // [!code focus]
+  channel: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  cumulativeAmount: 40_000000n,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
 
 ## Return Value
 

--- a/site/pages/tempo/actions/channel.topUp.mdx
+++ b/site/pages/tempo/actions/channel.topUp.mdx
@@ -66,6 +66,86 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.topUp.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Keep a Metered Channel Funded
+
+Combine [`channel.getStates`](/tempo/actions/channel.getStates) with a headroom check to refill before signed vouchers exhaust the deposit, so payments never stall mid-stream.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: client.account.address,
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Highest cumulative amount you have signed so far.
+const lastSignedCumulative = 88_000000n
+
+const state = await client.channel.getStates({ channel }) // [!code focus]
+
+if (state.deposit - lastSignedCumulative < 20_000000n) // [!code focus]
+  await client.channel.topUpSync({ // [!code focus]
+    additionalDeposit: 100_000000n, // [!code focus]
+    channel, // [!code focus]
+  }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Cover an Invoice That Exceeds the Deposit
+
+Size `additionalDeposit` to the exact shortfall before signing a voucher above the current deposit with [`channel.signVoucher`](/tempo/actions/channel.signVoucher).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: client.account.address,
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Next voucher total, including the new invoice.
+const cumulativeAmount = 150_000000n
+
+const state = await client.channel.getStates({ channel })
+const shortfall = cumulativeAmount - state.deposit // [!code focus]
+
+if (shortfall > 0n)
+  await client.channel.topUpSync({
+    additionalDeposit: shortfall, // [!code focus]
+    channel,
+  })
+
+const signature = await client.channel.signVoucher({ // [!code focus]
+  channel,
+  cumulativeAmount,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/channel.withdraw.mdx
+++ b/site/pages/tempo/actions/channel.withdraw.mdx
@@ -64,6 +64,81 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.channel.withdraw.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Withdraw as Soon as the Grace Period Elapses
+
+Check [`channel.getStates`](/tempo/actions/channel.getStates) against `Channel.closeGracePeriod` to withdraw the moment a requested close matures, without persisting the grace end timestamp yourself.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+const channel = Channel.from({
+  expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  payee: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  payer: client.account.address,
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+const state = await client.channel.getStates({ channel }) // [!code focus]
+const graceEnd = BigInt(state.closeRequestedAt) + Channel.closeGracePeriod // [!code focus]
+const now = BigInt(Math.floor(Date.now() / 1000))
+
+if (state.closeRequestedAt > 0 && now >= graceEnd) // [!code focus]
+  await client.channel.withdrawSync({ channel }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sweep Matured Channels Across Vendors
+
+Combine a batched [`channel.getStates`](/tempo/actions/channel.getStates) read with a withdrawal loop to reclaim deposits from every channel whose close timer has elapsed.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Channel } from 'viem/tempo'
+import { client } from './viem.config'
+
+// One channel per vendor, all previously close-requested.
+const vendors = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+const channels = vendors.map((payee) =>
+  Channel.from({
+    expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    payee,
+    payer: client.account.address,
+    salt: '0x0000000000000000000000000000000000000000000000000000000000000101',
+    token: '0x20c0000000000000000000000000000000000000',
+  }),
+)
+
+const states = await client.channel.getStates({ channel: channels }) // [!code focus]
+
+const now = BigInt(Math.floor(Date.now() / 1000))
+for (const [i, state] of states.entries()) { // [!code focus]
+  if (state.closeRequestedAt === 0) continue
+  if (now < BigInt(state.closeRequestedAt) + Channel.closeGracePeriod) continue
+  await client.channel.withdrawSync({ channel: channels[i] }) // [!code focus]
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.buy.mdx
+++ b/site/pages/tempo/actions/dex.buy.mdx
@@ -28,6 +28,83 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
+## Recipes
+
+### Derive the Slippage Bound from a Fresh Quote
+
+Combine [`dex.getBuyQuote`](/tempo/actions/dex.getBuyQuote) with `dex.buySync` to derive `maxAmountIn` from the live price instead of guessing a limit.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const invoice = 250_000000n
+
+const quote = await client.dex.getBuyQuote({ // [!code focus]
+  amountOut: invoice, // [!code focus]
+  tokenIn: pathUsd, // [!code focus]
+  tokenOut: alphaUsd, // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.dex.buySync({
+  amountOut: invoice,
+  maxAmountIn: (quote * 1_005n) / 1_000n, // [!code focus]
+  tokenIn: pathUsd,
+  tokenOut: alphaUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The bound above tolerates 0.5% of price movement between the quote and the swap. The buy reverts instead of overpaying if the price moves further.
+
+### Pay an Invoice in a Stablecoin You Don't Hold
+
+Batch the buy with [`dex.withdraw`](/tempo/actions/dex.withdraw) and [`token.transfer`](/tempo/actions/token.transfer) to convert, withdraw, and pay an exact invoice in one atomic transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const invoice = 250_000000n
+
+const receipt = await client.transaction.sendSync({
+  calls: [
+    Actions.dex.buy.call({ // [!code focus]
+      amountOut: invoice, // [!code focus]
+      maxAmountIn: 251_000000n, // [!code focus]
+      tokenIn: pathUsd, // [!code focus]
+      tokenOut: alphaUsd, // [!code focus]
+    }), // [!code focus]
+    Actions.dex.withdraw.call({ amount: invoice, token: alphaUsd }), // [!code focus]
+    Actions.token.transfer.call({ // [!code focus]
+      amount: invoice, // [!code focus]
+      to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      token: alphaUsd, // [!code focus]
+    }), // [!code focus]
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.cancel.mdx
+++ b/site/pages/tempo/actions/dex.cancel.mdx
@@ -43,6 +43,60 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.cancel.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Reprice an Order Atomically
+
+Combine `cancel` with [`dex.place`](/tempo/actions/dex.place) in one transaction so the old quote leaves the book at the same moment the new one lands.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions, Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const receipt = await client.transaction.sendSync({
+  calls: [
+    Actions.dex.cancel.call({ orderId: 123n }), // [!code focus]
+    Actions.dex.place.call({ // [!code focus]
+      amount: 100_000000n, // [!code focus]
+      tick: Tick.fromPrice('0.998'), // [!code focus]
+      token: '0x20c0000000000000000000000000000000000001', // [!code focus]
+      type: 'buy', // [!code focus]
+    }), // [!code focus]
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Pull Every Open Quote at Once
+
+Map your tracked order ids into a single batch to pull every quote in one transaction, for example when a pair moves off peg.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const openOrderIds = [123n, 124n, 125n]
+
+const receipt = await client.transaction.sendSync({
+  calls: openOrderIds.map((orderId) => Actions.dex.cancel.call({ orderId })), // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.cancelStale.mdx
+++ b/site/pages/tempo/actions/dex.cancelStale.mdx
@@ -43,6 +43,65 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.cancelStale.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Skip Cancels That Would Revert
+
+Simulate the cancel first: `cancelStaleOrder` reverts for healthy orders, so a keeper can filter candidates before paying for a transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const orderId = 123n
+
+// Throws if the order is still backed by balance and allowance.
+await Actions.dex.cancelStale.simulate(client, { orderId }) // [!code focus]
+
+const { orderId: cancelled } = await client.dex.cancelStaleSync({ orderId })
+
+console.log('Cleared stale order:', cancelled)
+// @log: Cleared stale order: 123n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sweep a Price Level for Stale Orders
+
+Combine [`dex.getTickLevel`](/tempo/actions/dex.getTickLevel) with [`dex.getOrder`](/tempo/actions/dex.getOrder) to walk every order resting at a tick and clear the ones no longer backed.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const level = await client.dex.getTickLevel({
+  base: '0x20c0000000000000000000000000000000000001',
+  isBid: true,
+  tick: -100,
+})
+
+let orderId = level.head // [!code focus]
+while (orderId !== 0n) { // [!code focus]
+  const order = await client.dex.getOrder({ orderId }) // [!code focus]
+  // Healthy orders revert; skip them. // [!code focus]
+  await client.dex.cancelStaleSync({ orderId }).catch(() => {}) // [!code focus]
+  orderId = order.next // [!code focus]
+} // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.createPair.mdx
+++ b/site/pages/tempo/actions/dex.createPair.mdx
@@ -43,6 +43,61 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.createPair.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### List a Newly Issued Stablecoin
+
+Combine [`token.create`](/tempo/actions/token.create) with `createPairSync` to issue a stablecoin and open its market against the default quote token in one flow.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { token } = await client.token.createSync({ // [!code focus]
+  currency: 'USD',
+  name: 'Alpha USD',
+  symbol: 'AUSD',
+})
+
+const { key, quote } = await client.dex.createPairSync({ base: token }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Seed a New Pair with Resting Liquidity
+
+A new pair opens with an empty book, so seed it with a [`dex.placeFlip`](/tempo/actions/dex.placeFlip) order that keeps quoting both sides as it fills.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const { base } = await client.dex.createPairSync({ base: alphaUsd })
+
+const { orderId } = await client.dex.placeFlipSync({ // [!code focus]
+  amount: 25_000_000000n, // [!code focus]
+  flipTick: Tick.fromPrice('1.001'), // [!code focus]
+  tick: Tick.fromPrice('0.999'), // [!code focus]
+  token: base, // [!code focus]
+  type: 'buy', // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getBalance.mdx
+++ b/site/pages/tempo/actions/dex.getBalance.mdx
@@ -26,6 +26,62 @@ console.log('DEX balance:', balance)
 
 :::
 
+## Recipes
+
+### Reconcile Wallet and Exchange Holdings
+
+Combine `dex.getBalance` with [`token.getBalance`](/tempo/actions/token.getBalance) to report where a token's funds sit before closing the books.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const onDex = await client.dex.getBalance({ token: pathUsd }) // [!code focus]
+const inWallet = await client.token.getBalance({ token: pathUsd }) // [!code focus]
+
+console.log('Total holdings:', onDex + inWallet.amount) // [!code focus]
+// @log: Total holdings: 350000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Spot Funds Left on the Exchange
+
+Map every token you trade through `dex.getBalance` to find balances worth [withdrawing](/tempo/actions/dex.withdraw) after a trading session.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const tokens = [
+  '0x20c0000000000000000000000000000000000000',
+  '0x20c0000000000000000000000000000000000001',
+] as const
+
+const balances = await Promise.all( // [!code focus]
+  tokens.map(async (token) => ({ // [!code focus]
+    balance: await client.dex.getBalance({ token }), // [!code focus]
+    token, // [!code focus]
+  })), // [!code focus]
+) // [!code focus]
+
+const idle = balances.filter(({ balance }) => balance > 0n)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getBuyQuote.mdx
+++ b/site/pages/tempo/actions/dex.getBuyQuote.mdx
@@ -27,6 +27,41 @@ console.log('Amount in:', amountIn)
 
 :::
 
+## Recipes
+
+### Fund an Exact Invoice Payment
+
+Combine `dex.getBuyQuote` with [`dex.buySync`](/tempo/actions/dex.buy) to pay an invoice denominated in a token you do not hold, deriving `maxAmountIn` from a fresh quote plus a tolerance.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const invoiceAmount = 2_500_000000n
+
+const amountIn = await client.dex.getBuyQuote({ // [!code focus]
+  amountOut: invoiceAmount, // [!code focus]
+  tokenIn: pathUsd, // [!code focus]
+  tokenOut: alphaUsd, // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.dex.buySync({
+  amountOut: invoiceAmount,
+  maxAmountIn: (amountIn * 1_005n) / 1_000n, // quote + 0.5% tolerance // [!code focus]
+  tokenIn: pathUsd,
+  tokenOut: alphaUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getOrder.mdx
+++ b/site/pages/tempo/actions/dex.getOrder.mdx
@@ -25,6 +25,64 @@ console.log('Order:', order)
 
 :::
 
+## Recipes
+
+### Show Fill Progress in an Order Status UI
+
+Use `amount` and `remaining` to derive how much of a resting order has filled, and `Tick.toPrice` to render its price for display.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const order = await client.dex.getOrder({ orderId: 123n })
+
+const filled = order.amount - order.remaining // [!code focus]
+const progress = Number((filled * 100n) / order.amount) // [!code focus]
+
+console.log(
+  `${order.isBid ? 'Buy' : 'Sell'} @ ${Tick.toPrice(order.tick)}: ${progress}% filled`,
+)
+// @log: Buy @ 1.001: 40% filled
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Reprice an Order by Re-Posting the Remainder
+
+Combine `dex.getOrder` with [`dex.cancelSync`](/tempo/actions/dex.cancel) and [`dex.placeSync`](/tempo/actions/dex.place) to pull a stale order and re-post its unfilled remainder at a new price.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const order = await client.dex.getOrder({ orderId: 123n })
+
+if (order.remaining > 0n) { // [!code focus]
+  await client.dex.cancelSync({ orderId: order.orderId })
+  await client.dex.placeSync({
+    amount: order.remaining, // [!code focus]
+    tick: Tick.fromPrice('0.999'), // [!code focus]
+    token: '0x20c0000000000000000000000000000000000001',
+    type: order.isBid ? 'buy' : 'sell', // [!code focus]
+  })
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getOrderbook.mdx
+++ b/site/pages/tempo/actions/dex.getOrderbook.mdx
@@ -26,6 +26,67 @@ console.log('Orderbook:', orderbook)
 
 :::
 
+## Recipes
+
+### Display Top-of-Book Prices and the Spread
+
+Use `Tick.toPrice` to convert the best ticks into quoted prices and derive the spread (one tick is 0.1 basis points) for a market dashboard.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const book = await client.dex.getOrderbook({
+  base: '0x20c0000000000000000000000000000000000001',
+  quote: '0x20c0000000000000000000000000000000000000',
+})
+
+const bid = Tick.toPrice(book.bestBidTick) // [!code focus]
+const ask = Tick.toPrice(book.bestAskTick) // [!code focus]
+const spreadBps = (book.bestAskTick - book.bestBidTick) / 10 // [!code focus]
+
+console.log(`Bid ${bid} / Ask ${ask} / Spread ${spreadBps} bps`)
+// @log: Bid 0.999 / Ask 1.001 / Spread 20 bps
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sample Bid Depth for a Depth Chart
+
+Combine `dex.getOrderbook` with [`dex.getTickLevel`](/tempo/actions/dex.getTickLevel) to read resting liquidity below the best bid, stepping by the 10-tick (1 basis point) grid orders rest on.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const base = '0x20c0000000000000000000000000000000000001'
+
+const book = await client.dex.getOrderbook({
+  base,
+  quote: '0x20c0000000000000000000000000000000000000',
+})
+
+const depth = []
+for (let i = 0; i < 5; i++) {
+  const tick = book.bestBidTick - i * 10 // [!code focus]
+  const level = await client.dex.getTickLevel({ base, isBid: true, tick }) // [!code focus]
+  depth.push({ tick, liquidity: level.totalLiquidity }) // [!code focus]
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getSellQuote.mdx
+++ b/site/pages/tempo/actions/dex.getSellQuote.mdx
@@ -27,6 +27,71 @@ console.log('Amount out:', amountOut)
 
 :::
 
+## Recipes
+
+### Convert an Entire Balance with a Slippage Bound
+
+Combine `dex.getSellQuote` with [`token.getBalance`](/tempo/actions/token.getBalance) and [`dex.sellSync`](/tempo/actions/dex.sell) to sweep a full balance into your settlement token, bounding the output with a fresh quote.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const balance = await client.token.getBalance({ token: alphaUsd }) // [!code focus]
+
+const quote = await client.dex.getSellQuote({ // [!code focus]
+  amountIn: balance.amount, // [!code focus]
+  tokenIn: alphaUsd, // [!code focus]
+  tokenOut: pathUsd, // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.dex.sellSync({
+  amountIn: balance.amount,
+  minAmountOut: (quote * 995n) / 1_000n, // quote - 0.5% tolerance // [!code focus]
+  tokenIn: alphaUsd,
+  tokenOut: pathUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Halt Automated Conversions When the Rate Drifts
+
+Use a fixed probe quote to derive the pair's effective conversion rate, and pause scheduled conversions when it moves past your tolerance.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const probeAmount = 10_000_000000n
+
+const amountOut = await client.dex.getSellQuote({
+  amountIn: probeAmount,
+  tokenIn: '0x20c0000000000000000000000000000000000001',
+  tokenOut: '0x20c0000000000000000000000000000000000000',
+})
+
+const rateBps = (amountOut * 10_000n) / probeAmount // [!code focus]
+
+if (rateBps < 9_980n) // [!code focus]
+  throw new Error(`alphaUSD rate ${rateBps} bps: pausing conversions`) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.getTickLevel.mdx
+++ b/site/pages/tempo/actions/dex.getTickLevel.mdx
@@ -27,6 +27,63 @@ console.log('Tick level:', level)
 
 :::
 
+## Recipes
+
+### Check Liquidity at a Target Price
+
+Use `Tick.fromPrice` to address a level by its human-readable price and read `totalLiquidity` before resting an order there: orders already at the tick fill ahead of yours.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const level = await client.dex.getTickLevel({
+  base: '0x20c0000000000000000000000000000000000001',
+  isBid: true,
+  tick: Tick.fromPrice('0.999'), // [!code focus]
+})
+
+console.log('Liquidity ahead:', level.totalLiquidity) // [!code focus]
+// @log: Liquidity ahead: 250000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Walk the Order Queue at a Tick
+
+Combine `dex.getTickLevel` with [`dex.getOrder`](/tempo/actions/dex.getOrder) to enumerate resting orders front to back, for example to find your queue position at a price level.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const level = await client.dex.getTickLevel({
+  base: '0x20c0000000000000000000000000000000000001',
+  isBid: true,
+  tick: -100,
+})
+
+let orderId = level.head // [!code focus]
+while (orderId !== 0n) { // [!code focus]
+  const order = await client.dex.getOrder({ orderId }) // [!code focus]
+  console.log(orderId, order.maker, order.remaining)
+  orderId = order.next // [!code focus]
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.place.mdx
+++ b/site/pages/tempo/actions/dex.place.mdx
@@ -49,6 +49,68 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.place.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Quote at a Human-Readable Price
+
+Use `Tick.fromPrice` to express the order price as a decimal string instead of computing raw ticks by hand.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const { orderId } = await client.dex.placeSync({
+  amount: 100_000000n,
+  tick: Tick.fromPrice('0.999'), // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  type: 'buy',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Rest Both Sides of the Spread in One Transaction
+
+Combine two `place` calls with [`transaction.sendSync`](/docs/actions/wallet/transaction/send) to quote a bid and an ask atomically when market making.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions, Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const receipt = await client.transaction.sendSync({
+  calls: [
+    Actions.dex.place.call({ // [!code focus]
+      amount: 5_000_000000n, // [!code focus]
+      tick: Tick.fromPrice('0.999'), // [!code focus]
+      token: alphaUsd, // [!code focus]
+      type: 'buy', // [!code focus]
+    }), // [!code focus]
+    Actions.dex.place.call({ // [!code focus]
+      amount: 5_000_000000n, // [!code focus]
+      tick: Tick.fromPrice('1.001'), // [!code focus]
+      token: alphaUsd, // [!code focus]
+      type: 'sell', // [!code focus]
+    }), // [!code focus]
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.placeFlip.mdx
+++ b/site/pages/tempo/actions/dex.placeFlip.mdx
@@ -51,6 +51,66 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.dex.placeFlip.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Capture the Spread on Every Fill
+
+Pass a `flipTick` on the opposite side of the peg so a filled bid re-posts as an ask, earning the spread without watching for fills.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const { orderId } = await client.dex.placeFlipSync({
+  amount: 10_000_000000n,
+  flipTick: Tick.fromPrice('1.001'), // [!code focus]
+  tick: Tick.fromPrice('0.999'), // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  type: 'buy',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Ladder Flip Orders Across Price Levels
+
+Combine `placeFlip` calls with [`transaction.sendSync`](/docs/actions/wallet/transaction/send) to deploy a ladder of flip orders at several ticks in one atomic transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const receipt = await client.transaction.sendSync({
+  calls: [-100, -200, -300].map((tick) => // [!code focus]
+    Actions.dex.placeFlip.call({ // [!code focus]
+      amount: 5_000_000000n, // [!code focus]
+      flipTick: -tick, // [!code focus]
+      tick, // [!code focus]
+      token: alphaUsd, // [!code focus]
+      type: 'buy', // [!code focus]
+    }), // [!code focus]
+  ), // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Each rung bids below the peg and flips to an ask the same distance above it once filled.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.sell.mdx
+++ b/site/pages/tempo/actions/dex.sell.mdx
@@ -28,6 +28,81 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
+## Recipes
+
+### Convert an Entire Merchant Balance
+
+Combine [`token.getBalance`](/tempo/actions/token.getBalance) with [`dex.getSellQuote`](/tempo/actions/dex.getSellQuote) to sweep a full stablecoin balance into your treasury token at a bounded price.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const { amount: amountIn } = await client.token.getBalance({ // [!code focus]
+  token: alphaUsd, // [!code focus]
+}) // [!code focus]
+
+const quote = await client.dex.getSellQuote({ // [!code focus]
+  amountIn, // [!code focus]
+  tokenIn: alphaUsd, // [!code focus]
+  tokenOut: pathUsd, // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.dex.sellSync({
+  amountIn,
+  minAmountOut: (quote * 995n) / 1_000n, // [!code focus]
+  tokenIn: alphaUsd,
+  tokenOut: pathUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Settle Proceeds Straight to Your Wallet
+
+Sell proceeds settle to your internal DEX balance, so batch the sell with [`dex.withdraw`](/tempo/actions/dex.withdraw) when you need funds in your wallet immediately.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const receipt = await client.transaction.sendSync({
+  calls: [
+    Actions.dex.sell.call({ // [!code focus]
+      amountIn: 1_000_000000n, // [!code focus]
+      minAmountOut: 995_000000n, // [!code focus]
+      tokenIn: alphaUsd, // [!code focus]
+      tokenOut: pathUsd, // [!code focus]
+    }), // [!code focus]
+    Actions.dex.withdraw.call({ // [!code focus]
+      amount: 995_000000n, // [!code focus]
+      token: pathUsd, // [!code focus]
+    }), // [!code focus]
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Withdraw the `minAmountOut` you are guaranteed to receive. Any excess output stays on your DEX balance.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/dex.watchFlipOrderPlaced.mdx
+++ b/site/pages/tempo/actions/dex.watchFlipOrderPlaced.mdx
@@ -39,6 +39,39 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchFlipOrderPlaced(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Monitor Two-Sided Liquidity Entering a Market
+
+Pass a `token` filter to see new flip orders in a pair you quote: each one is a maker committing liquidity to both sides of the spread.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Tick } from 'viem/tempo'
+import { client } from './viem.config'
+
+const watcher = client.dex.watchFlipOrderPlaced({
+  args: { token: '0x20c0000000000000000000000000000000000001' }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const { amount, flipTick, maker, tick } = log.args
+    console.log(
+      `${maker}: ${amount} at ${Tick.toPrice(tick)}, flips to ${Tick.toPrice(flipTick)}`, // [!code focus]
+    )
+    // @log: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: 100000000 at 0.999, flips to 1.001
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderCancelled.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderCancelled.mdx
@@ -30,6 +30,35 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderCancelled(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Detect Cancellations You Did Not Initiate
+
+Filter by your tracked order IDs to keep an open-orders store accurate: anyone can clear stale orders with [`dex.cancelStale`](/tempo/actions/dex.cancelStale), so cancellations can happen without your involvement.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const openOrderIds = [123n, 456n]
+
+const watcher = client.dex.watchOrderCancelled({
+  args: { orderId: openOrderIds }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log('Remove from store:', log.args.orderId) // [!code focus]
+  // @log: Remove from store: 123n
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderFilled.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderFilled.mdx
@@ -34,6 +34,64 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderFilled(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Update Order Status as Fills Land
+
+Pass a `maker` filter to receive only fills of your own orders, and branch on `partialFill` to mark them partially or fully filled in a status store.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.dex.watchOrderFilled({
+  args: { maker: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const { amountFilled, orderId, partialFill } = log.args
+    if (partialFill) console.log(`Order ${orderId}: filled ${amountFilled}`) // [!code focus]
+    else console.log(`Order ${orderId}: fully filled`) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Reconcile Fills After Downtime
+
+Pass `fromBlock` with the order IDs you track to replay fills that landed while your service was offline, then continue streaming live fills.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const openOrderIds = [123n, 456n, 789n]
+const lastProcessedBlock = 1_234_567n
+
+const watcher = client.dex.watchOrderFilled({
+  args: { orderId: openOrderIds }, // [!code focus]
+  fromBlock: lastProcessedBlock + 1n, // [!code focus]
+})
+
+for await (const { logs } of watcher) {
+  for (const log of logs) console.log(log.args.orderId, log.args.amountFilled)
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.watchOrderPlaced.mdx
+++ b/site/pages/tempo/actions/dex.watchOrderPlaced.mdx
@@ -37,6 +37,61 @@ watcher.off()
 
 Also callable standalone: `Actions.dex.watchOrderPlaced(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Record Order IDs as They Are Placed
+
+Pass a `maker` filter to capture the order IDs your trading service places, then persist them for later inspection or cancellation with [`dex.cancel`](/tempo/actions/dex.cancel).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.dex.watchOrderPlaced({
+  args: { maker: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log('Placed:', log.args.orderId, 'at tick', log.args.tick) // [!code focus]
+  // @log: Placed: 123n at tick 100
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Rebuild a Market Feed After a Restart
+
+Pass `fromBlock` with a `token` filter to replay placements missed while your indexer was offline, then continue streaming new ones.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const lastIndexedBlock = 1_234_567n
+
+const watcher = client.dex.watchOrderPlaced({
+  args: { token: '0x20c0000000000000000000000000000000000001' }, // [!code focus]
+  fromBlock: lastIndexedBlock + 1n, // [!code focus]
+})
+
+for await (const { logs } of watcher) {
+  for (const log of logs) console.log(log.blockNumber, log.args.orderId)
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/dex.withdraw.mdx
+++ b/site/pages/tempo/actions/dex.withdraw.mdx
@@ -26,6 +26,64 @@ console.log('Transaction hash:', receipt.transactionHash)
 
 :::
 
+## Recipes
+
+### Withdraw Your Full DEX Balance
+
+Read your internal balance with [`dex.getBalance`](/tempo/actions/dex.getBalance) first so the withdrawal amount matches what the exchange actually holds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const balance = await client.dex.getBalance({ token: pathUsd }) // [!code focus]
+
+const { receipt } = await client.dex.withdrawSync({
+  amount: balance, // [!code focus]
+  token: pathUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sweep Proceeds to a Treasury Wallet
+
+Withdrawals always land in the caller's wallet, so batch the withdrawal with [`token.transfer`](/tempo/actions/token.transfer) to forward funds to a treasury address atomically.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+const treasury = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const receipt = await client.transaction.sendSync({
+  calls: [
+    Actions.dex.withdraw.call({ amount: 250_000000n, token: pathUsd }), // [!code focus]
+    Actions.token.transfer.call({ // [!code focus]
+      amount: 250_000000n, // [!code focus]
+      to: treasury, // [!code focus]
+      token: pathUsd, // [!code focus]
+    }), // [!code focus]
+  ],
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.configureExitSafePolicy.mdx
@@ -31,6 +31,79 @@ const { policy, receipts } = await client.earn.configureExitSafePolicy({
 
 :::
 
+## Recipes
+
+### Protect a Vault Before Launch
+
+Resolve the share token with [`earn.getVault`](/tempo/actions/earn.getVault), then confirm the
+non-atomic setup with [`earn.validateExitSafePolicy`](/tempo/actions/earn.validateExitSafePolicy)
+before announcing the vault.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+const feeRecipient = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+const requiredMembers = [vault, feeRecipient] as const
+
+const { shareToken } = await client.earn.getVault({ vault }) // [!code focus]
+const { policy } = await client.earn.configureExitSafePolicy({
+  accessAdministrator: client.account.address,
+  initialMembers: requiredMembers, // [!code focus]
+  shareToken, // [!code focus]
+})
+
+await client.earn.validateExitSafePolicy({ // [!code focus]
+  accessAdministrator: client.account.address,
+  policy, // [!code focus]
+  requiredMembers,
+  shareToken,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Include every protocol address that must keep receiving Earn shares, such as the vault and active
+fee recipients. See [Protected Vaults](/tempo/guides/earn/protected-vaults) for the complete member
+checklist, and store the returned `policy` IDs with the deployment record.
+
+### Delegate Eligibility to a Compliance Team
+
+Pass an `accessAdministrator` other than the caller to hand whitelist control to the team that
+approves recipients. The action submits a fourth transaction transferring administration.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const complianceTeam = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const { receipts } = await client.earn.configureExitSafePolicy({
+  accessAdministrator: complianceTeam, // [!code focus]
+  initialMembers: ['0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'],
+  shareToken: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log(receipts.policyAdmin?.status) // [!code focus]
+// @log: success
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+After the transfer, only the administrator can update membership with
+[`policy.modifyWhitelist`](/tempo/actions/policy.modifyWhitelist).
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.deposit.mdx
+++ b/site/pages/tempo/actions/earn.deposit.mdx
@@ -80,6 +80,88 @@ const { args } = Actions.earn.deposit.extractEvent(receipt.logs, { vault })
 // @log: { assets: 100_000_000n, shares: 99_750_000n, ... }
 ```
 
+## Recipes
+
+### Sweep Idle Treasury into Yield
+
+Combine [`earn.getPosition`](/tempo/actions/earn.getPosition) with a deposit to move an account's
+full idle asset balance into the vault.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { assetBalance } = await client.earn.getPosition({ vault }) // [!code focus]
+
+const result = await client.earn.depositSync({
+  assetAmount: assetBalance, // [!code focus]
+  shareAmount: 12_437_500_000n, // provider quote for `assetBalance`
+  slippageBps: 50,
+  vault,
+})
+// @log: { assetAmount: 12_500_000_000n, shareAmount: 12_400_000_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Mint Earn Shares to a Cold Treasury
+
+Pass `recipient` when an operator wallet funds the position but a treasury address should hold the
+resulting Earn shares.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.earn.depositSync({
+  assetAmount: 5_000_000_000n,
+  recipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  shareAmountMin: 4_975_000_000n,
+  vault: '0x0000000000000000000000000000000000000001',
+})
+// @log: { recipient: '0x8ba1...BA72', shareAmount: 4_987_500_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The shares mint directly to the treasury; the operator account never holds them.
+
+### Deposit a Dollar-Denominated Amount
+
+Pass a formatted `assetAmount` when your accounting system works in display units; providing
+`decimals` skips the live decimals lookup.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.earn.depositSync({
+  assetAmount: { decimals: 6, formatted: '25000' }, // [!code focus]
+  shareAmountMin: 24_875_000_000n,
+  vault: '0x0000000000000000000000000000000000000001',
+})
+// @log: { assetAmount: 25_000_000_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.depositShares.mdx
+++ b/site/pages/tempo/actions/earn.depositShares.mdx
@@ -54,6 +54,80 @@ const hash = await client.earn.depositShares({
 // @log: 0x1234...abcd
 ```
 
+## Recipes
+
+### Confirm In-Kind Support Before Migrating
+
+Combine [`earn.getVault`](/tempo/actions/earn.getVault) with the deposit to verify the vault's
+venue integration accepts venue shares before moving a position.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000002'
+
+const { capabilities } = await client.earn.getVault({ vault }) // [!code focus]
+if (!capabilities.inKindDeposit) // [!code focus]
+  throw new Error('Vault does not accept venue share deposits.') // [!code focus]
+
+const result = await client.earn.depositSharesSync({
+  earnShareAmountMin: 497_000_000n,
+  vault,
+  venueShareAmount: 500_000_000n,
+  venueShareToken: '0x20c0000000000000000000000000000000000001',
+})
+// @log: { earnShareAmount: 498_750_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Quote the Migration Onchain
+
+Use [`contract.read`](/docs/actions/public/contract/read) with the vault's
+`convertEngineSharesToEarnShares` function to derive the Earn share quote from live vault
+accounting.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Abis } from 'viem/tempo'
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000002'
+const venueShareAmount = 500_000_000n
+
+const earnShareAmount = await client.contract.read({ // [!code focus]
+  abi: Abis.earnVault, // [!code focus]
+  address: vault, // [!code focus]
+  args: [venueShareAmount], // [!code focus]
+  functionName: 'convertEngineSharesToEarnShares', // [!code focus]
+}) // [!code focus]
+
+const result = await client.earn.depositSharesSync({
+  earnShareAmount,
+  slippageBps: 30,
+  vault,
+  venueShareAmount,
+  venueShareToken: '0x20c0000000000000000000000000000000000001',
+})
+// @log: { earnShareAmount: 498_750_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Quote immediately before submission; `slippageBps` absorbs small value changes between the read and
+the deposit.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getFeeState.mdx
+++ b/site/pages/tempo/actions/earn.getFeeState.mdx
@@ -52,6 +52,72 @@ const fees = await client.earn.getFeeState({
 
 :::
 
+## Recipes
+
+### Value Claimable Fee Revenue in Assets
+
+Combine `claimableShares` with [`earn.getRedeemQuote`](/tempo/actions/earn.getRedeemQuote) to
+report a fee recipient's accrued revenue in asset terms instead of shares.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { claimableShares } = await client.earn.getFeeState({ // [!code focus]
+  recipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  vault,
+})
+
+const revenue = await client.earn.getRedeemQuote({ // [!code focus]
+  shareAmount: claimableShares ?? 0n, // [!code focus]
+  vault,
+})
+// @log: 9_900_000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Detect Fee Configuration Changes
+
+Compare `configId` with the value recorded when the vault was approved to catch fee changes before
+committing more treasury funds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const approvedConfigId = 1n
+
+const feeState = await client.earn.getFeeState({
+  vault: '0x0000000000000000000000000000000000000001',
+})
+
+if (feeState.configId !== approvedConfigId) // [!code focus]
+  throw new Error('Fee configuration changed since approval.') // [!code focus]
+
+const totalFixedRate = feeState.config.fixedFees.reduce( // [!code focus]
+  (total, fee) => total + fee.rate,
+  0n,
+)
+// @log: 20_000_000_000_000_000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Fee rates are scaled to 18 decimals, so `20_000_000_000_000_000n` is a 2% fixed rate.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getPosition.mdx
+++ b/site/pages/tempo/actions/earn.getPosition.mdx
@@ -61,6 +61,71 @@ const position = await client.earn.getPosition({
 
 :::
 
+## Recipes
+
+### Fund a Payout from a Yield-Bearing Treasury
+
+Check `value` covers a payout before pulling it from the vault with
+[`earn.withdrawExactSync`](/tempo/actions/earn.withdrawExact), sending assets straight to the
+payee.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+const payout = 40_000_000n
+
+const position = await client.earn.getPosition({ vault }) // [!code focus]
+if (position.value < payout) // [!code focus]
+  throw new Error('Treasury position does not cover the payout.') // [!code focus]
+
+const result = await client.earn.withdrawExactSync({
+  assetAmount: payout,
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  slippageBps: 50,
+  vault,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Aggregate Positions Across Vaults
+
+Read every vault in parallel to build a treasury dashboard that totals current redeemable value.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vaults = [
+  '0x0000000000000000000000000000000000000001',
+  '0x0000000000000000000000000000000000000002',
+] as const
+
+const positions = await Promise.all( // [!code focus]
+  vaults.map((vault) => client.earn.getPosition({ vault })), // [!code focus]
+) // [!code focus]
+
+const totalValue = positions.reduce(
+  (total, position) => total + position.value,
+  0n,
+)
+// @log: 250_000_000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getRedeemQuote.mdx
+++ b/site/pages/tempo/actions/earn.getRedeemQuote.mdx
@@ -24,6 +24,75 @@ const assetAmount = await client.earn.getRedeemQuote({
 
 :::
 
+## Recipes
+
+### Confirm Proceeds Before a Full Exit
+
+Quote the entire balance from [`earn.getPosition`](/tempo/actions/earn.getPosition), display the
+proceeds, then pass the quote to [`earn.redeemSync`](/tempo/actions/earn.redeem) so execution
+cannot drift below the confirmed number.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { shareBalance } = await client.earn.getPosition({ vault })
+const assetAmount = await client.earn.getRedeemQuote({ // [!code focus]
+  shareAmount: shareBalance, // [!code focus]
+  vault, // [!code focus]
+}) // [!code focus]
+
+const result = await client.earn.redeemSync({
+  assetAmount, // [!code focus]
+  shareAmount: shareBalance,
+  slippageBps: 25, // [!code focus]
+  vault,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Batch Quotes Across Vaults
+
+Use `getRedeemQuote.call` with [`multicall`](/docs/actions/public/multicall) to compare redemption
+value across vaults in one round trip.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const shareAmount = 100_000_000n
+
+const { results } = await client.multicall({
+  allowFailure: false,
+  calls: [
+    client.earn.getRedeemQuote.call({ // [!code focus]
+      shareAmount, // [!code focus]
+      vault: '0x0000000000000000000000000000000000000001', // [!code focus]
+    }), // [!code focus]
+    client.earn.getRedeemQuote.call({
+      shareAmount,
+      vault: '0x0000000000000000000000000000000000000002',
+    }),
+  ],
+})
+// @log: [99_500_000n, 99_650_000n]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 `bigint`

--- a/site/pages/tempo/actions/earn.getVault.mdx
+++ b/site/pages/tempo/actions/earn.getVault.mdx
@@ -48,6 +48,70 @@ const vault = await client.earn.getVault({
 
 :::
 
+## Recipes
+
+### Gate Deposits on Vault Health
+
+Check `depositsPaused` and `isSynced` before routing customer funds into a vault with
+[`earn.depositSync`](/tempo/actions/earn.deposit).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vaultAddress = '0x0000000000000000000000000000000000000001'
+
+const vault = await client.earn.getVault({ vault: vaultAddress })
+if (vault.depositsPaused || !vault.isSynced) // [!code focus]
+  throw new Error('Vault is not accepting deposits.') // [!code focus]
+
+const result = await client.earn.depositSync({
+  assetAmount: 100_000_000n,
+  shareAmountMin: 99_500_000n,
+  vault: vaultAddress,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Check the matching field under `capabilities` before specialized entries and exits, such as venue
+share deposits or exact withdrawals.
+
+### Format Amounts with Token Metadata
+
+Combine `assetToken` and `shareToken` with
+[`token.getMetadata`](/tempo/actions/token.getMetadata) to resolve the symbols and decimals a
+dashboard needs to render vault balances.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = await client.earn.getVault({
+  vault: '0x0000000000000000000000000000000000000001',
+})
+
+const [asset, share] = await Promise.all([
+  client.token.getMetadata({ token: vault.assetToken }), // [!code focus]
+  client.token.getMetadata({ token: vault.shareToken }), // [!code focus]
+])
+
+console.log(`${share.symbol} is backed by ${asset.symbol}`)
+// @log: evUSD is backed by pathUSD
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.getWithdrawQuote.mdx
+++ b/site/pages/tempo/actions/earn.getWithdrawQuote.mdx
@@ -24,6 +24,45 @@ const shareAmount = await client.earn.getWithdrawQuote({
 
 :::
 
+## Recipes
+
+### Check Shares Cover an Invoice Payment
+
+Quote the shares an exact invoice amount requires, verify the position covers them with
+[`earn.getPosition`](/tempo/actions/earn.getPosition), then execute with
+[`earn.withdrawExactSync`](/tempo/actions/earn.withdrawExact) bound to the quote.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+const invoiceAmount = 250_000_000n
+
+const [shareAmount, position] = await Promise.all([
+  client.earn.getWithdrawQuote({ assetAmount: invoiceAmount, vault }), // [!code focus]
+  client.earn.getPosition({ vault }),
+])
+
+if (shareAmount > position.shareBalance) // [!code focus]
+  throw new Error('Position does not cover the invoice.') // [!code focus]
+
+const result = await client.earn.withdrawExactSync({
+  assetAmount: invoiceAmount,
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  shareAmount, // [!code focus]
+  slippageBps: 25, // [!code focus]
+  vault,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 `bigint`

--- a/site/pages/tempo/actions/earn.privateDeposit.mdx
+++ b/site/pages/tempo/actions/earn.privateDeposit.mdx
@@ -93,6 +93,139 @@ const prepared = await parentClient.earn.privateDeposit.prepare({
 When `assetToken` is the vault asset, the action always requires the exact withdrawn `assetAmount`.
 For swap-routed deposits, omitting `vaultAssetAmountMin` preserves the zero minimum.
 
+## Recipes
+
+### Await Vault Settlement Before Crediting
+
+Combine the deposit with [`earn.waitForPrivateDeposit`](/tempo/actions/earn.waitForPrivateDeposit)
+and [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) to credit a user only once
+the returned shares are usable in the Zone.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const gateway = '0x0000000000000000000000000000000000000001'
+const vault = '0x0000000000000000000000000000000000000002'
+
+const prepared = await parentClient.earn.privateDeposit.prepare({
+  assetAmount: 100_000_000n,
+  gateway,
+  recipient: zoneClient.account.address,
+  recoveryRecipient: parentClient.account.address,
+  shareAmountMin: 99_500_000n,
+  vault,
+  zoneId: 7,
+})
+await zoneClient.earn.privateDepositSync(prepared)
+
+const deposit = await parentClient.earn.waitForPrivateDeposit({ // [!code focus]
+  actionId: prepared.actionId, // [!code focus]
+  fromBlock: prepared.fromBlock, // [!code focus]
+  gateway, // [!code focus]
+  vault, // [!code focus]
+}) // [!code focus]
+// @log: { shares: 99_750_000n, tempoBlockNumber: 123456n, ... }
+
+await zoneClient.zone.waitForTempoBlock({ // [!code focus]
+  tempoBlockNumber: deposit.tempoBlockNumber, // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+See [Earn from a Private Zone](/tempo/guides/earn/zones) for the complete flow and its privacy
+boundary.
+
+### Tag Deposits for Treasury Reconciliation
+
+Supply your own `actionId` and a `withdrawalMemo` so the Zone withdrawal and its gateway callback
+correlate with an internal treasury record.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const prepared = await parentClient.earn.privateDeposit.prepare({
+  actionId: '0x00000000000000000000000000000000000000000000000000000000000004d2', // [!code focus]
+  assetAmount: 100_000_000n,
+  gateway: '0x0000000000000000000000000000000000000001',
+  recipient: zoneClient.account.address,
+  recoveryRecipient: parentClient.account.address,
+  shareAmountMin: 99_500_000n,
+  vault: '0x0000000000000000000000000000000000000002',
+  withdrawalMemo: '0x737765657020323032362d5133', // [!code focus]
+  zoneId: 7,
+})
+
+await zoneClient.earn.privateDepositSync(prepared)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+Persist `actionId` and `fromBlock` so a separate worker can pass them to
+`earn.waitForPrivateDeposit` later. Use `returnMemo` to attach the tag to the encrypted return
+deposit instead.
+
+### Route Callback Failures to a Monitored Wallet
+
+Set `fallbackRecipient` when a failed gateway callback should pay out to a monitored operations
+wallet on the public chain.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const prepared = await parentClient.earn.privateDeposit.prepare({
+  assetAmount: 100_000_000n,
+  fallbackRecipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  gateway: '0x0000000000000000000000000000000000000001',
+  recipient: zoneClient.account.address,
+  recoveryRecipient: parentClient.account.address,
+  shareAmountMin: 99_500_000n,
+  vault: '0x0000000000000000000000000000000000000002',
+  zoneId: 7,
+})
+
+const hash = await zoneClient.earn.privateDeposit(prepared)
+// @log: 0x1234...abcd
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+`fallbackRecipient` covers a failed parent-chain callback; `recoveryRecipient` still covers a
+failed encrypted return. Both addresses are public.
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.privateRedeem.mdx
+++ b/site/pages/tempo/actions/earn.privateRedeem.mdx
@@ -68,6 +68,87 @@ const hash = await zoneClient.earn.privateRedeem(prepared)
 // @log: 0x1234...abcd
 ```
 
+## Recipes
+
+### Redeem into a Different Zone Stablecoin
+
+Pass `assetToken` to swap the redeemed vault asset before it returns to the Zone, and bound the
+post-swap output with `assetAmountMin`.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const prepared = await parentClient.earn.privateRedeem.prepare({
+  assetAmountMin: 98_500_000n, // [!code focus]
+  assetToken: '0x20c0000000000000000000000000000000000001', // [!code focus]
+  gateway: '0x0000000000000000000000000000000000000001',
+  recipient: zoneClient.account.address,
+  recoveryRecipient: parentClient.account.address,
+  shareAmount: 100_000_000n,
+  vault: '0x0000000000000000000000000000000000000002',
+  zoneId: 7,
+})
+
+const { receipt } = await zoneClient.earn.privateRedeemSync(prepared)
+// @log: { transactionHash: '0x1234...abcd', ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+A live vault quote cannot price the swap, so set an explicit floor, or pass an alternate-asset
+quote as `assetAmount` with `slippageBps`.
+
+### Pay a Contractor Confidentially from Yield
+
+Set `recipient` to another Zone address to deliver the redeemed assets to a beneficiary whose
+balance stays private.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const contractor = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const prepared = await parentClient.earn.privateRedeem.prepare({
+  gateway: '0x0000000000000000000000000000000000000001',
+  recipient: contractor, // [!code focus]
+  recoveryRecipient: parentClient.account.address,
+  shareAmount: 100_000_000n,
+  slippageBps: 50,
+  vault: '0x0000000000000000000000000000000000000002',
+  zoneId: 7,
+})
+
+const { receipt } = await zoneClient.earn.privateRedeemSync(prepared)
+// @log: { transactionHash: '0x1234...abcd', ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+The submitting account supplies the shares and pays the withdrawal fee. The recipient is encrypted,
+while the amount, gateway, and timing remain public.
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.redeem.mdx
+++ b/site/pages/tempo/actions/earn.redeem.mdx
@@ -75,6 +75,63 @@ const hash = await client.earn.redeem({
 // @log: 0x1234...abcd
 ```
 
+## Recipes
+
+### Exit the Full Position
+
+Combine [`earn.getPosition`](/tempo/actions/earn.getPosition) with the redemption to burn every
+Earn share the account holds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { shareBalance } = await client.earn.getPosition({ vault }) // [!code focus]
+
+const result = await client.earn.redeemSync({
+  shareAmount: shareBalance, // [!code focus]
+  slippageBps: 50,
+  vault,
+})
+// @log: { assetAmount: 100_250_000n, shareAmount: 99_500_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Fund a Payroll Account from Yield
+
+Pass `recipient` to pay the redeemed assets straight to a disbursement address ahead of a payroll
+run.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.earn.redeemSync({
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  shareAmount: 52_000_000_000n,
+  slippageBps: 50,
+  vault: '0x0000000000000000000000000000000000000001',
+})
+// @log: { assetAmount: 52_130_000_000n, recipient: '0x742d...bEbb', ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The redemption still burns shares from the sending account; only the asset payout is redirected.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
+++ b/site/pages/tempo/actions/earn.validateExitSafePolicy.mdx
@@ -37,6 +37,83 @@ await client.earn.validateExitSafePolicy({
 
 :::
 
+## Recipes
+
+### Screen a Vault Before Listing It
+
+Validate a third-party vault against its published policy record before showing it to users.
+Resolve the live share token with [`earn.getVault`](/tempo/actions/earn.getVault).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { shareToken } = await client.earn.getVault({ vault }) // [!code focus]
+const listable = await client.earn
+  .validateExitSafePolicy({
+    accessAdministrator: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+    policy: {
+      transferPolicyId: 3n,
+      senderPolicyId: 1n,
+      recipientPolicyId: 2n,
+      mintRecipientPolicyId: 2n,
+    },
+    requiredMembers: [vault],
+    shareToken, // [!code focus]
+  })
+  .then(() => true) // [!code focus]
+  .catch(() => false) // [!code focus]
+// @log: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Revalidate After Membership Changes
+
+Rerun validation after every [`policy.modifyWhitelist`](/tempo/actions/policy.modifyWhitelist)
+update to catch accidental removal of a protocol recipient, such as the vault itself.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const vault = '0x0000000000000000000000000000000000000001'
+const shareToken = '0x20c0000000000000000000000000000000000001'
+const recipientPolicyId = 2n
+
+await client.policy.modifyWhitelistSync({ // [!code focus]
+  address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  allowed: false, // [!code focus]
+  policyId: recipientPolicyId,
+})
+
+await client.earn.validateExitSafePolicy({ // [!code focus]
+  accessAdministrator: client.account.address,
+  policy: {
+    transferPolicyId: 3n,
+    senderPolicyId: 1n,
+    recipientPolicyId,
+    mintRecipientPolicyId: recipientPolicyId,
+  },
+  requiredMembers: [vault], // [!code focus]
+  shareToken,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 `void`

--- a/site/pages/tempo/actions/earn.waitForPrivateDeposit.mdx
+++ b/site/pages/tempo/actions/earn.waitForPrivateDeposit.mdx
@@ -31,6 +31,73 @@ Use `tempoBlockNumber` from the result with
 [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) to confirm that the returned shares
 were imported by the Zone.
 
+## Recipes
+
+### Credit a Balance After Zone Import
+
+Combine the wait with [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) before
+treating the returned shares as spendable inside the Zone.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const deposit = await parentClient.earn.waitForPrivateDeposit({
+  actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  fromBlock: 123456n,
+  gateway: '0x0000000000000000000000000000000000000001',
+  vault: '0x0000000000000000000000000000000000000002',
+})
+// @log: { shares: 99_750_000n, tempoBlockNumber: 123456n, ... }
+
+await zoneClient.zone.waitForTempoBlock({ // [!code focus]
+  tempoBlockNumber: deposit.tempoBlockNumber, // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Handle Settlement Timeouts in a Worker
+
+Catch `WaitForPrivateDepositTimeoutError` to keep a settlement worker alive; the wait only scans
+logs, so retrying with the same fields is safe.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { WaitForPrivateDepositTimeoutError } from 'viem/tempo'
+import { client } from './viem.config'
+
+try {
+  await client.earn.waitForPrivateDeposit({
+    actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    fromBlock: 123456n,
+    gateway: '0x0000000000000000000000000000000000000001',
+    timeout: 300_000, // [!code focus]
+    vault: '0x0000000000000000000000000000000000000002',
+  })
+} catch (error) {
+  if (!(error instanceof WaitForPrivateDepositTimeoutError)) throw error // [!code focus]
+  // Settlement can still complete later; retry with the same fields.
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.waitForPrivateRedeem.mdx
+++ b/site/pages/tempo/actions/earn.waitForPrivateRedeem.mdx
@@ -31,6 +31,73 @@ Use `tempoBlockNumber` from the result with
 [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) to confirm that the returned assets
 were imported by the Zone.
 
+## Recipes
+
+### Release a Payout After Zone Import
+
+Combine the wait with [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) before
+notifying a payee that the redeemed funds are spendable in the Zone.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as parentClient } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const redemption = await parentClient.earn.waitForPrivateRedeem({
+  actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  fromBlock: 123456n,
+  gateway: '0x0000000000000000000000000000000000000001',
+  vault: '0x0000000000000000000000000000000000000002',
+})
+// @log: { outputAmount: 99_000_000n, tempoBlockNumber: 123457n, ... }
+
+await zoneClient.zone.waitForTempoBlock({ // [!code focus]
+  tempoBlockNumber: redemption.tempoBlockNumber, // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Reconcile Swap-Routed Redemptions
+
+Compare `vaultAssets` with `outputAmount` when the redemption swaps into another token, so your
+ledger records both the vault redemption and the swap output.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const redemption = await client.earn.waitForPrivateRedeem({
+  actionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  fromBlock: 123456n,
+  gateway: '0x0000000000000000000000000000000000000001',
+  vault: '0x0000000000000000000000000000000000000002',
+})
+
+console.log({
+  outputToken: redemption.outputToken, // [!code focus]
+  swapOutput: redemption.outputAmount, // [!code focus]
+  vaultAssetsRedeemed: redemption.vaultAssets, // [!code focus]
+})
+// @log: { outputToken: '0x20c0...0001', swapOutput: 98_920_000n, vaultAssetsRedeemed: 99_400_000n }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/earn.withdrawExact.mdx
+++ b/site/pages/tempo/actions/earn.withdrawExact.mdx
@@ -74,6 +74,69 @@ const hash = await client.earn.withdrawExact({
 // @log: 0x1234...abcd
 ```
 
+## Recipes
+
+### Skim Yield Above a Target Float
+
+Combine [`earn.getPosition`](/tempo/actions/earn.getPosition) with an exact withdrawal to pull only
+the value above a working balance target.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const target = 100_000_000_000n
+const vault = '0x0000000000000000000000000000000000000001'
+
+const { value } = await client.earn.getPosition({ vault }) // [!code focus]
+
+if (value > target) {
+  const result = await client.earn.withdrawExactSync({
+    assetAmount: value - target, // [!code focus]
+    slippageBps: 50,
+    vault,
+  })
+  // @log: { assetAmount: 1_250_000_000n, shareAmount: 1_243_800_000n, ... }
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+`value` already includes accrued yield and pending fees, so the skim keeps the deployed position at
+the target.
+
+### Pay an Exact Invoice from the Vault
+
+Pass `recipient` with a formatted `assetAmount` to settle an invoice for its exact amount directly
+from vault holdings.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.earn.withdrawExactSync({
+  assetAmount: { decimals: 6, formatted: '1249.99' }, // [!code focus]
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  slippageBps: 50,
+  vault: '0x0000000000000000000000000000000000000001',
+})
+// @log: { assetAmount: 1_249_990_000n, recipient: '0x742d...bEbb', shareAmount: 1_244_000_000n, ... }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The counterparty receives the exact `assetAmount`; slippage only affects the shares burned.
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/faucet.fund.mdx
+++ b/site/pages/tempo/actions/faucet.fund.mdx
@@ -35,6 +35,60 @@ const hashes = await client.faucet.fund({
 })
 ```
 
+## Recipes
+
+### Fund a Fresh Account for Each Test Run
+
+Create a throwaway account with [`Account.fromSecp256k1`](/tempo/accounts/account.fromSecp256k1) and fund it, giving each CI run an isolated, prefunded identity.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { Secp256k1 } from 'viem/utils'
+import { client } from './viem.config'
+
+const testAccount = Account.fromSecp256k1(Secp256k1.randomPrivateKey()) // [!code focus]
+
+await client.faucet.fundSync({ account: testAccount }) // [!code focus]
+
+const { receipt } = await client.token.transferSync({
+  account: testAccount,
+  amount: { formatted: '10' },
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Top Up a Test Runner When It Runs Low
+
+Check the balance with [`token.getBalance`](/tempo/actions/token.getBalance) and only hit the faucet when a long-lived runner drops below a threshold.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const balance = await client.token.getBalance({ // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+}) // [!code focus]
+
+if (Number(balance.formatted) < 100) // [!code focus]
+  await client.faucet.fundSync({ account: client.account }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.getUserToken.mdx
+++ b/site/pages/tempo/actions/fee.getUserToken.mdx
@@ -25,6 +25,58 @@ console.log('Fee token:', token)
 
 :::
 
+## Recipes
+
+### Show the Gas Token in Wallet Settings
+
+Use the `null` return to fall back to pathUSD when rendering fee settings for an account that has not chosen a token.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const token = await client.fee.getUserToken()
+const feeToken = token ?? pathUsd // [!code focus]
+
+console.log('Gas is paid in:', feeToken)
+// @log: Gas is paid in: 0x20c0000000000000000000000000000000000000
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Audit Preferences Across Payout Accounts
+
+Pass `account` to read the preference of any account, such as payout or treasury accounts a backend operates alongside the Client's own.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const payoutAccounts = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+for (const account of payoutAccounts) {
+  const token = await client.fee.getUserToken({ account }) // [!code focus]
+  console.log(account, token)
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.getValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.getValidatorToken.mdx
@@ -27,6 +27,63 @@ console.log('Fee token:', token)
 
 :::
 
+## Recipes
+
+### Resolve the Effective Fee Token
+
+Treat `null` as pathUSD when you need the token a validator actually gets paid in: unset preferences resolve to pathUSD at the node level.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const token = await client.fee.getValidatorToken({
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+const effectiveToken = token ?? pathUsd // [!code focus]
+
+console.log('Validator is paid in:', effectiveToken)
+// @log: Validator is paid in: 0x20c0000000000000000000000000000000000000
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Survey Preferences Across a Validator Set
+
+Read several validators in parallel to decide which stablecoins to stock before [providing Fee AMM liquidity](/tempo/guides/stablecoin-exchange/fee-amm-liquidity).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validators = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+const tokens = await Promise.all( // [!code focus]
+  validators.map((validator) => // [!code focus]
+    client.fee.getValidatorToken({ validator }), // [!code focus]
+  ), // [!code focus]
+)
+
+console.log(tokens)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.setUserToken.mdx
+++ b/site/pages/tempo/actions/fee.setUserToken.mdx
@@ -43,6 +43,77 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.fee.setUserToken.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Validate a Token Before Saving It
+
+Combine [`fee.validateToken`](/tempo/actions/fee.validateToken) with `setUserToken` to reject paused or non-USD tokens before persisting a user's choice.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const { address } = await client.fee.validateToken({ token: alphaUsd }) // [!code focus]
+
+const { receipt } = await client.fee.setUserTokenSync({ token: address }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Onboard a User Who Only Holds One Stablecoin
+
+Pass `feeToken` on the update itself so an account holding only the new token can pay for the switch, with no pathUSD required.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const { receipt } = await client.fee.setUserTokenSync({
+  feeToken: alphaUsd, // [!code focus]
+  token: alphaUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Set the Preference of a Payout Account
+
+Pass `account` to update an account other than the Client's default, such as a payout account a backend operates.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const payoutAccount = Account.fromSecp256k1('0x...')
+
+const { receipt } = await client.fee.setUserTokenSync({
+  account: payoutAccount, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.setValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.setValidatorToken.mdx
@@ -43,6 +43,81 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.fee.setValidatorToken.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Validate a Token Before Rotating
+
+Combine [`fee.validateToken`](/tempo/actions/fee.validateToken) with `setValidatorToken` so fee revenue never switches to a paused or non-USD token.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+const { address } = await client.fee.validateToken({ token: alphaUsd }) // [!code focus]
+
+const { receipt } = await client.fee.setValidatorTokenSync({ token: address }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sign with the Validator Key from an Ops Client
+
+Pass `account` to sign with the validator key when the Client defaults to another account: the preference applies to the sending account.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const validatorKey = Account.fromSecp256k1('0x...')
+
+const { receipt } = await client.fee.setValidatorTokenSync({
+  account: validatorKey, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Confirm the Rotation On-Chain
+
+Read the preference back with [`fee.getValidatorToken`](/tempo/actions/fee.getValidatorToken) after rotating, as a convergence check in a validator runbook.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+await client.fee.setValidatorTokenSync({ token: alphaUsd })
+
+const token = await client.fee.getValidatorToken({ // [!code focus]
+  validator: client.account.address, // [!code focus]
+}) // [!code focus]
+
+console.log('Receiving fees in:', token)
+// @log: Receiving fees in: 0x20c0000000000000000000000000000000000001
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.validateToken.mdx
+++ b/site/pages/tempo/actions/fee.validateToken.mdx
@@ -37,6 +37,69 @@ console.log('Fee token:', token)
 
 :::
 
+## Recipes
+
+### Screen a User-Entered Token Before Saving It
+
+Catch the specific validation errors to give users actionable feedback before persisting a preference with [`fee.setUserToken`](/tempo/actions/fee.setUserToken).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { FeeTokenNotUsdError, FeeTokenPausedError } from 'viem/tempo'
+import { client } from './viem.config'
+
+try {
+  const { address } = await client.fee.validateToken({
+    token: '0x20c0000000000000000000000000000000000001',
+  })
+  await client.fee.setUserTokenSync({ token: address })
+} catch (error) {
+  if (error instanceof FeeTokenPausedError) // [!code focus]
+    console.log('This token is paused. Choose another stablecoin.') // [!code focus]
+  else if (error instanceof FeeTokenNotUsdError) // [!code focus]
+    console.log('Fee tokens must be USD-denominated.') // [!code focus]
+  else throw error
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Build a Fee Token Picker
+
+Validate a list of candidate tokens and build picker options from the returned metadata, skipping candidates that cannot pay fees.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const candidates = [
+  '0x20c0000000000000000000000000000000000000',
+  '0x20c0000000000000000000000000000000000001',
+] as const
+
+const options: { address: string; symbol: string }[] = []
+for (const token of candidates) {
+  try {
+    const { address, metadata } = await client.fee.validateToken({ token }) // [!code focus]
+    options.push({ address, symbol: metadata.symbol }) // [!code focus]
+  } catch {
+    continue
+  }
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/fee.watchSetUserToken.mdx
+++ b/site/pages/tempo/actions/fee.watchSetUserToken.mdx
@@ -31,6 +31,62 @@ watcher.off()
 
 Also callable standalone: `Actions.fee.watchSetUserToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Invalidate Cached Preferences for Your Users
+
+Filter with `args.user` to react only when one of your users changes their preference, such as invalidating a fee token cached by a wallet backend.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.fee.watchSetUserToken({
+  args: { // [!code focus]
+    user: [ // [!code focus]
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+    ], // [!code focus]
+  }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log('Preference changed:', log.args.user, log.args.token)
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Backfill Changes After Downtime
+
+Pass `fromBlock` to replay events from the last block your indexer processed before continuing live.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.fee.watchSetUserToken({
+  fromBlock: 1_234_567n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log(log.args.user, log.args.token)
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
+++ b/site/pages/tempo/actions/fee.watchSetValidatorToken.mdx
@@ -31,6 +31,56 @@ watcher.off()
 
 Also callable standalone: `Actions.fee.watchSetValidatorToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Rebalance Inventory When a Validator Rotates
+
+Filter with `args.validator` to track the validators you [provide Fee AMM liquidity for](/tempo/guides/stablecoin-exchange/fee-amm-liquidity) and rebalance when their preferred token changes.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.fee.watchSetValidatorToken({
+  args: { validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log('Validator now prefers:', log.args.token)
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Process Rotations as a Stream
+
+Iterate the watcher with `for await` when a long-running job handles each batch sequentially instead of in callbacks.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.fee.watchSetValidatorToken()
+
+for await (const { logs } of watcher) { // [!code focus]
+  for (const log of logs)
+    console.log(log.args.validator, log.args.token)
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/nonce.get.mdx
+++ b/site/pages/tempo/actions/nonce.get.mdx
@@ -27,6 +27,60 @@ console.log('Nonce:', nonce)
 
 :::
 
+## Recipes
+
+### Prepare a Transaction on a Dedicated Lane
+
+Read the lane's current nonce and pass both `nonce` and `nonceKey` to [`transaction.prepare`](/docs/actions/public/transaction/prepare), since the node does not fill keyed nonces for manually prepared requests.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const nonceKey = 7n // this worker's payout lane
+const nonce = await client.nonce.get({ nonceKey }) // [!code focus]
+
+const { request } = await client.transaction.prepare({
+  data: '0xcafebabe00000000000000000000000000000001',
+  nonce: Number(nonce), // [!code focus]
+  nonceKey, // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Reconcile Dispatched Payouts from a Monitor
+
+Pass `account` to audit a lane of an account you do not sign for, such as a payout dispatcher's hot wallet: a lane's nonce counts its confirmed transactions.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const dispatched = 45n // payouts submitted, from your job queue
+
+const confirmed = await client.nonce.get({
+  account: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  nonceKey: 7n,
+})
+
+console.log(`${dispatched - confirmed} payouts pending`)
+// @log: 3 payouts pending
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/nonce.watchIncremented.mdx
+++ b/site/pages/tempo/actions/nonce.watchIncremented.mdx
@@ -32,6 +32,61 @@ watcher.off()
 
 Also callable standalone: `Actions.nonce.watchIncremented(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Follow Payout Lane Confirmations
+
+Filter `args` to your own account to turn nonce increments into per-lane confirmation events, for example to drive a payout dashboard.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.nonce.watchIncremented({
+  args: { account: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    console.log(`Lane ${log.args.nonceKey}: ${log.args.newNonce} confirmed`)
+  // @log: Lane 7: 46 confirmed
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Backfill Missed Increments After a Restart
+
+Pass `fromBlock` from a persisted checkpoint so increments emitted while your service was down are still delivered before live events.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const checkpoint = 1_204_560n // last processed block, from your store
+
+const watcher = client.nonce.watchIncremented({
+  args: { account: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' },
+  fromBlock: checkpoint + 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log(log.blockNumber, log.args.newNonce)
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.create.mdx
+++ b/site/pages/tempo/actions/policy.create.mdx
@@ -48,6 +48,87 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.create.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Seed a Whitelist with KYC-Approved Accounts
+
+Pass `addresses` to open the policy with your approved accounts in a single transaction. Verify membership with [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized) before the policy gates transfers.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { policyId } = await client.policy.createSync({
+  addresses: [ // [!code focus]
+    '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+    '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  ], // [!code focus]
+  type: 'whitelist',
+})
+
+const authorized = await client.policy.isAuthorized({
+  policyId,
+  user: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+console.log('Authorized:', authorized)
+// @log: Authorized: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Delegate Policy Administration to a Compliance Team
+
+Pass `admin` when a dedicated compliance account, rather than the deploying account, should manage membership. Only the admin can call [`policy.modifyBlacklist`](/tempo/actions/policy.modifyBlacklist) or [`policy.setAdmin`](/tempo/actions/policy.setAdmin).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+await client.policy.createSync({
+  admin: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  type: 'blacklist',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Enforce a Sanctions Blacklist on a Stablecoin
+
+Combine `policy.createSync` with [`token.changeTransferPolicySync`](/tempo/actions/token.changeTransferPolicy) to block designated addresses from sending or receiving your token. See the [Configure Transfer Policies](/tempo/guides/transfer-policies) guide for the full flow.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { policyId } = await client.policy.createSync({
+  addresses: ['0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'],
+  type: 'blacklist', // [!code focus]
+})
+
+await client.token.changeTransferPolicySync({ // [!code focus]
+  policyId, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.getData.mdx
+++ b/site/pages/tempo/actions/policy.getData.mdx
@@ -25,6 +25,59 @@ console.log('Policy data:', data)
 
 :::
 
+## Recipes
+
+### Verify a Policy Before Attaching It to a Token
+
+Use `policy.getData` to confirm a policy's type and admin before [`token.changeTransferPolicySync`](/tempo/actions/token.changeTransferPolicy) puts it in front of live transfers.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { admin, type } = await client.policy.getData({ policyId: 1n }) // [!code focus]
+
+if (type !== 'whitelist' || admin !== client.account.address) // [!code focus]
+  throw new Error('Unexpected policy configuration.') // [!code focus]
+
+await client.token.changeTransferPolicySync({
+  policyId: 1n,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Route Membership Updates by Policy Type
+
+Use the returned `type` to choose between [`policy.modifyWhitelistSync`](/tempo/actions/policy.modifyWhitelist) and [`policy.modifyBlacklistSync`](/tempo/actions/policy.modifyBlacklist) when your tooling manages policies of both kinds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const address = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const { type } = await client.policy.getData({ policyId: 1n }) // [!code focus]
+
+if (type === 'whitelist') // [!code focus]
+  await client.policy.modifyWhitelistSync({ address, allowed: true, policyId: 1n })
+else // [!code focus]
+  await client.policy.modifyBlacklistSync({ address, policyId: 1n, restricted: false })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.isAuthorized.mdx
+++ b/site/pages/tempo/actions/policy.isAuthorized.mdx
@@ -26,6 +26,71 @@ console.log('Authorized:', authorized)
 
 :::
 
+## Recipes
+
+### Screen a Recipient Before Sending a Payout
+
+Combine `policy.isAuthorized` with [`token.transferSync`](/tempo/actions/token.transfer) to hold payouts that the token's transfer policy would revert.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const recipient = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const authorized = await client.policy.isAuthorized({ // [!code focus]
+  policyId: 1n,
+  user: recipient,
+})
+
+if (authorized) // [!code focus]
+  await client.token.transferSync({
+    amount: { formatted: '1250' },
+    to: recipient,
+    token: '0x20c0000000000000000000000000000000000000',
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Audit a Payout List for Blocked Recipients
+
+Use one pass over your recipient list to surface accounts that fail compliance screening before a payroll run starts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const recipients = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+const checks = await Promise.all( // [!code focus]
+  recipients.map(async (user) => ({ // [!code focus]
+    authorized: await client.policy.isAuthorized({ policyId: 1n, user }), // [!code focus]
+    user, // [!code focus]
+  })), // [!code focus]
+)
+
+const blocked = checks.filter((check) => !check.authorized)
+
+console.log('Blocked:', blocked.map((check) => check.user))
+// @log: Blocked: ['0x8ba1f109551bD432803012645Ac136ddd64DBA72']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.modifyBlacklist.mdx
+++ b/site/pages/tempo/actions/policy.modifyBlacklist.mdx
@@ -49,6 +49,75 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.modifyBlacklist.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Apply a Sanctions List Update in Bulk
+
+Use the non-sync action to dispatch one designation per address, then wait for the receipts together, when a sanctions update contains many entries.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const designations = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+const hashes: `0x${string}`[] = []
+for (const address of designations) // [!code focus]
+  hashes.push( // [!code focus]
+    await client.policy.modifyBlacklist({ // [!code focus]
+      address, // [!code focus]
+      policyId: 1n, // [!code focus]
+      restricted: true, // [!code focus]
+    }), // [!code focus]
+  ) // [!code focus]
+
+await Promise.all(
+  hashes.map((hash) => client.transaction.waitForReceipt({ hash }).receipt), // [!code focus]
+)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Reinstate an Account After a Compliance Review
+
+Pass `restricted: false` once a review clears the account, and confirm reinstatement with [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const account = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+await client.policy.modifyBlacklistSync({
+  address: account,
+  policyId: 1n,
+  restricted: false, // [!code focus]
+})
+
+const authorized = await client.policy.isAuthorized({ // [!code focus]
+  policyId: 1n,
+  user: account,
+})
+
+console.log('Authorized:', authorized)
+// @log: Authorized: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.modifyWhitelist.mdx
+++ b/site/pages/tempo/actions/policy.modifyWhitelist.mdx
@@ -49,6 +49,71 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.modifyWhitelist.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Onboard a Customer After KYC Approval
+
+Combine `policy.modifyWhitelistSync` with [`token.transferSync`](/tempo/actions/token.transfer) to grant access and settle the customer's first payout in one flow.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const customer = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+await client.policy.modifyWhitelistSync({
+  address: customer,
+  allowed: true, // [!code focus]
+  policyId: 1n,
+})
+
+await client.token.transferSync({ // [!code focus]
+  amount: { formatted: '100' }, // [!code focus]
+  to: customer, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+}) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Stage a Replacement Whitelist Before Attaching It
+
+Populate a staged policy, then switch the token over with [`token.changeTransferPolicySync`](/tempo/actions/token.changeTransferPolicy), so live transfers are never gated by a half-built list.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const members = [
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+] as const
+
+for (const address of members) // [!code focus]
+  await client.policy.modifyWhitelistSync({ // [!code focus]
+    address, // [!code focus]
+    allowed: true, // [!code focus]
+    policyId: 2n, // [!code focus]
+  }) // [!code focus]
+
+await client.token.changeTransferPolicySync({
+  policyId: 2n,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.setAdmin.mdx
+++ b/site/pages/tempo/actions/policy.setAdmin.mdx
@@ -47,6 +47,59 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.policy.setAdmin.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Hand Off Policy Control to a Compliance Multisig
+
+Use `policy.setAdminSync` when a policy moves to production and a secured account should own membership changes; confirm the handoff with [`policy.getData`](/tempo/actions/policy.getData). The previous admin loses control as soon as the transaction is included.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+await client.policy.setAdminSync({
+  admin: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  policyId: 1n,
+})
+
+const { admin } = await client.policy.getData({ policyId: 1n }) // [!code focus]
+
+console.log('Admin:', admin)
+// @log: Admin: 0x8ba1f109551bD432803012645Ac136ddd64DBA72
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sign the Handoff with the Outgoing Admin Key
+
+Pass `account` to sign with the policy's current admin when it differs from your client's default account; only the current admin can set a new one.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const outgoingAdmin = Account.fromSecp256k1('0x...')
+
+await client.policy.setAdminSync({
+  account: outgoingAdmin, // [!code focus]
+  admin: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  policyId: 1n,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/policy.watchAdminUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchAdminUpdated.mdx
@@ -28,6 +28,38 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchAdminUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Alert on Unexpected Admin Handoffs
+
+Pass `args.policyId` to watch the policies your token relies on, and alert when control moves to an account outside your approved set.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const approved = ['0x8ba1f109551bD432803012645Ac136ddd64DBA72']
+
+const watcher = client.policy.watchAdminUpdated({
+  args: { policyId: [1n, 2n] }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (!approved.includes(log.args.admin)) // [!code focus]
+      console.log('Unexpected admin change:', log.args)
+  }
+  // @log: Unexpected admin change: { policyId: 1n, updater: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', admin: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchBlacklistUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchBlacklistUpdated.mdx
@@ -28,6 +28,70 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchBlacklistUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Maintain an Audit Trail of Sanctions Actions
+
+Pass `args.policyId` to record every designation and removal on your policy, keyed by transaction hash, for compliance reporting.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.policy.watchBlacklistUpdated({
+  args: { policyId: 1n }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    console.log({
+      account: log.args.account, // [!code focus]
+      action: log.args.restricted ? 'designated' : 'removed', // [!code focus]
+      reference: log.transactionHash, // [!code focus]
+    })
+  }
+  // @log: { account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', action: 'designated', reference: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Suspend Deposits When One of Your Addresses Is Blocked
+
+Pass `args.account` to monitor your own deposit addresses across every policy, and stop routing customer funds through an address that gets blocked.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.policy.watchBlacklistUpdated({
+  args: { // [!code focus]
+    account: [ // [!code focus]
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+    ], // [!code focus]
+  }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs)
+    if (log.args.restricted) console.log('Suspend deposits to:', log.args.account) // [!code focus]
+  // @log: Suspend deposits to: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchCreate.mdx
+++ b/site/pages/tempo/actions/policy.watchCreate.mdx
@@ -28,6 +28,66 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchCreate(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Track Policies Created by Your Organization
+
+Pass `args.updater` to only receive policies created by your deployment accounts, ignoring the rest of the registry.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.policy.watchCreate({
+  args: { // [!code focus]
+    updater: [ // [!code focus]
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+    ], // [!code focus]
+  }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log('New policy:', log.args.policyId)
+  // @log: New policy: 42n
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Backfill the Policy Registry into a Local Index
+
+Pass `fromBlock` to replay historical `PolicyCreated` events when bootstrapping a compliance dashboard, then keep receiving new ones.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.policy.watchCreate({
+  fromBlock: 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const type = log.args.policyType === 0 ? 'whitelist' : 'blacklist' // [!code focus]
+    console.log(`Policy ${log.args.policyId}: ${type}`)
+  }
+  // @log: Policy 1: whitelist
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/policy.watchWhitelistUpdated.mdx
+++ b/site/pages/tempo/actions/policy.watchWhitelistUpdated.mdx
@@ -28,6 +28,67 @@ watcher.off()
 
 Also callable standalone: `Actions.policy.watchWhitelistUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Rebuild Whitelist Membership from Event History
+
+Pass `fromBlock` and replay the `allowed` flag to derive current membership, since the registry only answers point queries via [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const members = new Set<string>()
+
+const watcher = client.policy.watchWhitelistUpdated({
+  args: { policyId: 1n },
+  fromBlock: 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) { // [!code focus]
+    if (log.args.allowed) members.add(log.args.account) // [!code focus]
+    else members.delete(log.args.account) // [!code focus]
+  } // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Pause Payouts When a Recipient Loses Access
+
+Pass `args.account` to track a payee's status under your token's policy, and pause scheduled payouts when they are removed.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.policy.watchWhitelistUpdated({
+  args: { // [!code focus]
+    account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+    policyId: 1n, // [!code focus]
+  }, // [!code focus]
+})
+
+for await (const { logs } of watcher) {
+  for (const log of logs)
+    if (!log.args.allowed) console.log('Pause payouts to:', log.args.account) // [!code focus]
+  // @log: Pause payouts to: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.burn.mdx
+++ b/site/pages/tempo/actions/receivePolicy.burn.mdx
@@ -45,6 +45,66 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.burn.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Destroy Payments from Sanctioned Senders
+
+Decode the receipt with `ReceivePolicyReceipt.decode` to screen the originator, then burn funds that must not be released and claim the rest with [`receivePolicy.claimSync`](/tempo/actions/receivePolicy.claim).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { ReceivePolicyReceipt } from 'viem/tempo'
+import { client } from './viem.config'
+
+const sanctioned = new Set(['0x000000000000000000000000000000000000dead'])
+
+// Receipt captured from a `TransferBlocked` event.
+const blockedReceipt = '0x1234'
+
+const { originator } = ReceivePolicyReceipt.decode(blockedReceipt) // [!code focus]
+if (sanctioned.has(originator.toLowerCase())) // [!code focus]
+  await client.receivePolicy.burnSync({ receipt: blockedReceipt }) // [!code focus]
+else
+  await client.receivePolicy.claimSync({
+    receipt: blockedReceipt,
+    to: client.account.address,
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Burn Airdrop Dust Automatically
+
+Combine [`receivePolicy.watchBlocked`](/tempo/actions/receivePolicy.watchBlocked) with a dust threshold to destroy unwanted airdrops your token policy blocks, instead of accumulating unclaimed receipts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.receivePolicy.watchBlocked({
+  args: { receiver: client.account.address },
+})
+
+watcher.onLogs(async (logs) => {
+  for (const log of logs) {
+    if (log.args.amount >= 1_000_000n) continue // [!code focus]
+    await client.receivePolicy.burnSync({ receipt: log.args.receipt }) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.claim.mdx
+++ b/site/pages/tempo/actions/receivePolicy.claim.mdx
@@ -47,6 +47,67 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.claim.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Recover a Payment Your Transfer Blocked
+
+A transfer blocked by the recipient's policy still succeeds, with the funds held instead of credited. When the policy's claimer is `'sender'`, extract the claim receipt from your [`token.transferSync`](/tempo/actions/token.transfer) receipt and reclaim the funds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { ReceivePolicyReceipt } from 'viem/tempo'
+import { client } from './viem.config'
+
+const { receipt } = await client.token.transferSync({
+  amount: { decimals: 6, formatted: '500' },
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+const [blocked] = ReceivePolicyReceipt.fromTransactionReceipt(receipt) // [!code focus]
+if (blocked) // [!code focus]
+  await client.receivePolicy.claimSync({ // [!code focus]
+    receipt: blocked, // [!code focus]
+    to: client.account.address, // [!code focus]
+  }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Return a Blocked Payment to Its Sender
+
+As the policy's claimer, decode the receipt with `ReceivePolicyReceipt.decode` and release the funds straight back to the originator: `to` accepts any destination, not just your own account.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { ReceivePolicyReceipt } from 'viem/tempo'
+import { client } from './viem.config'
+
+// Receipt captured from a `TransferBlocked` event.
+const blockedReceipt = '0x1234'
+
+const { originator } = ReceivePolicyReceipt.decode(blockedReceipt) // [!code focus]
+
+const { amount, token } = await client.receivePolicy.claimSync({
+  receipt: blockedReceipt,
+  to: originator, // [!code focus]
+})
+
+console.log(`Returned ${amount} of ${token} to ${originator}`)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.get.mdx
+++ b/site/pages/tempo/actions/receivePolicy.get.mdx
@@ -25,6 +25,60 @@ console.log('Receive policy:', policy.hasReceivePolicy)
 
 :::
 
+## Recipes
+
+### Apply a Default Policy Only Once
+
+Gate onboarding on `hasReceivePolicy` so you only apply your default policy with [`receivePolicy.setSync`](/tempo/actions/receivePolicy.set) to accounts that have none configured.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { hasReceivePolicy } = await client.receivePolicy.get({ // [!code focus]
+  account: client.account.address,
+}) // [!code focus]
+
+if (!hasReceivePolicy) // [!code focus]
+  await client.receivePolicy.setSync({
+    claimer: 'self',
+    senderPolicyId: 'allow-all',
+    tokenPolicyId: 'allow-all',
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Audit Who Can Recover Blocked Funds
+
+Use the returned `claimer` to confirm blocked funds route to an account you control before tightening a policy across treasury accounts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const operator = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const { claimer, hasReceivePolicy } = await client.receivePolicy.get({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+})
+
+if (hasReceivePolicy && claimer !== 'self' && claimer !== operator) // [!code focus]
+  throw new Error(`Blocked funds are not recoverable by treasury: ${claimer}`) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
+++ b/site/pages/tempo/actions/receivePolicy.getBlockedBalance.mdx
@@ -25,6 +25,60 @@ console.log('Blocked balance:', balance)
 
 :::
 
+## Recipes
+
+### Skip Receipts That Were Already Resolved
+
+A receipt's balance drops to zero once claimed or burned, so check it before [`receivePolicy.claimSync`](/tempo/actions/receivePolicy.claim) when replaying stored receipts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Claim receipts indexed from `TransferBlocked` events.
+const receipts = ['0x1234', '0x5678'] as const
+
+for (const receipt of receipts) {
+  const balance = await client.receivePolicy.getBlockedBalance({ receipt }) // [!code focus]
+  if (balance === 0n) continue // [!code focus]
+  await client.receivePolicy.claimSync({
+    receipt,
+    to: client.account.address,
+  })
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Inspect a Blocked Payment for Support
+
+Pair the held balance with `ReceivePolicyReceipt.decode` to show support staff who sent a blocked payment, in which token, and when.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { ReceivePolicyReceipt } from 'viem/tempo'
+import { client } from './viem.config'
+
+const receipt = '0x1234'
+
+const balance = await client.receivePolicy.getBlockedBalance({ receipt }) // [!code focus]
+const { originator, token, blockedAt } = ReceivePolicyReceipt.decode(receipt) // [!code focus]
+
+console.log(`${balance} base units of ${token} from ${originator}, held since ${blockedAt}`)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.set.mdx
+++ b/site/pages/tempo/actions/receivePolicy.set.mdx
@@ -52,6 +52,83 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.receivePolicy.set.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Accept Only Your Settlement Currencies
+
+Combine [`policy.createSync`](/tempo/actions/policy.create) with `tokenPolicyId` to limit a merchant account to the stablecoins it settles in. Transfers of any other token are blocked instead of credited.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+const alphaUsd = '0x20c0000000000000000000000000000000000001'
+
+// Whitelist of stablecoins the merchant settles in.
+const { policyId } = await client.policy.createSync({ // [!code focus]
+  addresses: [pathUsd, alphaUsd], // [!code focus]
+  admin: client.account.address, // [!code focus]
+  type: 'whitelist', // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.receivePolicy.setSync({
+  claimer: 'self',
+  tokenPolicyId: policyId, // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Route Blocked Payments to an Operations Claimer
+
+Pass an explicit address as `claimer` so a dedicated operations account, rather than each sender, recovers blocked payments with [`receivePolicy.claim`](/tempo/actions/receivePolicy.claim).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { claimer } = await client.receivePolicy.setSync({
+  claimer: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  senderPolicyId: 2n,
+})
+
+console.log('Claimer:', claimer)
+// @log: Claimer: 0x8ba1f109551bD432803012645Ac136ddd64DBA72
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Decommission a Deposit Address
+
+Pass `senderPolicyId: 'reject-all'` to stop accepting transfers on a retired exchange deposit address. Unspecified fields reset to defaults, so `claimer` becomes `'sender'` and late depositors can reclaim their own funds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.receivePolicy.setSync({
+  senderPolicyId: 'reject-all', // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.validate.mdx
+++ b/site/pages/tempo/actions/receivePolicy.validate.mdx
@@ -27,6 +27,79 @@ console.log('Authorized:', result.authorized)
 
 :::
 
+## Recipes
+
+### Screen a Payout Before Sending It
+
+Combine `receivePolicy.validate` with [`token.transferSync`](/tempo/actions/token.transfer) to hold a payroll payout that would block onchain, and surface the reason to your operators.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const payee = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const { authorized, blockedReason } = await client.receivePolicy.validate({ // [!code focus]
+  receiver: payee, // [!code focus]
+  sender: client.account.address, // [!code focus]
+  token: pathUsd, // [!code focus]
+}) // [!code focus]
+if (!authorized) throw new Error(`Payout blocked: ${blockedReason}`) // [!code focus]
+
+const { receipt } = await client.token.transferSync({
+  amount: { formatted: '1250' },
+  to: payee,
+  token: pathUsd,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Fall Back to a Token the Recipient Accepts
+
+Probe your settlement currencies in preference order and settle in the first one the recipient's policy authorizes.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const customer = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+// Settlement currencies in preference order.
+const tokens = [
+  '0x20c0000000000000000000000000000000000000',
+  '0x20c0000000000000000000000000000000000001',
+] as const
+
+let token
+for (const candidate of tokens) {
+  const { authorized } = await client.receivePolicy.validate({ // [!code focus]
+    receiver: customer, // [!code focus]
+    sender: client.account.address, // [!code focus]
+    token: candidate, // [!code focus]
+  }) // [!code focus]
+  if (!authorized) continue // [!code focus]
+  token = candidate
+  break
+}
+
+console.log('Settling in:', token)
+// @log: Settling in: 0x20c0000000000000000000000000000000000000
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBlocked.mdx
@@ -28,6 +28,63 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchBlocked(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Auto-Claim Blocked Deposits
+
+Filter `args.receiver` to your account and release each blocked payment with [`receivePolicy.claimSync`](/tempo/actions/receivePolicy.claim) as it lands. The account must be the policy's configured claimer.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.receivePolicy.watchBlocked({
+  args: { receiver: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs(async (logs) => {
+  for (const log of logs)
+    await client.receivePolicy.claimSync({ // [!code focus]
+      receipt: log.args.receipt, // [!code focus]
+      to: client.account.address, // [!code focus]
+    }) // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Backfill Missed Events After Downtime
+
+Pass `fromBlock` to replay `TransferBlocked` events your indexer missed. Persist each claim receipt: it is the only way to claim or burn the funds later.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const receipts = new Map<bigint, `0x${string}`>()
+
+// Resume from the last block the indexer processed.
+const watcher = client.receivePolicy.watchBlocked({
+  fromBlock: 1_284_000n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) receipts.set(log.args.blockedNonce, log.args.receipt) // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchBurned.mdx
@@ -28,6 +28,35 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchBurned(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Notify Senders When Blocked Funds Are Destroyed
+
+Watch burns on your account and use the `originator` from the event to tell the sender their payment was destroyed rather than credited.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.receivePolicy.watchBurned({
+  args: { receiver: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const { amount, originator, token } = log.args // [!code focus]
+    console.log(`Burned ${amount} of ${token} sent by ${originator}`) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchClaimed.mdx
@@ -28,6 +28,61 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchClaimed(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Reconcile Recovered Funds in Your Ledger
+
+Watch claims on your account and mark the matching blocked receipt resolved by `blockedNonce`, recording where the funds went.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.receivePolicy.watchClaimed({
+  args: { receiver: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    const { amount, blockedNonce, to } = log.args // [!code focus]
+    console.log(`Receipt ${blockedNonce}: released ${amount} to ${to}`) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Close a Support Ticket When a Claim Lands
+
+Filter `args.blockedNonce` to a single receipt under recovery, then tear the watcher down once the claim is observed.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Nonce decoded from the receipt under recovery.
+const watcher = client.receivePolicy.watchClaimed({
+  args: { blockedNonce: 42n }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log('Recovered to:', log.args.to)
+  watcher.off() // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
+++ b/site/pages/tempo/actions/receivePolicy.watchUpdated.mdx
@@ -28,6 +28,76 @@ watcher.off()
 
 Also callable standalone: `Actions.receivePolicy.watchUpdated(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Re-Validate Queued Payouts on Policy Changes
+
+Filter `args.account` to your payees and re-check queued payouts with [`receivePolicy.validate`](/tempo/actions/receivePolicy.validate) whenever a recipient's policy changes.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+// Payees with payouts queued in the payroll system.
+const watcher = client.receivePolicy.watchUpdated({
+  args: {
+    account: [ // [!code focus]
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+    ], // [!code focus]
+  },
+})
+
+watcher.onLogs(async (logs) => {
+  for (const log of logs) {
+    const { authorized } = await client.receivePolicy.validate({ // [!code focus]
+      receiver: log.args.account, // [!code focus]
+      sender: client.account.address, // [!code focus]
+      token: pathUsd, // [!code focus]
+    }) // [!code focus]
+    if (!authorized) console.log('Hold payouts for:', log.args.account)
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Alert on Unexpected Claimer Changes
+
+Watch your own account and alert when an update points the recovery authority away from your operations claimer, a sign of a compromised key redirecting blocked funds.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const opsClaimer = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const watcher = client.receivePolicy.watchUpdated({
+  args: { account: client.account.address }, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (log.args.recoveryAuthority === opsClaimer) continue // [!code focus]
+    console.log('Unexpected claimer change:', log.args.recoveryAuthority) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.approve.mdx
+++ b/site/pages/tempo/actions/token.approve.mdx
@@ -91,6 +91,75 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.approve.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Fund Subscription Billing with an Allowance
+
+Use an allowance to let your billing service charge on schedule: the customer approves a period's budget once, then the server pulls each charge with [`token.transferSync`](/tempo/actions/token.transfer).
+
+:::code-group
+
+```ts twoslash [customer.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.approveSync({
+  amount: { formatted: '120' }, // [!code focus]
+  spender: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [server.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.transferSync({
+  amount: { formatted: '10' },
+  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Revoke a Compromised Spender
+
+Set `amount` to `0n` to cut off a spender immediately, then confirm with [`token.getAllowance`](/tempo/actions/token.getAllowance), for example after a billing integration is compromised.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const spender = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+const token = '0x20c0000000000000000000000000000000000000'
+
+const { receipt } = await client.token.approveSync({
+  amount: 0n, // [!code focus]
+  spender,
+  token,
+})
+
+const allowance = await client.token.getAllowance({
+  account: client.account.address,
+  spender,
+  token,
+})
+
+console.log('Remaining allowance:', allowance.formatted)
+// @log: Remaining allowance: 0
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.burn.mdx
+++ b/site/pages/tempo/actions/token.burn.mdx
@@ -87,6 +87,58 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.burn.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Record a Redemption with a Burn Memo
+
+Pass `memo` to stamp each burn with the redemption reference it settles (for example, `redeem_5150` hex-encoded), keeping supply reductions auditable against fiat payouts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.burnSync({
+  amount: { formatted: '1000' },
+  memo: '0x72656465656d5f35313530', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Retire an Account's Remaining Balance
+
+Combine [`token.getBalance`](/tempo/actions/token.getBalance) with `token.burnSync` to burn the account's exact base-unit balance, for example when decommissioning a settlement wallet.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000000'
+
+const { amount } = await client.token.getBalance({ token }) // [!code focus]
+
+const { formatted } = await client.token.burnSync({
+  amount, // [!code focus]
+  token,
+})
+
+console.log('Burned:', formatted)
+// @log: Burned: 10.5
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.burnBlocked.mdx
+++ b/site/pages/tempo/actions/token.burnBlocked.mdx
@@ -91,6 +91,66 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.burnBlocked.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Confirm an Address Is Blocked Before Burning
+
+Check the address against your transfer policy with [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized) first: the burn is irreversible, so only proceed when the policy still blocks the holder.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const from = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+const token = '0x20c0000000000000000000000000000000000000'
+
+const isAuthorized = await client.policy.isAuthorized({ // [!code focus]
+  policyId: 1n, // [!code focus]
+  user: from, // [!code focus]
+}) // [!code focus]
+if (isAuthorized) throw new Error('address is not blocked by the policy') // [!code focus]
+
+const { receipt } = await client.token.burnBlockedSync({
+  amount: { formatted: '10.5' },
+  from,
+  token,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Burn a Blocked Account's Entire Balance
+
+Combine [`token.getBalance`](/tempo/actions/token.getBalance) with `token.burnBlockedSync` to clear a sanctioned account completely, for example when executing a documented seizure order.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const from = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+const token = '0x20c0000000000000000000000000000000000000'
+
+const { amount } = await client.token.getBalance({ account: from, token }) // [!code focus]
+
+const { receipt } = await client.token.burnBlockedSync({
+  amount, // [!code focus]
+  from,
+  token,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.changeTransferPolicy.mdx
+++ b/site/pages/tempo/actions/token.changeTransferPolicy.mdx
@@ -45,6 +45,64 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.changeTransferPolicy.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Launch a Token with a KYC Allowlist
+
+Combine [`policy.createSync`](/tempo/actions/policy.create) with `token.changeTransferPolicySync` to gate a new token to KYC-verified accounts from the first transfer.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { policyId } = await client.policy.createSync({ // [!code focus]
+  addresses: ['0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'], // [!code focus]
+  type: 'whitelist', // [!code focus]
+}) // [!code focus]
+
+const { receipt } = await client.token.changeTransferPolicySync({
+  policyId, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Verify Membership Before Migrating Policies
+
+Check critical accounts against the new policy with [`policy.isAuthorized`](/tempo/actions/policy.isAuthorized) before switching, so a compliance migration never strands your treasury or settlement partners.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const newPolicyId = 2n
+const treasury = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const isAuthorized = await client.policy.isAuthorized({ // [!code focus]
+  policyId: newPolicyId, // [!code focus]
+  user: treasury, // [!code focus]
+}) // [!code focus]
+if (!isAuthorized) throw new Error('treasury is not on the new policy') // [!code focus]
+
+const { receipt } = await client.token.changeTransferPolicySync({
+  policyId: newPolicyId,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.create.mdx
+++ b/site/pages/tempo/actions/token.create.mdx
@@ -51,6 +51,91 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args: { token } } = Actions.token.create.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Assign the Admin Role to a Treasury Multisig
+
+Pass `admin` to hand role administration to a treasury multisig at deployment, keeping the deployer key out of day-to-day control of the token.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { admin, token } = await client.token.createSync({
+  admin: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  currency: 'USD',
+  name: 'My Company USD',
+  symbol: 'CUSD',
+})
+
+console.log('Admin:', admin)
+// @log: Admin: 0x8ba1f109551bD432803012645Ac136ddd64DBA72
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Set Up Issuance for a Payments Backend
+
+Combine `token.createSync` with [`token.grantRolesSync`](/tempo/actions/token.grantRoles) to authorize your backend's minting key immediately after deployment, so it can issue supply on customer deposits.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { token } = await client.token.createSync({
+  currency: 'USD',
+  name: 'My Company USD',
+  symbol: 'CUSD',
+})
+
+const { value } = await client.token.grantRolesSync({ // [!code focus]
+  roles: ['issuer'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+console.log('Issuer granted:', value[0].hasRole)
+// @log: Issuer granted: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Pin the Token Address Across Environments
+
+Pass a fixed `salt` so redeploys with identical parameters land at a predictable address, letting downstream systems allowlist the token ahead of deployment.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { token } = await client.token.createSync({
+  currency: 'USD',
+  name: 'My Company USD',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000001', // [!code focus]
+  symbol: 'CUSD',
+})
+
+console.log('Address:', token)
+// @log: Address: 0x20c0000000000000000000000000000000000004
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getAllowance.mdx
+++ b/site/pages/tempo/actions/token.getAllowance.mdx
@@ -27,6 +27,43 @@ console.log('Allowance:', allowance)
 
 :::
 
+## Recipes
+
+### Verify an Allowance Covers the Next Charge
+
+Compare the base-unit `amount` with the upcoming charge before pulling funds with [`token.transferSync`](/tempo/actions/token.transfer), so a shortfall becomes a renewal prompt instead of a reverted transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const customer = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+const token = '0x20c0000000000000000000000000000000000000'
+const charge = Value.from('19.99', 6)
+
+const allowance = await client.token.getAllowance({
+  account: customer,
+  spender: client.account.address, // [!code focus]
+  token,
+})
+
+if (allowance.amount >= charge) // [!code focus]
+  await client.token.transferSync({
+    amount: charge,
+    from: customer,
+    to: client.account.address,
+    token,
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getBalance.mdx
+++ b/site/pages/tempo/actions/token.getBalance.mdx
@@ -26,6 +26,76 @@ console.log('Balance:', balance)
 
 :::
 
+## Recipes
+
+### Confirm the Payout Wallet Covers a Payroll Run
+
+Omit `account` to read the Client's connected account, and compare the base-unit `amount` against the batch total before dispatching [`token.transferSync`](/tempo/actions/token.transfer) payouts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const payouts = [
+  { amount: Value.from('1250.00', 6), to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' },
+  { amount: Value.from('980.50', 6), to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' },
+]
+const total = payouts.reduce((sum, { amount }) => sum + amount, 0n)
+
+const balance = await client.token.getBalance({ // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+}) // [!code focus]
+
+if (balance.amount < total) // [!code focus]
+  throw new Error(
+    `top up payout wallet by ${Value.format(total - balance.amount, balance.decimals)}`,
+  )
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Read Balances Across Tokens in One Round Trip
+
+Use `getBalance.call` with [`multicall`](/docs/actions/public/multicall) to fetch one account's balances across several tokens in a single request, for example to render a wallet dashboard.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const account = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const { results } = await client.multicall({
+  allowFailure: false,
+  calls: [
+    Actions.token.getBalance.call({ // [!code focus]
+      account, // [!code focus]
+      token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+    }), // [!code focus]
+    Actions.token.getBalance.call({
+      account,
+      token: '0x20c0000000000000000000000000000000000001',
+    }),
+  ],
+})
+
+console.log(results)
+// @log: [10_500_000n, 2_750_000n]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getMetadata.mdx
+++ b/site/pages/tempo/actions/token.getMetadata.mdx
@@ -36,6 +36,67 @@ console.log(metadata)
 
 :::
 
+## Recipes
+
+### Check Supply Headroom Before Minting
+
+Read `supplyCap` and `totalSupply` together to confirm an issuance fits under the cap before submitting [`token.mintSync`](/tempo/actions/token.mint), since mints that would exceed the cap revert.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+const issuance = Value.from('250000', 6)
+
+const { supplyCap, totalSupply } = await client.token.getMetadata({ token }) // [!code focus]
+
+if (supplyCap !== undefined && supplyCap - totalSupply < issuance) // [!code focus]
+  throw new Error('issuance exceeds the supply cap')
+
+await client.token.mintSync({
+  amount: issuance,
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  token,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Screen a Token Before Accepting It at Checkout
+
+Check `paused`, `transferPolicyId`, and `currency` before quoting a customer-selected token at checkout: a paused token or an always-reject transfer policy cannot settle the payment.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const metadata = await client.token.getMetadata({
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+const accepted =
+  metadata.currency === 'USD' && // [!code focus]
+  !metadata.paused && // [!code focus]
+  metadata.transferPolicyId !== 0n // [!code focus]
+
+console.log(accepted ? `Accepting ${metadata.symbol}` : 'Payment method unavailable')
+// @log: Accepting AlphaUSD
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getRoleAdmin.mdx
+++ b/site/pages/tempo/actions/token.getRoleAdmin.mdx
@@ -26,6 +26,39 @@ console.log('Admin role:', adminRole)
 
 :::
 
+## Recipes
+
+### Verify Your Admin Key Can Grant a Role
+
+Compare the returned hash against `TokenRole.serialize` to confirm the `defaultAdmin` role still governs issuer grants before calling [`token.grantRolesSync`](/tempo/actions/token.grantRoles) from your admin key.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { TokenRole } from 'viem/tempo'
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const adminRole = await client.token.getRoleAdmin({
+  role: 'issuer',
+  token,
+})
+
+if (adminRole === TokenRole.serialize('defaultAdmin')) // [!code focus]
+  await client.token.grantRolesSync({
+    roles: ['issuer'],
+    to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+    token,
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.getTotalSupply.mdx
+++ b/site/pages/tempo/actions/token.getTotalSupply.mdx
@@ -25,6 +25,34 @@ console.log('Total Supply:', totalSupply)
 
 :::
 
+## Recipes
+
+### Snapshot Supply for a Reserve Attestation
+
+Resolve the snapshot block with [`block.getNumber`](/docs/actions/public/block/getNumber), then pass `blockNumber` so the reported circulating supply matches custodian reserve balances captured at the same moment.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const blockNumber = await client.block.getNumber()
+
+const totalSupply = await client.token.getTotalSupply({
+  blockNumber, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log(`Supply at block ${blockNumber}:`, totalSupply.formatted)
+// @log: Supply at block 19868020: 48250000.5
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.grantRoles.mdx
+++ b/site/pages/tempo/actions/token.grantRoles.mdx
@@ -47,6 +47,72 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.grantRoles.extractEvents(receipt.logs)
 ```
 
+## Recipes
+
+### Separate Issuer and Pauser Duties Across Ops Teams
+
+Grant each operations account only the roles its job requires: the minting service holds `issuer`, while the incident-response desk holds `pause` and `unpause`.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.grantRolesSync({
+  roles: ['issuer'], // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  token,
+})
+
+const { value } = await client.token.grantRolesSync({
+  roles: ['pause', 'unpause'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token,
+})
+
+console.log('Roles granted:', value.length)
+// @log: Roles granted: 2
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Bootstrap Roles on a Newly Created Token
+
+Combine `grantRolesSync` with [`token.createSync`](/tempo/actions/token.create) to deploy a stablecoin and hand its issuer role to your minting service in one flow.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { token } = await client.token.createSync({ // [!code focus]
+  currency: 'USD',
+  name: 'Alpha USD',
+  symbol: 'alphaUSD',
+})
+
+const { value } = await client.token.grantRolesSync({
+  roles: ['issuer'],
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token, // [!code focus]
+})
+
+console.log('Issuer granted:', value[0].hasRole)
+// @log: Issuer granted: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.hasRole.mdx
+++ b/site/pages/tempo/actions/token.hasRole.mdx
@@ -27,6 +27,68 @@ console.log('Has issuer role:', hasRole)
 
 :::
 
+## Recipes
+
+### Skip Redundant Role Grants When Provisioning
+
+Combine `hasRole` with [`token.grantRolesSync`](/tempo/actions/token.grantRoles) to keep operator provisioning idempotent: grant the issuer role only when the operator does not already hold it.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const operator = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+const token = '0x20c0000000000000000000000000000000000001'
+
+const hasRole = await client.token.hasRole({
+  account: operator,
+  role: 'issuer',
+  token,
+})
+
+if (!hasRole) // [!code focus]
+  await client.token.grantRolesSync({ // [!code focus]
+    roles: ['issuer'],
+    to: operator,
+    token,
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Verify Pause Authority Before an Incident Response
+
+Omit `account` to check the Client's own account, for example verifying an incident-response key holds the `pause` role before it halts transfers with [`token.pauseSync`](/tempo/actions/token.pause).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const canPause = await client.token.hasRole({ // [!code focus]
+  role: 'pause', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+if (!canPause)
+  throw new Error('incident key is missing the pause role')
+
+await client.token.pauseSync({ token })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.mint.mdx
+++ b/site/pages/tempo/actions/token.mint.mdx
@@ -91,6 +91,60 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.mint.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Reconcile Fiat Deposits with a Mint Memo
+
+Pass `memo` to tag each mint with the fiat deposit reference it backs (for example, `deposit_8421` hex-encoded), so onchain issuance reconciles against your banking records.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.mintSync({
+  amount: { formatted: '1000' },
+  memo: '0x6465706f7369745f38343231', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Guard Large Mints Against the Supply Cap
+
+Combine [`token.getMetadata`](/tempo/actions/token.getMetadata) with `token.mintSync` to reject a mint that would exceed the token's supply cap before submitting a transaction that reverts.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const amount = 250_000_000_000n
+const token = '0x20c0000000000000000000000000000000000000'
+
+const { supplyCap, totalSupply } = await client.token.getMetadata({ token }) // [!code focus]
+if (supplyCap && totalSupply + amount > supplyCap) // [!code focus]
+  throw new Error('mint would exceed the supply cap') // [!code focus]
+
+const { receipt } = await client.token.mintSync({
+  amount,
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.pause.mdx
+++ b/site/pages/tempo/actions/token.pause.mdx
@@ -43,6 +43,67 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.pause.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Freeze Transfers While Rotating a Compromised Issuer Key
+
+Combine `token.pauseSync` with [`token.revokeRolesSync`](/tempo/actions/token.revokeRoles) to stop transfers while you remove a compromised issuer key, then [`token.unpauseSync`](/tempo/actions/token.unpause) once rotation completes.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { isPaused } = await client.token.pauseSync({ token })
+
+const { value } = await client.token.revokeRolesSync({ // [!code focus]
+  from: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  roles: ['issuer'], // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+console.log('Roles revoked:', value.length)
+// @log: Roles revoked: 1
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Pause a Token Family in One Batch
+
+Pass `nonceKey: 'expiring'` to pause every token you operate concurrently during an incident, without serializing the transactions on the operator account's nonce.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const tokens = [
+  '0x20c0000000000000000000000000000000000001',
+  '0x20c0000000000000000000000000000000000004',
+] as const
+
+const results = await Promise.all(
+  tokens.map((token) =>
+    client.token.pauseSync({ nonceKey: 'expiring', token }), // [!code focus]
+  ),
+)
+
+console.log(results.map(({ isPaused }) => isPaused))
+// @log: [true, true]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.prepareUpdateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.prepareUpdateQuoteToken.mdx
@@ -47,6 +47,68 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.prepareUpdateQuoteToken.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Migrate a Token's Quote Token in Two Steps
+
+Stage the new quote token, then complete the switch with [`token.updateQuoteTokenSync`](/tempo/actions/token.updateQuoteToken) once your change window opens.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.prepareUpdateQuoteTokenSync({
+  quoteToken: '0x20c0000000000000000000000000000000000002', // [!code focus]
+  token,
+})
+
+const { newQuoteToken } = await client.token.updateQuoteTokenSync({ // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+console.log('New quote token:', newQuoteToken)
+// @log: New quote token: 0x20C0000000000000000000000000000000000002
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Skip Staging When the Quote Token Already Matches
+
+Read the live value with [`token.getMetadata`](/tempo/actions/token.getMetadata) and stage only when it differs from your target, so migration scripts stay safe to re-run.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const target = '0x20c0000000000000000000000000000000000002'
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { quoteToken } = await client.token.getMetadata({ token }) // [!code focus]
+
+if (quoteToken?.toLowerCase() !== target.toLowerCase()) { // [!code focus]
+  const { nextQuoteToken } = await client.token.prepareUpdateQuoteTokenSync({
+    quoteToken: target,
+    token,
+  })
+  console.log('Staged:', nextQuoteToken)
+  // @log: Staged: 0x20C0000000000000000000000000000000000002
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.renounceRoles.mdx
+++ b/site/pages/tempo/actions/token.renounceRoles.mdx
@@ -45,6 +45,71 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.renounceRoles.extractEvents(receipt.logs)
 ```
 
+## Recipes
+
+### Decommission a Retired Minting Service
+
+Renounce the service's roles when you retire it, then confirm with [`token.hasRole`](/tempo/actions/token.hasRole) so credentials left on the old deployment stay harmless.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.renounceRolesSync({
+  roles: ['issuer'],
+  token,
+})
+
+const stillIssuer = await client.token.hasRole({ // [!code focus]
+  role: 'issuer', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+console.log('Still issuer:', stillIssuer)
+// @log: Still issuer: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Hand Over Administration and Step Down
+
+Combine `renounceRolesSync` with [`token.grantRolesSync`](/tempo/actions/token.grantRoles) to transfer `defaultAdmin` to a new operations account before giving up your own, so the token is never left without an admin.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.grantRolesSync({ // [!code focus]
+  roles: ['defaultAdmin'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+const { value } = await client.token.renounceRolesSync({
+  roles: ['defaultAdmin'], // [!code focus]
+  token,
+})
+
+console.log('Caller holds defaultAdmin:', value[0].hasRole)
+// @log: Caller holds defaultAdmin: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.revokeRoles.mdx
+++ b/site/pages/tempo/actions/token.revokeRoles.mdx
@@ -47,6 +47,66 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const events = Actions.token.revokeRoles.extractEvents(receipt.logs)
 ```
 
+## Recipes
+
+### Rotate an Operator Key Without Downtime
+
+Grant the replacement key with [`token.grantRolesSync`](/tempo/actions/token.grantRoles) before revoking the outgoing key, so a scheduled key rotation never interrupts minting.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.grantRolesSync({ // [!code focus]
+  roles: ['issuer'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+const { value } = await client.token.revokeRolesSync({
+  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  roles: ['issuer'],
+  token,
+})
+
+console.log('Old key holds issuer:', value[0].hasRole)
+// @log: Old key holds issuer: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Offboard an Operator in One Transaction
+
+Pass every role an outgoing operator holds to revoke them atomically, leaving no window where the account keeps partial access.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { value } = await client.token.revokeRolesSync({
+  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  roles: ['issuer', 'pause', 'unpause'], // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+console.log('Roles removed:', value.length)
+// @log: Roles removed: 3
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.setRoleAdmin.mdx
+++ b/site/pages/tempo/actions/token.setRoleAdmin.mdx
@@ -47,6 +47,71 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.setRoleAdmin.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Let the Issuer Team Manage Its Own Roster
+
+Set `issuer` as its own admin so senior minting keys onboard new keys directly with [`token.grantRolesSync`](/tempo/actions/token.grantRoles), without routing every change through `defaultAdmin`.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.setRoleAdminSync({
+  adminRole: 'issuer', // [!code focus]
+  role: 'issuer', // [!code focus]
+  token,
+})
+
+const { value } = await client.token.grantRolesSync({ // [!code focus]
+  roles: ['issuer'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+console.log('New issuer key active:', value[0].hasRole)
+// @log: New issuer key active: true
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Move Pause Control Under Incident Response
+
+Assign `pause` as the admin of both pause roles so the incident-response lead manages the on-call roster that can halt and resume transfers.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+await client.token.setRoleAdminSync({
+  adminRole: 'pause', // [!code focus]
+  role: 'pause', // [!code focus]
+  token,
+})
+
+await client.token.setRoleAdminSync({
+  adminRole: 'pause', // [!code focus]
+  role: 'unpause', // [!code focus]
+  token,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.setSupplyCap.mdx
+++ b/site/pages/tempo/actions/token.setSupplyCap.mdx
@@ -47,6 +47,65 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.setSupplyCap.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Freeze Issuance at the Current Supply
+
+Cap the token at its exact outstanding supply, read with [`token.getTotalSupply`](/tempo/actions/token.getTotalSupply), to stop further minting while payments keep flowing.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { amount } = await client.token.getTotalSupply({ token }) // [!code focus]
+
+const { newSupplyCap } = await client.token.setSupplyCapSync({
+  supplyCap: amount, // [!code focus]
+  token,
+})
+
+console.log('Issuance frozen at:', newSupplyCap)
+// @log: Issuance frozen at: 25000000000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Raise the Cap Ahead of a Scheduled Mint
+
+Read the current cap with [`token.getMetadata`](/tempo/actions/token.getMetadata) and raise it by exactly the next payroll run, so the cap always tracks planned issuance.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { supplyCap = 0n } = await client.token.getMetadata({ token }) // [!code focus]
+
+const { newSupplyCap } = await client.token.setSupplyCapSync({
+  supplyCap: supplyCap + Value.from('250000', 6), // [!code focus]
+  token,
+})
+
+console.log('New supply cap:', newSupplyCap)
+// @log: New supply cap: 25250000000000n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.transfer.mdx
+++ b/site/pages/tempo/actions/token.transfer.mdx
@@ -93,6 +93,90 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.transfer.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Reconcile Payments with an Order Memo
+
+Pass `memo` to stamp each payment with an order identifier (for example, `order_1024` hex-encoded), so reconciliation jobs can match onchain transfers to orders without external lookups.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.transferSync({
+  amount: { formatted: '249.99' },
+  memo: '0x6f726465725f31303234', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Charge a Customer from an Allowance
+
+Pass `from` to pull a charge from a customer's wallet through an allowance granted with [`token.approveSync`](/tempo/actions/token.approve), the standard server-side flow for subscription billing.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.token.transferSync({
+  amount: { formatted: '19.99' },
+  from: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Run Concurrent Payouts with Expiring Nonces
+
+Pass `nonceKey: 'expiring'` to submit a payroll batch concurrently from one account, without serializing the transfers on nonce order.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000000'
+
+const payouts = [
+  { amount: { formatted: '1250.00' }, to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' },
+  { amount: { formatted: '980.50' }, to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' },
+] as const
+
+const results = await Promise.all(
+  payouts.map((payout) =>
+    client.token.transferSync({
+      ...payout,
+      nonceKey: 'expiring', // [!code focus]
+      token,
+    }),
+  ),
+)
+
+console.log(results.map(({ receipt }) => receipt.status))
+// @log: ['success', 'success']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.unpause.mdx
+++ b/site/pages/tempo/actions/token.unpause.mdx
@@ -43,6 +43,65 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.unpause.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Resume Transfers After a Policy Fix
+
+Combine [`token.changeTransferPolicySync`](/tempo/actions/token.changeTransferPolicy) with `token.unpauseSync` to reopen transfers only after replacing the misconfigured policy that triggered the freeze.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { receipt } = await client.token.changeTransferPolicySync({ // [!code focus]
+  policyId: 2n, // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+const { isPaused } = await client.token.unpauseSync({ token })
+
+console.log('Is paused:', isPaused)
+// @log: Is paused: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Restore Issuer Roles Before Reopening Transfers
+
+Grant the rotated issuer key its roles with [`token.grantRolesSync`](/tempo/actions/token.grantRoles) while the token is still paused, then unpause to resume issuance and transfers together.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const { value } = await client.token.grantRolesSync({ // [!code focus]
+  roles: ['issuer'], // [!code focus]
+  to: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token, // [!code focus]
+}) // [!code focus]
+
+const { isPaused } = await client.token.unpauseSync({ token })
+
+console.log('Issuer restored:', value[0].hasRole, '| paused:', isPaused)
+// @log: Issuer restored: true | paused: false
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.updateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.updateQuoteToken.mdx
@@ -45,6 +45,61 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.token.updateQuoteToken.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Complete a Migration Staged by Another Operator
+
+Assert the applied quote token matches your change ticket after completing, since this action applies whatever [`token.prepareUpdateQuoteToken`](/tempo/actions/token.prepareUpdateQuoteToken) staged last.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const expected = '0x20c0000000000000000000000000000000000002'
+
+const { newQuoteToken } = await client.token.updateQuoteTokenSync({
+  token: '0x20c0000000000000000000000000000000000001',
+})
+
+if (newQuoteToken.toLowerCase() !== expected.toLowerCase()) // [!code focus]
+  throw new Error(`Unexpected quote token: ${newQuoteToken}`) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Trigger Downstream Updates When the Switch Lands
+
+Combine the update with [`token.watchUpdateQuoteToken`](/tempo/actions/token.watchUpdateQuoteToken) so pricing and settlement services react the moment the new quote token applies.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const watcher = client.token.watchUpdateQuoteToken({ token }) // [!code focus]
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (log.eventName !== 'QuoteTokenUpdate') continue // [!code focus]
+    console.log('New quote token live:', log.args.newQuoteToken) // [!code focus]
+  }
+})
+
+await client.token.updateQuoteTokenSync({ token })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/token.watchAdminRole.mdx
+++ b/site/pages/tempo/actions/token.watchAdminRole.mdx
@@ -34,6 +34,39 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchAdminRole(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Audit Admin Changes to Sensitive Roles
+
+Filter `args.role` with `TokenRole.serialize` to record who moves administration of the issuer and burnBlocked roles, feeding a compliance audit trail.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { TokenRole } from 'viem/tempo'
+import { client } from './viem.config'
+
+const watcher = client.token.watchAdminRole({
+  args: { // [!code focus]
+    role: [TokenRole.serialize('issuer'), TokenRole.serialize('burnBlocked')], // [!code focus]
+  }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Append to the audit trail and notify compliance.
+    console.log(log.args.sender, 'moved role admin to', log.args.newAdminRole)
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchApprove.mdx
+++ b/site/pages/tempo/actions/token.watchApprove.mdx
@@ -34,6 +34,75 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchApprove(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Collect Funds When a Payer Approves Your Processor
+
+Filter `args.spender` to your processor account, then pull the approved amount with [`token.transferSync`](/tempo/actions/token.transfer) and its `from` parameter.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.token.watchApprove({
+  args: { spender: client.account.address }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs(async (logs) => {
+  for (const log of logs) {
+    // Collect the approved amount from the payer.
+    const { receipt } = await client.token.transferSync({ // [!code focus]
+      amount: log.args.amount, // [!code focus]
+      from: log.args.owner, // [!code focus]
+      to: client.account.address, // [!code focus]
+      token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+    }) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Alert on Approvals From Treasury Accounts
+
+Filter `args.owner` to accounts you control and flag any approval that names a spender outside your allowlist, an early signal of a compromised key.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Spenders authorized by your treasury policy.
+const allowedSpenders = new Set<string>([
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+])
+
+const watcher = client.token.watchApprove({
+  args: { owner: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (allowedSpenders.has(log.args.spender)) continue // [!code focus]
+    console.log('Unexpected approval:', log.args.spender, log.args.amount) // [!code focus]
+    // @log: Unexpected approval: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 100000000n
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchBurn.mdx
+++ b/site/pages/tempo/actions/token.watchBurn.mdx
@@ -30,6 +30,65 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchBurn(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Reconcile Redemption Burns With Fiat Payouts
+
+Filter `args.from` to your redemption wallet to confirm the burn behind each fiat payout, keeping issuance records aligned with the offchain ledger.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.token.watchBurn({
+  args: { from: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Match the burn to a pending payout by transaction hash.
+    console.log('Redeemed:', log.args.amount, log.transactionHash) // [!code focus]
+    // @log: Redeemed: 250000000n 0x59a1c...
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Track Circulating Supply as Burns Land
+
+Combine the watcher with [`token.getTotalSupply`](/tempo/actions/token.getTotalSupply) to keep a treasury dashboard's supply figure current after every burn.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.token.watchBurn({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs(async () => {
+  const { formatted } = await client.token.getTotalSupply({ // [!code focus]
+    token: '0x20c0000000000000000000000000000000000000', // [!code focus]
+  }) // [!code focus]
+  console.log('Circulating supply:', formatted)
+  // @log: Circulating supply: 12500000
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchCreate.mdx
+++ b/site/pages/tempo/actions/token.watchCreate.mdx
@@ -36,6 +36,67 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchCreate(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Screen New Tokens Quoted in Your Stablecoin
+
+Watch factory creations and keep only tokens whose `quoteToken` matches your stablecoin, comparing addresses with [`Address.isEqual`](/docs/utilities/address), for example to seed a listing pipeline.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Address } from 'viem/utils'
+import { client } from './viem.config'
+
+const pathUsd = '0x20c0000000000000000000000000000000000000'
+
+const watcher = client.token.watchCreate({})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (!Address.isEqual(log.args.quoteToken, pathUsd)) continue // [!code focus]
+    console.log('Listing candidate:', log.args.token, log.args.symbol) // [!code focus]
+    // @log: Listing candidate: 0x20c0000000000000000000000000000000000042 MYT
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Keep a Token Registry Current After Restarts
+
+Pass `fromBlock` when your indexer restarts, so tokens created while it was offline are replayed into the registry before live events.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Last block the registry indexed, loaded from its store.
+const checkpoint = 1_204_320n
+
+const watcher = client.token.watchCreate({
+  fromBlock: checkpoint + 1n, // [!code focus]
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Upsert into the registry keyed by token address.
+    console.log(log.args.token, log.args.name, log.args.symbol, log.args.admin)
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchMint.mdx
+++ b/site/pages/tempo/actions/token.watchMint.mdx
@@ -30,6 +30,70 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchMint(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Alert on Mints Your Issuance Service Did Not Submit
+
+Watch every mint and compare it against the transactions your issuance service submitted; a mint you did not initiate is an early signal of a compromised issuer key.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Transaction hashes of mints your issuance service submitted.
+const pending = new Set<string>()
+
+const watcher = client.token.watchMint({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (log.transactionHash && pending.has(log.transactionHash)) continue // [!code focus]
+    console.log('Unexpected mint:', log.args.to, log.args.amount) // [!code focus]
+    // @log: Unexpected mint: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 100000000n
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Credit Accounts When On-Ramp Mints Settle
+
+Filter `args.to` to the customer wallets in an on-ramp batch, so each account is marked funded when its mint settles onchain.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.token.watchMint({
+  args: { // [!code focus]
+    to: [ // [!code focus]
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+      '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+    ], // [!code focus]
+  }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) console.log('Funded:', log.args.to, log.args.amount)
+  // @log: Funded: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb 100000000n
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchRole.mdx
+++ b/site/pages/tempo/actions/token.watchRole.mdx
@@ -35,6 +35,75 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchRole(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Alert on Unexpected issuer Grants
+
+Filter `args.role` with `TokenRole.serialize` and page an operator when the issuer role is granted to an account outside your allowlist.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { TokenRole } from 'viem/tempo'
+import { client } from './viem.config'
+
+// Accounts authorized to hold the issuer role.
+const knownIssuers = new Set<string>([
+  '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+])
+
+const watcher = client.token.watchRole({
+  args: { role: TokenRole.serialize('issuer') }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (!log.args.hasRole || knownIssuers.has(log.args.account)) continue // [!code focus]
+    console.log('Unexpected grant:', log.args.account, 'by', log.args.sender) // [!code focus]
+    // @log: Unexpected grant: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 by 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Pause Issuance When Your Service Loses the issuer Role
+
+Filter `args.account` and `args.role` together to react when your own service account's issuer access is revoked, halting mint jobs before they fail onchain.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { TokenRole } from 'viem/tempo'
+import { client } from './viem.config'
+
+const watcher = client.token.watchRole({
+  args: { // [!code focus]
+    account: client.account.address, // [!code focus]
+    role: TokenRole.serialize('issuer'), // [!code focus]
+  }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Halt issuance jobs until access is restored.
+    if (!log.args.hasRole) console.log('Issuer role revoked by', log.args.sender) // [!code focus]
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchTransfer.mdx
+++ b/site/pages/tempo/actions/token.watchTransfer.mdx
@@ -34,6 +34,69 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchTransfer(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Credit Customer Deposits as They Arrive
+
+Filter `args.to` to a deposit address to credit customer accounts on incoming transfers, formatting amounts for the ledger with [`Value.format`](/docs/utilities/value).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Value } from 'viem/utils'
+import { client } from './viem.config'
+
+const watcher = client.token.watchTransfer({
+  args: { to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    // Credit the customer account mapped to this deposit address.
+    console.log('Deposit:', log.args.from, Value.format(log.args.amount, 6)) // [!code focus]
+    // @log: Deposit: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 249.99
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sync an Offchain Ledger From a Checkpoint
+
+Pass `fromBlock` when a ledger service restarts: transfers missed while it was offline replay first, then live events follow on the same stream.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+// Last block the ledger recorded, loaded from its store.
+const checkpoint = 1_204_320n
+
+const watcher = client.token.watchTransfer({
+  fromBlock: checkpoint + 1n, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+for await (const { logs } of watcher) { // [!code focus]
+  for (const log of logs) {
+    // Record the transfer, then advance the checkpoint.
+    console.log(log.blockNumber, log.args.from, log.args.to, log.args.amount)
+  }
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/token.watchUpdateQuoteToken.mdx
+++ b/site/pages/tempo/actions/token.watchUpdateQuoteToken.mdx
@@ -33,6 +33,38 @@ watcher.off()
 
 Also callable standalone: `Actions.token.watchUpdateQuoteToken(client, options)`, with `Actions` imported from `'viem/tempo'`.
 
+## Recipes
+
+### Review Staged Quote Token Changes Before They Apply
+
+Branch on `eventName` to flag a staged change for risk review while it is pending, then refresh pricing configuration once the update lands.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const watcher = client.token.watchUpdateQuoteToken({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+watcher.onLogs((logs) => {
+  for (const log of logs) {
+    if (log.eventName === 'NextQuoteTokenSet') // [!code focus]
+      console.log('Review staged quote token:', log.args.nextQuoteToken) // [!code focus]
+    if (log.eventName === 'QuoteTokenUpdate') // [!code focus]
+      console.log('Quote token applied:', log.args.newQuoteToken) // [!code focus]
+    // @log: Review staged quote token: 0x20C0000000000000000000000000000000000001
+  }
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 Returns a watcher handle. Watching starts when the first listener (or async iterator) attaches, and stops when `off` is called.

--- a/site/pages/tempo/actions/validator.add.mdx
+++ b/site/pages/tempo/actions/validator.add.mdx
@@ -51,6 +51,62 @@ const hash = await client.validator.add({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Stage a Validator Before Activation
+
+Pass `active: false` to register a validator without adding it to consensus, then bring it in with [`validator.changeStatus`](/tempo/actions/validator.changeStatus) once the node passes health checks.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validator = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const { receipt } = await client.validator.addSync({
+  active: false, // [!code focus]
+  inboundAddress: 'validator.example.com:9000',
+  newValidatorAddress: validator,
+  outboundAddress: '203.0.113.10:9000',
+  publicKey: '0x1111111111111111111111111111111111111111111111111111111111111111',
+})
+
+await client.validator.changeStatusSync({ active: true, validator }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Schedule a Key Ceremony After Onboarding
+
+Combine `add` with [`validator.setNextFullDkgCeremony`](/tempo/actions/validator.setNextFullDkgCeremony) so the expanded set generates key shares that cover the new validator.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.validator.addSync({ // [!code focus]
+  active: true,
+  inboundAddress: 'validator.example.com:9000',
+  newValidatorAddress: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  outboundAddress: '203.0.113.10:9000',
+  publicKey: '0x1111111111111111111111111111111111111111111111111111111111111111',
+})
+
+await client.validator.setNextFullDkgCeremonySync({ epoch: 42n }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.changeOwner.mdx
+++ b/site/pages/tempo/actions/validator.changeOwner.mdx
@@ -40,6 +40,59 @@ const hash = await client.validator.changeOwner({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Hand Over Control to a Governance Multisig
+
+Combine `changeOwner` with [`validator.getOwner`](/tempo/actions/validator.getOwner) to confirm the handover before retiring the old key.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const multisig = '0x8ba1f109551bD432803012645Ac136ddd64DBA72'
+
+const { receipt } = await client.validator.changeOwnerSync({
+  newOwner: multisig, // [!code focus]
+})
+
+const owner = await client.validator.getOwner() // [!code focus]
+
+console.log('Owner is now:', owner)
+// @log: Owner is now: 0x8ba1f109551bD432803012645Ac136ddd64DBA72
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Sign with a Dedicated Owner Key
+
+Pass `account` to sign with the owner key your team keeps separate from the application's default account.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Account } from 'viem/tempo'
+import { client } from './viem.config'
+
+const ownerKey = Account.fromSecp256k1('0x...')
+
+const { receipt } = await client.validator.changeOwnerSync({
+  account: ownerKey, // [!code focus]
+  newOwner: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.changeStatus.mdx
+++ b/site/pages/tempo/actions/validator.changeStatus.mdx
@@ -42,6 +42,59 @@ const hash = await client.validator.changeStatus({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Reactivate a Validator After Maintenance
+
+Combine [`validator.get`](/tempo/actions/validator.get) with `changeStatus` to skip the transaction when the validator is already back in the set.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validator = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+
+const { active } = await client.validator.get({ validator }) // [!code focus]
+
+if (!active) // [!code focus]
+  await client.validator.changeStatusSync({ active: true, validator }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Deactivate Validators on a Compromised Host
+
+Combine [`validator.list`](/tempo/actions/validator.list) with `changeStatus` to pull every validator on a compromised host out of consensus.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validators = await client.validator.list() // [!code focus]
+const affected = validators.filter(
+  (validator) =>
+    validator.active && validator.outboundAddress.startsWith('203.0.113.10:'), // [!code focus]
+)
+
+for (const { validatorAddress } of affected)
+  await client.validator.changeStatusSync({
+    active: false, // [!code focus]
+    validator: validatorAddress,
+  })
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.get.mdx
+++ b/site/pages/tempo/actions/validator.get.mdx
@@ -25,6 +25,55 @@ console.log('Validator:', validator.validatorAddress)
 
 :::
 
+## Recipes
+
+### Alert When a Validator Leaves the Active Set
+
+Poll `active` from a monitoring job and page the operator when the validator drops out of consensus.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { active } = await client.validator.get({ // [!code focus]
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+if (!active) console.log('Validator dropped out of the active set') // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Audit a Node's Registered Endpoints
+
+Compare the on-chain record against your ops inventory after an infrastructure migration, then repair drift with [`validator.update`](/tempo/actions/validator.update).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const expected = 'validator-2.example.com:9000' // from your ops inventory
+
+const { inboundAddress } = await client.validator.get({ // [!code focus]
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+if (inboundAddress !== expected) // [!code focus]
+  console.log(`Stale endpoint: ${inboundAddress}, expected ${expected}`)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getByIndex.mdx
+++ b/site/pages/tempo/actions/validator.getByIndex.mdx
@@ -25,6 +25,33 @@ console.log('Validator:', validator)
 
 :::
 
+## Recipes
+
+### Sample a Random Validator for a Health Probe
+
+Combine [`validator.getCount`](/tempo/actions/validator.getCount) with `getByIndex` to pick a random validator, then load its record with [`validator.get`](/tempo/actions/validator.get) to probe its endpoint.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const count = await client.validator.getCount() // [!code focus]
+const index = BigInt(Math.floor(Math.random() * Number(count))) // [!code focus]
+
+const address = await client.validator.getByIndex({ index }) // [!code focus]
+const { inboundAddress } = await client.validator.get({ validator: address })
+
+console.log('Probing:', inboundAddress)
+// @log: Probing: validator.example.com:9000
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getCount.mdx
+++ b/site/pages/tempo/actions/validator.getCount.mdx
@@ -23,6 +23,32 @@ console.log('Result:', result)
 
 :::
 
+## Recipes
+
+### Derive Quorum Figures for a Health Dashboard
+
+Use the validator count to derive standard BFT fault-tolerance figures for a network health dashboard.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const count = await client.validator.getCount() // [!code focus]
+
+const faults = (count - 1n) / 3n // [!code focus]
+const quorum = count - faults // [!code focus]
+
+console.log(`Quorum: ${quorum} of ${count} validators`)
+// @log: Quorum: 3 of 4 validators
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getNextFullDkgCeremony.mdx
+++ b/site/pages/tempo/actions/validator.getNextFullDkgCeremony.mdx
@@ -23,6 +23,33 @@ console.log('Result:', result)
 
 :::
 
+## Recipes
+
+### Alert Operators Ahead of a Ceremony
+
+Combine the scheduled epoch with [`validator.get`](/tempo/actions/validator.get) so operators of active validators keep their nodes online for the ceremony.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const epoch = await client.validator.getNextFullDkgCeremony() // [!code focus]
+
+const { active } = await client.validator.get({
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // your validator
+})
+
+if (active) console.log(`Keep the node online for epoch ${epoch}`) // [!code focus]
+// @log: Keep the node online for epoch 42
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.getOwner.mdx
+++ b/site/pages/tempo/actions/validator.getOwner.mdx
@@ -23,6 +23,34 @@ console.log('Result:', result)
 
 :::
 
+## Recipes
+
+### Gate Admin Tooling to the Config Owner
+
+Check the owner before running restricted operations like [`validator.changeStatus`](/tempo/actions/validator.changeStatus): mutations from any other account revert.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const owner = await client.validator.getOwner() // [!code focus]
+
+if (owner !== client.account.address) // [!code focus]
+  throw new Error('connected account cannot manage the validator set')
+
+const { receipt } = await client.validator.changeStatusSync({
+  active: false,
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.list.mdx
+++ b/site/pages/tempo/actions/validator.list.mdx
@@ -23,6 +23,57 @@ console.log('Result:', result.length)
 
 :::
 
+## Recipes
+
+### Flag Inactive Validators on a Monitoring Dashboard
+
+Filter the set by `active` to surface validators that are registered but out of consensus.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validators = await client.validator.list()
+
+const inactive = validators.filter((validator) => !validator.active) // [!code focus]
+
+for (const { validatorAddress } of inactive)
+  console.log('Out of consensus:', validatorAddress)
+// @log: Out of consensus: 0x8ba1f109551bD432803012645Ac136ddd64DBA72
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Build a Peer List for a New Node
+
+Map active validators to their inbound endpoints to seed a new node's peer configuration.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const validators = await client.validator.list()
+
+const peers = validators
+  .filter((validator) => validator.active) // [!code focus]
+  .map((validator) => validator.inboundAddress) // [!code focus]
+
+console.log('Peers:', peers)
+// @log: Peers: ['validator.example.com:9000', '203.0.113.20:9000']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.setNextFullDkgCeremony.mdx
+++ b/site/pages/tempo/actions/validator.setNextFullDkgCeremony.mdx
@@ -40,6 +40,54 @@ const hash = await client.validator.setNextFullDkgCeremony({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Refresh Key Shares After Removing a Validator
+
+Combine [`validator.changeStatus`](/tempo/actions/validator.changeStatus) with a full ceremony so the remaining set regenerates its key shares at the chosen epoch.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.validator.changeStatusSync({ // [!code focus]
+  active: false, // [!code focus]
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+await client.validator.setNextFullDkgCeremonySync({ epoch: 42n }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Verify the Scheduled Epoch Before Announcing It
+
+Read the schedule back with [`validator.getNextFullDkgCeremony`](/tempo/actions/validator.getNextFullDkgCeremony) before notifying operators of the maintenance window.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+await client.validator.setNextFullDkgCeremonySync({ epoch: 42n })
+
+const scheduled = await client.validator.getNextFullDkgCeremony() // [!code focus]
+
+console.log('Ceremony scheduled for epoch:', scheduled)
+// @log: Ceremony scheduled for epoch: 42n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/validator.update.mdx
+++ b/site/pages/tempo/actions/validator.update.mdx
@@ -46,6 +46,62 @@ const hash = await client.validator.update({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Migrate a Node to New Infrastructure
+
+Combine [`validator.get`](/tempo/actions/validator.get) with `update` to point the record at new endpoints while keeping the validator's address and key.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const current = await client.validator.get({ // [!code focus]
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+const { receipt } = await client.validator.updateSync({
+  inboundAddress: 'validator-2.example.com:9000', // [!code focus]
+  newValidatorAddress: current.validatorAddress,
+  outboundAddress: '198.51.100.7:9000', // [!code focus]
+  publicKey: current.publicKey,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Rotate a Validator's Address
+
+Reuse the existing record from [`validator.get`](/tempo/actions/validator.get) and pass a fresh `newValidatorAddress` to rotate the address that identifies the validator on chain.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const current = await client.validator.get({
+  validator: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+})
+
+const { receipt } = await client.validator.updateSync({
+  inboundAddress: current.inboundAddress,
+  newValidatorAddress: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  outboundAddress: current.outboundAddress,
+  publicKey: current.publicKey,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.getMasterAddress.mdx
+++ b/site/pages/tempo/actions/virtualAddress.getMasterAddress.mdx
@@ -25,6 +25,35 @@ console.log('Address:', address)
 
 :::
 
+## Recipes
+
+### Guard Deposit Address Issuance
+
+Confirm a master ID still resolves to a registered master before deriving per-customer deposit addresses from it with `VirtualAddress.from`.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { VirtualAddress } from 'viem/tempo'
+import { client } from './viem.config'
+
+const masterId = '0x58e21090' // from your deployment records
+
+const master = await client.virtualAddress.getMasterAddress({ masterId }) // [!code focus]
+if (!master) throw new Error(`master ID ${masterId} is not registered`) // [!code focus]
+
+const depositAddress = VirtualAddress.from({ masterId, userTag: 4821n })
+
+console.log('Deposit address for customer 4821:', depositAddress)
+// @log: Deposit address for customer 4821: 0x58e21090fdfdfdfdfdfdfdfdfdfd0000000012d5
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.registerMaster.mdx
+++ b/site/pages/tempo/actions/virtualAddress.registerMaster.mdx
@@ -43,6 +43,68 @@ const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 const { args } = Actions.virtualAddress.registerMaster.extractEvent(receipt.logs)
 ```
 
+## Recipes
+
+### Onboard a Deposit Master for an Exchange
+
+Mine a proof-of-work salt for your wallet, register it once, then derive per-customer deposit addresses offchain with `VirtualAddress.from` (see the [register guide](/tempo/guides/virtual-addresses/register) for operational practices).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { VirtualAddress, VirtualMaster } from 'viem/tempo'
+import { client } from './viem.config'
+
+const mined = await VirtualMaster.mineSaltAsync({ // [!code focus]
+  address: client.account.address, // [!code focus]
+}) // [!code focus]
+
+const { masterId } = await client.virtualAddress.registerMasterSync({
+  salt: mined!.salt, // [!code focus]
+})
+
+const depositAddress = VirtualAddress.from({ masterId, userTag: 1n })
+
+console.log('Deposit address for customer 1:', depositAddress)
+// @log: Deposit address for customer 1: 0x58e21090fdfdfdfdfdfdfdfdfdfd000000000001
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Make Deploy-Time Registration Idempotent
+
+Derive the master ID from your stored salt with `VirtualMaster.getMasterId` and check [`virtualAddress.getMasterAddress`](/tempo/actions/virtualAddress.getMasterAddress) first, so a re-run deploy script skips the one-time registration.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { VirtualMaster } from 'viem/tempo'
+import { client } from './viem.config'
+
+// Mined ahead of time, from your deploy config.
+const salt =
+  '0x00000000000000000000000000000000000000000000000000000000abf52baf'
+
+const masterId = VirtualMaster.getMasterId({
+  address: client.account.address,
+  salt,
+})
+
+const registered = await client.virtualAddress.getMasterAddress({ masterId }) // [!code focus]
+if (!registered) // [!code focus]
+  await client.virtualAddress.registerMasterSync({ salt }) // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/virtualAddress.resolve.mdx
+++ b/site/pages/tempo/actions/virtualAddress.resolve.mdx
@@ -25,6 +25,72 @@ console.log('Recipient:', recipient)
 
 :::
 
+## Recipes
+
+### Screen a Withdrawal Destination
+
+Resolve a customer-supplied withdrawal address, then screen the beneficial owner against your denylist before sending with [`token.transferSync`](/tempo/actions/token.transfer).
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const denylist = new Set(['0x8ba1f109551bd432803012645ac136ddd64dba72'])
+
+const destination = '0x58e21090fdfdfdfdfdfdfdfdfdfd010203040506'
+
+const master = await client.virtualAddress.resolve({ address: destination }) // [!code focus]
+if (!master) throw new Error('destination forwards to an unregistered master') // [!code focus]
+if (denylist.has(master.toLowerCase())) // [!code focus]
+  throw new Error(`beneficial owner ${master} is denied`) // [!code focus]
+
+const { receipt } = await client.token.transferSync({
+  amount: { formatted: '2500' },
+  to: destination,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Group Ledger Entries by Beneficial Owner
+
+Normalize every counterparty through `resolve` when reconciling: virtual aliases collapse to their master, and regular addresses pass through unchanged.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const counterparties = [
+  '0x58e21090fdfdfdfdfdfdfdfdfdfd010203040506',
+  '0x58e21090fdfdfdfdfdfdfdfdfdfd010203040507',
+  '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+] as const
+
+const owners = await Promise.all(
+  counterparties.map((address) => client.virtualAddress.resolve({ address })), // [!code focus]
+)
+
+console.log(owners)
+// @log: [
+// @log:   '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+// @log:   '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+// @log:   '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
+// @log: ]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.deposit.mdx
+++ b/site/pages/tempo/actions/wallet.deposit.mdx
@@ -23,6 +23,45 @@ console.log('Receipts:', result?.receipts)
 // @log: Receipts: [{ status: 'success', transactionHash: '0x1234...' }]
 ```
 
+## Recipes
+
+### Onboard Funds from a Known Chain
+
+Pre-fill `chainId` when your onboarding flow already knows where the user's funds sit, such as bridging in from Ethereum.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+await client.wallet.deposit({
+  amount: '250',
+  chainId: 1, // [!code focus]
+})
+```
+
+### Deposit to a Labeled Exchange Address
+
+Pass `address` and `displayName` when funds should land somewhere other than the connected account, such as a customer's [virtual deposit address](/tempo/guides/virtual-addresses) at an exchange.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+await client.wallet.deposit({
+  address: '0x58e21090fdfdfdfdfdfdfdfdfdfd010203040506', // [!code focus]
+  displayName: 'Acme Exchange Deposit', // [!code focus]
+  token: 'pathusd',
+})
+```
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.swap.mdx
+++ b/site/pages/tempo/actions/wallet.swap.mdx
@@ -24,6 +24,49 @@ console.log('Transaction hash:', receipt.transactionHash)
 // @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 ```
 
+## Recipes
+
+### Buy an Exact Invoice Amount
+
+Set `type: 'buy'` when an invoice is priced in a token the customer does not hold: `amount` is the exact amount of `token` to receive, funded by selling `pairToken`.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+const { receipt } = await client.wallet.swap({
+  amount: '250',
+  pairToken: '0x20c0000000000000000000000000000000000000', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001', // [!code focus]
+  type: 'buy', // [!code focus]
+})
+```
+
+### Cap Slippage on a Treasury Rebalance
+
+Pass `slippage` to bound how far from quote a large conversion may fill, here 0.5%.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+const { receipt } = await client.wallet.swap({
+  amount: '100000',
+  pairToken: '0x20c0000000000000000000000000000000000000',
+  slippage: 0.005, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  type: 'sell',
+})
+```
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/wallet.transfer.mdx
+++ b/site/pages/tempo/actions/wallet.transfer.mdx
@@ -43,6 +43,68 @@ const { receipt } = await client.wallet.transfer({
 })
 ```
 
+## Recipes
+
+### Tag a Checkout Payment with an Order Memo
+
+Attach the order reference as a `memo` (UTF-8, max 32 bytes) so your backend can match the onchain transfer to the order.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+const { receipt } = await client.wallet.transfer({
+  amount: '249.99',
+  memo: 'order_1024', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: 'pathusd',
+})
+```
+
+### Charge a Subscription from an Allowance
+
+Set `from` to collect a recurring charge from a subscriber who granted your account an allowance with [`token.approve`](/tempo/actions/token.approve); the wallet submits a `transferFrom`.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+const { receipt } = await client.wallet.transfer({
+  amount: '15',
+  from: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: 'pathusd',
+})
+```
+
+### Sponsor Fees Through Your Own Service
+
+Point `feePayer` at your own fee payer service to sponsor customer transfers such as micropayments, or pass `false` to disable the wallet's default fee payer.
+
+```ts twoslash [example.ts]
+import { Client, custom } from 'viem/tempo'
+import 'viem/window'
+
+const client = Client.create({
+  transport: custom(window.ethereum!),
+})
+
+const { receipt } = await client.wallet.transfer({
+  amount: '0.05',
+  feePayer: 'https://sponsor.example.com', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: 'pathusd',
+})
+```
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.deposit.mdx
+++ b/site/pages/tempo/actions/zone.deposit.mdx
@@ -46,6 +46,90 @@ const hash = await client.zone.deposit({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Credit a Customer's Zone Balance
+
+Pass `recipient` to credit the deposit to a customer's address in the zone, and `memo` to carry the internal ledger reference your reconciliation jobs match on.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Hex } from 'viem/utils'
+import { client } from './viem.config'
+
+const { receipt } = await client.zone.depositSync({
+  amount: 100_000_000n,
+  memo: Hex.fromString('acct_9243', { size: 32 }), // [!code focus]
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  zoneId: 7,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Route Bounced Deposits to a Treasury Wallet
+
+Pass `bouncebackRecipient` when depositing from an operational hot wallet, so a deposit the zone cannot credit refunds to your treasury instead of the sender.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { receipt } = await client.zone.depositSync({
+  amount: 100_000_000n,
+  bouncebackRecipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  zoneId: 7,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Wait Until the Funds Are Spendable in the Zone
+
+Combine the deposit receipt's block number with [`zone.waitForTempoBlock`](/tempo/actions/zone.waitForTempoBlock) on the zone client to block until the zone has imported the deposit.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+import { client as zoneClient } from './zones.config'
+
+const { receipt } = await client.zone.depositSync({
+  amount: 100_000_000n,
+  token: '0x20c0000000000000000000000000000000000001',
+  zoneId: 7,
+})
+
+const info = await zoneClient.zone.waitForTempoBlock({ // [!code focus]
+  tempoBlockNumber: receipt.blockNumber, // [!code focus]
+}) // [!code focus]
+
+console.log('Imported Tempo block:', info.tempoBlockNumber)
+// @log: Imported Tempo block: 123456n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.encryptedDeposit.mdx
+++ b/site/pages/tempo/actions/zone.encryptedDeposit.mdx
@@ -82,6 +82,68 @@ const { encrypted, keyIndex } =
 
 The helper returns the encrypted payload and its key index together with the parent chain ID, portal address, and zone ID.
 
+## Recipes
+
+### Pay an Employee Without Revealing the Recipient
+
+Pass `recipient` and `memo` to run payroll into the zone: both fields are encrypted for the sequencer, so the public chain sees only the sender, token, and amount.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Hex } from 'viem/utils'
+import { client } from './viem.config'
+
+const { receipt } = await client.zone.encryptedDepositSync({
+  amount: 4_250_000_000n,
+  memo: Hex.fromString('payroll-2026-07', { size: 32 }), // [!code focus]
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+  zoneId: 7,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Run a Payroll Batch Concurrently
+
+Pass `nonceKey: 'expiring'` to submit one encrypted deposit per employee from a single funding account, without serializing the batch on nonce order.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const payouts = [
+  { amount: 4_250_000_000n, recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' },
+  { amount: 3_890_000_000n, recipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72' },
+] as const
+
+const results = await Promise.all(
+  payouts.map((payout) =>
+    client.zone.encryptedDepositSync({
+      ...payout,
+      nonceKey: 'expiring', // [!code focus]
+      token: '0x20c0000000000000000000000000000000000001',
+      zoneId: 7,
+    }),
+  ),
+)
+
+console.log(results.map(({ receipt }) => receipt.status))
+// @log: ['success', 'success']
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getAuthorizationTokenInfo.mdx
+++ b/site/pages/tempo/actions/zone.getAuthorizationTokenInfo.mdx
@@ -23,6 +23,32 @@ console.log('Expires At:', info.expiresAt)
 
 :::
 
+## Recipes
+
+### Re-Sign Before the Token Expires
+
+Combine the token expiry with [`zone.signAuthorizationToken`](/tempo/actions/zone.signAuthorizationToken) to refresh authentication in a long-running service before zone requests start failing.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const { expiresAt } = await client.zone.getAuthorizationTokenInfo()
+
+const oneHour = 60n * 60n
+const now = BigInt(Math.floor(Date.now() / 1000))
+
+if (expiresAt - now < oneHour) // [!code focus]
+  await client.zone.signAuthorizationToken() // [!code focus]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getEncryptionKey.mdx
+++ b/site/pages/tempo/actions/zone.getEncryptionKey.mdx
@@ -25,6 +25,42 @@ console.log('Public key:', publicKey)
 
 :::
 
+## Recipes
+
+### Detect Key Rotation Before Submitting a Prepared Deposit
+
+Compare a prepared payload's `keyIndex` with the current key before broadcasting, and re-encrypt with [`zone.encryptedDeposit`](/tempo/actions/zone.encryptedDeposit)'s `prepare` if the sequencer rotated keys.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const options = {
+  amount: 100_000_000n,
+  bouncebackRecipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72',
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000001',
+  zoneId: 7,
+} as const
+
+let prepared = await Actions.zone.encryptedDeposit.prepare(client, options)
+
+// Re-check the key once the batching window closes.
+const { keyIndex } = await client.zone.getEncryptionKey({ zoneId: 7 }) // [!code focus]
+if (keyIndex !== prepared.keyIndex) // [!code focus]
+  prepared = await Actions.zone.encryptedDeposit.prepare(client, options) // [!code focus]
+
+const hash = await client.zone.encryptedDeposit(prepared)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Type
 
 ```ts

--- a/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
+++ b/site/pages/tempo/actions/zone.getWithdrawalFee.mdx
@@ -33,6 +33,33 @@ const fee = await client.zone.getWithdrawalFee({
 })
 ```
 
+## Recipes
+
+### Check the Balance Covers Amount plus Fee
+
+Combine the fee with [`token.getBalance`](/tempo/actions/token.getBalance) before calling [`zone.requestWithdrawal`](/tempo/actions/zone.requestWithdrawal), so a withdrawal that cannot cover its fee never reaches the sequencer.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+const amount = 250_000_000n
+const token = '0x20c0000000000000000000000000000000000001'
+
+const fee = await client.zone.getWithdrawalFee() // [!code focus]
+const balance = await client.token.getBalance({ token })
+
+if (balance.amount >= amount + fee) // [!code focus]
+  await client.zone.requestWithdrawalSync({ amount, token })
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.getZoneInfo.mdx
+++ b/site/pages/tempo/actions/zone.getZoneInfo.mdx
@@ -27,6 +27,60 @@ console.log('Tempo block number:', info.tempoBlockNumber)
 
 :::
 
+## Recipes
+
+### Confirm a Token Is Enabled in the Zone
+
+Check `zoneTokens` before bridging funds with [`zone.deposit`](/tempo/actions/zone.deposit), so you only submit deposits the zone can credit.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+const token = '0x20c0000000000000000000000000000000000001'
+
+const info = await client.zone.getZoneInfo()
+
+if (!info.zoneTokens.includes(token)) // [!code focus]
+  throw new Error(`Token ${token} is not enabled in zone ${info.zoneId}.`) // [!code focus]
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Alert When the Zone Falls Behind Tempo
+
+Compare `tempoBlockNumber` with the Mainnet block number from [`block.getNumber`](/docs/actions/public/block/getNumber) to monitor import lag before it delays deposit settlement.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client as mainnet } from './viem.config'
+import { client } from './zones.config'
+
+const [tempoBlock, info] = await Promise.all([
+  mainnet.block.getNumber(),
+  client.zone.getZoneInfo(),
+])
+
+const lag = tempoBlock - info.tempoBlockNumber // [!code focus]
+if (lag > 10n) console.warn(`Zone import lag: ${lag} blocks`)
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestVerifiableWithdrawal.mdx
@@ -56,6 +56,59 @@ const hash = await client.zone.requestVerifiableWithdrawal({
 const receipt = await client.transaction.waitForReceipt({ hash }).receipt
 ```
 
+## Recipes
+
+### Let an Auditor Verify Treasury Withdrawals
+
+Pass an auditor's compressed public key as `revealTo`: withdrawals stay private onchain while only the auditor can decrypt and attest which zone account sent them.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+// Compressed public key received from the auditor.
+// The matching private key never leaves them.
+const revealTo = '0x0357e8a1e347b0c8e8c14290499e1281f84eae5d1cdd10cc5eb4d92aca17c5c1d4'
+
+const { receipt } = await client.zone.requestVerifiableWithdrawalSync({
+  amount: 100_000_000n,
+  revealTo, // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Settle with a Counterparty Who Can Verify the Sender
+
+Pass the counterparty's Mainnet address as `to` and their public key as `revealTo`, so they receive the funds and can decrypt proof of who paid.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Hex } from 'viem/utils'
+import { client } from './zones.config'
+
+const { receipt } = await client.zone.requestVerifiableWithdrawalSync({
+  amount: 250_000_000n,
+  memo: Hex.fromString('otc_trade_88', { size: 32 }),
+  revealTo: '0x02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.requestWithdrawal.mdx
+++ b/site/pages/tempo/actions/zone.requestWithdrawal.mdx
@@ -83,6 +83,57 @@ type PreparedWithdrawal = {
 }
 ```
 
+## Recipes
+
+### Pay a Vendor Directly on Tempo
+
+Pass `to` to settle an invoice straight from the zone to a vendor's Mainnet address, with a `memo` carrying the invoice reference for reconciliation.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Hex } from 'viem/utils'
+import { client } from './zones.config'
+
+const { receipt } = await client.zone.requestWithdrawalSync({
+  amount: 4_500_000_000n,
+  memo: Hex.fromString('inv_2049', { size: 32 }), // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Withdraw into a Contract with a Callback
+
+Reserve `callbackGas` and pass `data` when the Mainnet recipient is a contract, and set `fallbackRecipient` so funds recover to your treasury if the callback fails.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+const { receipt } = await client.zone.requestWithdrawalSync({
+  amount: 100_000_000n,
+  callbackGas: 100_000n, // [!code focus]
+  data: '0xd0e30db0', // [!code focus]
+  fallbackRecipient: '0x8ba1f109551bD432803012645Ac136ddd64DBA72', // [!code focus]
+  to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000001',
+})
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.signAuthorizationToken.mdx
+++ b/site/pages/tempo/actions/zone.signAuthorizationToken.mdx
@@ -21,6 +21,64 @@ console.log('Token:', token)
 
 :::
 
+## Recipes
+
+### Issue a Short-Lived Token for a Backend Job
+
+Pass `expiresAt` to bound the token's validity to the job's runtime, limiting exposure if the token leaks from a worker environment.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const now = Math.floor(Date.now() / 1000)
+
+const { token } = await client.zone.signAuthorizationToken({
+  expiresAt: now + 15 * 60, // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+### Share One Token Across Processes
+
+Pass a custom `storage` backed by a shared store, so a fleet of workers reuses a single signed token instead of each process re-signing.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Storage } from 'viem/tempo'
+import { client } from './viem.config'
+
+// Swap the Map for a shared store such as Redis.
+const store = new Map<string, string>()
+
+const storage = Storage.from({
+  getItem: (key) => store.get(key) ?? null,
+  setItem: (key, value) => {
+    store.set(key, value)
+  },
+  removeItem: (key) => {
+    store.delete(key)
+  },
+})
+
+const { token } = await client.zone.signAuthorizationToken({
+  storage, // [!code focus]
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 ```ts

--- a/site/pages/tempo/actions/zone.waitForTempoBlock.mdx
+++ b/site/pages/tempo/actions/zone.waitForTempoBlock.mdx
@@ -26,6 +26,66 @@ console.log('Imported Tempo block:', info.tempoBlockNumber)
 The action polls [`zone.getZoneInfo`](/tempo/actions/zone.getZoneInfo) and resolves when the zone's
 `tempoBlockNumber` reaches the requested block.
 
+## Recipes
+
+### Show Settlement Progress at Checkout
+
+Tighten `pollingInterval` and shorten `timeout` while a customer waits, treating a timeout as still settling rather than a failure.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+try {
+  await client.zone.waitForTempoBlock({
+    pollingInterval: 500, // [!code focus]
+    tempoBlockNumber: 123456n,
+    timeout: 15_000, // [!code focus]
+  })
+  console.log('Deposit settled')
+} catch {
+  // Timed out: the zone has not imported the block yet.
+  console.log('Still settling, check back shortly')
+}
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
+### Gate a Balance Read on Deposit Import
+
+Wait for the deposit's Mainnet block number before reading the balance with [`token.getBalance`](/tempo/actions/token.getBalance): the funds are spendable once the block imports.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './zones.config'
+
+// Block number from the Mainnet deposit receipt.
+const depositBlockNumber = 123456n
+
+await client.zone.waitForTempoBlock({
+  tempoBlockNumber: depositBlockNumber, // [!code focus]
+})
+
+const balance = await client.token.getBalance({ // [!code focus]
+  token: '0x20c0000000000000000000000000000000000001', // [!code focus]
+}) // [!code focus]
+
+console.log('Zone balance:', balance.formatted)
+// @log: Zone balance: 100
+```
+
+```ts twoslash [zones.config.ts] filename="zones.config.ts"
+// [!include ~/snippets/tempo/zones.config.ts:setup]
+```
+
+:::
+
 ## Return Value
 
 `Actions.zone.getZoneInfo.ReturnType`

--- a/site/pages/tempo/guides/access-keys/verify.mdx
+++ b/site/pages/tempo/guides/access-keys/verify.mdx
@@ -73,7 +73,7 @@ const valid = await Actions.accessKey.verifyHash(client, {
 
 Keep the default `admin: true` when a flow should only accept the account owner or an admin key,
 such as administrative actions. Use `admin: false` when any authorized access key should pass,
-such as session-key authentication.
+such as access-key authentication.
 
 ### Verify the Exact Signed Hash
 


### PR DESCRIPTION
Adds a `## Recipes` section to every Tempo Action page, with real-world use cases (checkout, payroll, compliance screening, market making) instead of the Usage restatements removed in https://github.com/wevm/viem/pull/4931.
