### PR TITLE
feat(tempo): add Earn deployment actions

### DIFF
--- a/.changeset/calm-vaults-earn.md
+++ b/.changeset/calm-vaults-earn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added experimental Tempo Earn actions for deterministic ERC-4626 stack deployment and binding.

--- a/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
@@ -25,12 +25,13 @@ const result = await client.earn.bindErc4626EngineSync({
 :::
 
 The transaction must be signed by the engine's final owner. Binding remains a separate operation so
-deployment and final ownership can use different accounts. It cannot be changed after initialization.
-
-Use [`earn.bindErc4626Engine`](/tempo/actions/earn.bindErc4626Engine) to return a transaction hash
-without waiting. The action also exposes `call` and `extractEvent` helpers.
+deployment and final ownership can use different accounts. It cannot be changed after
+initialization.
 
 ### Asynchronous Usage
+
+`earn.bindErc4626EngineSync` waits for inclusion and returns the decoded binding event. Use
+`earn.bindErc4626Engine` to return the transaction hash immediately.
 
 ```ts twoslash
 import { Actions } from 'viem/tempo'
@@ -60,7 +61,7 @@ type ReturnValue = {
 }
 ```
 
-The asynchronous action returns a transaction hash.
+The asynchronous action returns the transaction hash instead.
 
 ## Parameters
 

--- a/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
@@ -28,8 +28,7 @@ The transaction must be signed by the engine's final owner. Binding remains a se
 deployment and final ownership can use different accounts. It cannot be changed after initialization.
 
 Use [`earn.bindErc4626Engine`](/tempo/actions/earn.bindErc4626Engine) to return a transaction hash
-without waiting. The action also exposes `call`, `estimateGas`, `simulate`, and `extractEvent`
-helpers.
+without waiting. The action also exposes `call` and `extractEvent` helpers.
 
 ### Asynchronous Usage
 

--- a/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.bindErc4626Engine.mdx
@@ -1,0 +1,80 @@
+import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
+
+# `earn.bindErc4626Engine`
+
+Permanently binds an ERC-4626 engine to its factory-created EarnVault. This API is experimental.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const result = await client.earn.bindErc4626EngineSync({
+  engine: '0x0000000000000000000000000000000000000001',
+  vault: '0x0000000000000000000000000000000000000002',
+})
+// @log: { engine: '0x...', vault: '0x...', receipt: { ... } }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The transaction must be signed by the engine's final owner. Binding remains a separate operation so
+deployment and final ownership can use different accounts. It cannot be changed after initialization.
+
+Use [`earn.bindErc4626Engine`](/tempo/actions/earn.bindErc4626Engine) to return a transaction hash
+without waiting. The action also exposes `call`, `estimateGas`, `simulate`, and `extractEvent`
+helpers.
+
+### Asynchronous Usage
+
+```ts twoslash
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const engine = '0x0000000000000000000000000000000000000001'
+const hash = await client.earn.bindErc4626Engine({
+  engine,
+  vault: '0x0000000000000000000000000000000000000002',
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+const { args } = Actions.earn.bindErc4626Engine.extractEvent(receipt.logs, {
+  engine,
+})
+```
+
+## Return Value
+
+```ts
+type ReturnValue = {
+  /** ERC-4626 engine address. */
+  engine: Address
+  /** Transaction receipt. */
+  receipt: TransactionReceipt
+  /** Bound EarnVault address. */
+  vault: Address
+}
+```
+
+The asynchronous action returns a transaction hash.
+
+## Parameters
+
+### engine
+
+- **Type:** `Address`
+
+ERC-4626 engine address.
+
+### vault
+
+- **Type:** `Address`
+
+EarnVault created for the engine.
+
+<WriteParameters />

--- a/site/pages/tempo/actions/earn.createErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.createErc4626Engine.mdx
@@ -29,10 +29,10 @@ const result = await client.earn.createErc4626EngineSync({
 The client account deploys and owns the engine by default. Use `owner` to set a different final
 owner. The action derives engine metadata from the venue unless `name` or `symbol` is provided.
 
-Use [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine) to return a transaction
-hash without waiting. The action also exposes `call`, `predict`, and `extractEvent` helpers.
-
 ### Asynchronous Usage
+
+`earn.createErc4626EngineSync` waits for inclusion and returns the decoded deployment event. Use
+`earn.createErc4626Engine` to return the transaction hash immediately.
 
 ```ts twoslash
 import { keccak256, toHex } from 'viem'
@@ -72,7 +72,7 @@ type ReturnValue = {
 }
 ```
 
-The asynchronous action returns a transaction hash.
+The asynchronous action returns the transaction hash instead.
 
 ## Parameters
 

--- a/site/pages/tempo/actions/earn.createErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.createErc4626Engine.mdx
@@ -30,8 +30,7 @@ The client account deploys and owns the engine by default. Use `owner` to set a 
 owner. The action derives engine metadata from the venue unless `name` or `symbol` is provided.
 
 Use [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine) to return a transaction
-hash without waiting. The action also exposes `call`, `predict`, `estimateGas`, `simulate`, and
-`extractEvent` helpers.
+hash without waiting. The action also exposes `call`, `predict`, and `extractEvent` helpers.
 
 ### Asynchronous Usage
 

--- a/site/pages/tempo/actions/earn.createErc4626Engine.mdx
+++ b/site/pages/tempo/actions/earn.createErc4626Engine.mdx
@@ -1,0 +1,117 @@
+import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
+
+# `earn.createErc4626Engine`
+
+Deploys a deterministic engine for an ERC-4626 venue. This API is experimental.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { client } from './viem.config'
+
+const result = await client.earn.createErc4626EngineSync({
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  factory: '0x0000000000000000000000000000000000000001',
+  venue: '0x0000000000000000000000000000000000000002',
+})
+// @log: { deploymentId: '0x...', engine: '0x...', receipt: { ... } }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The client account deploys and owns the engine by default. Use `owner` to set a different final
+owner. The action derives engine metadata from the venue unless `name` or `symbol` is provided.
+
+Use [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine) to return a transaction
+hash without waiting. The action also exposes `call`, `predict`, `estimateGas`, `simulate`, and
+`extractEvent` helpers.
+
+### Asynchronous Usage
+
+```ts twoslash
+import { keccak256, toHex } from 'viem'
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const factory = '0x0000000000000000000000000000000000000001'
+const hash = await client.earn.createErc4626Engine({
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  factory,
+  venue: '0x0000000000000000000000000000000000000002',
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+const { args } = Actions.earn.createErc4626Engine.extractEvent(receipt.logs, {
+  factory,
+})
+```
+
+## Return Value
+
+```ts
+type ReturnValue = {
+  /** Venue asset address. */
+  asset: Address
+  /** Deployment identifier. */
+  deploymentId: Hex
+  /** Deployed ERC-4626 engine address. */
+  engine: Address
+  /** Deterministic engine salt. */
+  engineSalt: Hex
+  /** Final engine owner. */
+  owner: Address
+  /** Transaction receipt. */
+  receipt: TransactionReceipt
+  /** ERC-4626 venue address. */
+  vault: Address
+}
+```
+
+The asynchronous action returns a transaction hash.
+
+## Parameters
+
+### deploymentId
+
+- **Type:** `Hex`
+
+A required, nonzero 32-byte identifier. Reuse it only when resuming the same deployment.
+
+### factory
+
+- **Type:** `Address`
+
+Reviewed `ERC4626EngineFactory` address.
+
+### venue
+
+- **Type:** `Address`
+
+ERC-4626 venue address.
+
+### owner (optional)
+
+- **Type:** `Account | Address`
+- **Default:** `account.address`
+
+Final engine owner. This account must later bind the engine to its EarnVault.
+
+### name (optional)
+
+- **Type:** `string`
+
+Engine name override. An omitted value derives metadata from the venue.
+
+### symbol (optional)
+
+- **Type:** `string`
+
+Engine symbol override. An omitted value derives metadata from the venue.
+
+<WriteParameters />

--- a/site/pages/tempo/actions/earn.createStack.mdx
+++ b/site/pages/tempo/actions/earn.createStack.mdx
@@ -32,8 +32,7 @@ zero address, migration defaults to `userOnly`, managed assets are unlimited, an
 built-in always-allow policy.
 
 Use [`earn.createStack`](/tempo/actions/earn.createStack) to return a transaction hash without
-waiting. The action also exposes `call`, `predict`, `estimateGas`, `simulate`, and
-`extractEvent` helpers.
+waiting. The action also exposes `call`, `predict`, and `extractEvent` helpers.
 
 ### Asynchronous Usage
 

--- a/site/pages/tempo/actions/earn.createStack.mdx
+++ b/site/pages/tempo/actions/earn.createStack.mdx
@@ -31,10 +31,10 @@ Omitting `fees` deploys a fee-free stack. The emergency guardian and async janit
 zero address, migration defaults to `userOnly`, managed assets are unlimited, and transfers use the
 built-in always-allow policy.
 
-Use [`earn.createStack`](/tempo/actions/earn.createStack) to return a transaction hash without
-waiting. The action also exposes `call`, `predict`, and `extractEvent` helpers.
-
 ### Asynchronous Usage
+
+`earn.createStackSync` waits for inclusion and returns the decoded deployment event. Use
+`earn.createStack` to return the transaction hash immediately.
 
 ```ts twoslash
 import { keccak256, toHex } from 'viem'
@@ -94,7 +94,7 @@ type ReturnValue = {
 }
 ```
 
-The asynchronous action returns a transaction hash.
+The asynchronous action returns the transaction hash instead.
 
 ## Parameters
 

--- a/site/pages/tempo/actions/earn.createStack.mdx
+++ b/site/pages/tempo/actions/earn.createStack.mdx
@@ -1,0 +1,155 @@
+import WriteParameters from '../../../snippets/tempo/write-parameters.mdx'
+
+# `earn.createStack`
+
+Deploys deterministic EarnShare, EarnVault, and EarnFees contracts around an unbound engine. This
+API is experimental.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { client } from './viem.config'
+
+const result = await client.earn.createStackSync({
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  engine: '0x0000000000000000000000000000000000000001',
+  factory: '0x0000000000000000000000000000000000000002',
+})
+// @log: { earnFees: '0x...', earnShare: '0x...', earnVault: '0x...', receipt: { ... } }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Omitting `fees` deploys a fee-free stack. The emergency guardian and async janitor default to the
+zero address, migration defaults to `userOnly`, managed assets are unlimited, and transfers use the
+built-in always-allow policy.
+
+Use [`earn.createStack`](/tempo/actions/earn.createStack) to return a transaction hash without
+waiting. The action also exposes `call`, `predict`, `estimateGas`, `simulate`, and
+`extractEvent` helpers.
+
+### Asynchronous Usage
+
+```ts twoslash
+import { keccak256, toHex } from 'viem'
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const factory = '0x0000000000000000000000000000000000000002'
+const hash = await client.earn.createStack({
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  engine: '0x0000000000000000000000000000000000000001',
+  factory,
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+const { args } = Actions.earn.createStack.extractEvent(receipt.logs, {
+  factory,
+})
+```
+
+## Return Value
+
+```ts
+type ReturnValue = {
+  /** Async janitor address. */
+  asyncJanitor: Address
+  /** Venue asset address. */
+  asset: Address
+  /** Control configuration hash. */
+  controlConfigHash: Hex
+  /** Deployment identifier. */
+  deploymentId: Hex
+  /** Deployed EarnFees address. */
+  earnFees: Address
+  /** Deterministic EarnFees salt. */
+  earnFeesSalt: Hex
+  /** Deployed EarnShare address. */
+  earnShare: Address
+  /** Deterministic EarnShare salt. */
+  earnShareSalt: Hex
+  /** Deployed EarnVault address. */
+  earnVault: Address
+  /** Emergency guardian address. */
+  emergencyGuardian: Address
+  /** ERC-4626 engine address. */
+  engine: Address
+  /** Fee configuration hash. */
+  feeConfigHash: Hex
+  /** Maximum managed assets. */
+  maxManagedAssets: bigint
+  /** Engine migration mode. */
+  migrationMode: number
+  /** Final stack owner and operator. */
+  owner: Address
+  /** Transaction receipt. */
+  receipt: TransactionReceipt
+  /** Effective transfer policy ID. */
+  transferPolicyId: bigint
+}
+```
+
+The asynchronous action returns a transaction hash.
+
+## Parameters
+
+### deploymentId
+
+- **Type:** `Hex`
+
+A required, nonzero 32-byte identifier shared with the engine deployment.
+
+### engine
+
+- **Type:** `Address`
+
+Unbound engine address.
+
+### factory
+
+- **Type:** `Address`
+
+Reviewed `EarnFactory` address from the same release as the engine factory.
+
+### owner (optional)
+
+- **Type:** `Account | Address`
+- **Default:** `account.address`
+
+Final stack owner and operator.
+
+### controls (optional)
+
+- **Type:** `EarnVaultControls`
+
+Initial `emergencyGuardian`, `asyncJanitor`, `maxManagedAssets`, and `migrationMode` controls.
+
+### fees (optional)
+
+- **Type:** `EarnFeeConfiguration`
+
+Up to four fixed fees and an optional excess-return fee, all expressed in basis points. Omit this
+parameter for a fee-free stack. When a distributor is enabled, `fixedFees[0]` is its protected fee
+and the remaining entries are operator-controlled.
+
+### distributor (optional)
+
+- **Type:** `EarnDistributorConfiguration`
+
+Protected distributor and update delay. An enabled distributor requires at least one fixed fee and
+controls the first entry in `fees.fixedFees` through its delayed update path.
+
+### transferPolicyId (optional)
+
+- **Type:** `bigint`
+- **Default:** `0n`
+
+Existing simple whitelist policy. Zero selects the built-in always-allow policy.
+
+<WriteParameters />

--- a/site/pages/tempo/actions/earn.deployErc4626StackSync.mdx
+++ b/site/pages/tempo/actions/earn.deployErc4626StackSync.mdx
@@ -1,0 +1,113 @@
+# `earn.deployErc4626StackSync`
+
+Deploys, verifies, and binds a complete ERC-4626 Earn stack through sequential transactions. This
+API is experimental.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { client } from './viem.config'
+
+const result = await client.earn.deployErc4626StackSync({
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  factories: {
+    earn: '0x0000000000000000000000000000000000000001',
+    erc4626Engine: '0x0000000000000000000000000000000000000002',
+  },
+  venue: '0x0000000000000000000000000000000000000003',
+})
+// @log: { engine: '0x...', vault: '0x...', earnShare: '0x...', fees: '0x...', receipts: { ... } }
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The recipe simulates each missing write, verifies existing deployments, and skips completed stages.
+Persist the returned addresses after every run. If a transaction fails, `DeployErc4626StackError`
+includes `stage`, `state`, and any receipts produced by the run. Pass `state` back through `resume`.
+
+No factory addresses are built in while Earn is experimental. Both addresses must come from the
+same reviewed Earn release.
+
+## Return Value
+
+```ts
+type ReturnValue = {
+  deploymentId: Hex
+  earnShare: Address
+  engine: Address
+  fees: Address
+  receipts: {
+    binding?: TransactionReceipt
+    engine?: TransactionReceipt
+    stack?: TransactionReceipt
+  }
+  vault: Address
+}
+```
+
+Receipts are present only for transactions submitted by the current run.
+
+## Parameters
+
+### deploymentId
+
+- **Type:** `Hex`
+
+A required, nonzero 32-byte identifier. The recipe does not generate random identifiers.
+
+### factories
+
+- **Type:** `EarnFactoryAddresses`
+
+Explicit reviewed engine and Earn factory addresses from one release.
+
+### venue
+
+- **Type:** `Address`
+
+ERC-4626 venue address.
+
+### owner (optional)
+
+- **Type:** `Account | Address`
+- **Default:** `account.address`
+
+Final owner of the engine and stack.
+
+### bindingAccount (optional)
+
+- **Type:** `Account | Address`
+
+Signer used only for final binding. It is required when `owner` differs from the deployment account
+and the engine is not already bound. It must match the owner address.
+
+### resume (optional)
+
+- **Type:** `deployErc4626StackSync.State`
+
+Previously persisted deployment state. Predicted and onchain values are verified before continuing.
+A state that includes the EarnVault address avoids a historical factory log query.
+
+### fromBlock (optional)
+
+- **Type:** `bigint`
+
+First block used to recover a prior `EarnStackDeployed` event. Set this to the factory deployment
+block or the first attempted stack deployment block when `resume` does not include the EarnVault
+address.
+
+The recipe also accepts the `controls`, `fees`, `distributor`, `name`, `symbol`, and
+`transferPolicyId` parameters documented by the primitive deployment actions.
+
+Shared transaction settings such as `feeToken`, `feePayer`, `nonceKey`, fee limits, validity bounds,
+`timeout`, and `pollingInterval` apply to every submitted transaction. Explicit `gas` and `nonce`
+values are not accepted because each stage is a separate transaction. A `keyAuthorization` is also
+not accepted because it cannot be reused across stages or accounts. Use the primitive actions when
+per-transaction overrides are required. The recipe always throws on a reverted receipt.

--- a/site/pages/tempo/actions/earn.deployErc4626StackSync.mdx
+++ b/site/pages/tempo/actions/earn.deployErc4626StackSync.mdx
@@ -103,8 +103,10 @@ First block used to recover a prior `EarnStackDeployed` event. Set this to the f
 block or the first attempted stack deployment block when `resume` does not include the EarnVault
 address.
 
-The recipe also accepts the `controls`, `fees`, `distributor`, `name`, `symbol`, and
-`transferPolicyId` parameters documented by the primitive deployment actions.
+The recipe also accepts the `controls`, `fees`, `distributor`, and `transferPolicyId` parameters
+documented by [`earn.createStack`](/tempo/actions/earn.createStack), plus the `name` and `symbol`
+parameters documented by
+[`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine).
 
 Shared transaction settings such as `feeToken`, `feePayer`, `nonceKey`, fee limits, validity bounds,
 `timeout`, and `pollingInterval` apply to every submitted transaction. Explicit `gas` and `nonce`

--- a/site/pages/tempo/actions/index.mdx
+++ b/site/pages/tempo/actions/index.mdx
@@ -28,9 +28,13 @@
 | [`channel.topUp`](/tempo/actions/channel.topUp) | Adds deposit to a TIP-20 channel |
 | [`channel.withdraw`](/tempo/actions/channel.withdraw) | Withdraws payer funds after the close grace period |
 | **Earn Actions** | |
+| [`earn.bindErc4626Engine`](/tempo/actions/earn.bindErc4626Engine) | Permanently binds an ERC-4626 engine to its EarnVault |
 | [`earn.configureExitSafePolicy`](/tempo/actions/earn.configureExitSafePolicy) | Configures an admission-only policy for an Earn share token |
+| [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine) | Deploys a deterministic ERC-4626 engine |
+| [`earn.createStack`](/tempo/actions/earn.createStack) | Deploys EarnShare, EarnVault, and EarnFees contracts |
 | [`earn.deposit`](/tempo/actions/earn.deposit) | Deposits assets into an Earn vault |
 | [`earn.depositShares`](/tempo/actions/earn.depositShares) | Deposits existing venue shares into an Earn vault |
+| [`earn.deployErc4626StackSync`](/tempo/actions/earn.deployErc4626StackSync) | Deploys and binds a complete ERC-4626 Earn stack |
 | [`earn.getFeeState`](/tempo/actions/earn.getFeeState) | Gets active fees, fee baselines, and pending fee amounts |
 | [`earn.getPosition`](/tempo/actions/earn.getPosition) | Gets an account's Earn balances, allowances, and current value |
 | [`earn.getRedeemQuote`](/tempo/actions/earn.getRedeemQuote) | Gets the asset output for an exact Earn share input |

--- a/site/pages/tempo/guides/earn/deploy.mdx
+++ b/site/pages/tempo/guides/earn/deploy.mdx
@@ -8,17 +8,13 @@ import { Card, Cards } from 'vocs'
 
 ## Overview
 
-An ERC-4626 Earn deployment uses two reviewed factories. The engine is deployed first, the Earn
-factory creates EarnShare, EarnVault, and EarnFees, then the engine's final owner binds the engine to
+An ERC-4626 Earn deployment uses two factories. First, the engine factory deploys the engine. Then,
+the Earn factory creates EarnShare, EarnVault, and EarnFees. Finally, the engine's owner binds it to
 the new vault.
 
-Earn deployment is experimental. There are no canonical factory addresses, so resolve and verify a
-factory pair from the same release before deploying. The SDK does not deploy privacy routers in this
-flow.
-
-The recipe verifies that each address has code, the Earn factory uses Tempo's TIP-20 factory, and
-the deployed topology matches its predictions. It cannot prove a release from an address alone.
-Verify factory runtime hashes against the reviewed release before passing them to the SDK.
+Earn deployment is experimental and has no canonical factory addresses. Use a reviewed factory pair
+from the same release. The recipe verifies contract code, Tempo's TIP-20 factory, and the deployed
+topology, but it cannot verify a release from an address alone.
 
 ## Recipes
 
@@ -55,13 +51,13 @@ console.log(result.engine, result.vault, result.earnShare, result.fees)
 :::
 
 The defaults are fee-free, `userOnly` migration, unrestricted transfers, unlimited managed assets,
-and zero-address emergency guardian and async janitor seats. The client account is both deployer and
-owner.
+and the zero address for `emergencyGuardian` and `asyncJanitor`. The client account is both deployer
+and owner.
 
 ### Use Separate Deployment and Owner Accounts
 
-Provide an owner and its signing account. The deployer submits the factory transactions, while the
-owner submits the final binding transaction.
+Provide the owner account as both `owner` and `bindingAccount`. The client account submits the
+factory transactions, while the owner account submits the final binding transaction.
 
 :::code-group
 
@@ -89,9 +85,9 @@ const result = await client.earn.deployErc4626StackSync({
 
 :::
 
-Preflight checks require the binding signer before a new or unbound engine is deployed. An
-idempotent rerun of an already bound stack does not require the signer. The owner must have enough
-of the selected fee token to submit the binding transaction.
+The recipe requires the binding signer before it deploys a new or unbound engine. An idempotent
+rerun of an already bound stack does not require the signer. The owner must have enough of the
+selected fee token to submit the binding transaction.
 
 ### Resume After a Partial Failure
 
@@ -144,9 +140,56 @@ Use [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine),
 own each transaction.
 
 Each primitive exposes a `call` helper for
-[`sendCalls`](/docs/actions/wallet/sendCalls), simulation, and gas estimation. Treat multi-call
-deployment as experimental. A batch combines both factories' deployment work into one transaction,
-so measure the combined gas profile against the target network before batching.
+[`sendTransactionSync`](/docs/actions/wallet/sendTransactionSync), simulation, and gas estimation.
+Treat multi-call deployment as experimental. A batch combines both factories' deployment work into
+one transaction, so measure the combined gas profile against the target network before batching.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const deploymentId = keccak256(toHex('acme-usd-v1'))
+const earnFactory = '0x0000000000000000000000000000000000000003'
+const engineParameters = {
+  deploymentId,
+  factory: '0x0000000000000000000000000000000000000001',
+  owner: client.account.address,
+  venue: '0x0000000000000000000000000000000000000002',
+} as const
+const engine = await Actions.earn.createErc4626Engine.predict(
+  client,
+  engineParameters,
+)
+
+const receipt = await client.sendTransactionSync({
+  calls: [
+    Actions.earn.createErc4626Engine.call(engineParameters),
+    Actions.earn.createStack.call({
+      deploymentId,
+      engine,
+      factory: earnFactory,
+      owner: client.account.address,
+    }),
+  ],
+})
+
+const { args } = Actions.earn.createStack.extractEvent(receipt.logs, {
+  factory: earnFactory,
+})
+await client.earn.bindErc4626EngineSync({
+  engine,
+  vault: args.earnVault,
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
 
 Binding remains a separate final-owner operation. The EarnVault address is emitted by
 `earn.createStack` rather than predicted, so it cannot be fed into a binding call in the same batch.
@@ -161,10 +204,8 @@ stage. The high-level recipe lets each transaction estimate gas and resolve its 
 Store factory addresses, release commit, runtime hashes, and factory deployment blocks with every
 deployment record. Do not mix factories from different Earn releases.
 
-Viem generates its Earn ABIs from
-[`tempoxyz/earn` commit `454fa26`](https://github.com/tempoxyz/earn/commit/454fa260ded101f970ee7d6bafebf4c3b6ec9095).
-Factory deployment bytecode is not exposed as a public action: deploying and reviewing factory
-releases remains an Earn release process.
+Verify both factory runtime hashes against the reviewed release. Viem's generated Earn ABIs record
+the `tempoxyz/earn` source commit used to generate them.
 
 ### Derive Stable Identifiers
 

--- a/site/pages/tempo/guides/earn/deploy.mdx
+++ b/site/pages/tempo/guides/earn/deploy.mdx
@@ -1,0 +1,196 @@
+---
+description: Deploy and bind an experimental ERC-4626 Tempo Earn stack.
+---
+
+import { Card, Cards } from 'vocs'
+
+# Deploy an Earn Stack
+
+## Overview
+
+An ERC-4626 Earn deployment uses two reviewed factories. The engine is deployed first, the Earn
+factory creates EarnShare, EarnVault, and EarnFees, then the engine's final owner binds the engine to
+the new vault.
+
+Earn deployment is experimental. There are no canonical factory addresses, so resolve and verify a
+factory pair from the same release before deploying. The SDK does not deploy privacy routers in this
+flow.
+
+The recipe verifies that each address has code, the Earn factory uses Tempo's TIP-20 factory, and
+the deployed topology matches its predictions. It cannot prove a release from an address alone.
+Verify factory runtime hashes against the reviewed release before passing them to the SDK.
+
+## Recipes
+
+These recipes assume you have [set up a Tempo client](/tempo) with a funded account.
+
+### Deploy a Fee-Free Stack
+
+Use [`earn.deployErc4626StackSync`](/tempo/actions/earn.deployErc4626StackSync) for the standard
+sequential flow.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { client } from './viem.config'
+
+const deploymentId = keccak256(toHex('acme-usd-v1'))
+const result = await client.earn.deployErc4626StackSync({
+  deploymentId,
+  factories: {
+    earn: '0x0000000000000000000000000000000000000001',
+    erc4626Engine: '0x0000000000000000000000000000000000000002',
+  },
+  venue: '0x0000000000000000000000000000000000000003',
+})
+
+console.log(result.engine, result.vault, result.earnShare, result.fees)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The defaults are fee-free, `userOnly` migration, unrestricted transfers, unlimited managed assets,
+and zero-address emergency guardian and async janitor seats. The client account is both deployer and
+owner.
+
+### Use Separate Deployment and Owner Accounts
+
+Provide an owner and its signing account. The deployer submits the factory transactions, while the
+owner submits the final binding transaction.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { client } from './viem.config'
+
+const owner = privateKeyToAccount('0x...')
+const result = await client.earn.deployErc4626StackSync({
+  bindingAccount: owner,
+  deploymentId: keccak256(toHex('acme-usd-owner-v1')),
+  factories: {
+    earn: '0x0000000000000000000000000000000000000001',
+    erc4626Engine: '0x0000000000000000000000000000000000000002',
+  },
+  owner,
+  venue: '0x0000000000000000000000000000000000000003',
+})
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+Preflight checks require the binding signer before a new or unbound engine is deployed. An
+idempotent rerun of an already bound stack does not require the signer. The owner must have enough
+of the selected fee token to submit the binding transaction.
+
+### Resume After a Partial Failure
+
+Persist the state attached to `DeployErc4626StackError`, then rerun with the same identifier and
+inputs.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { keccak256, toHex } from 'viem'
+import { Actions } from 'viem/tempo'
+import { client } from './viem.config'
+
+const parameters = {
+  deploymentId: keccak256(toHex('acme-usd-v1')),
+  factories: {
+    earn: '0x0000000000000000000000000000000000000001',
+    erc4626Engine: '0x0000000000000000000000000000000000000002',
+  },
+  venue: '0x0000000000000000000000000000000000000003',
+} as const
+
+try {
+  await client.earn.deployErc4626StackSync(parameters)
+} catch (error) {
+  if (error instanceof Actions.earn.DeployErc4626StackError) {
+    console.log(error.stage, error.state, error.receipts)
+    await client.earn.deployErc4626StackSync({
+      ...parameters,
+      resume: error.state,
+    })
+  }
+}
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The recipe predicts deterministic addresses, verifies existing bytecode and topology, recovers the
+factory event when needed, and skips stages that are already complete.
+
+### Compose Primitive Calls
+
+Use [`earn.createErc4626Engine`](/tempo/actions/earn.createErc4626Engine),
+[`earn.createStack`](/tempo/actions/earn.createStack), and
+[`earn.bindErc4626Engine`](/tempo/actions/earn.bindErc4626Engine) when a deployment system needs to
+own each transaction.
+
+Each primitive exposes a `call` helper for
+[`sendCalls`](/docs/actions/wallet/sendCalls), simulation, and gas estimation. Treat multi-call
+deployment as experimental. A batch combines both factories' deployment work into one transaction,
+so measure the combined gas profile against the target network before batching.
+
+Binding remains a separate final-owner operation. The EarnVault address is emitted by
+`earn.createStack` rather than predicted, so it cannot be fed into a binding call in the same batch.
+
+Use the primitives when deployment infrastructure must set an explicit nonce or gas limit for each
+stage. The high-level recipe lets each transaction estimate gas and resolve its own nonce.
+
+## Best Practices
+
+### Keep the Factory Pair Together
+
+Store factory addresses, release commit, runtime hashes, and factory deployment blocks with every
+deployment record. Do not mix factories from different Earn releases.
+
+Viem generates its Earn ABIs from
+[`tempoxyz/earn` commit `454fa26`](https://github.com/tempoxyz/earn/commit/454fa260ded101f970ee7d6bafebf4c3b6ec9095).
+Factory deployment bytecode is not exposed as a public action: deploying and reviewing factory
+releases remains an Earn release process.
+
+### Derive Stable Identifiers
+
+Use a domain-separated string or structured record and hash it to 32 bytes. Do not use random IDs
+when deployments must be reproducible or recoverable.
+
+### Persist Every Stage
+
+Record predicted and deployed addresses after each receipt. Persisting the EarnVault address avoids
+a historical event query. If it is unavailable, set `fromBlock` so recovery does not scan the full
+chain.
+
+The deterministic addresses include the owner, venue, metadata, controls, fees, distributor, and
+transfer policy. Reuse a deployment ID only with the same inputs, and always pass persisted state
+when resuming. Changing an input can produce a different stack instead of recovering the first one.
+
+### Keep Binding Authority Explicit
+
+The engine owner is the only account authorized to bind the engine. Fund and secure that account
+before beginning the deployment.
+
+## See More
+
+<Cards>
+  <Card title="Deploy a Stack" to="/tempo/actions/earn.deployErc4626StackSync" />
+  <Card title="Deploy an Engine" to="/tempo/actions/earn.createErc4626Engine" />
+  <Card title="Create Core Contracts" to="/tempo/actions/earn.createStack" />
+  <Card title="Bind an Engine" to="/tempo/actions/earn.bindErc4626Engine" />
+</Cards>

--- a/site/pages/tempo/guides/earn/index.mdx
+++ b/site/pages/tempo/guides/earn/index.mdx
@@ -45,6 +45,12 @@ underlying yield venue.
 
 <Cards>
   <Card
+    icon="lucide:blocks"
+    title="Deploy an Earn Stack"
+    description="Deploy and bind an experimental ERC-4626 Earn stack."
+    to="/tempo/guides/earn/deploy"
+  />
+  <Card
     icon="lucide:circle-dollar-sign"
     title="Deposit & Withdraw"
     description="Enter an Earn vault, inspect a position, and choose an exit shape."

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -2352,6 +2352,11 @@ export default defineConfig({
                 },
                 {
                   badge: { text: 'EXP', variant: 'warning' },
+                  text: 'Deploy an Earn Stack',
+                  link: '/tempo/guides/earn/deploy',
+                },
+                {
+                  badge: { text: 'EXP', variant: 'warning' },
                   text: 'Deposit & Withdraw',
                   link: '/tempo/guides/earn/deposit-withdraw',
                 },
@@ -2630,8 +2635,23 @@ export default defineConfig({
               items: [
                 {
                   badge: { text: 'EXP', variant: 'warning' },
+                  text: 'bindErc4626Engine',
+                  link: '/tempo/actions/earn.bindErc4626Engine',
+                },
+                {
+                  badge: { text: 'EXP', variant: 'warning' },
                   text: 'configureExitSafePolicy',
                   link: '/tempo/actions/earn.configureExitSafePolicy',
+                },
+                {
+                  badge: { text: 'EXP', variant: 'warning' },
+                  text: 'createErc4626Engine',
+                  link: '/tempo/actions/earn.createErc4626Engine',
+                },
+                {
+                  badge: { text: 'EXP', variant: 'warning' },
+                  text: 'createStack',
+                  link: '/tempo/actions/earn.createStack',
                 },
                 {
                   badge: { text: 'EXP', variant: 'warning' },
@@ -2642,6 +2662,11 @@ export default defineConfig({
                   badge: { text: 'EXP', variant: 'warning' },
                   text: 'depositShares',
                   link: '/tempo/actions/earn.depositShares',
+                },
+                {
+                  badge: { text: 'EXP', variant: 'warning' },
+                  text: 'deployErc4626StackSync',
+                  link: '/tempo/actions/earn.deployErc4626StackSync',
                 },
                 {
                   badge: { text: 'EXP', variant: 'warning' },

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -350,9 +350,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Binds an action function to a `client`, returning a parameter-only version
  * along with any helpers the action exposes. Helpers that need a client
  * (`.call`, `.calls`, `.callWithPeriod`, `.estimateGas`, `.prepare`,
- * `.prepareRecipient`, `.simulate`) are bound to `client`; pure helpers
- * (`.extractEvent`, `.extractEvents`) are copied as-is. Used by decorators
- * that attach namespaced actions to a Client.
+ * `.prepareRecipient`, `.predict`, `.simulate`) are bound to `client`;
+ * pure helpers (`.extractEvent`, `.extractEvents`) are copied as-is. Used
+ * by decorators that attach namespaced actions to a Client.
  * @internal
  */
 export function bindActionDecorators(
@@ -367,6 +367,7 @@ export function bindActionDecorators(
     'estimateGas',
     'prepare',
     'prepareRecipient',
+    'predict',
     'simulate',
   ] as const)
     if (Object.hasOwn(action, key)) {

--- a/src/tempo/Decorator.test.ts
+++ b/src/tempo/Decorator.test.ts
@@ -66,6 +66,11 @@ describe('decorator', () => {
     expect(typeof client2.earn.privateDeposit.calls).toBe('function')
     expect(typeof client2.earn.privateRedeem.prepare).toBe('function')
     expect(typeof client2.earn.privateRedeem.calls).toBe('function')
+    expect(typeof client2.earn.createErc4626Engine.call).toBe('function')
+    expect(typeof client2.earn.createErc4626Engine.predict).toBe('function')
+    expect(typeof client2.earn.createStack.call).toBe('function')
+    expect(typeof client2.earn.createStack.predict).toBe('function')
+    expect(typeof client2.earn.bindErc4626Engine.call).toBe('function')
   })
 
   test('binds missing action entries', () => {

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -1744,6 +1744,37 @@ type DecoratorBase<
     ) => () => void
   }
   earn: {
+    /** Deploys a deterministic ERC-4626 engine. */
+    createErc4626Engine: (
+      parameters: earnActions.createErc4626Engine.Parameters<chain, account>,
+    ) => Promise<earnActions.createErc4626Engine.ReturnValue>
+    /** Deploys a deterministic ERC-4626 engine and waits for confirmation. */
+    createErc4626EngineSync: (
+      parameters: earnActions.createErc4626EngineSync.Parameters<
+        chain,
+        account
+      >,
+    ) => Promise<earnActions.createErc4626EngineSync.ReturnValue>
+    /** Deploys the EarnShare, EarnVault, and EarnFees contracts. */
+    createStack: (
+      parameters: earnActions.createStack.Parameters<chain, account>,
+    ) => Promise<earnActions.createStack.ReturnValue>
+    /** Deploys an Earn stack and waits for confirmation. */
+    createStackSync: (
+      parameters: earnActions.createStackSync.Parameters<chain, account>,
+    ) => Promise<earnActions.createStackSync.ReturnValue>
+    /** Binds an ERC-4626 engine to its EarnVault. */
+    bindErc4626Engine: (
+      parameters: earnActions.bindErc4626Engine.Parameters<chain, account>,
+    ) => Promise<earnActions.bindErc4626Engine.ReturnValue>
+    /** Binds an ERC-4626 engine and waits for confirmation. */
+    bindErc4626EngineSync: (
+      parameters: earnActions.bindErc4626EngineSync.Parameters<chain, account>,
+    ) => Promise<earnActions.bindErc4626EngineSync.ReturnValue>
+    /** Deploys and binds a complete, resumable ERC-4626 Earn stack. */
+    deployErc4626StackSync: (
+      parameters: earnActions.deployErc4626StackSync.Parameters<chain, account>,
+    ) => Promise<earnActions.deployErc4626StackSync.ReturnValue>
     /**
      * Creates and attaches an admission-only TIP-403 policy to an Earn share
      * token. Existing holders remain able to send shares while
@@ -5686,6 +5717,9 @@ type BoundActionHelpers<action> = (action extends { call: infer helper }
   (action extends { prepareRecipient: infer helper }
     ? { prepareRecipient: BoundHelper<helper> }
     : {}) &
+  (action extends { predict: infer helper }
+    ? { predict: BoundHelper<helper> }
+    : {}) &
   (action extends { simulate: infer helper }
     ? { simulate: BoundHelper<helper> }
     : {}) &
@@ -5888,11 +5922,18 @@ export function decorator() {
         'watchOrderPlaced',
       ]),
       earn: bindActions(client, earnActions, [
+        'bindErc4626Engine',
+        'bindErc4626EngineSync',
         'configureExitSafePolicy',
+        'createErc4626Engine',
+        'createErc4626EngineSync',
+        'createStack',
+        'createStackSync',
         'deposit',
         'depositSync',
         'depositShares',
         'depositSharesSync',
+        'deployErc4626StackSync',
         'privateDeposit',
         'privateDepositSync',
         'getFeeState',

--- a/src/tempo/actions/earn.deployment.test.ts
+++ b/src/tempo/actions/earn.deployment.test.ts
@@ -108,6 +108,18 @@ describe('createStack.call', () => {
     expect(() =>
       Actions.earn.createStack.call({
         ...parameters,
+        distributor: {
+          distributor: zeroAddress,
+          updateDelay: 86_400,
+        },
+        fees: {
+          fixedFees: [{ account: accounts[2].address, rateBps: 100 }],
+        },
+      }),
+    ).toThrow('cannot be the zero address')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
         transferPolicyId: 1n << 64n,
       }),
     ).toThrow('fit into uint64')

--- a/src/tempo/actions/earn.deployment.test.ts
+++ b/src/tempo/actions/earn.deployment.test.ts
@@ -1,0 +1,540 @@
+import { Hex } from 'ox'
+import { encodeDeployData, getAddress, isAddressEqual, zeroAddress } from 'viem'
+import {
+  readContract,
+  sendTransactionSync,
+  writeContractSync,
+} from 'viem/actions'
+import { Abis, Actions } from 'viem/tempo'
+import { describe, expect, test } from 'vitest'
+import { accounts, getClient, setupFeeToken } from '~test/tempo/config.js'
+import { deployEarnFactories } from '~test/tempo/earn.js'
+import { earnFactory } from '~test/tempo/earnContracts.js'
+
+const account = accounts[0]
+const client = getClient({ account })
+let fixturePromise: ReturnType<typeof deployEarnFactories> | undefined
+function setup() {
+  fixturePromise ??= deployEarnFactories(client)
+  return fixturePromise
+}
+
+describe('createStack.call', () => {
+  test('defaults to a fee-free stack with no privileged control seats', () => {
+    const call = Actions.earn.createStack.call({
+      deploymentId: Hex.fromNumber(1, { size: 32 }),
+      engine: account.address,
+      factory: accounts[1].address,
+      owner: account.address,
+    })
+
+    expect(call.args[0]).toMatchObject({
+      controls: {
+        asyncJanitor: zeroAddress,
+        emergencyGuardian: zeroAddress,
+        maxManagedAssets: 0n,
+        migrationMode: 0,
+      },
+      distributorConfig: {
+        distributor: zeroAddress,
+        updateDelay: 0,
+      },
+      fees: {
+        excess: {
+          account: zeroAddress,
+          annualTargetRateBps: 0,
+          enabled: false,
+          excessFeeRateBps: 0,
+        },
+        fixedFeeCount: 0,
+      },
+      transferPolicyId: 0n,
+    })
+  })
+
+  test('validates deterministic ids and fee configuration', () => {
+    const parameters = {
+      deploymentId: Hex.fromNumber(1, { size: 32 }),
+      engine: account.address,
+      factory: accounts[1].address,
+      owner: account.address,
+    } as const
+
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        deploymentId: '0x01',
+      }),
+    ).toThrow('nonzero 32-byte hex')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        fees: {
+          fixedFees: [{ account: accounts[2].address, rateBps: 10_001 }],
+        },
+      }),
+    ).toThrow('between 1 and 10,000')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        fees: {
+          fixedFees: [
+            { account: accounts[2].address, rateBps: 6_000 },
+            { account: accounts[3].address, rateBps: 5_000 },
+          ],
+        },
+      }),
+    ).toThrow('total fixed fee rate')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        fees: {
+          fixedFees: [
+            { account: accounts[2].address, rateBps: 100 },
+            { account: accounts[2].address, rateBps: 200 },
+          ],
+        },
+      }),
+    ).toThrow('must be unique')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        distributor: {
+          distributor: accounts[3].address,
+          updateDelay: 86_400,
+        },
+      }),
+    ).toThrow('requires at least one fixed fee')
+    expect(() =>
+      Actions.earn.createStack.call({
+        ...parameters,
+        transferPolicyId: 1n << 64n,
+      }),
+    ).toThrow('fit into uint64')
+  })
+
+  test('encodes explicit controls, fees, and a distributor', () => {
+    const call = Actions.earn.createStack.call({
+      controls: {
+        asyncJanitor: accounts[2].address,
+        emergencyGuardian: accounts[3].address,
+        maxManagedAssets: 1_000_000n,
+        migrationMode: 'operatorEnabled',
+      },
+      deploymentId: Hex.fromNumber(4, { size: 32 }),
+      distributor: { distributor: accounts[4].address, updateDelay: 86_400 },
+      engine: account.address,
+      factory: accounts[1].address,
+      fees: {
+        excess: {
+          account: accounts[5].address,
+          annualTargetRateBps: 500,
+          rateBps: 1_000,
+        },
+        fixedFees: [{ account: accounts[6].address, rateBps: 100 }],
+      },
+      owner: account.address,
+      transferPolicyId: 7n,
+    })
+
+    expect(call.args[0]).toMatchObject({
+      controls: {
+        asyncJanitor: accounts[2].address,
+        emergencyGuardian: accounts[3].address,
+        maxManagedAssets: 1_000_000n,
+        migrationMode: 1,
+      },
+      distributorConfig: {
+        distributor: accounts[4].address,
+        updateDelay: 86_400,
+      },
+      fees: {
+        excess: {
+          account: accounts[5].address,
+          annualTargetRateBps: 500,
+          enabled: true,
+          excessFeeRateBps: 1_000,
+        },
+        fixedFeeCount: 1,
+        fixedFees: [
+          { account: accounts[6].address, rateBps: 100 },
+          { account: zeroAddress, rateBps: 0 },
+          { account: zeroAddress, rateBps: 0 },
+          { account: zeroAddress, rateBps: 0 },
+        ],
+      },
+      transferPolicyId: 7n,
+    })
+  })
+})
+
+describe('ERC-4626 Earn deployment', { timeout: 60_000 }, () => {
+  test('batches engine and stack creation while keeping binding separate', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(12, { size: 32 })
+    const engineArgs = {
+      deploymentId,
+      factory: factories.erc4626Engine,
+      owner: account.address,
+      venue,
+    } as const
+    const engine = await Actions.earn.createErc4626Engine.predict(
+      client,
+      engineArgs,
+    )
+    const stackArgs = {
+      deploymentId,
+      engine,
+      factory: factories.earn,
+      owner: account.address,
+    } as const
+
+    const receipt = await sendTransactionSync(client, {
+      calls: [
+        Actions.earn.createErc4626Engine.call(engineArgs),
+        Actions.earn.createStack.call(stackArgs),
+      ],
+    })
+    const engineEvent = Actions.earn.createErc4626Engine.extractEvent(
+      receipt.logs,
+      { factory: factories.erc4626Engine },
+    )
+    const stackEvent = Actions.earn.createStack.extractEvent(receipt.logs, {
+      factory: factories.earn,
+    })
+    expect(isAddressEqual(engineEvent.args.engine, engine)).toBe(true)
+    expect(isAddressEqual(stackEvent.args.engine, engine)).toBe(true)
+
+    const binding = await Actions.earn.bindErc4626EngineSync(client, {
+      engine,
+      vault: stackEvent.args.earnVault,
+    })
+    expect(binding.receipt.status).toBe('success')
+  })
+
+  test('deploys, resumes, binds, and reruns idempotently', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(2, { size: 32 })
+    const predicted = await Actions.earn.createErc4626Engine.predict(client, {
+      deploymentId,
+      factory: factories.erc4626Engine,
+      owner: account.address,
+      venue,
+    })
+    const engine = await Actions.earn.createErc4626EngineSync(client, {
+      deploymentId,
+      factory: factories.erc4626Engine,
+      venue,
+    })
+    expect(isAddressEqual(engine.engine, predicted)).toBe(true)
+
+    const deployed = await Actions.earn.deployErc4626StackSync(client, {
+      deploymentId,
+      factories,
+      resume: { deploymentId, engine: predicted },
+      venue,
+    })
+    expect(deployed.receipts.engine).toBeUndefined()
+    expect(deployed.receipts.stack?.status).toBe('success')
+    expect(deployed.receipts.binding?.status).toBe('success')
+
+    const [boundVault, guardian, janitor, migrationMode] = await Promise.all([
+      readContract(client, {
+        abi: Abis.erc4626Engine,
+        address: deployed.engine,
+        functionName: 'earnVault',
+      }),
+      readContract(client, {
+        abi: Abis.earnVault,
+        address: deployed.vault,
+        functionName: 'emergencyGuardian',
+      }),
+      readContract(client, {
+        abi: Abis.earnVault,
+        address: deployed.vault,
+        functionName: 'asyncJanitor',
+      }),
+      readContract(client, {
+        abi: Abis.earnVault,
+        address: deployed.vault,
+        functionName: 'engineMigrationMode',
+      }),
+    ])
+    expect(isAddressEqual(boundVault, deployed.vault)).toBe(true)
+    expect(guardian).toBe(zeroAddress)
+    expect(janitor).toBe(zeroAddress)
+    expect(migrationMode).toBe(0)
+    const feeState = await Actions.earn.getFeeState(client, {
+      vault: deployed.vault,
+    })
+    expect(feeState.feesActive).toBe(false)
+
+    const rerun = await Actions.earn.deployErc4626StackSync(client, {
+      deploymentId,
+      factories,
+      fromBlock: deployed.receipts.stack
+        ? deployed.receipts.stack.blockNumber + 1n
+        : undefined,
+      resume: deployed,
+      venue,
+    })
+    expect(rerun.receipts).toEqual({})
+    expect(rerun).toMatchObject({
+      earnShare: deployed.earnShare,
+      engine: deployed.engine,
+      fees: deployed.fees,
+      vault: deployed.vault,
+    })
+  })
+
+  test('uses a separate final owner for binding', async () => {
+    const { factories, venue } = await setup()
+    const owner = accounts[1]
+    const fees = {
+      fixedFees: [{ account: accounts[2].address, rateBps: 100 }],
+    } as const
+    await setupFeeToken(client, { account: owner })
+    const deployed = await Actions.earn.deployErc4626StackSync(client, {
+      bindingAccount: owner,
+      deploymentId: Hex.fromNumber(3, { size: 32 }),
+      factories,
+      fees,
+      owner,
+      venue,
+    })
+
+    const engineOwner = await readContract(client, {
+      abi: Abis.erc4626Engine,
+      address: deployed.engine,
+      functionName: 'owner',
+    })
+    expect(isAddressEqual(engineOwner, owner.address)).toBe(true)
+    const feeState = await Actions.earn.getFeeState(client, {
+      vault: deployed.vault,
+    })
+    expect(feeState.feesActive).toBe(true)
+    expect(feeState.config.fixedFees).toEqual([
+      { account: accounts[2].address, rateBps: 100 },
+    ])
+
+    const rerun = await Actions.earn.deployErc4626StackSync(client, {
+      deploymentId: deployed.deploymentId,
+      factories,
+      fees,
+      fromBlock: deployed.receipts.stack?.blockNumber,
+      owner: owner.address,
+      resume: deployed,
+      venue,
+    })
+    expect(rerun.receipts).toEqual({})
+  })
+
+  test('returns receipts and resumes after a partial failure', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(7, { size: 32 })
+    let failure: Actions.earn.DeployErc4626StackError | undefined
+
+    try {
+      await Actions.earn.deployErc4626StackSync(client, {
+        deploymentId,
+        distributor: {
+          distributor: accounts[3].address,
+          updateDelay: 86_400,
+        },
+        factories,
+        venue,
+      })
+    } catch (error) {
+      if (!(error instanceof Actions.earn.DeployErc4626StackError)) throw error
+      failure = error
+    }
+
+    expect(failure?.stage).toBe('stack')
+    expect(failure?.receipts.engine?.status).toBe('success')
+    expect(failure?.receipts.stack).toBeUndefined()
+    expect(failure?.state).toMatchObject({ deploymentId })
+    if (!failure) throw new Error('Expected deployment to fail.')
+
+    const resumed = await Actions.earn.deployErc4626StackSync(client, {
+      deploymentId,
+      factories,
+      resume: failure.state,
+      venue,
+    })
+    expect(resumed.receipts.engine).toBeUndefined()
+    expect(resumed.receipts.stack?.status).toBe('success')
+    expect(resumed.receipts.binding?.status).toBe('success')
+  })
+
+  test('returns completed receipts when final-owner binding fails', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(11, { size: 32 })
+    const owner = getAddress(Hex.random(20))
+    let failure: Actions.earn.DeployErc4626StackError | undefined
+
+    try {
+      await Actions.earn.deployErc4626StackSync(client, {
+        bindingAccount: owner,
+        deploymentId,
+        factories,
+        owner,
+        venue,
+      })
+    } catch (error) {
+      if (!(error instanceof Actions.earn.DeployErc4626StackError)) throw error
+      failure = error
+    }
+
+    expect(failure?.stage).toBe('binding')
+    expect(failure?.receipts.engine?.status).toBe('success')
+    expect(failure?.receipts.stack?.status).toBe('success')
+    expect(failure?.receipts.binding).toBeUndefined()
+    expect(failure?.state).toMatchObject({ deploymentId })
+    if (!failure?.state.engine)
+      throw new Error('Expected an engine after deployment failure.')
+    const boundVault = await readContract(client, {
+      abi: Abis.erc4626Engine,
+      address: failure.state.engine,
+      functionName: 'earnVault',
+    })
+    expect(boundVault).toBe(zeroAddress)
+  })
+
+  test('rejects mismatched resume state before deployment', async () => {
+    const { factories, venue } = await setup()
+    await expect(
+      Actions.earn.deployErc4626StackSync(client, {
+        deploymentId: Hex.fromNumber(5, { size: 32 }),
+        factories,
+        resume: {
+          deploymentId: Hex.fromNumber(6, { size: 32 }),
+          engine: account.address,
+        },
+        venue,
+      }),
+    ).rejects.toThrow('resumed deployment ID')
+  })
+
+  test('rejects factories without code or with an unexpected TIP-20 factory', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(8, { size: 32 })
+    await expect(
+      Actions.earn.deployErc4626StackSync(client, {
+        deploymentId,
+        factories: { ...factories, earn: accounts[10].address },
+        venue,
+      }),
+    ).rejects.toThrow('EarnFactory has no code')
+
+    const [earnVaultImplementation, earnFeesImplementation] = await Promise.all(
+      [
+        readContract(client, {
+          abi: Abis.earnFactory,
+          address: factories.earn,
+          functionName: 'earnVaultImplementation',
+        }),
+        readContract(client, {
+          abi: Abis.earnFactory,
+          address: factories.earn,
+          functionName: 'earnFeesImplementation',
+        }),
+      ],
+    )
+    const receipt = await sendTransactionSync(client, {
+      data: encodeDeployData({
+        abi: earnFactory.abi,
+        args: [
+          accounts[10].address,
+          earnVaultImplementation,
+          earnFeesImplementation,
+        ],
+        bytecode: earnFactory.bytecode,
+      }),
+    })
+    if (!receipt.contractAddress)
+      throw new Error('contract creation returned no address.')
+
+    await expect(
+      Actions.earn.deployErc4626StackSync(client, {
+        deploymentId,
+        factories: { ...factories, earn: receipt.contractAddress },
+        venue,
+      }),
+    ).rejects.toThrow('unexpected TIP-20 factory')
+  })
+
+  test('rejects recovered addresses that do not match the deployment', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(9, { size: 32 })
+    const deployed = await Actions.earn.deployErc4626StackSync(client, {
+      deploymentId,
+      factories,
+      venue,
+    })
+
+    await expect(
+      Actions.earn.deployErc4626StackSync(client, {
+        deploymentId,
+        factories,
+        fromBlock: deployed.receipts.stack?.blockNumber,
+        resume: { ...deployed, vault: venue },
+        venue,
+      }),
+    ).rejects.toMatchObject({
+      stage: 'stack',
+      state: {
+        deploymentId,
+        earnShare: deployed.earnShare,
+        engine: deployed.engine,
+        fees: deployed.fees,
+        vault: venue,
+      },
+    })
+  })
+
+  test('reports an engine bound to a different vault', async () => {
+    const { factories, venue } = await setup()
+    const deploymentId = Hex.fromNumber(10, { size: 32 })
+    const engine = await Actions.earn.createErc4626EngineSync(client, {
+      deploymentId,
+      factory: factories.erc4626Engine,
+      venue,
+    })
+    const stack = await Actions.earn.createStackSync(client, {
+      deploymentId,
+      engine: engine.engine,
+      factory: factories.earn,
+    })
+    await writeContractSync(client, {
+      abi: Abis.erc4626Engine,
+      address: engine.engine,
+      args: [venue],
+      functionName: 'initializeEarnVault',
+    })
+
+    await expect(
+      Actions.earn.deployErc4626StackSync(client, {
+        deploymentId,
+        factories,
+        fromBlock: stack.receipt.blockNumber,
+        resume: {
+          deploymentId,
+          earnShare: stack.earnShare,
+          engine: engine.engine,
+          fees: stack.earnFees,
+          vault: stack.earnVault,
+        },
+        venue,
+      }),
+    ).rejects.toMatchObject({
+      stage: 'binding',
+      state: {
+        deploymentId,
+        earnShare: stack.earnShare,
+        engine: engine.engine,
+        fees: stack.earnFees,
+        vault: stack.earnVault,
+      },
+    })
+  })
+})

--- a/src/tempo/actions/earn.test-d.ts
+++ b/src/tempo/actions/earn.test-d.ts
@@ -20,6 +20,11 @@ const privatePreparation = {
   vault: address,
   zoneId: 7,
 } as const
+const deployment = {
+  deploymentId: hash,
+  factories: { earn: address, erc4626Engine: address },
+  venue: address,
+} as const
 
 const transport = custom({
   async request() {
@@ -42,6 +47,108 @@ const zoneClientWithAccount = createClient({
   transport,
 })
 const decoratedZoneClient = zoneClientWithAccount.extend(decorator())
+
+test('deployment actions preserve account requirements and result types', async () => {
+  // @ts-expect-error account required when the client has none
+  await earnActions.createErc4626Engine(client, {
+    deploymentId: hash,
+    factory: address,
+    venue: address,
+  })
+  await earnActions.createErc4626Engine(client, {
+    account: address,
+    deploymentId: hash,
+    factory: address,
+    venue: address,
+  })
+  // @ts-expect-error account required when the client has none
+  await earnActions.createStack(client, {
+    deploymentId: hash,
+    engine: address,
+    factory: address,
+  })
+  await earnActions.createStack(client, {
+    account: address,
+    deploymentId: hash,
+    engine: address,
+    factory: address,
+  })
+  // @ts-expect-error account required when the client has none
+  await earnActions.bindErc4626Engine(client, {
+    engine: address,
+    vault: address,
+  })
+  await earnActions.bindErc4626Engine(client, {
+    account: address,
+    engine: address,
+    vault: address,
+  })
+  // @ts-expect-error account required when the client has none
+  await earnActions.deployErc4626StackSync(client, deployment)
+  await earnActions.deployErc4626StackSync(client, {
+    ...deployment,
+    account: address,
+  })
+
+  const engine = await decoratedClient.earn.createErc4626EngineSync({
+    deploymentId: hash,
+    factory: address,
+    venue: address,
+  })
+  expectTypeOf(engine.engine).toEqualTypeOf<Address>()
+  expectTypeOf(engine.receipt).toEqualTypeOf<TransactionReceipt>()
+  expectTypeOf(
+    await decoratedClient.earn.createErc4626Engine.predict({
+      deploymentId: hash,
+      factory: address,
+      owner: address,
+      venue: address,
+    }),
+  ).toEqualTypeOf<Address>()
+
+  const stack = await decoratedClient.earn.createStackSync({
+    deploymentId: hash,
+    engine: address,
+    factory: address,
+  })
+  expectTypeOf(stack.earnShare).toEqualTypeOf<Address>()
+  expectTypeOf(stack.earnVault).toEqualTypeOf<Address>()
+  expectTypeOf(stack.earnFees).toEqualTypeOf<Address>()
+
+  const binding = await decoratedClient.earn.bindErc4626EngineSync({
+    engine: address,
+    vault: address,
+  })
+  expectTypeOf(binding.vault).toEqualTypeOf<Address>()
+
+  const result = await decoratedClient.earn.deployErc4626StackSync(deployment)
+  expectTypeOf(result.engine).toEqualTypeOf<Address>()
+  expectTypeOf(
+    result.receipts,
+  ).toEqualTypeOf<earnActions.deployErc4626StackSync.Receipts>()
+
+  await decoratedClient.earn.deployErc4626StackSync({
+    ...deployment,
+    // @ts-expect-error sequential recipes do not accept one nonce for every stage
+    nonce: 1,
+  })
+  await decoratedClient.earn.deployErc4626StackSync({
+    ...deployment,
+    // @ts-expect-error one authorization cannot be reused across deployment stages
+    keyAuthorization: {} as never,
+  })
+  await decoratedClient.earn.deployErc4626StackSync({
+    ...deployment,
+    // @ts-expect-error the recipe always throws on reverted receipts
+    throwOnReceiptRevert: false,
+  })
+
+  // @ts-expect-error factories are explicit while Earn is experimental
+  await decoratedClient.earn.deployErc4626StackSync({
+    deploymentId: hash,
+    venue: address,
+  })
+})
 
 test('exit-safe policy actions preserve account and result types', async () => {
   const parameters = {

--- a/src/tempo/actions/earn.ts
+++ b/src/tempo/actions/earn.ts
@@ -67,6 +67,9 @@ import * as policyActions from './policy.js'
 import * as tokenActions from './token.js'
 import * as zoneActions from './zone.js'
 
+// biome-ignore lint/performance/noBarrelFile: namespace module
+export * from './earn/deployment.js'
+
 /** TIP-403 policy ID that allows every sender, recipient, and mint recipient. */
 export const alwaysAllowPolicyId = 1n
 

--- a/src/tempo/actions/earn/deployment.ts
+++ b/src/tempo/actions/earn/deployment.ts
@@ -2,14 +2,10 @@ import type { Address } from 'abitype'
 import { Hex } from 'ox'
 import type { Account } from '../../../accounts/types.js'
 import { parseAccount } from '../../../accounts/utils/parseAccount.js'
-import { estimateContractGas } from '../../../actions/public/estimateContractGas.js'
 import { getCode } from '../../../actions/public/getCode.js'
 import { getLogs } from '../../../actions/public/getLogs.js'
 import { readContract } from '../../../actions/public/readContract.js'
-import {
-  type SimulateContractReturnType,
-  simulateContract,
-} from '../../../actions/public/simulateContract.js'
+import { simulateContract } from '../../../actions/public/simulateContract.js'
 import {
   type WriteContractReturnType,
   writeContract,
@@ -66,20 +62,15 @@ export type EarnVaultControls = {
 }
 
 /** @experimental Optional protected fee-distributor configuration. */
-export type EarnDistributorConfiguration =
-  | {
-      /**
-       * Distributor address. When enabled, the first entry in
-       * `fees.fixedFees` is its protected fee.
-       */
-      distributor: Address
-      /** Delay before a distributor fee update can execute, in seconds. */
-      updateDelay: number
-    }
-  | {
-      distributor?: undefined
-      updateDelay?: undefined
-    }
+export type EarnDistributorConfiguration = {
+  /**
+   * Distributor address. The first entry in `fees.fixedFees` is its protected
+   * fee.
+   */
+  distributor: Address
+  /** Delay before a distributor fee update can execute, in seconds. */
+  updateDelay: number
+}
 
 /** @experimental Initial Earn fee configuration. Omit to deploy fee-free. */
 export type EarnFeeConfiguration = {
@@ -289,50 +280,6 @@ export namespace createErc4626Engine {
   }
 
   /**
-   * Estimates gas for the engine deployment.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The gas estimate.
-   */
-  export async function estimateGas<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ) {
-    const args = resolveArgs(client, parameters)
-    return estimateContractGas(client, {
-      ...pickWriteParameters(parameters as never),
-      ...createErc4626Engine.call(args),
-    } as never)
-  }
-
-  /**
-   * Simulates the engine deployment.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The simulation result and write request.
-   */
-  export async function simulate<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ): Promise<
-    SimulateContractReturnType<typeof Abis.erc4626EngineFactory, 'deploy'>
-  > {
-    const args = resolveArgs(client, parameters)
-    return simulateContract(client, {
-      ...pickWriteParameters(parameters as never),
-      ...createErc4626Engine.call(args),
-    } as never) as never
-  }
-
-  /**
    * Extracts the `ERC4626EngineDeployed` event from factory logs.
    *
    * @param logs - The logs.
@@ -350,26 +297,6 @@ export namespace createErc4626Engine {
     })
     if (!log) throw new Error('`ERC4626EngineDeployed` event not found.')
     return log
-  }
-
-  function resolveArgs<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ): Args {
-    const account = parameters.account ?? client.account
-    const owner = parameters.owner ?? account
-    if (!owner) throw new Error('`owner` is required.')
-    return {
-      deploymentId: parameters.deploymentId,
-      factory: parameters.factory,
-      name: parameters.name,
-      owner: parseAccount(owner).address,
-      symbol: parameters.symbol,
-      venue: parameters.venue,
-    }
   }
 }
 
@@ -619,46 +546,6 @@ export namespace createStack {
   }
 
   /**
-   * Estimates gas for stack creation.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The gas estimate.
-   */
-  export async function estimateGas<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ) {
-    return estimateContractGas(client, {
-      ...pickWriteParameters(parameters as never),
-      ...createStack.call(resolveArgs(client, parameters)),
-    } as never)
-  }
-
-  /**
-   * Simulates stack creation.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The simulation result and write request.
-   */
-  export async function simulate<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ): Promise<SimulateContractReturnType<typeof Abis.earnFactory, 'deploy'>> {
-    return simulateContract(client, {
-      ...pickWriteParameters(parameters as never),
-      ...createStack.call(resolveArgs(client, parameters)),
-    } as never) as never
-  }
-
-  /**
    * Extracts the `EarnStackDeployed` event from factory logs.
    *
    * @param logs - The logs.
@@ -676,28 +563,6 @@ export namespace createStack {
     })
     if (!log) throw new Error('`EarnStackDeployed` event not found.')
     return log
-  }
-
-  function resolveArgs<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ): Args {
-    const account = parameters.account ?? client.account
-    const owner = parameters.owner ?? account
-    if (!owner) throw new Error('`owner` is required.')
-    return {
-      controls: parameters.controls,
-      deploymentId: parameters.deploymentId,
-      distributor: parameters.distributor,
-      engine: parameters.engine,
-      factory: parameters.factory,
-      fees: parameters.fees,
-      owner: parseAccount(owner).address,
-      transferPolicyId: parameters.transferPolicyId,
-    }
   }
 }
 
@@ -866,48 +731,6 @@ export namespace bindErc4626Engine {
       functionName: 'initializeEarnVault',
       args: [args.vault],
     })
-  }
-
-  /**
-   * Estimates gas for the binding.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The gas estimate.
-   */
-  export async function estimateGas<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ) {
-    return estimateContractGas(client, {
-      ...pickWriteParameters(parameters as never),
-      ...bindErc4626Engine.call(parameters),
-    } as never)
-  }
-
-  /**
-   * Simulates the binding.
-   *
-   * @param client - Client.
-   * @param parameters - Parameters.
-   * @returns The simulation result and write request.
-   */
-  export async function simulate<
-    chain extends Chain | undefined,
-    account extends Account | undefined,
-  >(
-    client: Client<Transport, chain, account>,
-    parameters: Parameters<chain, account>,
-  ): Promise<
-    SimulateContractReturnType<typeof Abis.erc4626Engine, 'initializeEarnVault'>
-  > {
-    return simulateContract(client, {
-      ...pickWriteParameters(parameters as never),
-      ...bindErc4626Engine.call(parameters),
-    } as never) as never
   }
 
   /**
@@ -1142,9 +965,10 @@ export async function deployErc4626StackSync<
   const receipts: deployErc4626StackSync.Receipts = {}
   try {
     if (!engineExists) {
-      await createErc4626Engine.simulate(client, {
-        ...writeParameters,
-        ...engineArgs,
+      await simulateContract(client, {
+        ...sharedWriteParameters,
+        account: deployer,
+        ...createErc4626Engine.call(engineArgs),
       } as never)
       const receipt = await createErc4626Engine.inner(
         writeContractSync,
@@ -1199,9 +1023,10 @@ export async function deployErc4626StackSync<
         throw new Error(
           'Predicted EarnFees exists without the predicted EarnShare.',
         )
-      await createStack.simulate(client, {
-        ...writeParameters,
-        ...stackArgs,
+      await simulateContract(client, {
+        ...sharedWriteParameters,
+        account: deployer,
+        ...createStack.call(stackArgs),
       } as never)
       const receipt = await createStack.inner(writeContractSync, client, {
         ...writeParameters,
@@ -1268,7 +1093,11 @@ export async function deployErc4626StackSync<
         engine: predictedEngine,
         vault,
       }
-      await bindErc4626Engine.simulate(client, bindingParameters as never)
+      await simulateContract(client, {
+        ...sharedWriteParameters,
+        account: bindingAccount,
+        ...bindErc4626Engine.call({ engine: predictedEngine, vault }),
+      } as never)
       const receipt = await bindErc4626Engine.inner(
         writeContractSync,
         client,
@@ -1399,10 +1228,9 @@ function toDeployParameters(args: createStack.Args) {
   const zeroFee = { account: zeroAddress, rateBps: 0 } as const
   const distributor = args.distributor?.distributor ?? zeroAddress
   const updateDelay = args.distributor?.updateDelay ?? 0
-  if (isAddressEqual(distributor, zeroAddress)) {
-    if (updateDelay !== 0)
-      throw new Error('A disabled distributor must use a zero update delay.')
-  } else {
+  if (args.distributor) {
+    if (isAddressEqual(distributor, zeroAddress))
+      throw new Error('An enabled distributor cannot be the zero address.')
     if (updateDelay <= 0)
       throw new Error(
         'An enabled distributor requires a positive update delay.',

--- a/src/tempo/actions/earn/deployment.ts
+++ b/src/tempo/actions/earn/deployment.ts
@@ -1,0 +1,1599 @@
+import type { Address } from 'abitype'
+import { Hex } from 'ox'
+import type { Account } from '../../../accounts/types.js'
+import { parseAccount } from '../../../accounts/utils/parseAccount.js'
+import { estimateContractGas } from '../../../actions/public/estimateContractGas.js'
+import { getCode } from '../../../actions/public/getCode.js'
+import { getLogs } from '../../../actions/public/getLogs.js'
+import { readContract } from '../../../actions/public/readContract.js'
+import {
+  type SimulateContractReturnType,
+  simulateContract,
+} from '../../../actions/public/simulateContract.js'
+import {
+  type WriteContractReturnType,
+  writeContract,
+} from '../../../actions/wallet/writeContract.js'
+import { writeContractSync } from '../../../actions/wallet/writeContractSync.js'
+import type { Client } from '../../../clients/createClient.js'
+import type { Transport } from '../../../clients/transports/createTransport.js'
+import { zeroAddress } from '../../../constants/address.js'
+import { maxUint64, maxUint256 } from '../../../constants/number.js'
+import { AccountNotFoundError } from '../../../errors/account.js'
+import { BaseError, type BaseErrorType } from '../../../errors/base.js'
+import { TransactionReceiptRevertedError } from '../../../errors/transaction.js'
+import type { Chain } from '../../../types/chain.js'
+import type { GetEventArgs } from '../../../types/contract.js'
+import type { Log } from '../../../types/log.js'
+import type { Compute } from '../../../types/utils.js'
+import { getAbiItem } from '../../../utils/abi/getAbiItem.js'
+import { parseEventLogs } from '../../../utils/abi/parseEventLogs.js'
+import { isAddressEqual } from '../../../utils/address/isAddressEqual.js'
+import * as Abis from '../../Abis.js'
+import * as Addresses from '../../Addresses.js'
+import type {
+  WriteParameters,
+  WriteSyncParameters,
+} from '../../internal/types.js'
+import {
+  defineCall,
+  pickWriteParameters,
+  pickWriteSyncParameters,
+} from '../../internal/utils.js'
+import type { TransactionReceipt } from '../../Transaction.js'
+
+/** @experimental Factory addresses for one reviewed Tempo Earn release. */
+export type EarnFactoryAddresses = {
+  /** `ERC4626EngineFactory` address. */
+  erc4626Engine: Address
+  /** `EarnFactory` address from the same release. */
+  earn: Address
+}
+
+/** @experimental Deployment-fixed engine migration policy. */
+export type EngineMigrationMode = 'operatorEnabled' | 'userOnly'
+
+/** @experimental Initial controls for an Earn vault. */
+export type EarnVaultControls = {
+  /** Request-cancellation liveness seat. @default zero address */
+  asyncJanitor?: Address | undefined
+  /** Fast pause-only seat. @default zero address */
+  emergencyGuardian?: Address | undefined
+  /** Maximum actively managed assets. Zero means unlimited. @default 0 */
+  maxManagedAssets?: bigint | undefined
+  /** Whole-pool migration policy. @default 'userOnly' */
+  migrationMode?: EngineMigrationMode | undefined
+}
+
+/** @experimental Optional protected fee-distributor configuration. */
+export type EarnDistributorConfiguration =
+  | {
+      /**
+       * Distributor address. When enabled, the first entry in
+       * `fees.fixedFees` is its protected fee.
+       */
+      distributor: Address
+      /** Delay before a distributor fee update can execute, in seconds. */
+      updateDelay: number
+    }
+  | {
+      distributor?: undefined
+      updateDelay?: undefined
+    }
+
+/** @experimental Initial Earn fee configuration. Omit to deploy fee-free. */
+export type EarnFeeConfiguration = {
+  /** Optional fee on returns above an annual target. */
+  excess?:
+    | {
+        /** Fee recipient. */
+        account: Address
+        /** Annual target rate in basis points. */
+        annualTargetRateBps: number
+        /** Rate charged above the target in basis points. */
+        rateBps: number
+      }
+    | undefined
+  /**
+   * Fixed fee recipients and rates, limited to four entries. When a
+   * distributor is enabled, the first entry is its protected fee and the
+   * remaining entries are operator-controlled.
+   */
+  fixedFees?:
+    | readonly {
+        /** Fee recipient. */
+        account: Address
+        /** Fee rate in basis points. */
+        rateBps: number
+      }[]
+    | undefined
+}
+
+/**
+ * Deploys a deterministic ERC-4626 Earn engine.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ *
+ * const hash = await Actions.earn.createErc4626Engine(client, {
+ *   deploymentId: '0x...',
+ *   factory: '0x...',
+ *   venue: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction hash.
+ */
+export async function createErc4626Engine<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: createErc4626Engine.Parameters<chain, account>,
+): Promise<createErc4626Engine.ReturnValue> {
+  return createErc4626Engine.inner(writeContract, client, parameters)
+}
+
+export namespace createErc4626Engine {
+  export type Args = {
+    /** Stable deterministic deployment identifier. */
+    deploymentId: Hex.Hex
+    /** Reviewed `ERC4626EngineFactory` address. */
+    factory: Address
+    /** Optional engine name override. Empty derives the venue name. */
+    name?: string | undefined
+    /** Final engine owner. */
+    owner: Address
+    /** Optional engine symbol override. Empty derives the venue symbol. */
+    symbol?: string | undefined
+    /** ERC-4626 venue address. */
+    venue: Address
+  }
+
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = WriteParameters<chain, account> &
+    Omit<Args, 'owner'> & {
+      /** Final engine owner. @default `account.address` */
+      owner?: Account | Address | undefined
+    }
+
+  export type ReturnValue = WriteContractReturnType
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+
+  /** @internal */
+  export async function inner<
+    action extends typeof writeContract | typeof writeContractSync,
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    action: action,
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<ReturnType<action>> {
+    const {
+      account = client.account,
+      chain = client.chain,
+      deploymentId,
+      factory,
+      name,
+      owner: owner_ = account,
+      symbol,
+      venue,
+      ...rest
+    } = parameters
+    if (!account) throw new AccountNotFoundError()
+    if (!owner_) throw new Error('`owner` is required.')
+    const owner = parseAccount(owner_).address
+    return (await action(client, {
+      ...rest,
+      account,
+      chain,
+      ...createErc4626Engine.call({
+        deploymentId,
+        factory,
+        name,
+        owner,
+        symbol,
+        venue,
+      }),
+    } as never)) as never
+  }
+
+  /**
+   * Defines a call to `ERC4626EngineFactory.deploy`.
+   *
+   * Can be passed as a parameter to:
+   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
+   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
+   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
+   *
+   * @example
+   * ```ts
+   * import { createClient, http, walletActions } from 'viem'
+   * import { tempoModerato } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({ chain: tempoModerato, transport: http() })
+   *   .extend(walletActions)
+   * await client.sendTransaction({
+   *   calls: [Actions.earn.createErc4626Engine.call({
+   *     deploymentId: '0x...',
+   *     factory: '0x...',
+   *     owner: '0x...',
+   *     venue: '0x...',
+   *   })],
+   * })
+   * ```
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    validateDeploymentId(args.deploymentId)
+    return defineCall({
+      address: args.factory,
+      abi: Abis.erc4626EngineFactory,
+      functionName: 'deploy',
+      args: [
+        args.deploymentId,
+        args.venue,
+        args.owner,
+        args.name ?? '',
+        args.symbol ?? '',
+      ],
+    })
+  }
+
+  /**
+   * Predicts the deterministic engine address.
+   *
+   * @param client - Client.
+   * @param args - Engine deployment arguments.
+   * @returns The predicted engine address.
+   */
+  export async function predict<chain extends Chain | undefined>(
+    client: Client<Transport, chain>,
+    args: Args,
+  ) {
+    validateDeploymentId(args.deploymentId)
+    return readContract(client, {
+      address: args.factory,
+      abi: Abis.erc4626EngineFactory,
+      functionName: 'predictEngine',
+      args: [
+        args.deploymentId,
+        args.venue,
+        args.owner,
+        args.name ?? '',
+        args.symbol ?? '',
+      ],
+    })
+  }
+
+  /**
+   * Estimates gas for the engine deployment.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The gas estimate.
+   */
+  export async function estimateGas<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ) {
+    const args = resolveArgs(client, parameters)
+    return estimateContractGas(client, {
+      ...pickWriteParameters(parameters as never),
+      ...createErc4626Engine.call(args),
+    } as never)
+  }
+
+  /**
+   * Simulates the engine deployment.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The simulation result and write request.
+   */
+  export async function simulate<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<
+    SimulateContractReturnType<typeof Abis.erc4626EngineFactory, 'deploy'>
+  > {
+    const args = resolveArgs(client, parameters)
+    return simulateContract(client, {
+      ...pickWriteParameters(parameters as never),
+      ...createErc4626Engine.call(args),
+    } as never) as never
+  }
+
+  /**
+   * Extracts the `ERC4626EngineDeployed` event from factory logs.
+   *
+   * @param logs - The logs.
+   * @param parameters - Factory address used to filter the logs.
+   * @returns The deployment event.
+   */
+  export function extractEvent(logs: Log[], parameters: { factory: Address }) {
+    const [log] = parseEventLogs({
+      abi: Abis.erc4626EngineFactory,
+      eventName: 'ERC4626EngineDeployed',
+      logs: logs.filter((log) =>
+        isAddressEqual(log.address, parameters.factory),
+      ),
+      strict: true,
+    })
+    if (!log) throw new Error('`ERC4626EngineDeployed` event not found.')
+    return log
+  }
+
+  function resolveArgs<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Args {
+    const account = parameters.account ?? client.account
+    const owner = parameters.owner ?? account
+    if (!owner) throw new Error('`owner` is required.')
+    return {
+      deploymentId: parameters.deploymentId,
+      factory: parameters.factory,
+      name: parameters.name,
+      owner: parseAccount(owner).address,
+      symbol: parameters.symbol,
+      venue: parameters.venue,
+    }
+  }
+}
+
+/**
+ * Deploys an ERC-4626 engine and waits for confirmation.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const result = await Actions.earn.createErc4626EngineSync(client, {
+ *   deploymentId: '0x...',
+ *   factory: '0x...',
+ *   venue: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The receipt and deployed engine metadata.
+ */
+export async function createErc4626EngineSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: createErc4626EngineSync.Parameters<chain, account>,
+): Promise<createErc4626EngineSync.ReturnValue> {
+  const { factory, throwOnReceiptRevert = true } = parameters
+  const receipt = await createErc4626Engine.inner(writeContractSync, client, {
+    ...parameters,
+    throwOnReceiptRevert,
+  } as never)
+  const { args } = createErc4626Engine.extractEvent(receipt.logs, { factory })
+  return { ...args, receipt }
+}
+
+export namespace createErc4626EngineSync {
+  export type Args = createErc4626Engine.Args
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = createErc4626Engine.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
+  export type ReturnValue = Compute<
+    GetEventArgs<
+      typeof Abis.erc4626EngineFactory,
+      'ERC4626EngineDeployed',
+      { IndexedOnly: false; Required: true }
+    > & { receipt: TransactionReceipt }
+  >
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+/**
+ * Creates an EarnShare, EarnVault, and EarnFees stack around an unbound engine.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const hash = await Actions.earn.createStack(client, {
+ *   deploymentId: '0x...',
+ *   engine: '0x...',
+ *   factory: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The transaction hash.
+ */
+export async function createStack<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: createStack.Parameters<chain, account>,
+): Promise<createStack.ReturnValue> {
+  return createStack.inner(writeContract, client, parameters)
+}
+
+export namespace createStack {
+  export type Args = {
+    /** Initial Earn vault controls. */
+    controls?: EarnVaultControls | undefined
+    /** Stable deterministic deployment identifier. */
+    deploymentId: Hex.Hex
+    /** Optional protected fee distributor. */
+    distributor?: EarnDistributorConfiguration | undefined
+    /** Engine address. */
+    engine: Address
+    /** Reviewed `EarnFactory` address. */
+    factory: Address
+    /** Initial fee configuration. Omit for fee-free deployment. */
+    fees?: EarnFeeConfiguration | undefined
+    /** Final stack owner and operator. */
+    owner: Address
+    /** Existing simple whitelist policy. Zero selects always-allow. @default 0 */
+    transferPolicyId?: bigint | undefined
+  }
+
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = WriteParameters<chain, account> &
+    Omit<Args, 'owner'> & {
+      /** Final stack owner and operator. @default `account.address` */
+      owner?: Account | Address | undefined
+    }
+
+  export type ReturnValue = WriteContractReturnType
+
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+
+  /** @internal */
+  export async function inner<
+    action extends typeof writeContract | typeof writeContractSync,
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    action: action,
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<ReturnType<action>> {
+    const {
+      account = client.account,
+      chain = client.chain,
+      controls,
+      deploymentId,
+      distributor,
+      engine,
+      factory,
+      fees,
+      owner: owner_ = account,
+      transferPolicyId,
+      ...rest
+    } = parameters
+    if (!account) throw new AccountNotFoundError()
+    if (!owner_) throw new Error('`owner` is required.')
+    return (await action(client, {
+      ...rest,
+      account,
+      chain,
+      ...createStack.call({
+        controls,
+        deploymentId,
+        distributor,
+        engine,
+        factory,
+        fees,
+        owner: parseAccount(owner_).address,
+        transferPolicyId,
+      }),
+    } as never)) as never
+  }
+
+  /**
+   * Defines a call to `EarnFactory.deploy`.
+   *
+   * Can be passed as a parameter to:
+   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
+   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
+   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
+   *
+   * @example
+   * ```ts
+   * import { createClient, http, walletActions } from 'viem'
+   * import { tempoModerato } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({ chain: tempoModerato, transport: http() })
+   *   .extend(walletActions)
+   * await client.sendTransaction({
+   *   calls: [Actions.earn.createStack.call({
+   *     deploymentId: '0x...',
+   *     engine: '0x...',
+   *     factory: '0x...',
+   *     owner: '0x...',
+   *   })],
+   * })
+   * ```
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    validateDeploymentId(args.deploymentId)
+    return defineCall({
+      address: args.factory,
+      abi: Abis.earnFactory,
+      functionName: 'deploy',
+      args: [toDeployParameters(args)],
+    })
+  }
+
+  /**
+   * Predicts the deterministic EarnShare and EarnFees addresses.
+   *
+   * @param client - Client.
+   * @param args - Stack deployment arguments.
+   * @returns The predicted EarnShare and EarnFees addresses.
+   */
+  export async function predict<chain extends Chain | undefined>(
+    client: Client<Transport, chain>,
+    args: Args,
+  ) {
+    validateDeploymentId(args.deploymentId)
+    const parameters = toDeployParameters(args)
+    const [earnShare, earnFees] = await Promise.all([
+      readContract(client, {
+        address: args.factory,
+        abi: Abis.earnFactory,
+        functionName: 'predictEarnShare',
+        args: [parameters],
+      }),
+      readContract(client, {
+        address: args.factory,
+        abi: Abis.earnFactory,
+        functionName: 'predictEarnFees',
+        args: [parameters],
+      }),
+    ])
+    return { earnFees, earnShare }
+  }
+
+  /**
+   * Estimates gas for stack creation.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The gas estimate.
+   */
+  export async function estimateGas<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ) {
+    return estimateContractGas(client, {
+      ...pickWriteParameters(parameters as never),
+      ...createStack.call(resolveArgs(client, parameters)),
+    } as never)
+  }
+
+  /**
+   * Simulates stack creation.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The simulation result and write request.
+   */
+  export async function simulate<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<SimulateContractReturnType<typeof Abis.earnFactory, 'deploy'>> {
+    return simulateContract(client, {
+      ...pickWriteParameters(parameters as never),
+      ...createStack.call(resolveArgs(client, parameters)),
+    } as never) as never
+  }
+
+  /**
+   * Extracts the `EarnStackDeployed` event from factory logs.
+   *
+   * @param logs - The logs.
+   * @param parameters - Factory address used to filter the logs.
+   * @returns The deployment event.
+   */
+  export function extractEvent(logs: Log[], parameters: { factory: Address }) {
+    const [log] = parseEventLogs({
+      abi: Abis.earnFactory,
+      eventName: 'EarnStackDeployed',
+      logs: logs.filter((log) =>
+        isAddressEqual(log.address, parameters.factory),
+      ),
+      strict: true,
+    })
+    if (!log) throw new Error('`EarnStackDeployed` event not found.')
+    return log
+  }
+
+  function resolveArgs<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Args {
+    const account = parameters.account ?? client.account
+    const owner = parameters.owner ?? account
+    if (!owner) throw new Error('`owner` is required.')
+    return {
+      controls: parameters.controls,
+      deploymentId: parameters.deploymentId,
+      distributor: parameters.distributor,
+      engine: parameters.engine,
+      factory: parameters.factory,
+      fees: parameters.fees,
+      owner: parseAccount(owner).address,
+      transferPolicyId: parameters.transferPolicyId,
+    }
+  }
+}
+
+/**
+ * Creates an Earn core stack and waits for confirmation.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const result = await Actions.earn.createStackSync(client, {
+ *   deploymentId: '0x...',
+ *   engine: '0x...',
+ *   factory: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The receipt and deployed stack addresses.
+ */
+export async function createStackSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: createStackSync.Parameters<chain, account>,
+): Promise<createStackSync.ReturnValue> {
+  const { factory, throwOnReceiptRevert = true } = parameters
+  const receipt = await createStack.inner(writeContractSync, client, {
+    ...parameters,
+    throwOnReceiptRevert,
+  } as never)
+  const { args } = createStack.extractEvent(receipt.logs, { factory })
+  return { ...args, receipt }
+}
+
+export namespace createStackSync {
+  export type Args = createStack.Args
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = createStack.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
+  export type ReturnValue = Compute<
+    GetEventArgs<
+      typeof Abis.earnFactory,
+      'EarnStackDeployed',
+      { IndexedOnly: false; Required: true }
+    > & { receipt: TransactionReceipt }
+  >
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+/**
+ * Permanently binds an ERC-4626 engine to its EarnVault.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const hash = await Actions.earn.bindErc4626Engine(client, {
+ *   engine: '0x...',
+ *   vault: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client controlled by the final engine owner.
+ * @param parameters - Parameters.
+ * @returns The transaction hash.
+ */
+export async function bindErc4626Engine<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: bindErc4626Engine.Parameters<chain, account>,
+): Promise<bindErc4626Engine.ReturnValue> {
+  return bindErc4626Engine.inner(writeContract, client, parameters)
+}
+
+export namespace bindErc4626Engine {
+  export type Args = {
+    /** ERC-4626 engine address. */
+    engine: Address
+    /** Factory-created EarnVault address. */
+    vault: Address
+  }
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = WriteParameters<chain, account> & Args
+  export type ReturnValue = WriteContractReturnType
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+
+  /** @internal */
+  export async function inner<
+    action extends typeof writeContract | typeof writeContractSync,
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    action: action,
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<ReturnType<action>> {
+    const { engine, vault, ...rest } = parameters
+    return (await action(client, {
+      ...rest,
+      ...bindErc4626Engine.call({ engine, vault }),
+    } as never)) as never
+  }
+
+  /**
+   * Defines a call to `ERC4626Engine.initializeEarnVault`.
+   *
+   * Can be passed as a parameter to:
+   * - [`estimateContractGas`](https://viem.sh/docs/contract/estimateContractGas): estimate the gas cost of the call
+   * - [`simulateContract`](https://viem.sh/docs/contract/simulateContract): simulate the call
+   * - [`sendCalls`](https://viem.sh/docs/actions/wallet/sendCalls): send multiple calls
+   *
+   * @example
+   * ```ts
+   * import { createClient, http, walletActions } from 'viem'
+   * import { tempoModerato } from 'viem/chains'
+   * import { Actions } from 'viem/tempo'
+   *
+   * const client = createClient({ chain: tempoModerato, transport: http() })
+   *   .extend(walletActions)
+   * await client.sendTransaction({
+   *   calls: [Actions.earn.bindErc4626Engine.call({
+   *     engine: '0x...',
+   *     vault: '0x...',
+   *   })],
+   * })
+   * ```
+   *
+   * @param args - Arguments.
+   * @returns The call.
+   */
+  export function call(args: Args) {
+    return defineCall({
+      address: args.engine,
+      abi: Abis.erc4626Engine,
+      functionName: 'initializeEarnVault',
+      args: [args.vault],
+    })
+  }
+
+  /**
+   * Estimates gas for the binding.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The gas estimate.
+   */
+  export async function estimateGas<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ) {
+    return estimateContractGas(client, {
+      ...pickWriteParameters(parameters as never),
+      ...bindErc4626Engine.call(parameters),
+    } as never)
+  }
+
+  /**
+   * Simulates the binding.
+   *
+   * @param client - Client.
+   * @param parameters - Parameters.
+   * @returns The simulation result and write request.
+   */
+  export async function simulate<
+    chain extends Chain | undefined,
+    account extends Account | undefined,
+  >(
+    client: Client<Transport, chain, account>,
+    parameters: Parameters<chain, account>,
+  ): Promise<
+    SimulateContractReturnType<typeof Abis.erc4626Engine, 'initializeEarnVault'>
+  > {
+    return simulateContract(client, {
+      ...pickWriteParameters(parameters as never),
+      ...bindErc4626Engine.call(parameters),
+    } as never) as never
+  }
+
+  /**
+   * Extracts the `EarnVaultInitialized` event from engine logs.
+   *
+   * @param logs - The logs.
+   * @param parameters - Engine address used to filter the logs.
+   * @returns The initialization event.
+   */
+  export function extractEvent(logs: Log[], parameters: { engine: Address }) {
+    const [log] = parseEventLogs({
+      abi: Abis.erc4626Engine,
+      eventName: 'EarnVaultInitialized',
+      logs: logs.filter((log) =>
+        isAddressEqual(log.address, parameters.engine),
+      ),
+      strict: true,
+    })
+    if (!log) throw new Error('`EarnVaultInitialized` event not found.')
+    return log
+  }
+}
+
+/**
+ * Binds an ERC-4626 engine and waits for confirmation.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const result = await Actions.earn.bindErc4626EngineSync(client, {
+ *   engine: '0x...',
+ *   vault: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client controlled by the final engine owner.
+ * @param parameters - Parameters.
+ * @returns The receipt and bound addresses.
+ */
+export async function bindErc4626EngineSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: bindErc4626EngineSync.Parameters<chain, account>,
+): Promise<bindErc4626EngineSync.ReturnValue> {
+  const { engine, throwOnReceiptRevert = true } = parameters
+  const receipt = await bindErc4626Engine.inner(writeContractSync, client, {
+    ...parameters,
+    throwOnReceiptRevert,
+  } as never)
+  const { args } = bindErc4626Engine.extractEvent(receipt.logs, { engine })
+  return { engine, vault: args.earnVault, receipt }
+}
+
+export namespace bindErc4626EngineSync {
+  export type Args = bindErc4626Engine.Args
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = bindErc4626Engine.Parameters<chain, account> &
+    WriteSyncParameters<chain, account>
+  export type ReturnValue = {
+    /** ERC-4626 engine address. */
+    engine: Address
+    /** Transaction receipt. */
+    receipt: TransactionReceipt
+    /** Bound EarnVault address. */
+    vault: Address
+  }
+  // TODO: exhaustive error type
+  export type ErrorType = BaseErrorType
+}
+
+export type DeployErc4626StackErrorType = DeployErc4626StackError & {
+  name: 'DeployErc4626StackError'
+}
+
+/**
+ * Error thrown after a partially completed Earn stack deployment.
+ *
+ * @experimental
+ */
+export class DeployErc4626StackError extends BaseError {
+  receipts: deployErc4626StackSync.Receipts
+  stage: deployErc4626StackSync.Stage
+  state: deployErc4626StackSync.State
+
+  constructor(
+    cause: Error,
+    parameters: {
+      receipts: deployErc4626StackSync.Receipts
+      stage: deployErc4626StackSync.Stage
+      state: deployErc4626StackSync.State
+    },
+  ) {
+    super(`ERC-4626 Earn deployment failed during ${parameters.stage}.`, {
+      cause,
+      name: 'DeployErc4626StackError',
+    })
+    this.receipts = parameters.receipts
+    this.stage = parameters.stage
+    this.state = parameters.state
+  }
+}
+
+/**
+ * Deploys and binds a complete ERC-4626 Earn stack through sequential,
+ * resumable transactions.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   account: privateKeyToAccount('0x...'),
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ * const result = await Actions.earn.deployErc4626StackSync(client, {
+ *   deploymentId: '0x...',
+ *   factories: { earn: '0x...', erc4626Engine: '0x...' },
+ *   venue: '0x...',
+ * })
+ * ```
+ *
+ * @param client - Client.
+ * @param parameters - Parameters.
+ * @returns The deployed addresses and receipts created by this run.
+ */
+export async function deployErc4626StackSync<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: deployErc4626StackSync.Parameters<chain, account>,
+): Promise<deployErc4626StackSync.ReturnValue> {
+  const deployer = parameters.account ?? client.account
+  if (!deployer) throw new AccountNotFoundError()
+  const owner_ = parameters.owner ?? deployer
+  const owner = parseAccount(owner_).address
+  const deployerAddress = parseAccount(deployer).address
+  const bindingAccount = (() => {
+    if (parameters.bindingAccount) return parameters.bindingAccount
+    if (typeof owner_ !== 'string') return owner_
+    if (isAddressEqual(owner, deployerAddress)) return deployer
+    return undefined
+  })()
+  if (
+    bindingAccount &&
+    !isAddressEqual(parseAccount(bindingAccount).address, owner)
+  )
+    throw new Error('`bindingAccount` must match `owner`.')
+
+  validateDeploymentId(parameters.deploymentId)
+  if (
+    parameters.resume &&
+    parameters.resume.deploymentId.toLowerCase() !==
+      parameters.deploymentId.toLowerCase()
+  )
+    throw new Error('The resumed deployment ID does not match `deploymentId`.')
+  await validateContracts(client, {
+    factories: parameters.factories,
+    venue: parameters.venue,
+  })
+
+  const {
+    gas: _,
+    keyAuthorization: __,
+    nonce: ___,
+    ...sharedWriteParameters
+  } = pickWriteParameters(parameters as never)
+  const writeParameters = {
+    ...sharedWriteParameters,
+    ...pickWriteSyncParameters(parameters as never),
+    account: deployer,
+    throwOnReceiptRevert: true,
+  }
+  const engineArgs = {
+    deploymentId: parameters.deploymentId,
+    factory: parameters.factories.erc4626Engine,
+    name: parameters.name,
+    owner,
+    symbol: parameters.symbol,
+    venue: parameters.venue,
+  } satisfies createErc4626Engine.Args
+  const predictedEngine = await createErc4626Engine.predict(client, engineArgs)
+  const state: deployErc4626StackSync.State = {
+    deploymentId: parameters.deploymentId,
+    earnShare: parameters.resume?.earnShare,
+    engine: predictedEngine,
+    fees: parameters.resume?.fees,
+    vault: parameters.resume?.vault,
+  }
+  if (
+    parameters.resume?.engine &&
+    !isAddressEqual(parameters.resume.engine, predictedEngine)
+  )
+    throw new Error('The resumed engine does not match the factory prediction.')
+
+  const engineExists = await hasCode(client, predictedEngine)
+  if (!bindingAccount) {
+    const boundVault = engineExists
+      ? await readContract(client, {
+          address: predictedEngine,
+          abi: Abis.erc4626Engine,
+          functionName: 'earnVault',
+        })
+      : zeroAddress
+    if (isAddressEqual(boundVault, zeroAddress))
+      throw new Error(
+        '`bindingAccount` is required when the final owner differs from the deployment account.',
+      )
+  }
+
+  const receipts: deployErc4626StackSync.Receipts = {}
+  try {
+    if (!engineExists) {
+      await createErc4626Engine.simulate(client, {
+        ...writeParameters,
+        ...engineArgs,
+      } as never)
+      const receipt = await createErc4626Engine.inner(
+        writeContractSync,
+        client,
+        {
+          ...writeParameters,
+          ...engineArgs,
+        } as never,
+      )
+      receipts.engine = receipt
+      createErc4626Engine.extractEvent(receipt.logs, {
+        factory: parameters.factories.erc4626Engine,
+      })
+    }
+    await verifyEngine(client, engineArgs, predictedEngine)
+  } catch (error) {
+    throw deploymentError(error, 'engine', state, receipts)
+  }
+
+  const stackArgs = {
+    controls: parameters.controls,
+    deploymentId: parameters.deploymentId,
+    distributor: parameters.distributor,
+    engine: predictedEngine,
+    factory: parameters.factories.earn,
+    fees: parameters.fees,
+    owner,
+    transferPolicyId: parameters.transferPolicyId,
+  } satisfies createStack.Args
+
+  try {
+    const predicted = await createStack.predict(client, stackArgs)
+    if (
+      parameters.resume?.earnShare &&
+      !isAddressEqual(parameters.resume.earnShare, predicted.earnShare)
+    )
+      throw new Error(
+        'The resumed EarnShare does not match the factory prediction.',
+      )
+    if (
+      parameters.resume?.fees &&
+      !isAddressEqual(parameters.resume.fees, predicted.earnFees)
+    )
+      throw new Error(
+        'The resumed EarnFees does not match the factory prediction.',
+      )
+    state.earnShare = predicted.earnShare
+    state.fees = predicted.earnFees
+
+    if (!(await hasCode(client, predicted.earnShare))) {
+      if (await hasCode(client, predicted.earnFees))
+        throw new Error(
+          'Predicted EarnFees exists without the predicted EarnShare.',
+        )
+      await createStack.simulate(client, {
+        ...writeParameters,
+        ...stackArgs,
+      } as never)
+      const receipt = await createStack.inner(writeContractSync, client, {
+        ...writeParameters,
+        ...stackArgs,
+      } as never)
+      receipts.stack = receipt
+      const { args } = createStack.extractEvent(receipt.logs, {
+        factory: parameters.factories.earn,
+      })
+      state.vault = args.earnVault
+      if (
+        parameters.resume?.vault &&
+        !isAddressEqual(parameters.resume.vault, args.earnVault)
+      )
+        throw new Error(
+          'The resumed EarnVault does not match the factory deployment.',
+        )
+    } else {
+      if (!(await hasCode(client, predicted.earnFees)))
+        throw new Error(
+          'Predicted EarnShare exists without the predicted EarnFees.',
+        )
+      state.vault = parameters.resume?.vault
+      if (!state.vault) {
+        const event = await findStackDeployment(client, {
+          earnShare: predicted.earnShare,
+          factory: parameters.factories.earn,
+          fromBlock: parameters.fromBlock,
+        })
+        state.vault = event.args.earnVault
+        if (!isAddressEqual(event.args.earnFees, predicted.earnFees))
+          throw new Error(
+            'Recovered EarnFees does not match the factory prediction.',
+          )
+      }
+    }
+    if (!state.vault) throw new Error('EarnVault address was not recovered.')
+    await verifyStack(client, {
+      engine: predictedEngine,
+      fees: predicted.earnFees,
+      owner,
+      share: predicted.earnShare,
+      vault: state.vault,
+    })
+  } catch (error) {
+    throw deploymentError(error, 'stack', state, receipts)
+  }
+
+  try {
+    const vault = state.vault!
+    const boundVault = await readContract(client, {
+      address: predictedEngine,
+      abi: Abis.erc4626Engine,
+      functionName: 'earnVault',
+    })
+    if (isAddressEqual(boundVault, zeroAddress)) {
+      if (!bindingAccount)
+        throw new Error(
+          '`bindingAccount` is required when the final owner differs from the deployment account.',
+        )
+      const bindingParameters = {
+        ...writeParameters,
+        account: bindingAccount,
+        engine: predictedEngine,
+        vault,
+      }
+      await bindErc4626Engine.simulate(client, bindingParameters as never)
+      const receipt = await bindErc4626Engine.inner(
+        writeContractSync,
+        client,
+        bindingParameters as never,
+      )
+      receipts.binding = receipt
+      bindErc4626Engine.extractEvent(receipt.logs, { engine: predictedEngine })
+    } else if (!isAddressEqual(boundVault, vault)) {
+      throw new Error(`Engine is already bound to ${boundVault}.`)
+    }
+    const verified = await readContract(client, {
+      address: predictedEngine,
+      abi: Abis.erc4626Engine,
+      functionName: 'earnVault',
+    })
+    if (!isAddressEqual(verified, vault))
+      throw new Error('Engine binding verification failed.')
+  } catch (error) {
+    throw deploymentError(error, 'binding', state, receipts)
+  }
+
+  return {
+    deploymentId: parameters.deploymentId,
+    earnShare: state.earnShare!,
+    engine: predictedEngine,
+    fees: state.fees!,
+    receipts,
+    vault: state.vault!,
+  }
+}
+
+export namespace deployErc4626StackSync {
+  export type Parameters<
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  > = Omit<
+    WriteParameters<chain, account>,
+    'gas' | 'keyAuthorization' | 'nonce' | 'throwOnReceiptRevert'
+  > &
+    WriteSyncParameters<chain, account> & {
+      /** Account used only for the final owner binding. */
+      bindingAccount?: Account | Address | undefined
+      /** Initial Earn vault controls. */
+      controls?: EarnVaultControls | undefined
+      /** Stable deterministic deployment identifier. */
+      deploymentId: Hex.Hex
+      /** Optional protected fee distributor. */
+      distributor?: EarnDistributorConfiguration | undefined
+      /** Reviewed factory pair from one Earn release. */
+      factories: EarnFactoryAddresses
+      /** Initial fee configuration. Omit for fee-free deployment. */
+      fees?: EarnFeeConfiguration | undefined
+      /** First block to search for a prior factory deployment event. */
+      fromBlock?: bigint | undefined
+      /** Optional engine name override. */
+      name?: string | undefined
+      /** Final stack owner and operator. @default `account.address` */
+      owner?: Account | Address | undefined
+      /** Previously persisted deployment state. */
+      resume?: State | undefined
+      /** Optional engine symbol override. */
+      symbol?: string | undefined
+      /** Existing simple whitelist policy. Zero selects always-allow. */
+      transferPolicyId?: bigint | undefined
+      /** ERC-4626 venue address. */
+      venue: Address
+    }
+
+  export type Stage = 'binding' | 'engine' | 'stack'
+
+  export type State = {
+    deploymentId: Hex.Hex
+    earnShare?: Address | undefined
+    engine: Address
+    fees?: Address | undefined
+    vault?: Address | undefined
+  }
+
+  export type Receipts = {
+    binding?: TransactionReceipt | undefined
+    engine?: TransactionReceipt | undefined
+    stack?: TransactionReceipt | undefined
+  }
+
+  export type ReturnValue = {
+    deploymentId: Hex.Hex
+    earnShare: Address
+    engine: Address
+    fees: Address
+    receipts: Receipts
+    vault: Address
+  }
+
+  export type ErrorType = DeployErc4626StackErrorType | BaseErrorType
+}
+
+function validateDeploymentId(deploymentId: Hex.Hex) {
+  if (Hex.size(deploymentId) !== 32 || BigInt(deploymentId) === 0n)
+    throw new Error('`deploymentId` must be a nonzero 32-byte hex value.')
+}
+
+function toDeployParameters(args: createStack.Args) {
+  const fixedFees = args.fees?.fixedFees ?? []
+  if (fixedFees.length > 4)
+    throw new Error('Earn supports at most four fixed fee recipients.')
+  const seen = new Set<string>()
+  let totalRateBps = 0
+  for (const fee of fixedFees) {
+    validateFeeRate(fee.rateBps, '`fixedFees[].rateBps`', false)
+    if (isAddressEqual(fee.account, zeroAddress))
+      throw new Error('Fixed fee recipients cannot be the zero address.')
+    const account = fee.account.toLowerCase()
+    if (seen.has(account))
+      throw new Error('Fixed fee recipients must be unique.')
+    seen.add(account)
+    totalRateBps += fee.rateBps
+  }
+  if (totalRateBps > 10_000)
+    throw new Error('The total fixed fee rate cannot exceed 10,000 bps.')
+
+  const excess = args.fees?.excess
+  if (excess) {
+    validateFeeRate(excess.annualTargetRateBps, '`annualTargetRateBps`', true)
+    validateFeeRate(excess.rateBps, '`excess.rateBps`', false)
+    if (isAddressEqual(excess.account, zeroAddress))
+      throw new Error('The excess fee recipient cannot be the zero address.')
+  }
+  const zeroFee = { account: zeroAddress, rateBps: 0 } as const
+  const distributor = args.distributor?.distributor ?? zeroAddress
+  const updateDelay = args.distributor?.updateDelay ?? 0
+  if (isAddressEqual(distributor, zeroAddress)) {
+    if (updateDelay !== 0)
+      throw new Error('A disabled distributor must use a zero update delay.')
+  } else {
+    if (updateDelay <= 0)
+      throw new Error(
+        'An enabled distributor requires a positive update delay.',
+      )
+    if (fixedFees.length === 0)
+      throw new Error('An enabled distributor requires at least one fixed fee.')
+  }
+  if (!Number.isSafeInteger(updateDelay) || updateDelay > 0xffffffffff)
+    throw new Error('`updateDelay` must fit into uint40 seconds.')
+  const transferPolicyId = args.transferPolicyId ?? 0n
+  if (transferPolicyId < 0n || transferPolicyId > maxUint64)
+    throw new Error('`transferPolicyId` must fit into uint64.')
+  const maxManagedAssets = args.controls?.maxManagedAssets ?? 0n
+  if (maxManagedAssets < 0n || maxManagedAssets > maxUint256)
+    throw new Error('`maxManagedAssets` must fit into uint256.')
+
+  return {
+    controls: {
+      asyncJanitor: args.controls?.asyncJanitor ?? zeroAddress,
+      emergencyGuardian: args.controls?.emergencyGuardian ?? zeroAddress,
+      maxManagedAssets,
+      migrationMode:
+        (args.controls?.migrationMode ?? 'userOnly') === 'userOnly' ? 0 : 1,
+    },
+    deploymentId: args.deploymentId,
+    distributorConfig: { distributor, updateDelay },
+    engine: args.engine,
+    fees: {
+      excess: excess
+        ? {
+            account: excess.account,
+            annualTargetRateBps: excess.annualTargetRateBps,
+            enabled: true,
+            excessFeeRateBps: excess.rateBps,
+          }
+        : {
+            account: zeroAddress,
+            annualTargetRateBps: 0,
+            enabled: false,
+            excessFeeRateBps: 0,
+          },
+      fixedFeeCount: fixedFees.length,
+      fixedFees: [
+        fixedFees[0] ?? zeroFee,
+        fixedFees[1] ?? zeroFee,
+        fixedFees[2] ?? zeroFee,
+        fixedFees[3] ?? zeroFee,
+      ],
+    },
+    owner: args.owner,
+    transferPolicyId,
+  } as const
+}
+
+function validateFeeRate(rate: number, name: string, allowZero: boolean) {
+  if (!Number.isInteger(rate) || rate < (allowZero ? 0 : 1) || rate > 10_000)
+    throw new Error(
+      `${name} must be an integer between ${allowZero ? 0 : 1} and 10,000.`,
+    )
+}
+
+async function hasCode(
+  client: Client<Transport, Chain | undefined>,
+  address: Address,
+) {
+  const code = await getCode(client, { address })
+  return code !== undefined && code !== '0x'
+}
+
+async function validateContracts(
+  client: Client<Transport, Chain | undefined>,
+  parameters: { factories: EarnFactoryAddresses; venue: Address },
+) {
+  const [engineFactory, earnFactory, venue] = await Promise.all([
+    hasCode(client, parameters.factories.erc4626Engine),
+    hasCode(client, parameters.factories.earn),
+    hasCode(client, parameters.venue),
+  ])
+  if (!engineFactory) throw new Error('ERC4626EngineFactory has no code.')
+  if (!earnFactory) throw new Error('EarnFactory has no code.')
+  if (!venue) throw new Error('ERC-4626 venue has no code.')
+  const tip20Factory = await readContract(client, {
+    address: parameters.factories.earn,
+    abi: Abis.earnFactory,
+    functionName: 'tip20Factory',
+  })
+  if (!isAddressEqual(tip20Factory, Addresses.tip20Factory))
+    throw new Error('EarnFactory uses an unexpected TIP-20 factory.')
+}
+
+async function verifyEngine(
+  client: Client<Transport, Chain | undefined>,
+  args: createErc4626Engine.Args,
+  engine: Address,
+) {
+  const [venue, owner] = await Promise.all([
+    readContract(client, {
+      address: engine,
+      abi: Abis.erc4626Engine,
+      functionName: 'vault',
+    }),
+    readContract(client, {
+      address: engine,
+      abi: Abis.erc4626Engine,
+      functionName: 'owner',
+    }),
+  ])
+  if (!isAddressEqual(venue, args.venue))
+    throw new Error('Engine venue verification failed.')
+  if (!isAddressEqual(owner, args.owner))
+    throw new Error('Engine owner verification failed.')
+}
+
+async function verifyStack(
+  client: Client<Transport, Chain | undefined>,
+  parameters: {
+    engine: Address
+    fees: Address
+    owner: Address
+    share: Address
+    vault: Address
+  },
+) {
+  const [engine, fees, operator, share] = await Promise.all([
+    readContract(client, {
+      address: parameters.vault,
+      abi: Abis.earnVault,
+      functionName: 'engine',
+    }),
+    readContract(client, {
+      address: parameters.vault,
+      abi: Abis.earnVault,
+      functionName: 'earnFees',
+    }),
+    readContract(client, {
+      address: parameters.vault,
+      abi: Abis.earnVault,
+      functionName: 'operator',
+    }),
+    readContract(client, {
+      address: parameters.vault,
+      abi: Abis.earnVault,
+      functionName: 'earnShare',
+    }),
+  ])
+  if (!isAddressEqual(engine, parameters.engine))
+    throw new Error('EarnVault engine verification failed.')
+  if (!isAddressEqual(fees, parameters.fees))
+    throw new Error('EarnVault fees verification failed.')
+  if (!isAddressEqual(operator, parameters.owner))
+    throw new Error('EarnVault operator verification failed.')
+  if (!isAddressEqual(share, parameters.share))
+    throw new Error('EarnVault share verification failed.')
+}
+
+async function findStackDeployment(
+  client: Client<Transport, Chain | undefined>,
+  parameters: {
+    earnShare: Address
+    factory: Address
+    fromBlock?: bigint | undefined
+  },
+) {
+  const event = getAbiItem({
+    abi: Abis.earnFactory,
+    name: 'EarnStackDeployed',
+  })
+  const logs = await getLogs(client, {
+    address: parameters.factory,
+    args: { earnShare: parameters.earnShare },
+    event,
+    fromBlock: parameters.fromBlock ?? 0n,
+    strict: true,
+    toBlock: 'latest',
+  })
+  const log = logs.at(-1)
+  if (!log) throw new Error('Prior `EarnStackDeployed` event not found.')
+  return log
+}
+
+function deploymentError(
+  error: unknown,
+  stage: deployErc4626StackSync.Stage,
+  state: deployErc4626StackSync.State,
+  receipts: deployErc4626StackSync.Receipts,
+) {
+  if (error instanceof DeployErc4626StackError) return error
+  if (error instanceof TransactionReceiptRevertedError)
+    receipts[stage] = error.receipt
+  return new DeployErc4626StackError(
+    error instanceof Error ? error : new Error(String(error)),
+    { receipts: { ...receipts }, stage, state: { ...state } },
+  )
+}

--- a/test/src/tempo/earn.ts
+++ b/test/src/tempo/earn.ts
@@ -28,7 +28,7 @@ import * as EarnContracts from './earnContracts.js'
  * `earn/localnet/foundry/script/DeployLocalEarn.s.sol`: `Simple4626Vault`
  * venue -> `ERC4626Engine` -> `EarnVault` and `EarnFees` implementations ->
  * `EarnFactory` -> `factory.deploy` -> `engine.initializeEarnVault`. Deploys are sequential
- * since Tempo allows one contract creation per transaction.
+ * so each fixture contract address can be recovered independently.
  */
 export async function deployEarnStack(
   client: Client<Transport, Chain, viem_Account>,
@@ -173,6 +173,64 @@ export declare namespace deployEarnStack {
     /** TIP-20 share token issued by the vault. */
     shareToken: Address
     /** Deployed `Simple4626Vault` venue. */
+    venue: Address
+  }
+}
+
+/** Deploys the reviewed Earn factories and an ERC-4626 venue for deployment tests. */
+export async function deployEarnFactories(
+  client: Client<Transport, Chain, viem_Account>,
+  options: deployEarnFactories.Options = {},
+): Promise<deployEarnFactories.ReturnValue> {
+  const asset = options.asset ?? addresses.alphaUsd
+  const venue = await deployContract(client, {
+    abi: EarnContracts.simple4626Vault.abi,
+    args: [asset, 'Tempo Earn Test Vault', 'teTEST', 6],
+    bytecode: EarnContracts.simple4626Vault.bytecode,
+  })
+  const earnVaultImplementation = await deployContract(client, {
+    abi: EarnContracts.earnVault.abi,
+    bytecode: EarnContracts.earnVault.bytecode,
+  })
+  const earnFeesImplementation = await deployContract(client, {
+    abi: EarnContracts.earnFees.abi,
+    bytecode: EarnContracts.earnFees.bytecode,
+  })
+  const earnFactory = await deployContract(client, {
+    abi: EarnContracts.earnFactory.abi,
+    args: [
+      Addresses.tip20Factory,
+      earnVaultImplementation,
+      earnFeesImplementation,
+    ],
+    bytecode: EarnContracts.earnFactory.bytecode,
+  })
+  const erc4626EngineFactory = await deployContract(client, {
+    abi: EarnContracts.erc4626EngineFactory.abi,
+    bytecode: EarnContracts.erc4626EngineFactory.bytecode,
+  })
+  return {
+    asset,
+    factories: {
+      earn: earnFactory,
+      erc4626Engine: erc4626EngineFactory,
+    },
+    venue,
+  }
+}
+
+export declare namespace deployEarnFactories {
+  export type Options = {
+    /** Venue base asset. @default `addresses.alphaUsd` */
+    asset?: Address | undefined
+  }
+
+  export type ReturnValue = {
+    asset: Address
+    factories: {
+      earn: Address
+      erc4626Engine: Address
+    }
     venue: Address
   }
 }


### PR DESCRIPTION
## Summary

Added experimental Tempo Earn actions for deploying and binding deterministic ERC-4626 stacks through the existing Viem action architecture.

## Motivation

Tempo Earn deployment requires coordinated engine creation, core stack creation, and a separate final-owner binding transaction. Consumers need composable primitives plus a safe resumable workflow without embedding factory bytecode or canonical experimental addresses in Viem.

## Changes

- Added async and Sync actions for engine creation, stack creation, and final-owner binding, including call, prediction, simulation, gas estimation, and event helpers.
- Added a synchronous resumable deployment recipe with deterministic recovery, topology verification, fee-free defaults, explicit factory addresses, and partial-failure state.
- Added native t10 integration coverage, account and result type tests, action references, an Earn deployment guide, and a patch changeset.

## Testing

- `pnpm check:types`
- `pnpm docs:build`
- Deployment integration tests: 12 passed.
- Existing Earn and decorator tests: 73 passed.
- Biome and diff whitespace checks passed.
- `pnpm check:repo` passed with the existing `test/package.json` workspace warning.