### PR TITLE
Fix withRetry hanging when retry callbacks throw

### DIFF
--- a/.changeset/fuzzy-pandas-retry.md
+++ b/.changeset/fuzzy-pandas-retry.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `withRetry` hanging when `shouldRetry` or the retry delay callback throws.

--- a/src/utils/promise/withRetry.test.ts
+++ b/src/utils/promise/withRetry.test.ts
@@ -43,6 +43,69 @@ test('shouldRetry: retries, and then errors', async () => {
   expect(retryTimes).toBe(2)
 })
 
+test('rejects when shouldRetry throws after a retry', async () => {
+  await expect(
+    Promise.race([
+      withRetry(
+        async () => {
+          throw new Error('fn failed')
+        },
+        {
+          delay: 0,
+          shouldRetry: ({ count }) => {
+            if (count === 0) return true
+            throw new Error('shouldRetry failed')
+          },
+        },
+      ),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timed out')), 100),
+      ),
+    ]),
+  ).rejects.toThrowError('shouldRetry failed')
+})
+
+test('rejects when async shouldRetry rejects', async () => {
+  await expect(
+    Promise.race([
+      withRetry(
+        async () => {
+          throw new Error('fn failed')
+        },
+        {
+          shouldRetry: async () => {
+            throw new Error('shouldRetry failed')
+          },
+        },
+      ),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timed out')), 100),
+      ),
+    ]),
+  ).rejects.toThrowError('shouldRetry failed')
+})
+
+test('rejects when delay callback throws after a retry', async () => {
+  await expect(
+    Promise.race([
+      withRetry(
+        async () => {
+          throw new Error('fn failed')
+        },
+        {
+          delay: ({ count }) => {
+            if (count === 0) return 0
+            throw new Error('delay calculation failed')
+          },
+        },
+      ),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timed out')), 100),
+      ),
+    ]),
+  ).rejects.toThrowError('delay calculation failed')
+})
+
 test('shouldRetry: retries, and then succeeds', async () => {
   let retryTimes = -1
   const server = await createHttpServer((_req, res) => {

--- a/src/utils/promise/withRetry.ts
+++ b/src/utils/promise/withRetry.ts
@@ -39,13 +39,13 @@ export function withRetry<data>(
   }: WithRetryParameters = {},
 ) {
   return new Promise<data>((resolve, reject) => {
-    const attemptRetry = async ({ count = 0 } = {}) => {
+    const attemptRetry = async ({ count = 0 } = {}): Promise<void> => {
       if (signal?.aborted) {
         reject(getAbortError(signal))
         return
       }
 
-      const retry = async ({ error }: { error: Error }) => {
+      const retry = async ({ error }: { error: Error }): Promise<void> => {
         const delay =
           typeof delay_ === 'function' ? delay_({ count, error }) : delay_
         if (delay) {

--- a/src/utils/promise/withRetry.ts
+++ b/src/utils/promise/withRetry.ts
@@ -56,7 +56,7 @@ export function withRetry<data>(
             return
           }
         }
-        attemptRetry({ count: count + 1 })
+        return attemptRetry({ count: count + 1 })
       }
 
       try {
@@ -79,6 +79,6 @@ export function withRetry<data>(
         reject(err)
       }
     }
-    attemptRetry()
+    void attemptRetry().catch(reject)
   })
 }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Viem!
----------------------------------------------------------------------->

`withRetry` could remain pending indefinitely when `shouldRetry` threw or rejected, or when the retry delay callback threw.

`attemptRetry()` is asynchronous, but its initial invocation did not handle its rejection. The recursive retry invocation was also not returned, which broke the rejection chain for errors occurring after the first retry.

This change:

- returns the recursive `attemptRetry` invocation;
- forwards the initial `attemptRetry` rejection to the outer promise;
- adds regression coverage for:
  - a synchronous `shouldRetry` exception after a retry;
  - an asynchronous `shouldRetry` rejection;
  - a delay callback exception after a retry.

This preserves the existing retry and abort behavior while ensuring callback failures reject the promise returned by `withRetry`.

