### PR TITLE
fix(tempo): include withdrawal fallback nonce

### DIFF
--- a/.changeset/quiet-zones-withdraw.md
+++ b/.changeset/quiet-zones-withdraw.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Zone withdrawal sender tags to include the emitted fallback nonce.

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -7,7 +7,6 @@ import {
   decodeAbiParameters,
   decodeFunctionData,
   encodeFunctionData,
-  encodePacked,
   type Hash,
   isAddressEqual,
   keccak256,
@@ -789,15 +788,16 @@ describe('depositSync', () => {
 })
 
 describe('requestWithdrawal', () => {
-  test('behavior: derives a deterministic Solidity-compatible sender tag', () => {
+  test('behavior: derives the production sender tag', () => {
     expect(
       WithdrawalSenderTag.from({
-        sender: '0x0000000000000000000000000000000000000001',
+        fallbackNonce: 19n,
+        sender: '0x0F0896dbf0465E5c07963301dcFEA1101Fa91EaC',
         transactionHash:
-          '0x1111111111111111111111111111111111111111111111111111111111111111',
+          '0xae628bdc4bd24a9f9a917825a208baa16c384ab8a96a40cd5146bd20d9b3f6d9',
       }),
-    ).toMatchInlineSnapshot(
-      `"0x7d1d33bbd5371cad19c9200930eb7f1f5374473cdfb76b88a1bcc0d0a2efc5bc"`,
+    ).toBe(
+      '0xf1acbae45cd689281144042331e3379cf631a8d2db83057ccf38754a0b0108f2',
     )
   })
 
@@ -914,13 +914,21 @@ describe('requestWithdrawal', () => {
 
     expect(clientAccountResult.receipt).toEqual(clientAccountReceipt)
     expect(clientAccountResult.receipt.status).toBe('success')
+    const [clientAccountEvent] = parseEventLogs({
+      abi: ZoneAbis.zoneOutbox,
+      logs: clientAccountResult.receipt.logs,
+      eventName: 'WithdrawalRequested',
+      strict: true,
+    })
+    if (!clientAccountEvent)
+      throw new Error('`WithdrawalRequested` event not found.')
+    expect(clientAccountEvent.args.fallbackNonce).toBeGreaterThan(0n)
     expect(clientAccountResult.senderTag).toBe(
-      keccak256(
-        encodePacked(
-          ['address', 'bytes32'],
-          [account.address, clientAccountResult.receipt.transactionHash],
-        ),
-      ),
+      WithdrawalSenderTag.from({
+        fallbackNonce: clientAccountEvent.args.fallbackNonce,
+        sender: clientAccountEvent.args.sender,
+        transactionHash: clientAccountResult.receipt.transactionHash,
+      }),
     )
 
     const explicitAccountClient = getZoneClient({})
@@ -943,13 +951,21 @@ describe('requestWithdrawal', () => {
 
     expect(explicitAccountResult.receipt).toEqual(explicitAccountReceipt)
     expect(explicitAccountResult.receipt.status).toBe('success')
+    const [explicitAccountEvent] = parseEventLogs({
+      abi: ZoneAbis.zoneOutbox,
+      logs: explicitAccountResult.receipt.logs,
+      eventName: 'WithdrawalRequested',
+      strict: true,
+    })
+    if (!explicitAccountEvent)
+      throw new Error('`WithdrawalRequested` event not found.')
+    expect(explicitAccountEvent.args.fallbackNonce).toBeGreaterThan(0n)
     expect(explicitAccountResult.senderTag).toBe(
-      keccak256(
-        encodePacked(
-          ['address', 'bytes32'],
-          [account.address, explicitAccountResult.receipt.transactionHash],
-        ),
-      ),
+      WithdrawalSenderTag.from({
+        fallbackNonce: explicitAccountEvent.args.fallbackNonce,
+        sender: explicitAccountEvent.args.sender,
+        transactionHash: explicitAccountResult.receipt.transactionHash,
+      }),
     )
   }, 20_000)
 

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -29,6 +29,7 @@ import { zeroHash } from '../../constants/bytes.js'
 import type { BaseErrorType } from '../../errors/base.js'
 import type { Chain, GetChainParameter } from '../../types/chain.js'
 import type { Compute, UnionOmit } from '../../types/utils.js'
+import { parseEventLogs } from '../../utils/abi/parseEventLogs.js'
 import type { RequestErrorType } from '../../utils/buildRequest.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
@@ -1547,8 +1548,16 @@ export async function requestWithdrawalSync<
     gas: parameters.gas ?? defaultWithdrawalGas,
     throwOnReceiptRevert,
   } as never)
+  const [event] = parseEventLogs({
+    abi: ZoneAbis.zoneOutbox,
+    logs: receipt.logs,
+    eventName: 'WithdrawalRequested',
+    strict: true,
+  })
+  if (!event) throw new Error('`WithdrawalRequested` event not found.')
   const senderTag = WithdrawalSenderTag.from({
-    sender: account_.address,
+    fallbackNonce: event.args.fallbackNonce,
+    sender: event.args.sender,
     transactionHash: receipt.transactionHash,
   })
   return { receipt, senderTag }

--- a/src/tempo/internal/WithdrawalSenderTag.ts
+++ b/src/tempo/internal/WithdrawalSenderTag.ts
@@ -1,19 +1,33 @@
 import type { Address } from 'abitype'
 import { AbiParameters, Hash, type Hex } from 'ox'
 
-/** Derives a withdrawal sender tag from its sender and transaction hash. @internal */
+/** Derives a withdrawal sender tag. @internal */
 export function from(options: from.Options): Hex.Hex {
-  const { sender, transactionHash } = options
+  const { fallbackNonce, sender, transactionHash } = options
+  if (
+    sender === '0x0000000000000000000000000000000000000000' &&
+    fallbackNonce === 0n
+  )
+    return Hash.keccak256(
+      AbiParameters.encodePacked(
+        ['address', 'bytes32'],
+        [
+          sender,
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        ],
+      ),
+    )
   return Hash.keccak256(
     AbiParameters.encodePacked(
-      ['address', 'bytes32'],
-      [sender, transactionHash],
+      ['address', 'bytes32', 'uint64'],
+      [sender, transactionHash, fallbackNonce],
     ),
   )
 }
 
 export declare namespace from {
   type Options = {
+    fallbackNonce: bigint
     sender: Address
     transactionHash: Hex.Hex
   }

--- a/src/tempo/internal/WithdrawalSenderTag.ts
+++ b/src/tempo/internal/WithdrawalSenderTag.ts
@@ -1,22 +1,9 @@
 import type { Address } from 'abitype'
 import { AbiParameters, Hash, type Hex } from 'ox'
 
-/** Derives a withdrawal sender tag. @internal */
+/** Derives a user withdrawal sender tag. @internal */
 export function from(options: from.Options): Hex.Hex {
   const { fallbackNonce, sender, transactionHash } = options
-  if (
-    sender === '0x0000000000000000000000000000000000000000' &&
-    fallbackNonce === 0n
-  )
-    return Hash.keccak256(
-      AbiParameters.encodePacked(
-        ['address', 'bytes32'],
-        [
-          sender,
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        ],
-      ),
-    )
   return Hash.keccak256(
     AbiParameters.encodePacked(
       ['address', 'bytes32', 'uint64'],

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -1,4 +1,11 @@
-import { encodeFunctionData, type Hex, zeroAddress, zeroHash } from 'viem'
+import {
+  type Address,
+  encodeFunctionData,
+  type Hex,
+  parseEventLogs,
+  zeroAddress,
+  zeroHash,
+} from 'viem'
 import { Abis } from 'viem/tempo/zones'
 import { expectTypeOf, test } from 'vitest'
 
@@ -41,4 +48,17 @@ test('zoneFactory supports both parameter shapes', () => {
 
   expectTypeOf(sequencerSet).toEqualTypeOf<Hex>()
   expectTypeOf(sequencer).toEqualTypeOf<Hex>()
+})
+
+test('zoneOutbox decodes WithdrawalRequested fallback nonces', () => {
+  const [event] = parseEventLogs({
+    abi: Abis.zoneOutbox,
+    eventName: 'WithdrawalRequested',
+    logs: [],
+    strict: true,
+  })
+
+  if (!event) return
+  expectTypeOf(event.args.fallbackNonce).toEqualTypeOf<bigint>()
+  expectTypeOf(event.args.sender).toEqualTypeOf<Address>()
 })

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -169,6 +169,23 @@ export const zonePortal = [
 
 export const zoneOutbox = [
   {
+    name: 'WithdrawalRequested',
+    type: 'event',
+    inputs: [
+      { name: 'withdrawalIndex', type: 'uint64', indexed: true },
+      { name: 'sender', type: 'address', indexed: true },
+      { name: 'token', type: 'address', indexed: false },
+      { name: 'to', type: 'address', indexed: false },
+      { name: 'amount', type: 'uint128', indexed: false },
+      { name: 'fee', type: 'uint128', indexed: false },
+      { name: 'memo', type: 'bytes32', indexed: false },
+      { name: 'gasLimit', type: 'uint64', indexed: false },
+      { name: 'fallbackNonce', type: 'uint64', indexed: false },
+      { name: 'data', type: 'bytes', indexed: false },
+      { name: 'revealTo', type: 'bytes', indexed: false },
+    ],
+  },
+  {
     name: 'requestWithdrawal',
     type: 'function',
     stateMutability: 'nonpayable',


### PR DESCRIPTION
## Summary

Fixes Zone withdrawal sender tags by deriving them from the fallback nonce emitted in the Zone receipt.

## Motivation

Zone user withdrawals hash `sender || transactionHash || fallbackNonce`. The previous two-field hash returned a sender tag that could not locate the parent-chain `WithdrawalProcessed` event.

The implementation follows the production Zone source at revision `689ffbe`: [`Withdrawal::sender_tag`](https://github.com/tempoxyz/zones/blob/689ffbe34fd9f149965a3297a8915f097e7e6029/crates/contracts/src/precompiles/zone_portal.rs#L469-L505) defines the hash preimage, and [`WithdrawalRequested`](https://github.com/tempoxyz/zones/blob/689ffbe34fd9f149965a3297a8915f097e7e6029/crates/contracts/src/precompiles/outbox.rs#L29-L43) exposes `fallbackNonce` in the Zone receipt.

## Changes

- Added `WithdrawalRequested` to the Zone Outbox ABI.
- Decoded the receipt event in `requestWithdrawalSync` and included its `fallbackNonce` and `sender` in the tag.
- Updated the existing internal user-withdrawal sender-tag helper.
- Added runtime/type coverage and a patch changeset.

## Testing

- Added the confirmed production vector, which expects `0xf1acbae45cd689281144042331e3379cf631a8d2db83057ccf38754a0b0108f2`.
- `git diff --check`
- The focused Viem command was blocked before test execution by a local Bun executable failure during pnpm's dependency check.
