### PR TITLE
fix: bypass fill cache for sponsorship

### DIFF
--- a/.changeset/kind-relays-fill.md
+++ b/.changeset/kind-relays-fill.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Allow relay-routed sponsorship fills to bypass unsupported fill state cached from non-sponsored requests.

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -2199,6 +2199,41 @@ describe('behavior: attemptFill', () => {
     expect(fillTransactionSpy).not.toHaveBeenCalled()
   })
 
+  test('behavior: sponsorship bypasses cached unsupported fill state', async () => {
+    supportsFillTransaction.set(client.uid, false)
+
+    const fillTransactionSpy = vi
+      .spyOn(fillTransaction, 'fillTransaction')
+      .mockResolvedValue({
+        raw: '0x',
+        transaction: {
+          chainId: 1,
+          feePayerSignature: { r: '0x1', s: '0x2', yParity: 0 },
+          gas: 21_000n,
+          maxFeePerGas: 2n,
+          maxPriorityFeePerGas: 1n,
+          nonce: 0,
+          type: 'eip1559',
+        },
+      } as never)
+
+    const request = await prepareTransactionRequest(client, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      chainId: 1,
+      feePayer: true,
+      gas: 21_000n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 1n,
+      nonce: 0,
+      parameters: ['nonce'],
+      to: targetAccount.address,
+      type: 'eip1559',
+    } as never)
+
+    expect(fillTransactionSpy).toHaveBeenCalledOnce()
+    expect((request as any).feePayerSignature).toBeDefined()
+  })
+
   test('behavior: do not attempt fill when all parameters are already provided', async () => {
     await setup()
 

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -380,9 +380,6 @@ export async function prepareTransactionRequest<
     )
       return false
 
-    // Do not attempt if `eth_fillTransaction` is not supported.
-    if (supportsFillTransaction.get(client.uid) === false) return false
-
     // Always attempt if the caller explicitly requested a non-empty set of
     // `parameters` and a fee payer signature is being requested (e.g. Tempo
     // sponsorship via `feePayer: true`/`Account`) and has not already been
@@ -407,6 +404,10 @@ export async function prepareTransactionRequest<
       !('feePayerSignature' in request && (request as any).feePayerSignature)
     )
       return true
+
+    // Sponsorship can route fill requests to a different endpoint, so it must
+    // bypass support state cached from a non-sponsored request.
+    if (supportsFillTransaction.get(client.uid) === false) return false
 
     // Should attempt `eth_fillTransaction` if "fees" or "gas" are required to be populated,
     // otherwise, can just use the other individual calls.


### PR DESCRIPTION
## Motivation

Fill support is cached per client, but Tempo transports can route sponsored fills to a relay and non-sponsored fills to the default RPC. An unsupported response from the default RPC could therefore suppress a later relay-routed sponsorship request and omit its fee payer signature.

## Summary

- Let fee payer sponsorship bypass cached unsupported fill state
- Add regression coverage for a cached default-RPC failure followed by sponsorship
- Add a patch changeset

## Key design considerations

- Preserve the unsupported-method optimization for non-sponsored requests
- Keep the existing empty-parameters behavior for internal prepare calls
