### PR TITLE
fix(tempo): respect token metadata batching config

### DIFF
--- a/.changeset/tidy-pans-fetch.md
+++ b/.changeset/tidy-pans-fetch.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Respect explicit client multicall configuration when fetching Tempo token metadata.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   fastify: '>=5.8.5'
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0
-  postcss@<8.5.18: 8.5.18
+  postcss@<8.5.23: 8.5.23
   protobufjs@<=7.6.4: 7.6.5
   protobufjs@>=8.0.0 <8.6.6: 8.6.6
   '@protobufjs/utf8@<=1.1.0': 1.1.1
@@ -51,8 +51,8 @@ overrides:
   find-my-way@>=5.5.0 <8.2.2: ^8.2.2
   find-my-way@>=9.0.0 <9.6.1: 9.7.0
   glob@>=10.3.7 <=11.0.3: '>=11.1.0'
-  hono: '>=4.12.27'
-  ip-address@<=10.1.0: 10.1.1
+  hono: '>=4.12.34'
+  ip-address@<=10.3.0: 10.3.1
   lodash@>=4.0.0 <=4.17.23: 4.18.1
   lodash-es@>=4.0.0 <=4.17.22: 4.17.23
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
@@ -73,7 +73,7 @@ overrides:
   tar: '>=7.5.21'
   tar-fs@>=3.0.0 <3.1.1: '>=3.1.1'
   tmp: '>=0.2.7'
-  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=7.0.0 <7.29.0: 7.29.0
   vite@>=6.0.0 <=6.4.2: 6.4.3
   vite@>=7.0.0 <=7.3.1: 7.3.2
   vite@>=8.0.0 <=8.0.15: 8.0.16
@@ -92,13 +92,13 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   srvx@<0.11.13: 0.11.13
-  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
   next@>=16.0.0-beta.0 <16.2.11: 16.2.11
   react-server-dom-webpack@>=19.2.0 <19.2.6: 19.2.6
   basic-ftp@<=5.3.0: 5.3.1
-  fast-uri@<=3.1.3: 3.1.4
+  fast-uri@<=3.1.4: 3.1.5
   sharp@<0.35.0: 0.35.0
 
 importers:
@@ -3569,8 +3569,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4271,8 +4271,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
@@ -4559,8 +4559,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -4673,12 +4673,8 @@ packages:
     resolution: {integrity: sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.1.1:
-    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
-    engines: {node: '>= 12'}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5380,8 +5376,8 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5767,8 +5763,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -6711,8 +6707,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unhead@3.1.7:
@@ -7885,7 +7881,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/error@4.2.0': {}
 
@@ -7978,9 +7974,9 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.30(vue@3.5.39(typescript@5.9.3))
       vue: 3.5.39(typescript@5.9.3)
 
-  '@hono/node-server@2.0.10(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.12.34
 
   '@iconify-json/lucide@1.2.114':
     dependencies:
@@ -8285,7 +8281,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.18.0
       ajv-formats: 3.0.1
       content-type: 1.0.5
@@ -8295,7 +8291,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10080,7 +10076,7 @@ snapshots:
       '@vue/shared': 3.5.39
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.39':
@@ -10269,10 +10265,10 @@ snapshots:
 
   accounts@0.9.0(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(@types/react@19.0.8)(express@5.2.1)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(viem@src):
     dependencies:
-      hono: 4.12.27
+      hono: 4.12.34
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
-      mppx: 0.6.5(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(express@5.2.1)(hono@4.12.27)(typescript@5.9.3)(viem@src)
+      mppx: 0.6.5(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(express@5.2.1)(hono@4.12.34)(typescript@5.9.3)(viem@src)
       ox: 0.14.33(typescript@5.9.3)(zod@4.3.6)
       webauthx: 0.1.2(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
@@ -10339,7 +10335,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10505,7 +10501,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.3
 
@@ -11154,7 +11150,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
 
   express@5.2.1:
     dependencies:
@@ -11230,7 +11226,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -11242,7 +11238,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastify-plugin@4.5.1: {}
 
@@ -11659,7 +11655,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.27: {}
+  hono@4.12.34: {}
 
   hookable@6.1.1: {}
 
@@ -11791,9 +11787,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.1.1: {}
-
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -12636,7 +12630,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -12669,7 +12663,7 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  mppx@0.6.5(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(express@5.2.1)(hono@4.12.27)(typescript@5.9.3)(viem@src):
+  mppx@0.6.5(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1))(express@5.2.1)(hono@4.12.34)(typescript@5.9.3)(viem@src):
     dependencies:
       incur: 0.3.25
       ox: 0.14.15(typescript@5.9.3)(zod@4.3.6)
@@ -12678,7 +12672,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)
       express: 5.2.1
-      hono: 4.12.27
+      hono: 4.12.34
     transitivePeerDependencies:
       - typescript
 
@@ -12713,7 +12707,7 @@ snapshots:
   nan@2.24.0:
     optional: true
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.0.9: {}
 
@@ -12741,7 +12735,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
@@ -12768,7 +12762,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
@@ -13183,9 +13177,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13919,7 +13913,7 @@ snapshots:
 
   socks@2.8.3:
     dependencies:
-      ip-address: 10.1.1
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   sonic-boom@3.8.1:
@@ -14208,7 +14202,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.1
       tmp: 0.2.7
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bare-buffer
       - supports-color
@@ -14354,7 +14348,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unhead@3.1.7(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.59.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.28.1)):
     dependencies:
@@ -14548,7 +14542,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.59.0
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14564,7 +14558,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14580,7 +14574,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14639,7 +14633,7 @@ snapshots:
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.0.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       '@iconify-json/lucide': 1.2.114
       '@iconify-json/ri': 1.2.10
       '@iconify-json/simple-icons': 1.2.87
@@ -14675,7 +14669,7 @@ snapshots:
       estree-util-visit: 2.0.0
       extend: 3.0.2
       github-slugger: 2.0.0
-      hono: 4.12.27
+      hono: 4.12.34
       image-size: 2.0.2
       lz-string: 1.5.0
       magic-string: 0.30.21
@@ -14783,11 +14777,11 @@ snapshots:
 
   waku@1.0.0-beta.6(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       '@vitejs/plugin-react': 6.0.3(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))
       '@vitejs/plugin-rsc': 0.5.27(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.6)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.8.3))
       dotenv: 17.4.2
-      hono: 4.12.27
+      hono: 4.12.34
       magic-string: 0.30.21
       picocolors: 1.1.1
       react: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ overrides:
   fastify: '>=5.8.5'
   follow-redirects@<1.16.0: 1.16.0
   uuid@<14.0.0: 14.0.0
-  postcss@<8.5.18: 8.5.18
+  postcss@<8.5.23: 8.5.23
   protobufjs@<=7.6.4: 7.6.5
   protobufjs@>=8.0.0 <8.6.6: 8.6.6
   '@protobufjs/utf8@<=1.1.0': 1.1.1
@@ -72,8 +72,8 @@ overrides:
   find-my-way@>=5.5.0 <8.2.2: ^8.2.2
   find-my-way@>=9.0.0 <9.6.1: 9.7.0
   glob@>=10.3.7 <=11.0.3: '>=11.1.0'
-  hono: '>=4.12.27'
-  ip-address@<=10.1.0: 10.1.1
+  hono: '>=4.12.34'
+  ip-address@<=10.3.0: 10.3.1
   lodash@>=4.0.0 <=4.17.23: 4.18.1
   lodash-es@>=4.0.0 <=4.17.22: 4.17.23
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
@@ -94,7 +94,7 @@ overrides:
   tar: '>=7.5.21'
   tar-fs@>=3.0.0 <3.1.1: '>=3.1.1'
   tmp: '>=0.2.7'
-  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=7.0.0 <7.29.0: 7.29.0
   vite@>=6.0.0 <=6.4.2: 6.4.3
   vite@>=7.0.0 <=7.3.1: 7.3.2
   vite@>=8.0.0 <=8.0.15: 8.0.16
@@ -113,13 +113,13 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   srvx@<0.11.13: 0.11.13
-  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
   yaml@>=2.0.0 <2.8.3: 2.8.3
   '@vitejs/plugin-rsc@<=0.5.25': 0.5.26
   next@>=16.0.0-beta.0 <16.2.11: 16.2.11
   react-server-dom-webpack@>=19.2.0 <19.2.6: 19.2.6
   basic-ftp@<=5.3.0: 5.3.1
-  fast-uri@<=3.1.3: 3.1.4
+  fast-uri@<=3.1.4: 3.1.5
   sharp@<0.35.0: 0.35.0
 
 allowBuilds:

--- a/src/tempo/actions/token.test.ts
+++ b/src/tempo/actions/token.test.ts
@@ -3,8 +3,8 @@ import { Hex } from 'ox'
 import { TokenId, TokenRole } from 'ox/tempo'
 import { formatUnits, parseUnits } from 'viem'
 import { getCode, writeContractSync } from 'viem/actions'
-import { Abis, Addresses, TokenIds } from 'viem/tempo'
-import { describe, expect, test } from 'vitest'
+import { Abis, Addresses, Selectors, TokenIds } from 'viem/tempo'
+import { describe, expect, test, vi } from 'vitest'
 import {
   accounts,
   addresses,
@@ -28,6 +28,16 @@ const tokenlessClient = getClient({
   chain: chain.extend({ feeToken }),
   tokens: undefined,
 })
+
+type RequestCall = [
+  {
+    method: string
+    params?: readonly [
+      { data?: Hex.Hex | undefined; to?: string | undefined },
+      ...unknown[],
+    ]
+  },
+]
 
 describe('call (without client)', () => {
   test('default: builds the same call as the client form', () => {
@@ -459,6 +469,7 @@ describe('getTotalSupply', () => {
 
 describe('getMetadata', () => {
   test('default', async () => {
+    const request = vi.spyOn(client, 'request')
     const metadata = await actions.token.getMetadata(client, {
       token: addresses.alphaUsd,
     })
@@ -477,6 +488,104 @@ describe('getMetadata', () => {
         "transferPolicyId": 1n,
       }
     `)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request.mock.calls[0]?.[0]).toMatchObject({
+      method: 'eth_call',
+      params: [{ data: expect.any(String) }, 'latest'],
+    })
+    const calls = request.mock.calls as unknown as RequestCall[]
+    expect(calls[0]?.[0].params?.[0]).not.toHaveProperty('to')
+    request.mockRestore()
+  })
+
+  test('behavior: respects disabled client multicall', async () => {
+    const client = getClient({
+      batch: { multicall: false },
+      chain: chainWithFeeToken,
+      tokens: undefined,
+    })
+    const request = vi.spyOn(client, 'request')
+
+    const metadata = await actions.token.getMetadata(client, {
+      token: addresses.alphaUsd,
+    })
+
+    expect(metadata.name).toBe('AlphaUSD')
+    expect(request).toHaveBeenCalledTimes(10)
+    const calls = request.mock.calls as unknown as RequestCall[]
+    for (const [{ method, params }] of calls) {
+      expect(method).toBe('eth_call')
+      expect(params?.[0]).toMatchObject({ to: addresses.alphaUsd })
+    }
+    request.mockRestore()
+  })
+
+  test('behavior: respects explicit deployless client multicall', async () => {
+    const client = getClient({
+      batch: { multicall: { deployless: true } },
+      chain: chainWithFeeToken,
+      tokens: undefined,
+    })
+    const request = vi.spyOn(client, 'request')
+
+    const metadata = await actions.token.getMetadata(client, {
+      token: addresses.alphaUsd,
+    })
+
+    expect(metadata.name).toBe('AlphaUSD')
+    expect(request).toHaveBeenCalledTimes(1)
+    const calls = request.mock.calls as unknown as RequestCall[]
+    expect(calls[0]?.[0].params?.[0]).not.toHaveProperty('to')
+    request.mockRestore()
+  })
+
+  test('behavior: falls back when logo URI fails', async () => {
+    const client = getClient({
+      batch: { multicall: false },
+      chain: chainWithFeeToken,
+      tokens: undefined,
+    })
+    const request_ = client.request
+    const request = vi
+      .spyOn(client, 'request')
+      .mockImplementation(async (parameters, options) => {
+        const [{ data }] = (parameters as { params: [{ data: Hex.Hex }] })
+          .params
+        if (data === Selectors.tip20.logoURI) throw new Error('logo URI failed')
+        return request_(parameters, options)
+      })
+
+    const metadata = await actions.token.getMetadata(client, {
+      token: addresses.alphaUsd,
+    })
+
+    expect(metadata.logoURI).toBe('')
+    request.mockRestore()
+  })
+
+  test('behavior: throws required field failures in return order', async () => {
+    const client = getClient({
+      batch: { multicall: false },
+      chain: chainWithFeeToken,
+      tokens: undefined,
+    })
+    const request_ = client.request
+    const request = vi
+      .spyOn(client, 'request')
+      .mockImplementation(async (parameters, options) => {
+        const [{ data }] = (parameters as { params: [{ data: Hex.Hex }] })
+          .params
+        if (data === Selectors.tip20.name) throw new Error('name failed')
+        if (data === Selectors.tip20.symbol) throw new Error('symbol failed')
+        return request_(parameters, options)
+      })
+
+    await expect(
+      actions.token.getMetadata(client, {
+        token: addresses.alphaUsd,
+      }),
+    ).rejects.toThrow('name failed')
+    request.mockRestore()
   })
 
   test('behavior: custom token (address)', async () => {
@@ -540,6 +649,29 @@ describe('getMetadata', () => {
         }
       `)
     }
+  })
+
+  test('behavior: quote token with disabled client multicall', async () => {
+    const client = getClient({
+      batch: { multicall: false },
+      chain: chainWithFeeToken,
+      tokens: undefined,
+    })
+    const request = vi.spyOn(client, 'request')
+
+    const metadata = await actions.token.getMetadata(client, {
+      token: Addresses.pathUsd,
+    })
+
+    expect(metadata).toMatchObject({
+      currency: 'USD',
+      decimals: 6,
+      logoURI: '',
+      name: 'pathUSD',
+      symbol: 'pathUSD',
+    })
+    expect(request).toHaveBeenCalledTimes(6)
+    request.mockRestore()
   })
 
   test('behavior: custom token (id)', async () => {

--- a/src/tempo/actions/token.test.ts
+++ b/src/tempo/actions/token.test.ts
@@ -1,7 +1,13 @@
 import { setTimeout } from 'node:timers/promises'
 import { Hex } from 'ox'
 import { TokenId, TokenRole } from 'ox/tempo'
-import { formatUnits, parseUnits } from 'viem'
+import {
+  type EIP1193Parameters,
+  type EIP1193RequestOptions,
+  formatUnits,
+  type PublicRpcSchema,
+  parseUnits,
+} from 'viem'
 import { getCode, writeContractSync } from 'viem/actions'
 import { Abis, Addresses, Selectors, TokenIds } from 'viem/tempo'
 import { describe, expect, test, vi } from 'vitest'
@@ -29,15 +35,9 @@ const tokenlessClient = getClient({
   tokens: undefined,
 })
 
-type RequestCall = [
-  {
-    method: string
-    params?: readonly [
-      { data?: Hex.Hex | undefined; to?: string | undefined },
-      ...unknown[],
-    ]
-  },
-]
+type EthCallSchema = [Extract<PublicRpcSchema[number], { Method: 'eth_call' }>]
+type EthCallRequest = EIP1193Parameters<EthCallSchema>
+type RequestCall = [EthCallRequest, EIP1193RequestOptions?]
 
 describe('call (without client)', () => {
   test('default: builds the same call as the client form', () => {
@@ -549,8 +549,7 @@ describe('getMetadata', () => {
     const request = vi
       .spyOn(client, 'request')
       .mockImplementation(async (parameters, options) => {
-        const [{ data }] = (parameters as { params: [{ data: Hex.Hex }] })
-          .params
+        const [{ data }] = (parameters as EthCallRequest).params
         if (data === Selectors.tip20.logoURI) throw new Error('logo URI failed')
         return request_(parameters, options)
       })
@@ -573,8 +572,7 @@ describe('getMetadata', () => {
     const request = vi
       .spyOn(client, 'request')
       .mockImplementation(async (parameters, options) => {
-        const [{ data }] = (parameters as { params: [{ data: Hex.Hex }] })
-          .params
+        const [{ data }] = (parameters as EthCallRequest).params
         if (data === Selectors.tip20.name) throw new Error('name failed')
         if (data === Selectors.tip20.symbol) throw new Error('symbol failed')
         return request_(parameters, options)

--- a/src/tempo/actions/token.test.ts
+++ b/src/tempo/actions/token.test.ts
@@ -39,6 +39,14 @@ type EthCallSchema = [Extract<PublicRpcSchema[number], { Method: 'eth_call' }>]
 type EthCallRequest = EIP1193Parameters<EthCallSchema>
 type RequestCall = [EthCallRequest, EIP1193RequestOptions?]
 
+function getEthCallRequest(
+  request: EIP1193Parameters<PublicRpcSchema>,
+): EthCallRequest {
+  if (request.method !== 'eth_call')
+    throw new Error(`Expected eth_call, received ${request.method}.`)
+  return request
+}
+
 describe('call (without client)', () => {
   test('default: builds the same call as the client form', () => {
     const args = {
@@ -493,7 +501,7 @@ describe('getMetadata', () => {
       method: 'eth_call',
       params: [{ data: expect.any(String) }, 'latest'],
     })
-    const calls = request.mock.calls as unknown as RequestCall[]
+    const calls: RequestCall[] = request.mock.calls
     expect(calls[0]?.[0].params?.[0]).not.toHaveProperty('to')
     request.mockRestore()
   })
@@ -512,7 +520,7 @@ describe('getMetadata', () => {
 
     expect(metadata.name).toBe('AlphaUSD')
     expect(request).toHaveBeenCalledTimes(10)
-    const calls = request.mock.calls as unknown as RequestCall[]
+    const calls: RequestCall[] = request.mock.calls
     for (const [{ method, params }] of calls) {
       expect(method).toBe('eth_call')
       expect(params?.[0]).toMatchObject({ to: addresses.alphaUsd })
@@ -534,7 +542,7 @@ describe('getMetadata', () => {
 
     expect(metadata.name).toBe('AlphaUSD')
     expect(request).toHaveBeenCalledTimes(1)
-    const calls = request.mock.calls as unknown as RequestCall[]
+    const calls: RequestCall[] = request.mock.calls
     expect(calls[0]?.[0].params?.[0]).not.toHaveProperty('to')
     request.mockRestore()
   })
@@ -549,7 +557,7 @@ describe('getMetadata', () => {
     const request = vi
       .spyOn(client, 'request')
       .mockImplementation(async (parameters, options) => {
-        const [{ data }] = (parameters as EthCallRequest).params
+        const [{ data }] = getEthCallRequest(parameters).params
         if (data === Selectors.tip20.logoURI) throw new Error('logo URI failed')
         return request_(parameters, options)
       })
@@ -572,7 +580,7 @@ describe('getMetadata', () => {
     const request = vi
       .spyOn(client, 'request')
       .mockImplementation(async (parameters, options) => {
-        const [{ data }] = (parameters as EthCallRequest).params
+        const [{ data }] = getEthCallRequest(parameters).params
         if (data === Selectors.tip20.name) throw new Error('name failed')
         if (data === Selectors.tip20.symbol) throw new Error('symbol failed')
         return request_(parameters, options)

--- a/src/tempo/actions/token.ts
+++ b/src/tempo/actions/token.ts
@@ -1547,6 +1547,7 @@ async function readMetadataContracts<
     | 'stateOverride'
   >,
 ): Promise<MulticallReturnType<contracts>> {
+  // Preserve the action's deployless default unless the client overrides it.
   if (client.batch?.multicall === undefined)
     return multicall(client, {
       ...parameters,

--- a/src/tempo/actions/token.ts
+++ b/src/tempo/actions/token.ts
@@ -4,7 +4,11 @@ import { TokenId, TokenRole } from 'ox/tempo'
 import type { Account } from '../../accounts/types.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import { estimateContractGas } from '../../actions/public/estimateContractGas.js'
-import { multicall } from '../../actions/public/multicall.js'
+import {
+  type MulticallParameters,
+  type MulticallReturnType,
+  multicall,
+} from '../../actions/public/multicall.js'
 import type { ReadContractReturnType } from '../../actions/public/readContract.js'
 import { readContract } from '../../actions/public/readContract.js'
 import {
@@ -30,7 +34,11 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
 import type { BaseErrorType } from '../../errors/base.js'
 import type { Chain } from '../../types/chain.js'
-import type { ExtractAbiItem, GetEventArgs } from '../../types/contract.js'
+import type {
+  ContractFunctionParameters,
+  ExtractAbiItem,
+  GetEventArgs,
+} from '../../types/contract.js'
 import type { Log, Log as viem_Log } from '../../types/log.js'
 import type { Compute, OneOf, UnionOmit } from '../../types/utils.js'
 import { encodeFunctionData } from '../../utils/abi/encodeFunctionData.js'
@@ -1399,7 +1407,7 @@ export async function getMetadata<chain extends Chain | undefined>(
   }
 
   if (TokenId.fromAddress(address) === TokenId.fromAddress(Addresses.pathUsd))
-    return multicall(client, {
+    return readMetadataContracts(client, {
       ...rest,
       contracts: [
         {
@@ -1433,8 +1441,6 @@ export async function getMetadata<chain extends Chain | undefined>(
           functionName: 'totalSupply',
         },
       ] as const,
-      allowFailure: true,
-      deployless: true,
     }).then(([currency, decimals, logoURI, name, symbol, totalSupply]) => ({
       name: unwrapMulticallResult(name),
       symbol: unwrapMulticallResult(symbol),
@@ -1445,7 +1451,7 @@ export async function getMetadata<chain extends Chain | undefined>(
       ...overrides,
     }))
 
-  return multicall(client, {
+  return readMetadataContracts(client, {
     ...rest,
     contracts: [
       {
@@ -1499,8 +1505,6 @@ export async function getMetadata<chain extends Chain | undefined>(
         functionName: 'transferPolicyId',
       },
     ] as const,
-    allowFailure: true,
-    deployless: true,
   }).then(
     ([
       currency,
@@ -1527,6 +1531,43 @@ export async function getMetadata<chain extends Chain | undefined>(
       ...overrides,
     }),
   )
+}
+
+async function readMetadataContracts<
+  chain extends Chain | undefined,
+  const contracts extends readonly unknown[],
+>(
+  client: Client<Transport, chain>,
+  parameters: Pick<
+    MulticallParameters<contracts>,
+    | 'blockNumber'
+    | 'blockOverrides'
+    | 'blockTag'
+    | 'contracts'
+    | 'stateOverride'
+  >,
+): Promise<MulticallReturnType<contracts>> {
+  if (client.batch?.multicall === undefined)
+    return multicall(client, {
+      ...parameters,
+      allowFailure: true,
+      deployless: true,
+    })
+
+  const { contracts, ...rest } = parameters
+  const results = await Promise.allSettled(
+    (contracts as readonly ContractFunctionParameters[]).map((contract) =>
+      readContract(client, {
+        ...rest,
+        ...contract,
+      } as never),
+    ),
+  )
+  return results.map((result) =>
+    result.status === 'fulfilled'
+      ? { result: result.value, status: 'success' }
+      : { error: result.reason, status: 'failure' },
+  ) as never
 }
 
 function unwrapMulticallResult<result>(

--- a/src/tempo/actions/token.ts
+++ b/src/tempo/actions/token.ts
@@ -9,8 +9,10 @@ import {
   type MulticallReturnType,
   multicall,
 } from '../../actions/public/multicall.js'
-import type { ReadContractReturnType } from '../../actions/public/readContract.js'
-import { readContract } from '../../actions/public/readContract.js'
+import {
+  type ReadContractReturnType,
+  readContract,
+} from '../../actions/public/readContract.js'
 import {
   type SimulateContractReturnType,
   simulateContract,
@@ -34,11 +36,7 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
 import type { BaseErrorType } from '../../errors/base.js'
 import type { Chain } from '../../types/chain.js'
-import type {
-  ContractFunctionParameters,
-  ExtractAbiItem,
-  GetEventArgs,
-} from '../../types/contract.js'
+import type { ExtractAbiItem, GetEventArgs } from '../../types/contract.js'
 import type { Log, Log as viem_Log } from '../../types/log.js'
 import type { Compute, OneOf, UnionOmit } from '../../types/utils.js'
 import { encodeFunctionData } from '../../utils/abi/encodeFunctionData.js'
@@ -1546,7 +1544,18 @@ async function readMetadataContracts<
     | 'contracts'
     | 'stateOverride'
   >,
-): Promise<MulticallReturnType<contracts>> {
+): Promise<MulticallReturnType<contracts>>
+async function readMetadataContracts<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  parameters: Pick<
+    MulticallParameters,
+    | 'blockNumber'
+    | 'blockOverrides'
+    | 'blockTag'
+    | 'contracts'
+    | 'stateOverride'
+  >,
+): Promise<MulticallReturnType> {
   // Preserve the action's deployless default unless the client overrides it.
   if (client.batch?.multicall === undefined)
     return multicall(client, {
@@ -1557,18 +1566,18 @@ async function readMetadataContracts<
 
   const { contracts, ...rest } = parameters
   const results = await Promise.allSettled(
-    (contracts as readonly ContractFunctionParameters[]).map((contract) =>
+    contracts.map((contract) =>
       readContract(client, {
         ...rest,
         ...contract,
-      } as never),
+      }),
     ),
   )
   return results.map((result) =>
     result.status === 'fulfilled'
       ? { result: result.value, status: 'success' }
       : { error: result.reason, status: 'failure' },
-  ) as never
+  )
 }
 
 function unwrapMulticallResult<result>(

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -366,6 +366,25 @@ describe('getZoneInfo', () => {
   })
 })
 
+describe('getTokenMetadata', () => {
+  test('behavior: supports disabled client multicall', async () => {
+    const client = getZoneClient({
+      account,
+      batch: { multicall: false },
+    })
+    await zoneActions.signAuthorizationToken(client, { zoneId })
+    const info = await zoneActions.getZoneInfo(client)
+
+    const metadata = await tokenActions.getMetadata(client, {
+      token: info.zoneTokens[0]!,
+    })
+
+    expect(metadata.decimals).toBe(6)
+    expect(metadata.name.length).toBeGreaterThan(0)
+    expect(metadata.symbol.length).toBeGreaterThan(0)
+  })
+})
+
 describe('waitForTempoBlock', () => {
   test('behavior: returns after the zone imports the block', async () => {
     await zoneActions.signAuthorizationToken(zoneClient, { zoneId })

--- a/test/src/tempo/config.ts
+++ b/test/src/tempo/config.ts
@@ -131,7 +131,7 @@ export function getClient<
   parameters: Partial<
     Pick<
       ClientConfig<Transport, chain_, accountOrAddress>,
-      'account' | 'chain' | 'tokens' | 'transport'
+      'account' | 'batch' | 'chain' | 'tokens' | 'transport'
     >
   > = {},
 ): Client<

--- a/test/src/tempo/zones.ts
+++ b/test/src/tempo/zones.ts
@@ -67,7 +67,7 @@ export function getClient<
   parameters: Partial<
     Pick<
       ClientConfig<Transport, typeof zone, accountOrAddress>,
-      'account' | 'chain' | 'transport'
+      'account' | 'batch' | 'chain' | 'transport'
     >
   > = {},
 ) {


### PR DESCRIPTION
## Summary

Updates Tempo token metadata reads to honor explicit client multicall configuration while preserving deployless Multicall3 as the action's default.

## Motivation

Zone clients cannot execute deployless contract-creation `eth_call` requests. Explicitly disabling client multicall should allow `token.getMetadata` to use ordinary contract reads without changing the default behavior for existing Tempo clients.

## Changes

- Preserved deployless metadata multicall when the client does not specify a multicall setting.
- Used concurrent `readContract` calls when the client explicitly configures multicall behavior.
- Preserved pathUSD fields, declared-token overrides, logo URI fallback, and deterministic required-field errors.
- Added focused Tempo and Zone coverage plus a patch changeset.

## Testing

- `pnpm test src/tempo/actions/token.test.ts --run` — 76 passed, 1 existing skip.
- `pnpm check:types`
- `pnpm build:types`
- Attempted `VITE_TEMPO_ZONES=true pnpm test src/tempo/actions/zone.test.ts --run`; the local Zone container exited before tests because the configured dev key did not own `ZoneFactory`.