### PR TITLE
feat(chains): add CashCat Chain

### DIFF
--- a/.changeset/add-cashcat-chain.md
+++ b/.changeset/add-cashcat-chain.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added CashCat Chain.

--- a/src/chains/definitions/cashcat.ts
+++ b/src/chains/definitions/cashcat.ts
@@ -1,0 +1,21 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const cashcat = /*#__PURE__*/ defineChain({
+  id: 2_274_228,
+  name: 'CashCat Chain',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Cash Cat',
+    symbol: 'CASHCAT',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.cashcat.network'] },
+  },
+  blockExplorers: {
+    default: {
+      name: 'CashCat Explorer',
+      url: 'https://explorer.cashcat.network',
+      apiUrl: 'https://explorer.cashcat.network/api',
+    },
+  },
+})

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -108,6 +108,7 @@ export { bxn } from './definitions/bxn.js'
 export { bxnTestnet } from './definitions/bxnTestnet.js'
 export { cannon } from './definitions/cannon.js'
 export { canto } from './definitions/canto.js'
+export { cashcat } from './definitions/cashcat.js'
 export { celo } from './definitions/celo.js'
 /** @deprecated use `celoSepolia` instead */
 export { celoAlfajores } from './definitions/celoAlfajores.js'


### PR DESCRIPTION
Adds CashCat Chain (id 2274228), an Arbitrum Orbit L3 that settles to Robinhood Chain and uses CASHCAT as its native gas token.

- **Name:** CashCat Chain
- **id:** 2274228
- **Native currency:** Cash Cat (CASHCAT), 18 decimals
- **RPC:** https://rpc.cashcat.network
- **Block explorer:** https://explorer.cashcat.network (Blockscout, EIP-3091)

Changes:
- Added `src/chains/definitions/cashcat.ts`
- Exported `cashcat` from `src/chains/index.ts` (alphabetical order, between `canto` and `celo`)
- Added a changeset

multicall3 is not deployed on this chain, so no `contracts` entry is included.