### PR TITLE
fix: preserve zero fee token ID

### DIFF
--- a/.changeset/zero-tokens-stay.md
+++ b/.changeset/zero-tokens-stay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Preserve an explicit zero Tempo fee token ID when a chain default is configured.

--- a/src/tempo/chainConfig.test.ts
+++ b/src/tempo/chainConfig.test.ts
@@ -184,6 +184,23 @@ describe('prepareTransactionRequest', () => {
     expect(request.feeToken).toBe(feeToken)
   })
 
+  test('behavior: explicit zero fee token ID overrides chain config', async () => {
+    const chainWithFeeToken = defineChain({
+      ...tempoLocalnet,
+      feeToken: 1n,
+    })
+    const clientWithFeeToken = getClient({
+      account: accounts.at(0)!,
+      chain: chainWithFeeToken,
+    })
+    const request = await prepareTransactionRequest(clientWithFeeToken, {
+      feeToken: 0n,
+      parameters: [],
+    })
+
+    expect(request.feeToken).toBe(0n)
+  })
+
   test('behavior: multisigSignatureCount inferred from equal weights', async () => {
     const config = MultisigConfig.from({
       threshold: 2,

--- a/src/tempo/chainConfig.ts
+++ b/src/tempo/chainConfig.ts
@@ -183,7 +183,10 @@ export const chainConfig = {
         request.nonce = typeof request.nonce === 'number' ? request.nonce : 0
       }
 
-      if (!request.feeToken && request.chain?.feeToken)
+      if (
+        typeof request.feeToken === 'undefined' &&
+        typeof request.chain?.feeToken !== 'undefined'
+      )
         request.feeToken = request.chain.feeToken
 
       return request as unknown as typeof r


### PR DESCRIPTION
## Motivation

Token ID zero is a valid Tempo fee token. A falsy check treated it as absent and replaced it with the chain default, potentially changing the token selected by the caller.

## Summary

- Apply the chain fee token only when the request value is undefined
- Preserve an explicit zero token ID
- Add regression coverage with a different chain default and a patch changeset

## Key design considerations

- Retain the existing chain-default fallback
- Distinguish valid falsy values from omitted values
