### PR TITLE
fix: detect concurrent address accounts

### DIFF
--- a/.changeset/calm-addresses-meet.md
+++ b/.changeset/calm-addresses-meet.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Detect concurrent Tempo requests made with equivalent JSON-RPC address accounts.
+Detected concurrent Tempo requests made with equivalent JSON-RPC address accounts.

--- a/.changeset/calm-addresses-meet.md
+++ b/.changeset/calm-addresses-meet.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Detect concurrent Tempo requests made with equivalent JSON-RPC address accounts.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -140,6 +140,23 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBe(customValidBefore)
   })
 
+  test('behavior: detects concurrent JSON-RPC address accounts', async () => {
+    const address = accounts.at(0)!.address
+    const requests = await Promise.all([
+      prepareTransactionRequest(client, {
+        account: address,
+        parameters: [],
+      }),
+      prepareTransactionRequest(client, {
+        account: address.toLowerCase() as typeof address,
+        parameters: [],
+      }),
+    ])
+
+    expect(requests[0].nonceKey).toBe(maxUint256)
+    expect(requests[1].nonceKey).toBe(maxUint256)
+  })
+
   test('behavior: sendTransaction with expiring nonces', async () => {
     const receipts = await Promise.all([
       sendTransactionSync(client, {

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -165,9 +165,14 @@ export const chainConfig = {
         if (multisig) return false
         if (request.feePayer && typeof request.nonceKey === 'undefined')
           return true
-        const address = request.account?.address
+        const account = request.account as
+          | Account
+          | MultisigAccount
+          | Address
+          | undefined
+        const address = typeof account === 'string' ? account : account?.address
         if (address && typeof request.nonceKey === 'undefined')
-          return await Concurrent.detect(address)
+          return await Concurrent.detect(address.toLowerCase())
         return false
       })()
 


### PR DESCRIPTION
## Motivation

Transaction preparation accepts JSON-RPC address accounts, but Tempo concurrency detection inspected the account before core normalized it. Raw address strings therefore bypassed detection, and equivalent address casing produced different concurrency keys.

## Summary

- Resolve both account objects and address strings for concurrency detection
- Normalize only the internal concurrency key
- Add mixed-case JSON-RPC address regression coverage and a patch changeset

## Key design considerations

- Preserve the caller's account representation and address casing in the prepared request
- Keep multisig and explicit nonce-key behavior unchanged
