### PR TITLE
feat: add passkey accounts

### DIFF
--- a/.changeset/brave-passkeys-sign.md
+++ b/.changeset/brave-passkeys-sign.md
@@ -1,5 +1,5 @@
 ---
-'viem': minor
+'viem': patch
 ---
 
 Added `Account.fromPrf` to derive local secp256k1 accounts from WebAuthn PRF output.

--- a/.changeset/brave-passkeys-sign.md
+++ b/.changeset/brave-passkeys-sign.md
@@ -1,0 +1,16 @@
+---
+'viem': minor
+---
+
+Added `Account.fromPrf` to derive local secp256k1 accounts from WebAuthn PRF output.
+
+```ts
+import { Account } from 'viem'
+import { WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.createCredential({
+  name: 'Example',
+  prf: true,
+})
+const account = Account.fromPrf(credential.prf)
+```

--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
   },
   "dependencies": {
     "abitype": "1.3.0",
-    "ox": "1.3.1"
+    "ox": "1.4.0"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,8 +230,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0(typescript@7.0.2)(zod@4.4.3)
       ox:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@7.0.2)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@7.0.2)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -289,7 +289,7 @@ importers:
         version: 0.18.1
       permissionless:
         specifier: 'catalog:'
-        version: 0.2.57(ox@1.3.1(typescript@7.0.2))
+        version: 0.2.57(ox@1.4.0(typescript@7.0.2))
       prool:
         specifier: 'catalog:'
         version: 0.2.13(@pimlico/alto@0.0.18(supports-color@8.1.1)(typescript@7.0.2))(debug@4.4.3(supports-color@8.1.1))(testcontainers@11.10.0(supports-color@8.1.1))
@@ -6042,6 +6042,14 @@ packages:
 
   ox@1.3.1:
     resolution: {integrity: sha512-DFeeFN7Ff9IM69ErVifrx7JGCnPirFc+nZcEnma215K/lr8/7eklsrMAyr7ZxnFMIo0OCy3QRmdLoBODzT3weA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@1.4.0:
+    resolution: {integrity: sha512-18qIhYhvZvvbgtAffdavrYyj3/RtTvEdq4lJ7HeIRGJlQ3a0Hz3fchh6HQn7wfBrsqrjnRXh2up3+eBCQRNhWQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -13998,6 +14006,20 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
+  ox@1.4.0(typescript@7.0.2):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 2.2.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
+      eventemitter3: 5.0.1
+      zod: 4.4.3
+    optionalDependencies:
+      typescript: 7.0.2
+
   oxc-parser@0.133.0:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -14235,11 +14257,11 @@ snapshots:
 
   pend@1.2.0: {}
 
-  permissionless@0.2.57(ox@1.3.1(typescript@7.0.2)):
+  permissionless@0.2.57(ox@1.4.0(typescript@7.0.2)):
     dependencies:
       viem: 'link:'
     optionalDependencies:
-      ox: 1.3.1(typescript@7.0.2)
+      ox: 1.4.0(typescript@7.0.2)
 
   pg-int8@1.0.1: {}
 

--- a/scripts/docs:sync-utils.ts
+++ b/scripts/docs:sync-utils.ts
@@ -27,7 +27,7 @@ import { join } from 'node:path'
 // They are preserved across the regenerate-from-scratch wipe and committed; the
 // generated pages are ignored via a generated `docs/utilities/.gitignore`.
 
-const origin = 'https://v1.oxlib.sh'
+const origin = 'https://oxlib.sh'
 const srcUtilsDir = join(import.meta.dirname, '../src/utils')
 const outDir = join(import.meta.dirname, '../site/pages/docs/utilities')
 const sidebarPath = join(import.meta.dirname, '../site/sidebar.generated.ts')
@@ -96,21 +96,14 @@ const categories: Record<string, string> = {
   Blobs: 'Blobs (EIP-4844)',
   BlobCells: 'Blobs (EIP-4844)',
   Kzg: 'Blobs (EIP-4844)',
-  Hash: 'Crypto',
-  HdKey: 'Crypto',
-  Mnemonic: 'Crypto',
-  P256: 'Crypto',
-  WebAuthnP256: 'Crypto',
-  Bytes: 'Encoding',
-  Hex: 'Encoding',
-  Json: 'Encoding',
-  Rlp: 'Encoding',
-  Value: 'Encoding',
+  P256: 'Keys & Signatures',
+  Prf: 'Keys & Signatures',
   PublicKey: 'Keys & Signatures',
   Secp256k1: 'Keys & Signatures',
   Signature: 'Keys & Signatures',
   SignatureErc6492: 'Keys & Signatures',
   SignatureErc8010: 'Keys & Signatures',
+  WebAuthn: 'Keys & Signatures',
   Provider: 'Providers (EIP-1193)',
   RpcResponse: 'JSON-RPC',
   RpcSchema: 'JSON-RPC',
@@ -134,21 +127,32 @@ const rootModules = new Set([
   'AccountProof',
   'Block',
   'BlockOverrides',
+  'Bytes',
   'Fee',
   'Filter',
+  'Hash',
+  'HdKey',
+  'Hex',
+  'Json',
   'Log',
+  'Mnemonic',
+  'Rlp',
   'StateOverrides',
   'Transaction',
   'TransactionReceipt',
   'TransactionRequest',
+  'Value',
   'Withdrawal',
   'Siwe',
 ])
 
 /** Sidebar label overrides (module name → displayed text). */
 const labels: Record<string, string> = {
+  HdKey: 'HdKey',
   Siwe: 'Siwe (Sign-in with Ethereum)',
 }
+
+const alphabeticalFunctions = new Set(['WebAuthn'])
 
 type Module = {
   name: string
@@ -382,6 +386,8 @@ async function syncModule(
     if (isExtra) extras.push(s)
     else functions.push(s)
   })
+  if (alphabeticalFunctions.has(name))
+    functions.sort((a, b) => a.localeCompare(b))
 
   // Restore the hand-authored viem-helper pages (preserved across the wipe).
   const addedHelpers: string[] = []
@@ -495,7 +501,7 @@ function writeSidebar(synced: Synced[]) {
     if (!(m.name in categories))
       console.warn(`  ! uncategorized module: ${m.name}`)
     const list = groups.get(category) ?? groups.set(category, []).get(category)!
-    list.push(moduleItem(m))
+    list.push(moduleItem(m, labels[m.name] ?? m.name))
   }
 
   // Category groups and root modules share one alphabetical ordering, keyed by

--- a/site/pages/docs/accounts/index.mdx
+++ b/site/pages/docs/accounts/index.mdx
@@ -34,6 +34,12 @@ account.address
     to="/docs/accounts/local/private-key"
   />
   <Card
+    title="Passkey Accounts"
+    description="Local account derived from a credential-bound WebAuthn PRF."
+    icon="lucide:fingerprint"
+    to="/docs/accounts/local/passkey"
+  />
+  <Card
     title="Mnemonic Accounts"
     description="Local account derived from a BIP-39 mnemonic phrase."
     icon="lucide:spell-check"

--- a/site/pages/docs/accounts/local/passkey.mdx
+++ b/site/pages/docs/accounts/local/passkey.mdx
@@ -1,0 +1,177 @@
+# Passkey Accounts
+
+## Overview
+
+A **Passkey Account** is a [local account](/docs/accounts) (`Account.PrivateKey`) derived from a
+credential-bound WebAuthn pseudo-random function (PRF).
+
+The passkey authorizes access to the PRF output. `Prf.tag` creates a stable application-owned PRF
+input. [`Account.fromPrf`](#accountfromprf) derives a secp256k1 private key from the output, then
+creates an account that can sign messages, transactions, typed data, and authorizations locally.
+
+:::warning
+The derived account is a software-key account. It does not sign with the authenticator's P256 key.
+Losing access to the passkey also loses access to the account unless you provide a recovery method.
+Treat the PRF output as secret key material and do not persist it.
+:::
+
+## Recipes
+
+### Create a Passkey Account
+
+Set `prf: true` when you create the WebAuthn credential, then pass its PRF output to
+`Account.fromPrf`.
+
+```ts twoslash
+import { Account } from 'viem'
+import { WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.createCredential({
+  name: 'Example',
+  prf: true,
+})
+
+const account = Account.fromPrf(credential.prf)
+
+// Store this identifier to retrieve the account later.
+const credentialId = credential.id
+```
+
+### Retrieve a Passkey Account
+
+Request the same PRF output with the credential identifier. The same credential and PRF input
+derive the same account.
+
+```ts twoslash
+import { Account } from 'viem'
+import { WebAuthn } from 'viem/utils'
+
+const credentialId = '...'
+
+const credential = await WebAuthn.getCredential({
+  credentialId,
+  prf: true,
+})
+
+const account = Account.fromPrf(credential.prf)
+```
+
+### Create Multiple Accounts from One Passkey
+
+Use a different stable tag when your application needs separate accounts for the same passkey, such
+as personal and business accounts. The same passkey produces a different account for each tag.
+
+```ts twoslash
+import { Account } from 'viem'
+import { Prf, WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.createCredential({
+  name: 'Example',
+  prf: Prf.tag('account.1'),
+})
+
+const firstAccount = Account.fromPrf(credential.prf)
+
+const response = await WebAuthn.getCredential({
+  credentialId: credential.id,
+  prf: Prf.tag('account.2'),
+})
+
+const secondAccount = Account.fromPrf(response.prf)
+
+// Store this identifier to retrieve either account later.
+const credentialId = credential.id
+```
+
+Creating each additional account requires a WebAuthn prompt. Tags are public application constants,
+not secrets or per-user state. Keep the tag strings stable across versions. To retrieve an account,
+evaluate the credential with the same tag and pass the resulting PRF output to `Account.fromPrf`.
+
+### Set a Default Client Account
+
+Pass the account to [`Client.create`](/docs/clients/create). Wallet Actions use this account when
+you do not pass an `account` option.
+
+```ts twoslash
+import { Account, Client, http, walletActions } from 'viem'
+import { mainnet } from 'viem/chains'
+import { WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.getCredential({
+  credentialId: '...',
+  prf: true,
+})
+const account = Account.fromPrf(credential.prf)
+
+const client = Client.create({
+  account,
+  chain: mainnet,
+  transport: http(),
+}).extend(walletActions())
+
+const signature = await client.signMessage({ message: 'hello world' })
+```
+
+## `Account.fromPrf`
+
+Creates a private-key-backed local account from a 32-byte WebAuthn PRF output.
+
+### Usage
+
+```ts twoslash
+import { Account } from 'viem'
+import { WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.getCredential({
+  credentialId: '...',
+  prf: true,
+})
+
+const account = Account.fromPrf(credential.prf)
+
+account.address
+// '0x...'
+account.publicKey
+// '0x...'
+```
+
+### Parameters
+
+#### prf
+
+- **Type:** `Hex.Hex | Bytes.Bytes`
+
+The 32-byte WebAuthn PRF output used to derive the account.
+
+#### options.nonceManager
+
+- **Type:** `NonceManager.NonceManager`
+
+The [nonce manager](/docs/accounts/nonce-manager) attached to the account.
+
+```ts twoslash
+import { Account, NonceManager } from 'viem'
+import { WebAuthn } from 'viem/utils'
+
+const credential = await WebAuthn.getCredential({
+  credentialId: '...',
+  prf: true,
+})
+const account = Account.fromPrf(credential.prf, {
+  nonceManager: NonceManager.jsonRpc(),
+})
+```
+
+### Return Value
+
+`Account.PrivateKey`
+
+A private-key-backed local account (`keyType: 'secp256k1'`) exposing `address`, `publicKey`, and the
+signing methods.
+
+### Errors
+
+| Error | Description |
+| --- | --- |
+| `Secp256k1.InvalidPrfSizeError` | The PRF output is not 32 bytes. |
+| `PublicKey.InvalidError` | The derived private key produces an invalid public key. |

--- a/site/sidebar.generated.ts
+++ b/site/sidebar.generated.ts
@@ -675,478 +675,108 @@ export const utilities = {
       ],
     },
     {
-      text: 'Crypto',
+      text: 'Bytes',
       collapsed: true,
       items: [
         {
-          text: 'Hash',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/hash',
-            },
-            {
-              text: 'hmac256',
-              link: '/docs/utilities/hash/hmac256',
-            },
-            {
-              text: 'keccak256',
-              link: '/docs/utilities/hash/keccak256',
-            },
-            {
-              text: 'ripemd160',
-              link: '/docs/utilities/hash/ripemd160',
-            },
-            {
-              text: 'sha256',
-              link: '/docs/utilities/hash/sha256',
-            },
-            {
-              text: 'validate',
-              link: '/docs/utilities/hash/validate',
-            },
-          ],
+          text: 'Overview',
+          link: '/docs/utilities/bytes',
         },
         {
-          text: 'HdKey',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/hdkey',
-            },
-            {
-              text: 'fromExtendedKey',
-              link: '/docs/utilities/hdkey/fromExtendedKey',
-            },
-            {
-              text: 'fromJson',
-              link: '/docs/utilities/hdkey/fromJson',
-            },
-            {
-              text: 'fromSeed',
-              link: '/docs/utilities/hdkey/fromSeed',
-            },
-            {
-              text: 'path',
-              link: '/docs/utilities/hdkey/path',
-            },
-            {
-              text: 'Types',
-              link: '/docs/utilities/hdkey/types',
-            },
-          ],
+          text: 'fromArray',
+          link: '/docs/utilities/bytes/fromArray',
         },
         {
-          text: 'Mnemonic',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/mnemonic',
-            },
-            {
-              text: 'random',
-              link: '/docs/utilities/mnemonic/random',
-            },
-            {
-              text: 'toPrivateKey',
-              link: '/docs/utilities/mnemonic/toPrivateKey',
-            },
-            {
-              text: 'toHdKey',
-              link: '/docs/utilities/mnemonic/toHdKey',
-            },
-            {
-              text: 'toSeed',
-              link: '/docs/utilities/mnemonic/toSeed',
-            },
-            {
-              text: 'path',
-              link: '/docs/utilities/mnemonic/path',
-            },
-            {
-              text: 'validate',
-              link: '/docs/utilities/mnemonic/validate',
-            },
-          ],
+          text: 'fromBoolean',
+          link: '/docs/utilities/bytes/fromBoolean',
         },
         {
-          text: 'P256',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/p256',
-            },
-            {
-              text: 'randomPrivateKey',
-              link: '/docs/utilities/p256/randomPrivateKey',
-            },
-            {
-              text: 'getPublicKey',
-              link: '/docs/utilities/p256/getPublicKey',
-            },
-            {
-              text: 'sign',
-              link: '/docs/utilities/p256/sign',
-            },
-            {
-              text: 'verify',
-              link: '/docs/utilities/p256/verify',
-            },
-            {
-              text: 'createKeyPair',
-              link: '/docs/utilities/p256/createKeyPair',
-            },
-            {
-              text: 'getSharedSecret',
-              link: '/docs/utilities/p256/getSharedSecret',
-            },
-            {
-              text: 'recoverPublicKey',
-              link: '/docs/utilities/p256/recoverPublicKey',
-            },
-          ],
+          text: 'fromHex',
+          link: '/docs/utilities/bytes/fromHex',
         },
         {
-          text: 'WebAuthnP256',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/webauthnp256',
-            },
-            {
-              text: 'createCredential',
-              link: '/docs/utilities/webauthnp256/createCredential',
-            },
-            {
-              text: 'sign',
-              link: '/docs/utilities/webauthnp256/sign',
-            },
-            {
-              text: 'verify',
-              link: '/docs/utilities/webauthnp256/verify',
-            },
-            {
-              text: 'Types',
-              link: '/docs/utilities/webauthnp256/types',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      text: 'Encoding',
-      collapsed: true,
-      items: [
-        {
-          text: 'Bytes',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/bytes',
-            },
-            {
-              text: 'fromArray',
-              link: '/docs/utilities/bytes/fromArray',
-            },
-            {
-              text: 'fromBoolean',
-              link: '/docs/utilities/bytes/fromBoolean',
-            },
-            {
-              text: 'fromHex',
-              link: '/docs/utilities/bytes/fromHex',
-            },
-            {
-              text: 'fromNumber',
-              link: '/docs/utilities/bytes/fromNumber',
-            },
-            {
-              text: 'fromString',
-              link: '/docs/utilities/bytes/fromString',
-            },
-            {
-              text: 'toBigInt',
-              link: '/docs/utilities/bytes/toBigInt',
-            },
-            {
-              text: 'toBoolean',
-              link: '/docs/utilities/bytes/toBoolean',
-            },
-            {
-              text: 'toHex',
-              link: '/docs/utilities/bytes/toHex',
-            },
-            {
-              text: 'toNumber',
-              link: '/docs/utilities/bytes/toNumber',
-            },
-            {
-              text: 'toString',
-              link: '/docs/utilities/bytes/toString',
-            },
-            {
-              text: 'concat',
-              link: '/docs/utilities/bytes/concat',
-            },
-            {
-              text: 'slice',
-              link: '/docs/utilities/bytes/slice',
-            },
-            {
-              text: 'padLeft',
-              link: '/docs/utilities/bytes/padLeft',
-            },
-            {
-              text: 'padRight',
-              link: '/docs/utilities/bytes/padRight',
-            },
-            {
-              text: 'trimLeft',
-              link: '/docs/utilities/bytes/trimLeft',
-            },
-            {
-              text: 'trimRight',
-              link: '/docs/utilities/bytes/trimRight',
-            },
-            {
-              text: 'assert',
-              link: '/docs/utilities/bytes/assert',
-            },
-            {
-              text: 'from',
-              link: '/docs/utilities/bytes/from',
-            },
-            {
-              text: 'isEqual',
-              link: '/docs/utilities/bytes/isEqual',
-            },
-            {
-              text: 'random',
-              link: '/docs/utilities/bytes/random',
-            },
-            {
-              text: 'size',
-              link: '/docs/utilities/bytes/size',
-            },
-            {
-              text: 'validate',
-              link: '/docs/utilities/bytes/validate',
-            },
-            {
-              text: 'Errors',
-              link: '/docs/utilities/bytes/errors',
-            },
-            {
-              text: 'Types',
-              link: '/docs/utilities/bytes/types',
-            },
-          ],
+          text: 'fromNumber',
+          link: '/docs/utilities/bytes/fromNumber',
         },
         {
-          text: 'Hex',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/hex',
-            },
-            {
-              text: 'fromBoolean',
-              link: '/docs/utilities/hex/fromBoolean',
-            },
-            {
-              text: 'fromBytes',
-              link: '/docs/utilities/hex/fromBytes',
-            },
-            {
-              text: 'fromNumber',
-              link: '/docs/utilities/hex/fromNumber',
-            },
-            {
-              text: 'fromString',
-              link: '/docs/utilities/hex/fromString',
-            },
-            {
-              text: 'toBoolean',
-              link: '/docs/utilities/hex/toBoolean',
-            },
-            {
-              text: 'toBytes',
-              link: '/docs/utilities/hex/toBytes',
-            },
-            {
-              text: 'toNumber',
-              link: '/docs/utilities/hex/toNumber',
-            },
-            {
-              text: 'toString',
-              link: '/docs/utilities/hex/toString',
-            },
-            {
-              text: 'concat',
-              link: '/docs/utilities/hex/concat',
-            },
-            {
-              text: 'slice',
-              link: '/docs/utilities/hex/slice',
-            },
-            {
-              text: 'padLeft',
-              link: '/docs/utilities/hex/padLeft',
-            },
-            {
-              text: 'padRight',
-              link: '/docs/utilities/hex/padRight',
-            },
-            {
-              text: 'trimLeft',
-              link: '/docs/utilities/hex/trimLeft',
-            },
-            {
-              text: 'trimRight',
-              link: '/docs/utilities/hex/trimRight',
-            },
-            {
-              text: 'assert',
-              link: '/docs/utilities/hex/assert',
-            },
-            {
-              text: 'from',
-              link: '/docs/utilities/hex/from',
-            },
-            {
-              text: 'isEqual',
-              link: '/docs/utilities/hex/isEqual',
-            },
-            {
-              text: 'random',
-              link: '/docs/utilities/hex/random',
-            },
-            {
-              text: 'size',
-              link: '/docs/utilities/hex/size',
-            },
-            {
-              text: 'toBigInt',
-              link: '/docs/utilities/hex/toBigInt',
-            },
-            {
-              text: 'validate',
-              link: '/docs/utilities/hex/validate',
-            },
-            {
-              text: 'Errors',
-              link: '/docs/utilities/hex/errors',
-            },
-            {
-              text: 'Types',
-              link: '/docs/utilities/hex/types',
-            },
-          ],
+          text: 'fromString',
+          link: '/docs/utilities/bytes/fromString',
         },
         {
-          text: 'Json',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/json',
-            },
-            {
-              text: 'stringify',
-              link: '/docs/utilities/json/stringify',
-            },
-            {
-              text: 'parse',
-              link: '/docs/utilities/json/parse',
-            },
-            {
-              text: 'canonicalize',
-              link: '/docs/utilities/json/canonicalize',
-            },
-            {
-              text: 'prettyPrint',
-              link: '/docs/utilities/json/prettyPrint',
-            },
-          ],
+          text: 'toBigInt',
+          link: '/docs/utilities/bytes/toBigInt',
         },
         {
-          text: 'Rlp',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/rlp',
-            },
-            {
-              text: 'from',
-              link: '/docs/utilities/rlp/from',
-            },
-            {
-              text: 'fromBytes',
-              link: '/docs/utilities/rlp/fromBytes',
-            },
-            {
-              text: 'fromHex',
-              link: '/docs/utilities/rlp/fromHex',
-            },
-            {
-              text: 'toBytes',
-              link: '/docs/utilities/rlp/toBytes',
-            },
-            {
-              text: 'toHex',
-              link: '/docs/utilities/rlp/toHex',
-            },
-            {
-              text: 'Errors',
-              link: '/docs/utilities/rlp/errors',
-            },
-          ],
+          text: 'toBoolean',
+          link: '/docs/utilities/bytes/toBoolean',
         },
         {
-          text: 'Value',
-          collapsed: true,
-          items: [
-            {
-              text: 'Overview',
-              link: '/docs/utilities/value',
-            },
-            {
-              text: 'format',
-              link: '/docs/utilities/value/format',
-            },
-            {
-              text: 'formatEther',
-              link: '/docs/utilities/value/formatEther',
-            },
-            {
-              text: 'formatGwei',
-              link: '/docs/utilities/value/formatGwei',
-            },
-            {
-              text: 'from',
-              link: '/docs/utilities/value/from',
-            },
-            {
-              text: 'fromEther',
-              link: '/docs/utilities/value/fromEther',
-            },
-            {
-              text: 'fromGwei',
-              link: '/docs/utilities/value/fromGwei',
-            },
-            {
-              text: 'Errors',
-              link: '/docs/utilities/value/errors',
-            },
-          ],
+          text: 'toHex',
+          link: '/docs/utilities/bytes/toHex',
+        },
+        {
+          text: 'toNumber',
+          link: '/docs/utilities/bytes/toNumber',
+        },
+        {
+          text: 'toString',
+          link: '/docs/utilities/bytes/toString',
+        },
+        {
+          text: 'concat',
+          link: '/docs/utilities/bytes/concat',
+        },
+        {
+          text: 'slice',
+          link: '/docs/utilities/bytes/slice',
+        },
+        {
+          text: 'padLeft',
+          link: '/docs/utilities/bytes/padLeft',
+        },
+        {
+          text: 'padRight',
+          link: '/docs/utilities/bytes/padRight',
+        },
+        {
+          text: 'trimLeft',
+          link: '/docs/utilities/bytes/trimLeft',
+        },
+        {
+          text: 'trimRight',
+          link: '/docs/utilities/bytes/trimRight',
+        },
+        {
+          text: 'assert',
+          link: '/docs/utilities/bytes/assert',
+        },
+        {
+          text: 'from',
+          link: '/docs/utilities/bytes/from',
+        },
+        {
+          text: 'isEqual',
+          link: '/docs/utilities/bytes/isEqual',
+        },
+        {
+          text: 'random',
+          link: '/docs/utilities/bytes/random',
+        },
+        {
+          text: 'size',
+          link: '/docs/utilities/bytes/size',
+        },
+        {
+          text: 'validate',
+          link: '/docs/utilities/bytes/validate',
+        },
+        {
+          text: 'Errors',
+          link: '/docs/utilities/bytes/errors',
+        },
+        {
+          text: 'Types',
+          link: '/docs/utilities/bytes/types',
         },
       ],
     },
@@ -1239,6 +869,226 @@ export const utilities = {
       ],
     },
     {
+      text: 'Hash',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/hash',
+        },
+        {
+          text: 'blake3',
+          link: '/docs/utilities/hash/blake3',
+        },
+        {
+          text: 'createBlake3',
+          link: '/docs/utilities/hash/createBlake3',
+        },
+        {
+          text: 'createHmac256',
+          link: '/docs/utilities/hash/createHmac256',
+        },
+        {
+          text: 'createKeccak256',
+          link: '/docs/utilities/hash/createKeccak256',
+        },
+        {
+          text: 'createRipemd160',
+          link: '/docs/utilities/hash/createRipemd160',
+        },
+        {
+          text: 'createSha256',
+          link: '/docs/utilities/hash/createSha256',
+        },
+        {
+          text: 'hmac256',
+          link: '/docs/utilities/hash/hmac256',
+        },
+        {
+          text: 'keccak256',
+          link: '/docs/utilities/hash/keccak256',
+        },
+        {
+          text: 'ripemd160',
+          link: '/docs/utilities/hash/ripemd160',
+        },
+        {
+          text: 'sha256',
+          link: '/docs/utilities/hash/sha256',
+        },
+        {
+          text: 'validate',
+          link: '/docs/utilities/hash/validate',
+        },
+        {
+          text: 'Errors',
+          link: '/docs/utilities/hash/errors',
+        },
+        {
+          text: 'Types',
+          link: '/docs/utilities/hash/types',
+        },
+      ],
+    },
+    {
+      text: 'HdKey',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/hdkey',
+        },
+        {
+          text: 'fromExtendedKey',
+          link: '/docs/utilities/hdkey/fromExtendedKey',
+        },
+        {
+          text: 'fromJson',
+          link: '/docs/utilities/hdkey/fromJson',
+        },
+        {
+          text: 'fromSeed',
+          link: '/docs/utilities/hdkey/fromSeed',
+        },
+        {
+          text: 'path',
+          link: '/docs/utilities/hdkey/path',
+        },
+        {
+          text: 'Types',
+          link: '/docs/utilities/hdkey/types',
+        },
+      ],
+    },
+    {
+      text: 'Hex',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/hex',
+        },
+        {
+          text: 'fromBoolean',
+          link: '/docs/utilities/hex/fromBoolean',
+        },
+        {
+          text: 'fromBytes',
+          link: '/docs/utilities/hex/fromBytes',
+        },
+        {
+          text: 'fromNumber',
+          link: '/docs/utilities/hex/fromNumber',
+        },
+        {
+          text: 'fromString',
+          link: '/docs/utilities/hex/fromString',
+        },
+        {
+          text: 'toBoolean',
+          link: '/docs/utilities/hex/toBoolean',
+        },
+        {
+          text: 'toBytes',
+          link: '/docs/utilities/hex/toBytes',
+        },
+        {
+          text: 'toNumber',
+          link: '/docs/utilities/hex/toNumber',
+        },
+        {
+          text: 'toString',
+          link: '/docs/utilities/hex/toString',
+        },
+        {
+          text: 'concat',
+          link: '/docs/utilities/hex/concat',
+        },
+        {
+          text: 'slice',
+          link: '/docs/utilities/hex/slice',
+        },
+        {
+          text: 'padLeft',
+          link: '/docs/utilities/hex/padLeft',
+        },
+        {
+          text: 'padRight',
+          link: '/docs/utilities/hex/padRight',
+        },
+        {
+          text: 'trimLeft',
+          link: '/docs/utilities/hex/trimLeft',
+        },
+        {
+          text: 'trimRight',
+          link: '/docs/utilities/hex/trimRight',
+        },
+        {
+          text: 'assert',
+          link: '/docs/utilities/hex/assert',
+        },
+        {
+          text: 'from',
+          link: '/docs/utilities/hex/from',
+        },
+        {
+          text: 'isEqual',
+          link: '/docs/utilities/hex/isEqual',
+        },
+        {
+          text: 'random',
+          link: '/docs/utilities/hex/random',
+        },
+        {
+          text: 'size',
+          link: '/docs/utilities/hex/size',
+        },
+        {
+          text: 'toBigInt',
+          link: '/docs/utilities/hex/toBigInt',
+        },
+        {
+          text: 'validate',
+          link: '/docs/utilities/hex/validate',
+        },
+        {
+          text: 'Errors',
+          link: '/docs/utilities/hex/errors',
+        },
+        {
+          text: 'Types',
+          link: '/docs/utilities/hex/types',
+        },
+      ],
+    },
+    {
+      text: 'Json',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/json',
+        },
+        {
+          text: 'stringify',
+          link: '/docs/utilities/json/stringify',
+        },
+        {
+          text: 'parse',
+          link: '/docs/utilities/json/parse',
+        },
+        {
+          text: 'canonicalize',
+          link: '/docs/utilities/json/canonicalize',
+        },
+        {
+          text: 'prettyPrint',
+          link: '/docs/utilities/json/prettyPrint',
+        },
+      ],
+    },
+    {
       text: 'JSON-RPC',
       collapsed: true,
       items: [
@@ -1296,6 +1146,44 @@ export const utilities = {
       text: 'Keys & Signatures',
       collapsed: true,
       items: [
+        {
+          text: 'P256',
+          collapsed: true,
+          items: [
+            {
+              text: 'Overview',
+              link: '/docs/utilities/p256',
+            },
+            {
+              text: 'randomPrivateKey',
+              link: '/docs/utilities/p256/randomPrivateKey',
+            },
+            {
+              text: 'getPublicKey',
+              link: '/docs/utilities/p256/getPublicKey',
+            },
+            {
+              text: 'sign',
+              link: '/docs/utilities/p256/sign',
+            },
+            {
+              text: 'verify',
+              link: '/docs/utilities/p256/verify',
+            },
+            {
+              text: 'createKeyPair',
+              link: '/docs/utilities/p256/createKeyPair',
+            },
+            {
+              text: 'getSharedSecret',
+              link: '/docs/utilities/p256/getSharedSecret',
+            },
+            {
+              text: 'recoverPublicKey',
+              link: '/docs/utilities/p256/recoverPublicKey',
+            },
+          ],
+        },
         {
           text: 'PublicKey',
           collapsed: true,
@@ -1375,6 +1263,10 @@ export const utilities = {
               link: '/docs/utilities/secp256k1/createKeyPair',
             },
             {
+              text: 'fromPrf',
+              link: '/docs/utilities/secp256k1/fromPrf',
+            },
+            {
               text: 'getSharedSecret',
               link: '/docs/utilities/secp256k1/getSharedSecret',
             },
@@ -1385,6 +1277,10 @@ export const utilities = {
             {
               text: 'recoverPublicKey',
               link: '/docs/utilities/secp256k1/recoverPublicKey',
+            },
+            {
+              text: 'Errors',
+              link: '/docs/utilities/secp256k1/errors',
             },
           ],
         },
@@ -1578,6 +1474,40 @@ export const utilities = {
             },
           ],
         },
+        {
+          text: 'WebAuthn',
+          collapsed: true,
+          items: [
+            {
+              text: 'Overview',
+              link: '/docs/utilities/webauthn',
+            },
+            {
+              text: 'createCredential',
+              link: '/docs/utilities/webauthn/createCredential',
+            },
+            {
+              text: 'getCredential',
+              link: '/docs/utilities/webauthn/getCredential',
+            },
+            {
+              text: 'sign',
+              link: '/docs/utilities/webauthn/sign',
+            },
+            {
+              text: 'verify',
+              link: '/docs/utilities/webauthn/verify',
+            },
+            {
+              text: 'Errors',
+              link: '/docs/utilities/webauthn/errors',
+            },
+            {
+              text: 'Types',
+              link: '/docs/utilities/webauthn/types',
+            },
+          ],
+        },
       ],
     },
     {
@@ -1599,6 +1529,40 @@ export const utilities = {
         {
           text: 'Types',
           link: '/docs/utilities/log/types',
+        },
+      ],
+    },
+    {
+      text: 'Mnemonic',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/mnemonic',
+        },
+        {
+          text: 'random',
+          link: '/docs/utilities/mnemonic/random',
+        },
+        {
+          text: 'toPrivateKey',
+          link: '/docs/utilities/mnemonic/toPrivateKey',
+        },
+        {
+          text: 'toHdKey',
+          link: '/docs/utilities/mnemonic/toHdKey',
+        },
+        {
+          text: 'toSeed',
+          link: '/docs/utilities/mnemonic/toSeed',
+        },
+        {
+          text: 'path',
+          link: '/docs/utilities/mnemonic/path',
+        },
+        {
+          text: 'validate',
+          link: '/docs/utilities/mnemonic/validate',
         },
       ],
     },
@@ -1635,6 +1599,44 @@ export const utilities = {
               link: '/docs/utilities/provider/types',
             },
           ],
+        },
+      ],
+    },
+    {
+      text: 'Rlp',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/rlp',
+        },
+        {
+          text: 'encodeTo',
+          link: '/docs/utilities/rlp/encodeTo',
+        },
+        {
+          text: 'from',
+          link: '/docs/utilities/rlp/from',
+        },
+        {
+          text: 'fromBytes',
+          link: '/docs/utilities/rlp/fromBytes',
+        },
+        {
+          text: 'fromHex',
+          link: '/docs/utilities/rlp/fromHex',
+        },
+        {
+          text: 'toBytes',
+          link: '/docs/utilities/rlp/toBytes',
+        },
+        {
+          text: 'toHex',
+          link: '/docs/utilities/rlp/toHex',
+        },
+        {
+          text: 'Errors',
+          link: '/docs/utilities/rlp/errors',
         },
       ],
     },
@@ -2173,6 +2175,44 @@ export const utilities = {
         {
           text: 'Types',
           link: '/docs/utilities/transactionrequest/types',
+        },
+      ],
+    },
+    {
+      text: 'Value',
+      collapsed: true,
+      items: [
+        {
+          text: 'Overview',
+          link: '/docs/utilities/value',
+        },
+        {
+          text: 'format',
+          link: '/docs/utilities/value/format',
+        },
+        {
+          text: 'formatEther',
+          link: '/docs/utilities/value/formatEther',
+        },
+        {
+          text: 'formatGwei',
+          link: '/docs/utilities/value/formatGwei',
+        },
+        {
+          text: 'from',
+          link: '/docs/utilities/value/from',
+        },
+        {
+          text: 'fromEther',
+          link: '/docs/utilities/value/fromEther',
+        },
+        {
+          text: 'fromGwei',
+          link: '/docs/utilities/value/fromGwei',
+        },
+        {
+          text: 'Errors',
+          link: '/docs/utilities/value/errors',
         },
       ],
     },

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -26,7 +26,7 @@ try {
 // directories).
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const oxDist = resolve(root, 'node_modules/ox/dist')
-const oxDocsOrigin = 'https://v1.oxlib.sh'
+const oxDocsOrigin = 'https://oxlib.sh'
 const vercelEnvironment = process.env.VERCEL_ENV
 const vercelRef = process.env.VERCEL_GIT_COMMIT_REF
 // TODO(v3): Remove the v3 deployment and source overrides when Viem v3 is stable.
@@ -1714,6 +1714,10 @@ export default defineConfig({
               {
                 text: 'Private Key Accounts',
                 link: '/docs/accounts/local/private-key',
+              },
+              {
+                text: 'Passkey Accounts',
+                link: '/docs/accounts/local/passkey',
               },
               {
                 text: 'Mnemonic Accounts',

--- a/src/core/Account.test.ts
+++ b/src/core/Account.test.ts
@@ -299,6 +299,43 @@ describe('fromPrivateKey', () => {
   })
 })
 
+describe('fromPrf', () => {
+  const prf =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('default', () => {
+    expect(Account.fromPrf(prf)).toMatchInlineSnapshot(`
+      {
+        "address": "0xA059C450ef5aC1BF72be9267d3939401e124466a",
+        "keyType": "secp256k1",
+        "publicKey": "0x0414b0779aa01eb12b0a75c1bbd32b2bc91f709597400104a5e922c941dc2a6b02db71558de3625a8e3787f79c555b837fd57a69fce0442720106369e0f9909cf6",
+        "sign": [Function],
+        "signAuthorization": [Function],
+        "signMessage": [Function],
+        "signTransaction": [Function],
+        "signTypedData": [Function],
+        "type": "local",
+      }
+    `)
+  })
+
+  test('bytes', () => {
+    expect(Account.fromPrf(Hex.toBytes(prf)).address).toBe(
+      '0xA059C450ef5aC1BF72be9267d3939401e124466a',
+    )
+  })
+
+  test('args: nonceManager', () => {
+    const nonceManager = NonceManager.jsonRpc()
+    const account = Account.fromPrf(prf, { nonceManager })
+    expect(account.nonceManager).toBe(nonceManager)
+  })
+
+  test('error: invalid PRF size', () => {
+    expect(() => Account.fromPrf('0x00')).toThrow(Secp256k1.InvalidPrfSizeError)
+  })
+})
+
 describe('fromHdKey', () => {
   test('default', () => {
     expect(Account.fromHdKey(hdKey)).toMatchInlineSnapshot(`

--- a/src/core/Account.ts
+++ b/src/core/Account.ts
@@ -268,6 +268,38 @@ export declare namespace fromPrivateKey {
 }
 
 /**
+ * Creates a {@link PrivateKey} from a 32-byte WebAuthn PRF output.
+ *
+ * @example
+ * ```ts
+ * import { Account } from 'viem'
+ * import { WebAuthn } from 'viem/utils'
+ *
+ * const credential = await WebAuthn.createCredential({
+ *   name: 'Example',
+ *   prf: true,
+ * })
+ * const account = Account.fromPrf(credential.prf)
+ * ```
+ */
+export function fromPrf(
+  prf: Hex.Hex | Bytes.Bytes,
+  options: fromPrf.Options = {},
+): PrivateKey {
+  return fromPrivateKey(Secp256k1.fromPrf(prf), options)
+}
+
+export declare namespace fromPrf {
+  /** Options for {@link fromPrf}. */
+  type Options = fromPrivateKey.Options
+
+  type ErrorType =
+    | Secp256k1.fromPrf.ErrorType
+    | fromPrivateKey.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Creates an {@link Hd} from an HD key.
  *
  * @example

--- a/src/utils/Prf.ts
+++ b/src/utils/Prf.ts
@@ -1,0 +1,1 @@
+export * from 'ox/Prf'

--- a/src/utils/WebAuthn.ts
+++ b/src/utils/WebAuthn.ts
@@ -1,0 +1,1 @@
+export * from 'ox/WebAuthn'

--- a/src/utils/WebAuthnP256.ts
+++ b/src/utils/WebAuthnP256.ts
@@ -1,1 +1,0 @@
-export * from 'ox/WebAuthnP256'

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -37,6 +37,7 @@ test('exports', () => {
       "Mnemonic",
       "P256",
       "PersonalMessage",
+      "Prf",
       "Provider",
       "PublicKey",
       "Rlp",
@@ -62,7 +63,7 @@ test('exports', () => {
       "TxEnvelopeLegacy",
       "TypedData",
       "Value",
-      "WebAuthnP256",
+      "WebAuthn",
       "Withdrawal",
     ]
   `)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,6 +94,9 @@ export * as P256 from './P256.js'
 /** Utilities for [EIP-191](https://eips.ethereum.org/EIPS/eip-191) personal messages. Re-exports `ox/PersonalMessage`, plus recovery & verification helpers. */
 export * as PersonalMessage from './PersonalMessage.js'
 
+/** Utilities for credential-bound PRF configurations. Re-exports `ox/Prf`. */
+export * as Prf from './Prf.js'
+
 /** Utilities & types for EIP-1193 providers. Re-exports `ox/Provider`. */
 export * as Provider from './Provider.js'
 
@@ -169,8 +172,8 @@ export * as TypedData from './TypedData.js'
 /** Utilities for parsing & formatting ether values. Re-exports `ox/Value`. */
 export * as Value from './Value.js'
 
-/** Utilities for WebAuthn P-256 signing. Re-exports `ox/WebAuthnP256`. */
-export * as WebAuthnP256 from './WebAuthnP256.js'
+/** Utilities for WebAuthn credentials. Re-exports `ox/WebAuthn`. */
+export * as WebAuthn from './WebAuthn.js'
 
 /** Utilities & types for beacon chain withdrawals. Re-exports `ox/Withdrawal`. */
 export * as Withdrawal from './Withdrawal.js'


### PR DESCRIPTION
Adds passkey-derived local accounts and tagged PRF utilities, replaces the deprecated `WebAuthnP256` export, and lifts Encoding and Crypto modules into the utility root.