### PR TITLE
fix: repair dependency audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,8 @@ overrides:
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
   micromatch@<4.0.8: ^4.0.8
   minimatch: '>=10.2.3'
-  nanoid@>=4.0.0 <5.0.9: 5.0.9
+  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=4.0.0 <5.1.16: 5.1.16
   next@>=15.6.0-canary.0 <16.1.5: '>=16.1.5'
   next@>=16.0.0-beta.0 <16.1.5: '>=16.1.5'
   on-headers@<1.1.0: 1.1.0
@@ -81,7 +82,7 @@ overrides:
   ws@>=7.0.0 <7.5.10: ^7.5.10
   ws@>=8.0.0 <8.21.0: ^8.21.0
   yauzl@<3.2.1: 3.2.1
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   js-yaml@>=5.0.0 <=5.2.0: 5.2.1
   '@changesets/read>@changesets/parse': 0.4.3
   '@manypkg/get-packages>read-yaml-file': 2.1.0
@@ -4836,8 +4837,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5391,23 +5392,13 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.0.9:
-    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanoid@5.1.16:
     resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -7622,7 +7613,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -9624,7 +9615,7 @@ snapshots:
 
   '@size-limit/webpack@11.2.0(size-limit@11.2.0)':
     dependencies:
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       size-limit: 11.2.0
       webpack: 5.104.1
     transitivePeerDependencies:
@@ -10761,7 +10752,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -11054,7 +11045,7 @@ snapshots:
       '@sitespeed.io/tracium': 0.3.3
       commander: 12.1.0
       find-chrome-bin: 2.0.2
-      nanoid: 5.0.9
+      nanoid: 5.1.16
       puppeteer-core: 22.6.5
     transitivePeerDependencies:
       - bare-buffer
@@ -11921,7 +11912,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -11967,7 +11958,7 @@ snapshots:
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimist: 1.2.8
       oxc-resolver: 11.8.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.2)
       picocolors: 1.1.1
@@ -12734,13 +12725,9 @@ snapshots:
   nan@2.24.0:
     optional: true
 
-  nanoid@3.3.16: {}
-
-  nanoid@5.0.9: {}
+  nanoid@3.3.17: {}
 
   nanoid@5.1.16: {}
-
-  nanoid@5.1.6: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -13206,7 +13193,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13346,7 +13333,7 @@ snapshots:
       aria-hidden: 1.2.6
       defu: 6.1.7
       fast-deep-equal: 3.1.3
-      nanoid: 5.0.9
+      nanoid: 5.1.16
       vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -13395,7 +13382,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       strip-bom: 4.0.0
 
   readable-stream@2.3.8:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,12 @@ enablePrePostScripts: true
 provenance: true
 strictPeerDependencies: false
 
+auditConfig:
+  ignoreGhsas:
+    # image-size has no patched release.
+    - GHSA-5p2g-fcmc-qvqq
+    - GHSA-w3rx-r6r6-pgpr
+
 overrides:
   typescript: ^5.9.3
   '@opentelemetry/api@^1.8.0': ~1.7.0
@@ -79,7 +85,8 @@ overrides:
   mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
   micromatch@<4.0.8: ^4.0.8
   minimatch: '>=10.2.3'
-  nanoid@>=4.0.0 <5.0.9: 5.0.9
+  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=4.0.0 <5.1.16: 5.1.16
   next@>=15.6.0-canary.0 <16.1.5: '>=16.1.5'
   next@>=16.0.0-beta.0 <16.1.5: '>=16.1.5'
   on-headers@<1.1.0: 1.1.0
@@ -102,7 +109,7 @@ overrides:
   ws@>=7.0.0 <7.5.10: ^7.5.10
   ws@>=8.0.0 <8.21.0: ^8.21.0
   yauzl@<3.2.1: 3.2.1
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   js-yaml@>=5.0.0 <=5.2.0: 5.2.1
   '@changesets/read>@changesets/parse': 0.4.3
   '@manypkg/get-packages>read-yaml-file': 2.1.0


### PR DESCRIPTION
Updates transitive dependency overrides and lockfile resolutions for newly disclosed `js-yaml` and `nanoid` advisories. Temporarily ignores two `image-size` advisories because no patched release is available.