### PR TITLE
fix: avoid consuming nonces for expiring transactions

### DIFF
--- a/.changeset/fresh-nonces-wait.md
+++ b/.changeset/fresh-nonces-wait.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Avoid consuming sequential nonces when chain preparation selects an expiring nonce.

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -341,20 +341,6 @@ export async function prepareTransactionRequest<
 
   let nonce = request.nonce
   if (
-    parameters.includes('nonce') &&
-    typeof nonce === 'undefined' &&
-    account &&
-    nonceManager
-  ) {
-    const chainId = await getChainId()
-    nonce = await nonceManager.consume({
-      address: account.address,
-      chainId,
-      client,
-    })
-  }
-
-  if (
     prepareTransactionRequest?.fn &&
     prepareTransactionRequest.runAt?.includes('beforeFillTransaction')
   ) {
@@ -368,6 +354,20 @@ export async function prepareTransactionRequest<
     nonce ??= request.nonce
     const sender = request.account ?? (request as TransactionRequest).from
     account = sender ? parseAccount(sender) : undefined
+  }
+
+  if (
+    parameters.includes('nonce') &&
+    typeof nonce === 'undefined' &&
+    account &&
+    nonceManager
+  ) {
+    const chainId = await getChainId()
+    nonce = await nonceManager.consume({
+      address: account.address,
+      chainId,
+      client,
+    })
   }
 
   const attemptFill = (() => {

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -47,6 +47,7 @@ import {
 } from '../../utils/formatters/transactionRequest.js'
 import { getAction } from '../../utils/getAction.js'
 import { LruMap } from '../../utils/lru.js'
+import type { NonceManager } from '../../utils/nonceManager.js'
 import {
   type AssertRequestErrorType,
   type AssertRequestParameters,
@@ -310,15 +311,29 @@ export async function sendTransaction<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
-      }
+      const nonceManager = ((): NonceManager | undefined => {
+        if (!account.nonceManager || typeof nonce !== 'undefined')
+          return account.nonceManager
+        const nonceManager = account.nonceManager
+        return {
+          consume(parameters) {
+            nonceManagerParameters = {
+              address: parameters.address,
+              chainId: parameters.chainId,
+            }
+            return nonceManager.consume(parameters)
+          },
+          get(parameters) {
+            return nonceManager.get(parameters)
+          },
+          increment(parameters) {
+            return nonceManager.increment(parameters)
+          },
+          reset(parameters) {
+            return nonceManager.reset(parameters)
+          },
+        }
+      })()
 
       // Prepare the request for signing (assign appropriate fees, etc.)
       const request = await getAction(
@@ -338,7 +353,7 @@ export async function sendTransaction<
         maxFeePerGas,
         maxPriorityFeePerGas,
         nonce,
-        nonceManager: account.nonceManager,
+        nonceManager,
         parameters: [...defaultParameters, 'sidecars'],
         type,
         value,

--- a/src/actions/wallet/sendTransactionSync.ts
+++ b/src/actions/wallet/sendTransactionSync.ts
@@ -51,6 +51,7 @@ import {
 } from '../../utils/formatters/transactionRequest.js'
 import { getAction } from '../../utils/getAction.js'
 import { LruMap } from '../../utils/lru.js'
+import type { NonceManager } from '../../utils/nonceManager.js'
 import {
   type AssertRequestErrorType,
   type AssertRequestParameters,
@@ -349,15 +350,29 @@ export async function sendTransactionSync<
     }
 
     if (account?.type === 'local') {
-      if (account.nonceManager && typeof nonce === 'undefined') {
-        const requestChainId = (rest as unknown as { chainId?: number }).chainId
-        const chainId = await (async () => {
-          if (typeof requestChainId === 'number') return requestChainId
-          if (chain) return chain.id
-          return getAction(client, getChainId, 'getChainId')({})
-        })()
-        nonceManagerParameters = { address: account.address, chainId }
-      }
+      const nonceManager = ((): NonceManager | undefined => {
+        if (!account.nonceManager || typeof nonce !== 'undefined')
+          return account.nonceManager
+        const nonceManager = account.nonceManager
+        return {
+          consume(parameters) {
+            nonceManagerParameters = {
+              address: parameters.address,
+              chainId: parameters.chainId,
+            }
+            return nonceManager.consume(parameters)
+          },
+          get(parameters) {
+            return nonceManager.get(parameters)
+          },
+          increment(parameters) {
+            return nonceManager.increment(parameters)
+          },
+          reset(parameters) {
+            return nonceManager.reset(parameters)
+          },
+        }
+      })()
 
       // Prepare the request for signing (assign appropriate fees, etc.)
       const request = await getAction(
@@ -377,7 +392,7 @@ export async function sendTransactionSync<
         maxFeePerGas,
         maxPriorityFeePerGas,
         nonce,
-        nonceManager: account.nonceManager,
+        nonceManager,
         parameters: [...defaultParameters, 'sidecars'],
         type,
         value,

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -140,6 +140,24 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBe(customValidBefore)
   })
 
+  test('behavior: expiring nonces do not consume a sequential nonce', async () => {
+    const consume = vi.fn(async () => 7)
+    const request = await prepareTransactionRequest(client, {
+      feePayer: true,
+      nonceManager: {
+        consume,
+        get: vi.fn(async () => 7),
+        increment: vi.fn(),
+        reset: vi.fn(),
+      },
+      parameters: ['nonce'],
+    })
+
+    expect(consume).not.toHaveBeenCalled()
+    expect(request.nonceKey).toBe(maxUint256)
+    expect(request.nonce).toBe(0)
+  })
+
   test('behavior: sendTransaction with expiring nonces', async () => {
     const receipts = await Promise.all([
       sendTransactionSync(client, {

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -14,6 +14,7 @@ import { mainnet, tempoLocalnet } from '../chains/index.js'
 import { createClient, http } from '../index.js'
 import { defineChain } from '../utils/chain/defineChain.js'
 import { hashMessage } from '../utils/index.js'
+import { withResolvers } from '../utils/promise/withResolvers.js'
 import * as accessKeyActions from './actions/accessKey.js'
 import {
   Account,
@@ -156,6 +157,60 @@ describe('prepareTransactionRequest', () => {
     expect(consume).not.toHaveBeenCalled()
     expect(request.nonceKey).toBe(maxUint256)
     expect(request.nonce).toBe(0)
+  })
+
+  test('behavior: staggered requests use sequential nonces', async () => {
+    const entered_1 = withResolvers<void>()
+    const entered_2 = withResolvers<void>()
+    const release = withResolvers<void>()
+    let getCount = 0
+    const keyAuthorizationManager = KeyAuthorizationManager.from({
+      source: {
+        async get() {
+          getCount++
+          if (getCount === 1) entered_1.resolve()
+          if (getCount === 2) entered_2.resolve()
+          await release.promise
+          return undefined
+        },
+        remove() {},
+        set() {},
+      },
+    })
+    const accessKey = Account.fromP256(generatePrivateKey(), {
+      access: accounts.at(0)!,
+      keyAuthorizationManager,
+    })
+    let nonce = 7
+    const consume = vi.fn(async () => nonce++)
+    const nonceManager = {
+      consume,
+      get: vi.fn(async () => nonce),
+      increment: vi.fn(),
+      reset: vi.fn(),
+    }
+
+    const request_1 = prepareTransactionRequest(client, {
+      account: accessKey,
+      nonceManager,
+      parameters: ['nonce'],
+    })
+    await entered_1.promise
+    const request_2 = prepareTransactionRequest(client, {
+      account: accessKey,
+      nonceManager,
+      parameters: ['nonce'],
+    })
+    await entered_2.promise
+    release.resolve()
+
+    const requests = await Promise.all([request_1, request_2])
+    expect(requests.map((request) => request.nonce)).toEqual([7, 8])
+    expect(requests.map((request) => request.nonceKey)).toEqual([
+      undefined,
+      undefined,
+    ])
+    expect(consume).toHaveBeenCalledTimes(2)
   })
 
   test('behavior: sendTransaction with expiring nonces', async () => {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -116,6 +116,19 @@ export const chainConfig = {
         if (request.account?.source !== 'multisig') delete request.account
       }
 
+      // Use expiring nonces for explicit, fee-payer, and concurrent transactions (TIP-1009).
+      // Detect concurrency before asynchronous preparation changes the event-loop boundary.
+      const useExpiringNonce = await (async () => {
+        if (request.nonceKey === 'expiring') return true
+        if (multisig) return false
+        if (request.feePayer && typeof request.nonceKey === 'undefined')
+          return true
+        const address = request.account?.address
+        if (address && typeof request.nonceKey === 'undefined')
+          return await Concurrent.detect(address)
+        return false
+      })()
+
       if (
         !request.keyAuthorization &&
         request.account?.source === 'accessKey'
@@ -155,21 +168,6 @@ export const chainConfig = {
           }
         }
       }
-
-      // Use expiring nonces for concurrent transactions (TIP-1009).
-      // When nonceKey is 'expiring', feePayer is specified, or concurrent requests
-      // are detected, we use expiring nonces (nonceKey = uint256.max) with a
-      // validBefore timestamp.
-      const useExpiringNonce = await (async () => {
-        if (request.nonceKey === 'expiring') return true
-        if (multisig) return false
-        if (request.feePayer && typeof request.nonceKey === 'undefined')
-          return true
-        const address = request.account?.address
-        if (address && typeof request.nonceKey === 'undefined')
-          return await Concurrent.detect(address)
-        return false
-      })()
 
       if (useExpiringNonce) {
         request.nonceKey = maxUint256

--- a/src/utils/nonceManager.test.ts
+++ b/src/utils/nonceManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, expect, test } from 'vitest'
+import { beforeAll, expect, test, vi } from 'vitest'
 import { anvilMainnet } from '~test/anvil.js'
 import { generatePrivateKey } from '../accounts/generatePrivateKey.js'
 import { privateKeyToAccount } from '../accounts/privateKeyToAccount.js'
@@ -12,6 +12,7 @@ import {
 import { mainnet } from '../chains/index.js'
 import { createWalletClient } from '../clients/createWalletClient.js'
 import { custom } from '../clients/transports/custom.js'
+import { defineChain } from './chain/defineChain.js'
 import { createNonceManager, jsonRpc, nonceManager } from './nonceManager.js'
 import { parseEther } from './unit/parseEther.js'
 
@@ -284,6 +285,92 @@ test('failed sendTransactionSync resets consumed nonce', async () => {
       client,
     }),
   ).toBe(1)
+})
+
+test('failed sendTransaction does not reset an unconsumed nonce', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+  const consume = vi.spyOn(nonceManager, 'consume')
+  const reset = vi.spyOn(nonceManager, 'reset')
+  const account = privateKeyToAccount(privateKey, { nonceManager })
+  const chain = defineChain({
+    ...mainnet,
+    async prepareTransactionRequest(request) {
+      return { ...request, nonce: 1 }
+    },
+  })
+  const client = createWalletClient({
+    chain,
+    transport: custom({
+      async request({ method }) {
+        if (method === 'eth_sendRawTransaction')
+          throw new Error('rate limit exceeded')
+        return '0x0'
+      },
+    }),
+  })
+
+  await expect(
+    sendTransaction(client, {
+      account,
+      chainId: chain.id,
+      gas: 21_000n,
+      gasPrice: 1n,
+      to: account.address,
+      type: 'legacy',
+      value: 1n,
+    }),
+  ).rejects.toThrow()
+
+  expect(consume).not.toHaveBeenCalled()
+  expect(reset).not.toHaveBeenCalled()
+})
+
+test('failed sendTransactionSync does not reset an unconsumed nonce', async () => {
+  const nonceManager = createNonceManager({
+    source: {
+      get: () => 1,
+      set: () => {},
+    },
+  })
+  const consume = vi.spyOn(nonceManager, 'consume')
+  const reset = vi.spyOn(nonceManager, 'reset')
+  const account = privateKeyToAccount(privateKey, { nonceManager })
+  const chain = defineChain({
+    ...mainnet,
+    async prepareTransactionRequest(request) {
+      return { ...request, nonce: 1 }
+    },
+  })
+  const client = createWalletClient({
+    chain,
+    transport: custom({
+      async request({ method }) {
+        if (method === 'eth_sendRawTransactionSync')
+          throw new Error('rate limit exceeded')
+        return '0x0'
+      },
+    }),
+  })
+
+  await expect(
+    sendTransactionSync(client, {
+      account,
+      chainId: chain.id,
+      gas: 21_000n,
+      gasPrice: 1n,
+      to: account.address,
+      type: 'legacy',
+      value: 1n,
+    }),
+  ).rejects.toThrow()
+
+  expect(consume).not.toHaveBeenCalled()
+  expect(reset).not.toHaveBeenCalled()
 })
 
 test('dropped tx', async () => {


### PR DESCRIPTION
## Motivation

Core transaction preparation consumed a nonce manager before chain-specific preparation ran. When Tempo subsequently selected an expiring nonce, the sequential nonce was discarded and replaced with nonce zero, leaving an unnecessary gap in nonce-manager state.

## Summary

- Run chain-specific preparation before consuming a managed nonce
- Consume a managed nonce only when the chain hook did not provide one
- Add a Tempo expiring-nonce regression and patch changeset

## Key design considerations

- Keep nonce-manager behavior unchanged for chains that do not populate a nonce
- Allow chain hooks to select nonce modes without mutating unrelated nonce state
