### PR TITLE
fix: detect concurrency before access key preparation

### DIFF
--- a/.changeset/early-nonces-meet.md
+++ b/.changeset/early-nonces-meet.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Detect concurrent Tempo requests before asynchronous access key preparation.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -140,6 +140,44 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBe(customValidBefore)
   })
 
+  test('behavior: detects concurrency before asynchronous account preparation', async () => {
+    let reads = 0
+    let releaseSecondRead: (() => void) | undefined
+    const secondRead = new Promise<undefined>((resolve) => {
+      releaseSecondRead = () => resolve(undefined)
+    })
+    const keyAuthorizationManager = KeyAuthorizationManager.from({
+      source: {
+        get() {
+          reads++
+          if (reads === 1) return undefined
+          return secondRead
+        },
+        remove() {},
+        set() {},
+      },
+    })
+    const account = Account.fromP256(generatePrivateKey(), {
+      access: accounts.at(0)!,
+      keyAuthorizationManager,
+    })
+
+    const firstPromise = prepareTransactionRequest(client, {
+      account,
+      parameters: [],
+    })
+    const secondPromise = prepareTransactionRequest(client, {
+      account,
+      parameters: [],
+    })
+    const first = await firstPromise
+    releaseSecondRead?.()
+    const second = await secondPromise
+
+    expect(first.nonceKey).toBe(maxUint256)
+    expect(second.nonceKey).toBe(maxUint256)
+  })
+
   test('behavior: sendTransaction with expiring nonces', async () => {
     const receipts = await Promise.all([
       sendTransactionSync(client, {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -116,6 +116,30 @@ export const chainConfig = {
         if (request.account?.source !== 'multisig') delete request.account
       }
 
+      // Register concurrency before account preparation performs storage or
+      // network I/O so overlapping requests cannot miss each other.
+      const useExpiringNonce = await (async () => {
+        if (request.nonceKey === 'expiring') return true
+        if (multisig) return false
+        if (request.feePayer && typeof request.nonceKey === 'undefined')
+          return true
+        const address = request.account?.address
+        if (address && typeof request.nonceKey === 'undefined')
+          return await Concurrent.detect(address)
+        return false
+      })()
+
+      if (useExpiringNonce) {
+        request.nonceKey = maxUint256
+        request.nonce = 0
+        if (typeof request.validAfter === 'undefined')
+          request.validAfter = randomValidAfter()
+        if (typeof request.validBefore === 'undefined')
+          request.validBefore = Math.floor(Date.now() / 1000) + maxExpirySecs
+      } else if (typeof request.nonceKey !== 'undefined') {
+        request.nonce = typeof request.nonce === 'number' ? request.nonce : 0
+      }
+
       if (
         !request.keyAuthorization &&
         request.account?.source === 'accessKey'
@@ -154,33 +178,6 @@ export const chainConfig = {
             }
           }
         }
-      }
-
-      // Use expiring nonces for concurrent transactions (TIP-1009).
-      // When nonceKey is 'expiring', feePayer is specified, or concurrent requests
-      // are detected, we use expiring nonces (nonceKey = uint256.max) with a
-      // validBefore timestamp.
-      const useExpiringNonce = await (async () => {
-        if (request.nonceKey === 'expiring') return true
-        if (multisig) return false
-        if (request.feePayer && typeof request.nonceKey === 'undefined')
-          return true
-        const address = request.account?.address
-        if (address && typeof request.nonceKey === 'undefined')
-          return await Concurrent.detect(address)
-        return false
-      })()
-
-      if (useExpiringNonce) {
-        request.nonceKey = maxUint256
-        request.nonce = 0
-        if (typeof request.validAfter === 'undefined')
-          request.validAfter = randomValidAfter()
-        if (typeof request.validBefore === 'undefined')
-          request.validBefore = Math.floor(Date.now() / 1000) + maxExpirySecs
-      } else if (typeof request.nonceKey !== 'undefined') {
-        // Explicit nonceKey provided (2D nonce mode)
-        request.nonce = typeof request.nonce === 'number' ? request.nonce : 0
       }
 
       if (!request.feeToken && request.chain?.feeToken)


### PR DESCRIPTION
## Motivation

Tempo detected concurrent transactions after asynchronous access-key storage and network work. Different lookup latencies could cause overlapping requests to reach detection separately and miss expiring-nonce selection.

## Summary

- Detect concurrent requests before asynchronous access-key preparation
- Add a deterministic latency-skew regression
- Add a patch changeset

## Key design considerations

- Preserve explicit nonce keys and multisig handling
- Keep access-key authorization lookup behavior unchanged
