### PR TITLE
docs: remove nonexistent getAccount import in recoverTypedDataAddress example

### DIFF
--- a/site/pages/docs/utilities/recoverTypedDataAddress.md
+++ b/site/pages/docs/utilities/recoverTypedDataAddress.md
@@ -69,7 +69,7 @@ export const types = {
 ```
 
 ```ts [client.ts]
-import { createWalletClient, custom, getAccount } from 'viem'
+import { createWalletClient, custom } from 'viem'
 
 export const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 


### PR DESCRIPTION
The `recoverTypedDataAddress` example imports `getAccount` from `viem`, but `viem` does not export `getAccount` (it was removed in v1), so this import fails to resolve. It is also unused in the snippet: the account is a hardcoded address string and the wallet client is built from `createWalletClient` + `custom` only.

Removed `getAccount` from the import so the example compiles.
