### PR TITLE
docs: update WebAuthn references

### DIFF
--- a/site/pages/account-abstraction/accounts/coinbase.mdx
+++ b/site/pages/account-abstraction/accounts/coinbase.mdx
@@ -36,10 +36,10 @@ export const owner = Account.fromPrivateKey('0x...')
 
 ```ts twoslash [owner.ts (Passkey)] filename="owner.ts"
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 
 // Register a credential (ie. passkey).
-const credential = await WebAuthnP256.createCredential({ name: 'Wallet' })
+const credential = await WebAuthn.createCredential({ name: 'Wallet' })
 
 // Create a WebAuthn owner account from the credential.
 export const owner = WebAuthnAccount.fromCredential(credential)

--- a/site/pages/account-abstraction/accounts/webauthn.mdx
+++ b/site/pages/account-abstraction/accounts/webauthn.mdx
@@ -24,11 +24,11 @@ import {
   CoinbaseSmartAccount,
   WebAuthnAccount,
 } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 import { client } from './client'
 
 // 1. Register a credential (ie. passkey).
-const credential = await WebAuthnP256.createCredential({
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 

--- a/site/pages/account-abstraction/accounts/webauthn/createCredential.mdx
+++ b/site/pages/account-abstraction/accounts/webauthn/createCredential.mdx
@@ -1,21 +1,21 @@
-# `WebAuthnP256.createCredential`
+# `WebAuthn.createCredential`
 
 Registers a **WebAuthn Credential** designed to be used to create a [WebAuthn Account](/account-abstraction/accounts/webauthn/fromCredential).
 
 :::note
-This function uses [`ox/WebAuthnP256`](https://github.com/wevm/ox) under the hood.
+This function uses [`ox/WebAuthn`](https://github.com/wevm/ox) under the hood.
 :::
 
 ## Overview
 
-`WebAuthnP256.createCredential` initiates the WebAuthn (passkey) registration flow on the user's device, creating a cryptographic P256 credential that can later be used for authentication.
+`WebAuthn.createCredential` initiates the WebAuthn (passkey) registration flow on the user's device, creating a cryptographic P256 credential that can later be used for authentication.
 
 This function uses `navigator.credentials.create()` internally. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create).
 
 ## Import
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 ```
 
 ## Usage
@@ -24,10 +24,10 @@ At minimum, you need to provide a name to identify the credential:
 
 ```ts twoslash
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 
 // Register a credential (ie. passkey). // [!code focus]
-const credential = await WebAuthnP256.createCredential({ // [!code focus]
+const credential = await WebAuthn.createCredential({ // [!code focus]
   name: 'Example', // [!code focus]
 }) // [!code focus]
 
@@ -64,8 +64,8 @@ This credential object is designed to be passed to `WebAuthnAccount.fromCredenti
 A random cryptographic value that proves the credential creation request. If you don't provide one, the function generates a random one.
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   challenge: new Uint8Array([1, 2, 3]),
   name: 'Example',
 })
@@ -81,10 +81,10 @@ Allows you to override the default credential creation function. By default, it 
 ```ts twoslash
 // @noErrors
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 import * as passkey from 'react-native-passkeys'
 
-const credential = await WebAuthnP256.createCredential({
+const credential = await WebAuthn.createCredential({
   name: 'Example',
   createFn: passkey.create,
 })
@@ -99,8 +99,8 @@ const account = WebAuthnAccount.fromCredential(credential)
 An array of credential IDs you want to prevent from being re-registered. If a user already has a credential with one of these IDs on their device, the registration will fail. Use this to prevent duplicate credentials and ensure each device can only register once.
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   excludeCredentialIds: ['abc', 'def'],
   name: 'Example',
 })
@@ -113,8 +113,8 @@ const credential = await WebAuthnP256.createCredential({
 A user-friendly display name for the credential. This appears in your browser's credential manager and helps users identify which passkey they're using. Use something descriptive like "My Laptop Fingerprint" or "Security Key".
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 ```
@@ -126,8 +126,8 @@ const credential = await WebAuthnP256.createCredential({
 An object describing the relying party. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#rp).
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   name: 'Example',
   rp: {
     id: 'example.com',
@@ -143,8 +143,8 @@ const credential = await WebAuthnP256.createCredential({
 How long (in milliseconds) to wait for the user to complete the registration.
 
 ```ts twoslash
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   name: 'Example',
   timeout: 1000,
 })

--- a/site/pages/account-abstraction/accounts/webauthn/fromCredential.mdx
+++ b/site/pages/account-abstraction/accounts/webauthn/fromCredential.mdx
@@ -18,10 +18,10 @@ import { WebAuthnAccount } from 'viem/erc4337'
 
 ```ts twoslash
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 
 // Register a credential (ie. passkey).
-const credential = await WebAuthnP256.createCredential({
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 
@@ -45,8 +45,8 @@ A P256 WebAuthn Credential.
 
 ```ts twoslash
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
-const credential = await WebAuthnP256.createCredential({
+import { WebAuthn } from 'viem/utils'
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 
@@ -63,10 +63,10 @@ Credential request function. Useful for environments that do not support the Web
 ```ts twoslash
 // @noErrors
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 import * as passkey from 'react-native-passkeys' // [!code focus]
 
-const credential = await WebAuthnP256.createCredential({
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 
@@ -85,9 +85,9 @@ Relying Party ID.
 ```ts twoslash
 // @noErrors
 import { WebAuthnAccount } from 'viem/erc4337'
-import { WebAuthnP256 } from 'viem/utils'
+import { WebAuthn } from 'viem/utils'
 
-const credential = await WebAuthnP256.createCredential({
+const credential = await WebAuthn.createCredential({
   name: 'Example',
 })
 

--- a/site/pages/account-abstraction/migration.mdx
+++ b/site/pages/account-abstraction/migration.mdx
@@ -13,7 +13,7 @@ The v3 API groups actions by resource, moves constructors into module namespaces
 | `toSoladySmartAccount(options)` | `SoladySmartAccount.from(options)` |
 | `toSimple7702SmartAccount(options)` | `Simple7702SmartAccount.from(options)` |
 | `toWebAuthnAccount({ credential, getFn, rpId })` | `WebAuthnAccount.fromCredential(credential, { getFn, rpId })` |
-| `createWebAuthnCredential(options)` | `WebAuthnP256.createCredential(options)` from `viem/utils` |
+| `createWebAuthnCredential(options)` | `WebAuthn.createCredential(options)` from `viem/utils` |
 
 ## Actions
 

--- a/site/pages/docs/v2-migration.mdx
+++ b/site/pages/docs/v2-migration.mdx
@@ -494,9 +494,9 @@ Every mechanical rename on this page, alphabetized by v2 symbol. Semantic change
 | `createTestClient` | `Client.create` + `.extend(testActions({ mode }))` | [Client](#client) |
 | `createTransport` | `Transport.from` | [Transports](#transports) |
 | `createWalletClient` | `Client.create` (pass `account` directly) | [Client](#client) |
-| `createWebAuthnCredential` | `WebAuthnP256.createCredential` (from `viem/utils`) | [Smart Accounts](#smart-accounts) |
-| `CreateWebAuthnCredentialParameters` | `WebAuthnP256.createCredential.Options` | [Smart Accounts](#smart-accounts) |
-| `CreateWebAuthnCredentialReturnType` | `WebAuthnP256.P256Credential` | [Smart Accounts](#smart-accounts) |
+| `createWebAuthnCredential` | `WebAuthn.createCredential` (from `viem/utils`) | [Smart Accounts](#smart-accounts) |
+| `CreateWebAuthnCredentialParameters` | `WebAuthn.createCredential.Options` | [Smart Accounts](#smart-accounts) |
+| `CreateWebAuthnCredentialReturnType` | `WebAuthn.P256Credential` | [Smart Accounts](#smart-accounts) |
 | `custom` (chain field) | Typed top-level fields via `Chain.extendSchema` | [Chains](#chains) |
 | `CustomSource` | `Account.from.Account` | [Accounts](#accounts) |
 | `CustomTransport` | `Transport.Transport<'custom'>` | [Transports](#transports) |
@@ -837,7 +837,7 @@ Every mechanical rename on this page, alphabetized by v2 symbol. Semantic change
 | `OnBlockNumberParameter` | `Parameters<Actions.block.watchNumber.OnBlockNumberFn>[0]` | [Events & Filters](#events--filters) |
 | `OnBlockParameter` | `Parameters<Actions.block.watch.OnBlockFn>[0]` | [Events & Filters](#events--filters) |
 | `OnTransactionsParameter` | `Parameters<Actions.transaction.watchPending.OnTransactionsFn>[0]` | [Events & Filters](#events--filters) |
-| `P256Credential` | `WebAuthnP256.P256Credential` | [Smart Accounts](#smart-accounts) |
+| `P256Credential` | `WebAuthn.P256Credential` | [Smart Accounts](#smart-accounts) |
 | `PackedUserOperation` | `UserOperation.Packed` | [User Operations](#user-operations) |
 | `packetToBytes` | Internalized | [Messages & ENS](#messages--ens) |
 | `pad` | `Hex.padLeft`/`Bytes.padLeft` (positional size; `padRight` for right) | [Encoding & Units](#encoding--units) |
@@ -2502,11 +2502,11 @@ const bundler = BundlerClient.create({
 
 ### Smart Accounts
 
-Smart-account constructors moved into namespaces, and WebAuthn credential creation moved to the `WebAuthnP256` utilities:
+Smart-account constructors moved into namespaces, and WebAuthn credential creation moved to the `WebAuthn` utilities:
 
 | v2 | v3 |
 | --- | --- |
-| `createWebAuthnCredential(options)` | `WebAuthnP256.createCredential(options)` (from `viem/utils`) |
+| `createWebAuthnCredential(options)` | `WebAuthn.createCredential(options)` (from `viem/utils`) |
 | `toCoinbaseSmartAccount(options)` | `CoinbaseSmartAccount.from(options)` |
 | `toSimple7702SmartAccount(options)` | `Simple7702SmartAccount.from(options)` |
 | `toSmartAccount(implementation)` | `SmartAccount.from(implementation)` |
@@ -2518,9 +2518,9 @@ The account and credential types moved with them:
 | v2 | v3 |
 | --- | --- |
 | `CoinbaseSmartAccountImplementation` | `CoinbaseSmartAccount.Implementation` |
-| `CreateWebAuthnCredentialParameters` | `WebAuthnP256.createCredential.Options` |
-| `CreateWebAuthnCredentialReturnType` | `WebAuthnP256.P256Credential` |
-| `P256Credential` | `WebAuthnP256.P256Credential` |
+| `CreateWebAuthnCredentialParameters` | `WebAuthn.createCredential.Options` |
+| `CreateWebAuthnCredentialReturnType` | `WebAuthn.P256Credential` |
+| `P256Credential` | `WebAuthn.P256Credential` |
 | `Simple7702SmartAccountImplementation` | `Simple7702SmartAccount.Implementation` |
 | `SmartAccount` | `SmartAccount.SmartAccount` |
 | `SmartAccountImplementation` | `SmartAccount.Implementation` |


### PR DESCRIPTION
Updates account abstraction examples and migration references to the renamed `WebAuthn` utility, preventing Vocs Twoslash failures after `WebAuthnP256` was removed from `viem/utils`.