### PR TITLE
Add Tempo API callout

### DIFF
--- a/site/pages/tempo/index.mdx
+++ b/site/pages/tempo/index.mdx
@@ -6,6 +6,10 @@
 
 It enshrines features like [token management](https://docs.tempo.xyz/protocol/tip20/overview), [Fee AMM](https://docs.tempo.xyz/protocol/fees), and a [stablecoin DEX](https://docs.tempo.xyz/protocol/exchange) directly into the protocol, as well as a [Tempo transaction type](https://docs.tempo.xyz/protocol/transactions) with support for batch calls, fee sponsorship, configurable fee tokens, concurrent transactions, access keys, and scheduled execution.
 
+:::tip
+Need direct access to Tempo data? [Try the Tempo API](https://api.tempo.xyz).
+:::
+
 ## Setup
 
 Setup the Tempo extension for Viem by following the steps below.

--- a/site/pages/tokens/index.mdx
+++ b/site/pages/tokens/index.mdx
@@ -81,8 +81,7 @@ export const client = createWalletClient({
 
 :::tip
 Instead of listing tokens one by one, pass a curated **token set** from the `tokens` object, like
-`tokens.tempo` (every token on Tempo chains). For direct access to Tempo data, [use the Tempo
-API](https://api.tempo.xyz). See [Token Sets](/tokens/tokens#token-sets) for more.
+`tokens.tempo` (every token on Tempo chains). See [Token Sets](/tokens/tokens#token-sets) for more.
 
 ```ts twoslash
 import { createWalletClient, http } from 'viem'
@@ -97,6 +96,10 @@ export const client = createWalletClient({
   transport: http(),
 })
 ```
+:::
+
+:::tip
+For direct access to Tempo data, [use the Tempo API](https://api.tempo.xyz).
 :::
 
 :::tip

--- a/site/pages/tokens/index.mdx
+++ b/site/pages/tokens/index.mdx
@@ -99,10 +99,6 @@ export const client = createWalletClient({
 :::
 
 :::tip
-For direct access to Tempo data, [use the Tempo API](https://api.tempo.xyz).
-:::
-
-:::tip
 To use both read and write Token Actions on a single Client, extend a Client with both
 [Public Actions](/docs/actions/public/introduction) and
 [Wallet Actions](/docs/actions/wallet/introduction):

--- a/site/pages/tokens/index.mdx
+++ b/site/pages/tokens/index.mdx
@@ -17,10 +17,6 @@ Each Action selects its token either by `token` symbol (resolved to its token ad
 [`transfer`](/tokens/actions/transfer) and [`getBalance`](/tokens/actions/getBalance) without looking
 up an address or decimals.
 
-:::tip
-Building on Tempo? [Use the Tempo API](https://api.tempo.xyz) alongside Viem's token Actions.
-:::
-
 ## Setup
 
 Setup token Actions for Viem by following the steps below.
@@ -85,7 +81,8 @@ export const client = createWalletClient({
 
 :::tip
 Instead of listing tokens one by one, pass a curated **token set** from the `tokens` object, like
-`tokens.tempo` (every token on Tempo chains). See [Token Sets](/tokens/tokens#token-sets) for more.
+`tokens.tempo` (every token on Tempo chains). For direct access to Tempo data, [use the Tempo
+API](https://api.tempo.xyz). See [Token Sets](/tokens/tokens#token-sets) for more.
 
 ```ts twoslash
 import { createWalletClient, http } from 'viem'

--- a/site/pages/tokens/index.mdx
+++ b/site/pages/tokens/index.mdx
@@ -17,6 +17,10 @@ Each Action selects its token either by `token` symbol (resolved to its token ad
 [`transfer`](/tokens/actions/transfer) and [`getBalance`](/tokens/actions/getBalance) without looking
 up an address or decimals.
 
+:::tip
+Building on Tempo? [Use the Tempo API](https://api.tempo.xyz) alongside Viem's token Actions.
+:::
+
 ## Setup
 
 Setup token Actions for Viem by following the steps below.


### PR DESCRIPTION
## Summary

- Add a Tempo API callout to the Tempo getting started page.

## Tests

- `./node_modules/.bin/vocs build` from `site/`

Prompted by: @tmm