### PR TITLE
fix(test): use public sepolia rpc

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -129,7 +129,6 @@ jobs:
           VITE_ANVIL_FORK_URL: ${{ secrets.VITE_ANVIL_FORK_URL }}
           VITE_ANVIL_FORK_URL_OPTIMISM: ${{ secrets.VITE_ANVIL_FORK_URL_OPTIMISM }}
           VITE_ANVIL_FORK_URL_OPTIMISM_SEPOLIA: ${{ secrets.VITE_ANVIL_FORK_URL_OPTIMISM_SEPOLIA }}
-          VITE_ANVIL_FORK_URL_SEPOLIA: ${{ secrets.VITE_ANVIL_FORK_URL_SEPOLIA }}
           VITE_ANVIL_FORK_URL_ZKSYNC: ${{ secrets.VITE_ANVIL_FORK_URL_ZKSYNC }}
           VITE_BATCH_MULTICALL: ${{ matrix.multicall }}
           VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}

--- a/test/src/anvil.ts
+++ b/test/src/anvil.ts
@@ -34,7 +34,7 @@ export const anvilSepolia = defineAnvil({
     'VITE_ANVIL_FORK_URL_SEPOLIA',
     'https://rpc.sepolia.ethpandaops.io',
   ),
-  forkBlockNumber: undefined,
+  forkBlockNumber: 10_000_000n,
   noMining: true,
   port: 8845,
 })
@@ -72,23 +72,20 @@ function getEnv(key: string, fallback: string): string {
   return fallback
 }
 
-type DefineAnvilParameters<
-  chain extends Chain,
-  forkBlockNumber extends bigint | undefined = bigint,
-> = Omit<Instance.anvil.Parameters, 'forkBlockNumber' | 'forkUrl'> & {
+type DefineAnvilParameters<chain extends Chain> = Omit<
+  Instance.anvil.Parameters,
+  'forkBlockNumber' | 'forkUrl'
+> & {
   chain: chain
-  forkBlockNumber: forkBlockNumber
+  forkBlockNumber: bigint
   forkUrl: string
   port: number
 }
 
-type DefineAnvilReturnType<
-  chain extends Chain,
-  forkBlockNumber extends bigint | undefined = bigint,
-> = {
+type DefineAnvilReturnType<chain extends Chain> = {
   chain: chain
   clientConfig: ClientConfig<Transport, chain, undefined>
-  forkBlockNumber: forkBlockNumber
+  forkBlockNumber: bigint
   forkUrl: string
   getClient<
     config extends ExactPartial<
@@ -123,12 +120,9 @@ type DefineAnvilReturnType<
   start(): Promise<() => Promise<void>>
 }
 
-function defineAnvil<
-  const chain extends Chain,
-  const forkBlockNumber extends bigint | undefined,
->(
-  parameters: DefineAnvilParameters<chain, forkBlockNumber>,
-): DefineAnvilReturnType<chain, forkBlockNumber> {
+function defineAnvil<const chain extends Chain>(
+  parameters: DefineAnvilParameters<chain>,
+): DefineAnvilReturnType<chain> {
   const {
     chain: chain_,
     forkUrl,


### PR DESCRIPTION
Uses the public ethPandaOps Sepolia endpoint for local CI tests, which supports Anvil proof requests, and restores the pinned fixture types removed by the previous workaround.