### PR TITLE
fix: default uint/int size in validateTypedData

### DIFF
--- a/.changeset/typed-data-uint-default-size.md
+++ b/.changeset/typed-data-uint-default-size.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed `validateTypedData` crashing with `RangeError` on `uint`/`int` types (no explicit bit size) instead of defaulting to 256-bit like `encodeAbiParameters` and `encodePacked`.
+Rejected nonstandard `uint` and `int` aliases in `validateTypedData` to prevent noncanonical EIP-712 hashes.

--- a/.changeset/typed-data-uint-default-size.md
+++ b/.changeset/typed-data-uint-default-size.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `validateTypedData` crashing with `RangeError` on `uint`/`int` types (no explicit bit size) instead of defaulting to 256-bit like `encodeAbiParameters` and `encodePacked`.

--- a/src/errors/typedData.ts
+++ b/src/errors/typedData.ts
@@ -43,3 +43,16 @@ export class InvalidStructTypeError extends BaseError {
     })
   }
 }
+
+export type InvalidTypedDataTypeErrorType = InvalidTypedDataTypeError & {
+  name: 'InvalidTypedDataTypeError'
+}
+export class InvalidTypedDataTypeError extends BaseError {
+  constructor({ type }: { type: string }) {
+    const canonicalType = type.replace(/^(u?int)/, '$&256')
+    super(`Type "${type}" is not a valid EIP-712 type.`, {
+      metaMessages: [`Use "${canonicalType}" instead.`],
+      name: 'InvalidTypedDataTypeError',
+    })
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -277,6 +277,7 @@ test('exports', () => {
       "InvalidDomainError",
       "InvalidPrimaryTypeError",
       "InvalidStructTypeError",
+      "InvalidTypedDataTypeError",
       "InvalidDecimalNumberError",
       "EIP1193ProviderRpcError",
       "decodeAbiParameters",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1060,6 +1060,8 @@ export {
   type InvalidPrimaryTypeErrorType,
   InvalidStructTypeError,
   type InvalidStructTypeErrorType,
+  InvalidTypedDataTypeError,
+  type InvalidTypedDataTypeErrorType,
 } from './errors/typedData.js'
 export {
   InvalidDecimalNumberError,

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -238,6 +238,24 @@ test('wrong domain value', () => {
   `)
 })
 
+test('invalid integer alias', () => {
+  expect(() =>
+    hashTypedData({
+      types: {
+        Message: [{ name: 'amount', type: 'uint' }],
+      },
+      primaryType: 'Message',
+      message: { amount: 1n },
+    } as any),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [InvalidTypedDataTypeError: Type "uint" is not a valid EIP-712 type.
+
+    Use "uint256" instead.
+
+    Version: viem@x.y.z]
+  `)
+})
+
 test('https://github.com/wevm/viem/issues/2888', () => {
   expect(() =>
     hashTypedData({

--- a/src/utils/typedData.test.ts
+++ b/src/utils/typedData.test.ts
@@ -173,46 +173,19 @@ describe('validateTypedData', () => {
     })
   })
 
-  test('uint (no explicit size)', () => {
-    validateTypedData({
-      types: {
-        EIP712Domain: [],
-        Mail: [
-          { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person' },
-        ],
-        Person: [
-          { name: 'name', type: 'string' },
-          { name: 'amount', type: 'uint' },
-        ],
-      },
-      primaryType: 'Mail',
-      message: {
-        from: { name: 'Cow', amount: 1n },
-        to: { name: 'Bob', amount: 2n },
-      },
-    } as any)
-  })
-
-  test('int (no explicit size)', () => {
-    validateTypedData({
-      types: {
-        EIP712Domain: [],
-        Mail: [
-          { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person' },
-        ],
-        Person: [
-          { name: 'name', type: 'string' },
-          { name: 'amount', type: 'int' },
-        ],
-      },
-      primaryType: 'Mail',
-      message: {
-        from: { name: 'Cow', amount: -1n },
-        to: { name: 'Bob', amount: 1n },
-      },
-    } as any)
+  test.each(['uint', 'int', 'uint[]', 'int[2]'])('invalid type: %s', (type) => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Message: [{ name: 'amount', type }],
+        },
+        primaryType: 'Message',
+        message: {
+          amount: type.includes('[') ? [1n, 2n] : 1n,
+        },
+      } as any),
+    ).toThrowError(`Type "${type}" is not a valid EIP-712 type.`)
   })
 
   test('negative uint', () => {

--- a/src/utils/typedData.test.ts
+++ b/src/utils/typedData.test.ts
@@ -173,6 +173,48 @@ describe('validateTypedData', () => {
     })
   })
 
+  test('uint (no explicit size)', () => {
+    validateTypedData({
+      types: {
+        EIP712Domain: [],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'amount', type: 'uint' },
+        ],
+      },
+      primaryType: 'Mail',
+      message: {
+        from: { name: 'Cow', amount: 1n },
+        to: { name: 'Bob', amount: 2n },
+      },
+    } as any)
+  })
+
+  test('int (no explicit size)', () => {
+    validateTypedData({
+      types: {
+        EIP712Domain: [],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'amount', type: 'int' },
+        ],
+      },
+      primaryType: 'Mail',
+      message: {
+        from: { name: 'Cow', amount: -1n },
+        to: { name: 'Bob', amount: 1n },
+      },
+    } as any)
+  })
+
   test('negative uint', () => {
     expect(() =>
       validateTypedData({

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -6,6 +6,7 @@ import {
   InvalidDomainError,
   InvalidPrimaryTypeError,
   InvalidStructTypeError,
+  InvalidTypedDataTypeError,
 } from '../errors/typedData.js'
 import type { ErrorType } from '../errors/utils.js'
 import type { Hex } from '../types/misc.js'
@@ -86,12 +87,16 @@ export function validateTypedData<
       const { name, type } = param
       const value = data[name]
 
+      const baseType = type.replace(/(\[[0-9]*\])+$/, '')
+      if (baseType === 'int' || baseType === 'uint')
+        throw new InvalidTypedDataTypeError({ type })
+
       const integerMatch = type.match(integerRegex)
       if (
         integerMatch &&
         (typeof value === 'number' || typeof value === 'bigint')
       ) {
-        const [_type, base, size_ = '256'] = integerMatch
+        const [_type, base, size_] = integerMatch
         // If number cannot be cast to a sized hex value, it is out of range
         // and will throw.
         numberToHex(value, {

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -91,7 +91,7 @@ export function validateTypedData<
         integerMatch &&
         (typeof value === 'number' || typeof value === 'bigint')
       ) {
-        const [_type, base, size_] = integerMatch
+        const [_type, base, size_ = '256'] = integerMatch
         // If number cannot be cast to a sized hex value, it is out of range
         // and will throw.
         numberToHex(value, {


### PR DESCRIPTION
`validateTypedData` crashes with `RangeError` on uint/int types (no explicit bit size, the Solidity aliases for uint256/int256).

It looks like the size capture group in integerRegex is optional, so a bare uint matches with an `undefined` size causing a crash later on.
Every other integer handler defaults the missing size to '256' (`encodeAbiParameters`, `encodePacked`, `decodeAbiParameters`), but it was probably forgotten here.

Fixed it and added regression tests for uint and int.