### PR TITLE
fix(test): unpin sepolia fork block

### DIFF
--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -34,7 +34,7 @@ export const anvilSepolia = defineAnvil({
     'VITE_ANVIL_FORK_URL_SEPOLIA',
     'https://rpc.sepolia.ethpandaops.io',
   ),
-  forkBlockNumber: 10_000_000n,
+  forkBlockNumber: undefined,
   noMining: true,
   port: 8845,
 })
@@ -72,20 +72,23 @@ function getEnv(key: string, fallback: string): string {
   return fallback
 }
 
-type DefineAnvilParameters<chain extends Chain> = Omit<
-  Instance.anvil.Parameters,
-  'forkBlockNumber' | 'forkUrl'
-> & {
+type DefineAnvilParameters<
+  chain extends Chain,
+  forkBlockNumber extends bigint | undefined = bigint,
+> = Omit<Instance.anvil.Parameters, 'forkBlockNumber' | 'forkUrl'> & {
   chain: chain
-  forkBlockNumber: bigint
+  forkBlockNumber: forkBlockNumber
   forkUrl: string
   port: number
 }
 
-type DefineAnvilReturnType<chain extends Chain> = {
+type DefineAnvilReturnType<
+  chain extends Chain,
+  forkBlockNumber extends bigint | undefined = bigint,
+> = {
   chain: chain
   clientConfig: ClientConfig<Transport, chain, undefined>
-  forkBlockNumber: bigint
+  forkBlockNumber: forkBlockNumber
   forkUrl: string
   getClient<
     config extends ExactPartial<
@@ -120,9 +123,12 @@ type DefineAnvilReturnType<chain extends Chain> = {
   start(): Promise<() => Promise<void>>
 }
 
-function defineAnvil<const chain extends Chain>(
-  parameters: DefineAnvilParameters<chain>,
-): DefineAnvilReturnType<chain> {
+function defineAnvil<
+  const chain extends Chain,
+  const forkBlockNumber extends bigint | undefined,
+>(
+  parameters: DefineAnvilParameters<chain, forkBlockNumber>,
+): DefineAnvilReturnType<chain, forkBlockNumber> {
   const {
     chain: chain_,
     forkUrl,


### PR DESCRIPTION
Forks Sepolia test instances at the provider head so local state mutations no longer require historical proofs. Follow-up to https://github.com/wevm/viem/pull/4992.