### PR TITLE
Bind encrypted Zone deposits to sender

### DIFF
--- a/.changeset/fuzzy-zones-bind.md
+++ b/.changeset/fuzzy-zones-bind.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Bound encrypted Zone deposits to the parent-chain portal caller.

--- a/site/pages/tempo/actions/zone.encryptedDeposit.mdx
+++ b/site/pages/tempo/actions/zone.encryptedDeposit.mdx
@@ -53,7 +53,7 @@ const receipt = await client.waitForTransactionReceipt({ hash })
 Use `zone.encryptedDeposit.prepare` when one party should choose the private zone recipient, but another party will submit the parent-chain deposit transaction.
 
 :::warning
-Prepared encrypted deposits contain public transaction intent. If you receive a prepared payload from another party, validate `chainId`, `zoneId`, `portalAddress`, `token`, and `amount` before passing it to `zone.encryptedDeposit`.
+Prepared encrypted deposits contain public transaction intent. If you receive a prepared payload from another party, validate `chainId`, `zoneId`, `portalAddress`, `sender`, `token`, and `amount` before passing it to `zone.encryptedDeposit`. The sender must match the account that calls the Zone portal.
 :::
 
 :::code-group
@@ -65,6 +65,7 @@ import { broadcaster, client } from './viem.config'
 const prepared = await client.zone.encryptedDeposit.prepare({
   amount: parseUnits('100', 6),
   recipient: '0x0000000000000000000000000000000000000001',
+  sender: broadcaster.account.address,
   token: '0x20c0000000000000000000000000000000000001',
   zoneId: 7,
 })
@@ -90,6 +91,7 @@ import { client } from './viem.config'
 const { encrypted, keyIndex } =
   await client.zone.encryptedDeposit.prepareRecipient({
     recipient: '0x0000000000000000000000000000000000000001',
+    sender: '0x0000000000000000000000000000000000000002',
     zoneId: 7,
   })
 ```

--- a/site/pages/tempo/guides/earn/zones.mdx
+++ b/site/pages/tempo/guides/earn/zones.mdx
@@ -337,6 +337,7 @@ const encrypted = await parentClient.zone.encryptedDeposit.prepare({
   amount: earnShareAmount,
   bouncebackRecipient: parentClient.account.address,
   recipient: zoneClient.account.address,
+  sender: parentClient.account.address,
   token: vault.shareToken,
   zoneId,
 })

--- a/src/tempo/actions/earn.ts
+++ b/src/tempo/actions/earn.ts
@@ -1051,6 +1051,7 @@ export namespace privateDeposit {
         memo: returnMemo,
         portalAddress: config.zonePortal,
         recipient,
+        sender: gateway,
         zoneId: config.zoneId,
       })
     const shareAmountMin = resolveMinimumShareAmount(parameters)
@@ -2429,6 +2430,7 @@ export namespace privateRedeem {
         memo: returnMemo,
         portalAddress: config.zonePortal,
         recipient,
+        sender: gateway,
         zoneId: config.zoneId,
       }),
       (async () => {

--- a/src/tempo/actions/zone.test-d.ts
+++ b/src/tempo/actions/zone.test-d.ts
@@ -33,6 +33,7 @@ test('encryptedDeposit.prepare returns a reusable encrypted deposit payload', as
     amount: 1n,
     bouncebackRecipient: '0x0000000000000000000000000000000000000001',
     recipient: '0x0000000000000000000000000000000000000001',
+    sender: '0x0000000000000000000000000000000000000001',
     zoneId: 7,
   })
 
@@ -52,6 +53,7 @@ test('encryptedDeposit.prepareRecipient returns reusable encrypted recipient dat
   const prepared = await zoneActions.encryptedDeposit.prepareRecipient(client, {
     portalAddress: '0x0000000000000000000000000000000000000002',
     recipient: '0x0000000000000000000000000000000000000001',
+    sender: '0x0000000000000000000000000000000000000001',
     zoneId: 7,
   })
 

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -89,6 +89,7 @@ const preparedEncryptedDeposit = {
   },
   keyIndex: 0n,
   portalAddress,
+  sender: account.address,
   token: '0x20c0000000000000000000000000000000000000',
   zoneId,
 } satisfies zoneActions.PreparedEncryptedDeposit
@@ -96,6 +97,7 @@ const prepareEncryptedDepositParameters = {
   amount: parseUnits('1', 6),
   bouncebackRecipient: account.address,
   recipient: account.address,
+  sender: account.address,
   token: parentToken,
   zoneId: 7,
 } as const
@@ -584,6 +586,7 @@ describe('encryptedDeposit', () => {
       {
         portalAddress,
         recipient: account.address,
+        sender: account.address,
         zoneId,
       },
     )

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -81,6 +81,8 @@ export type PreparedEncryptedDeposit = {
   keyIndex: bigint
   /** Zone portal address on the parent chain. */
   portalAddress: Address
+  /** Address that will call the Zone portal. */
+  sender: Address
   /** Token address or ID to deposit. */
   token: TokenId.TokenIdOrAddress
   /** Zone ID (e.g. `7`). */
@@ -96,6 +98,8 @@ export type PreparedEncryptedDepositRecipient = {
   keyIndex: bigint
   /** Zone portal address on the parent chain. */
   portalAddress: Address
+  /** Address that will call the Zone portal. */
+  sender: Address
   /** Zone ID (e.g. `7`). */
   zoneId: number
 }
@@ -494,6 +498,7 @@ export async function encryptedDeposit<
     memo: parameters.memo,
     portalAddress: parameters.portalAddress,
     recipient,
+    sender: account_.address,
     token: parameters.token,
     zoneId: parameters.zoneId,
   })
@@ -573,6 +578,7 @@ export namespace encryptedDeposit {
    *   amount: 1_000_000n,
    *   bouncebackRecipient: '0x...',
    *   recipient: '0x...',
+   *   sender: '0x...',
    *   zoneId: 7,
    * })
    * ```
@@ -597,6 +603,7 @@ export namespace encryptedDeposit {
       memo,
       portalAddress: portalAddress_,
       recipient,
+      sender,
       token,
       zoneId,
       ...rest
@@ -612,6 +619,7 @@ export namespace encryptedDeposit {
     const encrypted = await encryptDepositPayload(
       publicKey,
       recipient,
+      sender,
       portalAddress,
       keyIndex,
       memo,
@@ -624,6 +632,7 @@ export namespace encryptedDeposit {
       encrypted,
       keyIndex,
       portalAddress,
+      sender,
       token,
       zoneId,
     }
@@ -643,6 +652,8 @@ export namespace encryptedDeposit {
       portalAddress?: Address | undefined
       /** Recipient address in the zone. */
       recipient: Address
+      /** Address that will call the Zone portal. */
+      sender: Address
       /** Token address or ID to deposit. */
       token: TokenId.TokenIdOrAddress
       /** Zone ID (e.g. `7`). */
@@ -674,6 +685,7 @@ export namespace encryptedDeposit {
    *
    * const recipient = await Actions.zone.encryptedDeposit.prepareRecipient(client, {
    *   recipient: '0x...',
+   *   sender: '0x...',
    *   zoneId: 7,
    * })
    * ```
@@ -696,6 +708,7 @@ export namespace encryptedDeposit {
       memo,
       portalAddress: portalAddress_,
       recipient,
+      sender,
       zoneId,
       ...rest
     } = parameters
@@ -708,6 +721,7 @@ export namespace encryptedDeposit {
     const encrypted = await encryptDepositPayload(
       publicKey,
       recipient,
+      sender,
       portalAddress,
       keyIndex,
       memo,
@@ -718,6 +732,7 @@ export namespace encryptedDeposit {
       encrypted,
       keyIndex,
       portalAddress,
+      sender,
       zoneId,
     }
   }
@@ -732,6 +747,8 @@ export namespace encryptedDeposit {
       portalAddress?: Address | undefined
       /** Recipient address in the zone. */
       recipient: Address
+      /** Address that will call the Zone portal. */
+      sender: Address
       /** Zone ID (e.g. `7`). */
       zoneId: number
     }
@@ -864,6 +881,7 @@ export async function encryptedDepositSync<
     memo: parameters.memo,
     portalAddress: parameters.portalAddress,
     recipient,
+    sender: account_.address,
     token: parameters.token,
     zoneId: parameters.zoneId,
   })
@@ -1883,6 +1901,7 @@ export namespace signAuthorizationToken {
 async function encryptDepositPayload(
   publicKey: { prefix: 2 | 3; x: Hex.Hex },
   recipient: Address,
+  sender: Address,
   portalAddress: Address,
   keyIndex: bigint,
   memo: Hex.Hex = zeroHash,
@@ -1918,6 +1937,7 @@ async function encryptDepositPayload(
         portalAddress,
         keyIndex,
         Hex.fromNumber(compressedEphemeral.x, { size: 32 }),
+        sender,
       ) as BufferSource,
     },
     hkdfKey,
@@ -1961,11 +1981,13 @@ function buildDepositHkdfInfo(
   portalAddress: Address,
   keyIndex: bigint,
   ephemeralPubkeyX: Hex.Hex,
+  sender: Address,
 ): Bytes.Bytes {
   return Bytes.concat(
     Bytes.from(portalAddress),
     Bytes.fromNumber(keyIndex, { size: 32 }),
     Bytes.from(ephemeralPubkeyX),
+    Bytes.from(sender),
   )
 }
 

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -45,6 +45,7 @@ describe.runIf(nodeEnv === 'testnet')('zone.encryptedDeposit.prepare', () => {
       amount: 1n,
       bouncebackRecipient: accounts[0].address,
       recipient: accounts[0].address,
+      sender: accounts[0].address,
       memo: Hex.fromNumber(1n, { size: 32 }),
       zoneId: 7,
     })


### PR DESCRIPTION
## Summary

- bind encrypted Zone deposit payloads to the parent-chain portal caller
- require callers to provide the sender when preparing reusable encrypted payloads
- pass the Earn gateway as the sender for viem Earn actions

## Motivation

[tempoxyz/zones#1028](https://github.com/tempoxyz/zones/pull/1028) binds encrypted-deposit HKDF input to the authenticated parent-chain sender. Viem must include that sender so payloads produced by `encryptedDeposit` and `prepareRecipient` remain valid.

## Dependencies

- Required by [tempoxyz/earn#203](https://github.com/tempoxyz/earn/pull/203)
- Required by [tempoxyz/docs#802](https://github.com/tempoxyz/docs/pull/802)
- Required by [wevm/wagmi#5222](https://github.com/wevm/wagmi/pull/5222)

## Validation

- `pnpm exec biome check` on changed TypeScript files
- `pnpm check:types` reached repository-wide generated-contract imports; generation was blocked because SSH submodules are unavailable in this sandbox

Prompted by: @0xrusowsky