### PR TITLE
test: update sepolia fork fallback

### DIFF
--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -30,7 +30,10 @@ export const anvilMainnet = defineAnvil({
 
 export const anvilSepolia = defineAnvil({
   chain: sepolia,
-  forkUrl: getEnv('VITE_ANVIL_FORK_URL_SEPOLIA', 'https://sepolia.drpc.org'),
+  forkUrl: getEnv(
+    'VITE_ANVIL_FORK_URL_SEPOLIA',
+    'https://rpc.sepolia.ethpandaops.io',
+  ),
   forkBlockNumber: 5858117n,
   noMining: true,
   port: 8845,


### PR DESCRIPTION
Updates the Sepolia Anvil fork fallback to a Chainlist-listed archive RPC. The previous dRPC free endpoint rejects historical proofs, causing cross-chain authorization fixture setup to fail.