### PR TITLE
fix: prepare numeric expiring nonce sentinel

### DIFF
--- a/.changeset/valid-nonces-expire.md
+++ b/.changeset/valid-nonces-expire.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Populate the required validity window for the numeric Tempo expiring nonce sentinel.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -127,6 +127,19 @@ describe('prepareTransactionRequest', () => {
     expect(request?.validBefore).toBeLessThanOrEqual(now + 31)
   })
 
+  test('behavior: numeric expiring nonce sentinel gets a validity window', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const request = await prepareTransactionRequest(client, {
+      nonceKey: maxUint256,
+      parameters: [],
+    })
+
+    expect(request.nonceKey).toBe(maxUint256)
+    expect(request.nonce).toBe(0)
+    expect(request.validBefore).toBeGreaterThanOrEqual(now)
+    expect(request.validBefore).toBeLessThanOrEqual(now + 31)
+  })
+
   test('behavior: explicit validity window is preserved', async () => {
     const customValidAfter = Math.floor(Date.now() / 1000) - 15
     const customValidBefore = Math.floor(Date.now() / 1000) + 15

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -161,7 +161,8 @@ export const chainConfig = {
       // are detected, we use expiring nonces (nonceKey = uint256.max) with a
       // validBefore timestamp.
       const useExpiringNonce = await (async () => {
-        if (request.nonceKey === 'expiring') return true
+        if (request.nonceKey === 'expiring' || request.nonceKey === maxUint256)
+          return true
         if (multisig) return false
         if (request.feePayer && typeof request.nonceKey === 'undefined')
           return true


### PR DESCRIPTION
## Motivation

Tempo's public transaction request type accepts both the expiring alias and numeric nonce keys. The numeric maximum-uint256 sentinel was treated as a regular 2D nonce, so its required validity window was omitted and the node rejected the request.

## Summary

- Treat numeric maximum uint256 as the expiring nonce sentinel
- Populate the same nonce and validity fields as the expiring alias
- Add regression coverage and a patch changeset

## Key design considerations

- Preserve caller-provided validity windows
- Leave all other explicit numeric nonce keys in 2D nonce mode
