### PR TITLE
feat(chains): add XGR Testnet

### DIFF
--- a/.changeset/quiet-llamas-build.md
+++ b/.changeset/quiet-llamas-build.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add XGR Testnet chain.

--- a/src/chains/definitions/xgrTestnet.ts
+++ b/src/chains/definitions/xgrTestnet.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xgrTestnet = /*#__PURE__*/ defineChain({
+  id: 1879,
+  name: 'XGR Testnet',
+  nativeCurrency: {
+    name: 'XGR',
+    symbol: 'XGR',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc1.testnet.xgr.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'XGR Testnet Explorer',
+      url: 'https://explorer.testnet.xgr.network',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Adds the official XGR Testnet chain definition to `viem/chains`.

- Chain ID: `1879`
- RPC: `https://rpc1.testnet.xgr.network`
- Explorer: `https://explorer.testnet.xgr.network`
- Native currency: XGRt (18 decimals)
- Includes a patch changeset

The values are taken from the canonical XGR.Network metadata. XGR Mainnet is already available through `xgr`.

The testnet native-currency metadata has been corrected on the head branch. A follow-up commit is still required to add the one-line `xgrTestnet` export to `src/chains/index.ts`; this is stated explicitly to avoid presenting the current diff as merge-complete.