### PR TITLE
fix(tempo): include withdrawal fallback nonce

### DIFF
--- a/.changeset/calm-zones-withdraw.md
+++ b/.changeset/calm-zones-withdraw.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed Zone withdrawal sender tags to include the emitted fallback nonce.

--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
   },
   "dependencies": {
     "abitype": "1.3.0",
-    "ox": "1.6.0"
+    "ox": "1.6.2"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,6 @@ catalogs:
       version: 5.9.3
 
 overrides:
-  ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
   '@arethetypeswrong/core>typescript': ^5.9.3
   '@babel/core': '>=7.29.6 <8'
   '@opentelemetry/api@^1.8.0': ~1.7.0
@@ -231,8 +230,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0(typescript@7.0.2)(zod@4.4.3)
       ox:
-        specifier: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
-        version: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
+        specifier: 1.6.2
+        version: 1.6.2(typescript@7.0.2)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -290,7 +289,7 @@ importers:
         version: 0.18.1
       permissionless:
         specifier: 'catalog:'
-        version: 0.2.57(ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2))
+        version: 0.2.57(ox@1.6.2(typescript@7.0.2))
       prool:
         specifier: 'catalog:'
         version: 0.2.13(@pimlico/alto@0.0.18(supports-color@8.1.1)(typescript@7.0.2))(debug@4.4.3(supports-color@8.1.1))(testcontainers@11.10.0(supports-color@8.1.1))
@@ -1347,6 +1346,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -6026,9 +6029,24 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
-  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2:
-    resolution: {integrity: sha512-+HB8ktDKiJQrOHJXmCyHIN3fqMYJf547e9WhUXV9HQaVAHbN/Wau89JCI4uTzxdn30/QStDNXkeHDs6qK/ilZw==, tarball: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2}
-    version: 1.6.1
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.33:
+    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@1.6.2:
+    resolution: {integrity: sha512-Jcll+tKlUV0sUPJ6YlmcpKRcefipswF5DI9lz+kn8Qc6fY5UrMEoeL+E9Y+9h6apKnvQ4N4anggJWNqFC7Vxiw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -6196,7 +6214,6 @@ packages:
 
   permissionless@0.2.57:
     resolution: {integrity: sha512-QrzAoQGYPV/NJ2x5Sj18h7qed6f+kCyQAojrncN091UPiGqHjFNjgdsgreiv8pxlQgF4UcpuJUvsHLpOEBd6cQ==}
-    version: 0.2.57
     peerDependencies:
       ox: ^0.8.0
     peerDependenciesMeta:
@@ -8815,6 +8832,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/ciphers@2.2.0': {}
 
   '@noble/curves@1.9.1':
@@ -11402,6 +11421,11 @@ snapshots:
       typescript: 5.9.3
       zod: 4.4.3
 
+  abitype@1.3.0(typescript@7.0.2)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 7.0.2
+      zod: 3.25.76
+
   abitype@1.3.0(typescript@7.0.2)(zod@4.4.3):
     optionalDependencies:
       typescript: 7.0.2
@@ -13927,7 +13951,37 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@5.9.3):
+  ox@0.14.29(typescript@7.0.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.3.0(typescript@7.0.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.33(typescript@7.0.2)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@1.6.2(typescript@5.9.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 2.2.0
@@ -13942,7 +13996,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2):
+  ox@1.6.2(typescript@7.0.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 2.2.0
@@ -14194,11 +14248,11 @@ snapshots:
 
   pend@1.2.0: {}
 
-  permissionless@0.2.57(ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)):
+  permissionless@0.2.57(ox@1.6.2(typescript@7.0.2)):
     dependencies:
       viem: 'link:'
     optionalDependencies:
-      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
+      ox: 1.6.2(typescript@7.0.2)
 
   pg-int8@1.0.1: {}
 
@@ -15622,7 +15676,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.1)
-      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
+      ox: 0.14.29(typescript@7.0.2)(zod@3.25.76)
       ws: 8.21.1
     optionalDependencies:
       typescript: 7.0.2
@@ -15639,7 +15693,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@7.0.2)(zod@4.4.3)
       isows: 1.0.7(ws@8.21.0)
-      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
+      ox: 0.14.33(typescript@7.0.2)(zod@4.4.3)
       ws: 8.21.0
     optionalDependencies:
       typescript: 7.0.2
@@ -15651,7 +15705,7 @@ snapshots:
   viem@file:(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       abitype: 1.3.0(typescript@5.9.3)(zod@4.4.3)
-      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@5.9.3)
+      ox: 1.6.2(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15660,7 +15714,7 @@ snapshots:
   viem@file:(typescript@7.0.2)(zod@4.4.3):
     dependencies:
       abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
-      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
+      ox: 1.6.2(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,7 @@ catalogs:
       version: 5.9.3
 
 overrides:
+  ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
   '@arethetypeswrong/core>typescript': ^5.9.3
   '@babel/core': '>=7.29.6 <8'
   '@opentelemetry/api@^1.8.0': ~1.7.0
@@ -230,8 +231,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0(typescript@7.0.2)(zod@4.4.3)
       ox:
-        specifier: 1.6.0
-        version: 1.6.0(typescript@7.0.2)
+        specifier: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
+        version: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -289,7 +290,7 @@ importers:
         version: 0.18.1
       permissionless:
         specifier: 'catalog:'
-        version: 0.2.57(ox@1.6.0(typescript@7.0.2))
+        version: 0.2.57(ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2))
       prool:
         specifier: 'catalog:'
         version: 0.2.13(@pimlico/alto@0.0.18(supports-color@8.1.1)(typescript@7.0.2))(debug@4.4.3(supports-color@8.1.1))(testcontainers@11.10.0(supports-color@8.1.1))
@@ -1346,10 +1347,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@noble/ciphers@1.3.0':
-    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -6029,24 +6026,9 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
-  ox@0.14.29:
-    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  ox@0.14.33:
-    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  ox@1.6.0:
-    resolution: {integrity: sha512-71YfuIEOeNKMEMEhIlrQQHHV07YRnEHsLybCLvPfaDZ0f2oWQp2OGDKSkToXzPDkvOslnw8/usyabwdKc7aBHQ==}
+  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2:
+    resolution: {integrity: sha512-+HB8ktDKiJQrOHJXmCyHIN3fqMYJf547e9WhUXV9HQaVAHbN/Wau89JCI4uTzxdn30/QStDNXkeHDs6qK/ilZw==, tarball: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2}
+    version: 1.6.1
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -6214,6 +6196,7 @@ packages:
 
   permissionless@0.2.57:
     resolution: {integrity: sha512-QrzAoQGYPV/NJ2x5Sj18h7qed6f+kCyQAojrncN091UPiGqHjFNjgdsgreiv8pxlQgF4UcpuJUvsHLpOEBd6cQ==}
+    version: 0.2.57
     peerDependencies:
       ox: ^0.8.0
     peerDependenciesMeta:
@@ -8832,8 +8815,6 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
-  '@noble/ciphers@1.3.0': {}
-
   '@noble/ciphers@2.2.0': {}
 
   '@noble/curves@1.9.1':
@@ -11421,11 +11402,6 @@ snapshots:
       typescript: 5.9.3
       zod: 4.4.3
 
-  abitype@1.3.0(typescript@7.0.2)(zod@3.25.76):
-    optionalDependencies:
-      typescript: 7.0.2
-      zod: 3.25.76
-
   abitype@1.3.0(typescript@7.0.2)(zod@4.4.3):
     optionalDependencies:
       typescript: 7.0.2
@@ -13951,37 +13927,7 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  ox@0.14.29(typescript@7.0.2)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.3.0(typescript@7.0.2)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.14.33(typescript@7.0.2)(zod@4.4.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - zod
-
-  ox@1.6.0(typescript@5.9.3):
+  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@5.9.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 2.2.0
@@ -13996,7 +13942,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  ox@1.6.0(typescript@7.0.2):
+  ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 2.2.0
@@ -14248,11 +14194,11 @@ snapshots:
 
   pend@1.2.0: {}
 
-  permissionless@0.2.57(ox@1.6.0(typescript@7.0.2)):
+  permissionless@0.2.57(ox@https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)):
     dependencies:
       viem: 'link:'
     optionalDependencies:
-      ox: 1.6.0(typescript@7.0.2)
+      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
 
   pg-int8@1.0.1: {}
 
@@ -15676,7 +15622,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.1)
-      ox: 0.14.29(typescript@7.0.2)(zod@3.25.76)
+      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
       ws: 8.21.1
     optionalDependencies:
       typescript: 7.0.2
@@ -15693,7 +15639,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@7.0.2)(zod@4.4.3)
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.33(typescript@7.0.2)(zod@4.4.3)
+      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
       ws: 8.21.0
     optionalDependencies:
       typescript: 7.0.2
@@ -15705,7 +15651,7 @@ snapshots:
   viem@file:(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       abitype: 1.3.0(typescript@5.9.3)(zod@4.4.3)
-      ox: 1.6.0(typescript@5.9.3)
+      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15714,7 +15660,7 @@ snapshots:
   viem@file:(typescript@7.0.2)(zod@4.4.3):
     dependencies:
       abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
-      ox: 1.6.0(typescript@7.0.2)
+      ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ autoInstallPeers: false
 enablePrePostScripts: true
 
 overrides:
+  ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
   '@arethetypeswrong/core>typescript': '^5.9.3'
   '@babel/core': '>=7.29.6 <8'
   '@opentelemetry/api@^1.8.0': '~1.7.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,6 @@ autoInstallPeers: false
 enablePrePostScripts: true
 
 overrides:
-  ox: https://pkg.pr.new/ox@8100dbf8d4835d27b241d0078616e8852b2a77f2
   '@arethetypeswrong/core>typescript': '^5.9.3'
   '@babel/core': '>=7.29.6 <8'
   '@opentelemetry/api@^1.8.0': '~1.7.0'

--- a/src/tempo/actions/zone/integration.test.ts
+++ b/src/tempo/actions/zone/integration.test.ts
@@ -11,6 +11,7 @@ import {
   Secp256k1,
   Value,
 } from 'ox'
+import { WithdrawalSenderTag } from 'ox/tempo'
 import { Actions as CoreActions } from 'viem'
 import { Account, Abis, Actions } from 'viem/tempo'
 import { Abis as ZoneAbis } from 'viem/tempo/zones'
@@ -264,6 +265,23 @@ describe.skipIf(Boolean(process.env.OFFLINE))('local zone', () => {
           hash: withdrawalHash,
         }).receipt,
       ).resolves.toMatchObject({ status: 'success' })
+
+      const withdrawal = await Actions.zone.requestWithdrawalSync(zoneClient, {
+        amount: 10_000n,
+        token,
+      })
+      expect(withdrawal.receipt.status).toBe('success')
+      const { args } = Actions.zone.requestWithdrawal.extractEvent(
+        withdrawal.receipt.logs,
+      )
+      expect(args.fallbackNonce).toBeGreaterThan(0n)
+      expect(withdrawal.senderTag).toBe(
+        WithdrawalSenderTag.from({
+          fallbackNonce: args.fallbackNonce,
+          sender: args.sender,
+          transactionHash: withdrawal.receipt.transactionHash,
+        }),
+      )
 
       const { publicKey } = Secp256k1.createKeyPair()
       const revealTo = PublicKey.toHex(PublicKey.compress(publicKey))

--- a/src/tempo/actions/zone/integration.test.ts
+++ b/src/tempo/actions/zone/integration.test.ts
@@ -22,6 +22,11 @@ const account = parentClient.account
 const zoneAdmin = Account.fromSecp256k1(tempo.zoneAdminKey)
 const zoneAdminClient = tempo.getClient({ account: zoneAdmin })
 const zoneClient = tempoZone.getClient({ account })
+// Zone clients initially use Tempo API in practice, which provides unredacted Zone RPC access.
+const unredactedZoneClient = tempoZone.getClient({
+  account,
+  rpcUrl: tempoZone.unredactedRpcUrl,
+})
 const hardfork = process.env.VITE_TEMPO_HARDFORK
 const legacyZoneCallback =
   hardfork === 'T7' || hardfork === 'T8' || hardfork === 'T9'
@@ -266,10 +271,13 @@ describe.skipIf(Boolean(process.env.OFFLINE))('local zone', () => {
         }).receipt,
       ).resolves.toMatchObject({ status: 'success' })
 
-      const withdrawal = await Actions.zone.requestWithdrawalSync(zoneClient, {
-        amount: 10_000n,
-        token,
-      })
+      const withdrawal = await Actions.zone.requestWithdrawalSync(
+        unredactedZoneClient,
+        {
+          amount: 10_000n,
+          token,
+        },
+      )
       expect(withdrawal.receipt.status).toBe('success')
       const { args } = Actions.zone.requestWithdrawal.extractEvent(
         withdrawal.receipt.logs,

--- a/src/tempo/actions/zone/requestWithdrawal.test.ts
+++ b/src/tempo/actions/zone/requestWithdrawal.test.ts
@@ -1,5 +1,4 @@
 import * as tempo from '~test/tempo.js'
-import { WithdrawalSenderTag } from 'ox/tempo'
 import { expect, test } from 'vitest'
 
 import { Account, Client, http } from 'viem/tempo'
@@ -151,19 +150,6 @@ test('behavior: sends withdrawals', async () => {
       token: tempo.pathUsd,
     }),
   ).resolves.toMatch(/^0x[\da-f]{64}$/)
-
-  const { receipt, senderTag } = await requestWithdrawalSync(client, {
-    amount: 0n,
-    gas: 1_000_000n,
-    token: tempo.pathUsd,
-  })
-  expect(receipt.status).toMatchInlineSnapshot('"success"')
-  expect(senderTag).toBe(
-    WithdrawalSenderTag.from({
-      sender: account.address,
-      transactionHash: receipt.transactionHash,
-    }),
-  )
 })
 
 test('error: no account', async () => {

--- a/src/tempo/actions/zone/requestWithdrawal.ts
+++ b/src/tempo/actions/zone/requestWithdrawal.ts
@@ -1,4 +1,4 @@
-import type { Address, Errors, Hex } from 'ox'
+import { AbiEvent, type Address, type Errors, type Hex, type Log } from 'ox'
 
 import type * as Account from '../../../core/Account.js'
 import type * as Chain from '../../../core/Chain.js'
@@ -137,6 +137,16 @@ export namespace requestWithdrawal {
         ],
       }),
     ] as const
+  }
+
+  /** Extracts the `WithdrawalRequested` event from logs. */
+  export function extractEvent(logs: readonly Log.Log[]) {
+    const [log] = AbiEvent.extractLogs(ZoneAbis.zoneOutbox, logs, {
+      eventName: 'WithdrawalRequested',
+      strict: true,
+    })
+    if (!log) throw new Error('`WithdrawalRequested` event not found.')
+    return log
   }
 
   /** Prepares a withdrawal transaction request without broadcasting it. */

--- a/src/tempo/actions/zone/requestWithdrawalSync.ts
+++ b/src/tempo/actions/zone/requestWithdrawalSync.ts
@@ -6,7 +6,7 @@ import type * as Chain from '../../../core/Chain.js'
 import type * as Client from '../../../core/Client.js'
 import { sendSync } from '../../../core/actions/transaction/sendSync.js'
 import type { WriteSyncParameters } from '../../internal/types.js'
-import { getAccount, getAddress, type ReceiptReturn } from './internal.js'
+import type { ReceiptReturn } from './internal.js'
 import { requestWithdrawal } from './requestWithdrawal.js'
 
 /**
@@ -43,11 +43,12 @@ export async function requestWithdrawalSync<
     ...options,
     throwOnReceiptRevert,
   })
-  const account = getAccount(options.account ?? client.account)
+  const { args } = requestWithdrawal.extractEvent(receipt.logs)
   return {
     receipt,
     senderTag: WithdrawalSenderTag.from({
-      sender: getAddress(account),
+      fallbackNonce: args.fallbackNonce,
+      sender: args.sender,
       transactionHash: receipt.transactionHash,
     }),
   }

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -54,3 +54,14 @@ test('zonePortal decodes withdrawal events', () => {
     callbackSuccess: boolean
   }>()
 })
+
+test('zoneOutbox decodes withdrawal events', () => {
+  const event = AbiEvent.fromAbi(Abis.zoneOutbox, 'WithdrawalRequested')
+  const decoded = AbiEvent.decode(event, {
+    topics: [AbiEvent.getSelector(event), zeroHash, zeroHash],
+    data: `${zeroHash}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}${zeroHash.slice(2)}`,
+  })
+
+  expectTypeOf(decoded.fallbackNonce).toEqualTypeOf<bigint>()
+  expectTypeOf(decoded.sender).toEqualTypeOf<Address.Address>()
+})

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -168,6 +168,23 @@ export const zonePortal = [
 /** Zone outbox contract ABI. */
 export const zoneOutbox = [
   {
+    name: 'WithdrawalRequested',
+    type: 'event',
+    inputs: [
+      { name: 'withdrawalIndex', type: 'uint64', indexed: true },
+      { name: 'sender', type: 'address', indexed: true },
+      { name: 'token', type: 'address', indexed: false },
+      { name: 'to', type: 'address', indexed: false },
+      { name: 'amount', type: 'uint128', indexed: false },
+      { name: 'fee', type: 'uint128', indexed: false },
+      { name: 'memo', type: 'bytes32', indexed: false },
+      { name: 'gasLimit', type: 'uint64', indexed: false },
+      { name: 'fallbackNonce', type: 'uint64', indexed: false },
+      { name: 'data', type: 'bytes', indexed: false },
+      { name: 'revealTo', type: 'bytes', indexed: false },
+    ],
+  },
+  {
     name: 'requestWithdrawal',
     type: 'function',
     stateMutability: 'nonpayable',

--- a/test/src/tempoZone.ts
+++ b/test/src/tempoZone.ts
@@ -17,6 +17,9 @@ export const factoryAddress = runtime?.factoryAddress
 /** Runtime zone portal address. */
 export const portalAddress = runtime?.portalAddress
 
+/** Runtime unredacted zone RPC URL. */
+export const unredactedRpcUrl = runtime?.rpcUrl ?? 'http://127.0.0.1:0'
+
 /** Runtime zone chain. */
 export const chain = Chain.from({
   ...tempoLocalnet,
@@ -40,7 +43,7 @@ export function getClient(options: getClient.Options = {}) {
     account: options.account,
     chain,
     pollingInterval: 100,
-    transport: http(),
+    transport: http(options.rpcUrl),
   })
 }
 
@@ -49,5 +52,7 @@ export namespace getClient {
   export type Options = {
     /** Account for the Client. */
     account?: Account.Account | Address.Address | undefined
+    /** RPC URL for the Client. Defaults to the authenticated, redacted RPC. */
+    rpcUrl?: string | undefined
   }
 }


### PR DESCRIPTION
## Summary

Updated Viem v3’s Zone withdrawal flow to derive sender tags with the fallback nonce emitted in the Zone receipt, using Ox’s existing `WithdrawalSenderTag` utility.

## Motivation

Zone user withdrawals hash `sender || transactionHash || fallbackNonce`. The previous two-field call returned a tag that could not locate the parent-chain `WithdrawalProcessed` event.

The implementation follows [`Withdrawal::sender_tag`](https://github.com/tempoxyz/zones/blob/689ffbe34fd9f149965a3297a8915f097e7e6029/crates/contracts/src/precompiles/zone_portal.rs#L469-L505) and the [`WithdrawalRequested`](https://github.com/tempoxyz/zones/blob/689ffbe34fd9f149965a3297a8915f097e7e6029/crates/contracts/src/precompiles/outbox.rs#L29-L43) event.

## Changes

- Added `WithdrawalRequested` to the Zone Outbox ABI.
- Added an event extractor to `requestWithdrawal`.
- Passed the emitted `sender` and `fallbackNonce` to Ox’s `WithdrawalSenderTag.from`.
- Used the unredacted Zone RPC for the integration withdrawal receipt while retaining the authenticated, redacted client for private reads.
- Updated Ox to `1.6.2` and removed the commit-scoped preview override.
- Added runtime/type coverage and a patch changeset.

## Testing

- `pnpm check:types` against `ox@1.6.2` (passed).
- `pnpm check` (passed with unrelated existing warnings).
- The focused withdrawal suite against `ox@1.6.2` was attempted, but the Tempo fixture timed out before importing the test file.
- The local Zone integration reached setup but timed out importing a Tempo block before the withdrawal assertion; an exact T10-image rerun was blocked during Docker image setup by a local digest-cache error.