### PR TITLE
feat: add block header watcher

### DIFF
--- a/.changeset/swift-heads-arrive.md
+++ b/.changeset/swift-heads-arrive.md
@@ -1,0 +1,9 @@
+---
+"viem": patch
+---
+
+Added `watchBlockHeaders` for emitting formatted subscription headers without refetching full blocks.
+
+```ts
+watchBlockHeaders(client, { onBlockHeader })
+```

--- a/site/pages/docs/actions/public/watchBlockHeaders.md
+++ b/site/pages/docs/actions/public/watchBlockHeaders.md
@@ -1,0 +1,47 @@
+---
+description: Watches and returns incoming block headers.
+---
+
+# watchBlockHeaders
+
+Watches and returns incoming block headers without fetching full blocks. This Action requires a WebSocket or IPC Client.
+
+## Usage
+
+```ts twoslash
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket(),
+})
+
+const unwatch = publicClient.watchBlockHeaders({
+  onBlockHeader: (blockHeader) => console.log(blockHeader),
+})
+```
+
+## Returns
+
+`UnwatchFn`
+
+A function that can be invoked to stop watching for new block headers.
+
+## Parameters
+
+### onBlockHeader
+
+- **Type:** `(blockHeader: BlockHeader, prevBlockHeader?: BlockHeader) => void`
+
+The incoming block header and the previously emitted block header.
+
+### onError (optional)
+
+- **Type:** `(error: Error) => void`
+
+Error thrown while listening for new block headers.
+
+## JSON-RPC Methods
+
+Uses a WebSocket or IPC subscription via [`eth_subscribe`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_subscribe) and the `"newHeads"` event.

--- a/site/pages/docs/actions/public/watchBlocks.md
+++ b/site/pages/docs/actions/public/watchBlocks.md
@@ -6,6 +6,8 @@ description: Watches and returns information for incoming blocks.
 
 Watches and returns information for incoming blocks.
 
+To receive block headers without fetching full blocks, use [`watchBlockHeaders`](/docs/actions/public/watchBlockHeaders).
+
 ## Usage
 
 Pass through your Public Client, along with a listener.

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -342,6 +342,10 @@ export default defineConfig({
                 link: '/docs/actions/public/watchBlockNumber',
               },
               {
+                text: 'watchBlockHeaders',
+                link: '/docs/actions/public/watchBlockHeaders',
+              },
+              {
                 text: 'watchBlocks',
                 link: '/docs/actions/public/watchBlocks',
               },

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -307,6 +307,15 @@ export {
   waitForTransactionReceipt,
 } from './public/waitForTransactionReceipt.js'
 export {
+  type BlockHeader,
+  type OnBlockHeader,
+  type OnBlockHeaderParameter,
+  type WatchBlockHeadersErrorType,
+  type WatchBlockHeadersParameters,
+  type WatchBlockHeadersReturnType,
+  watchBlockHeaders,
+} from './public/watchBlockHeaders.js'
+export {
   type OnBlockNumberFn,
   type OnBlockNumberParameter,
   type WatchBlockNumberErrorType,

--- a/src/actions/public/watchBlockHeaders.test-d.ts
+++ b/src/actions/public/watchBlockHeaders.test-d.ts
@@ -1,0 +1,47 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { mainnet, zksync } from '../../chains/index.js'
+import { createPublicClient } from '../../clients/createPublicClient.js'
+import { http } from '../../clients/transports/http.js'
+import { webSocket } from '../../clients/transports/webSocket.js'
+import { watchBlockHeaders } from './watchBlockHeaders.js'
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: webSocket(),
+})
+const httpClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+const zksyncClient = createPublicClient({
+  chain: zksync,
+  transport: webSocket(),
+})
+
+test('block header', () => {
+  client.watchBlockHeaders({
+    onBlockHeader(blockHeader) {
+      expectTypeOf(blockHeader.timestamp).toEqualTypeOf<bigint>()
+      // @ts-expect-error Block headers omit full block fields.
+      blockHeader.size
+      // @ts-expect-error Block headers omit full block fields.
+      blockHeader.transactions
+    },
+  })
+})
+
+test('requires a subscription transport', () => {
+  // @ts-expect-error Block headers require a WebSocket or IPC transport.
+  watchBlockHeaders(httpClient, { onBlockHeader() {} })
+  // @ts-expect-error Block headers require a WebSocket or IPC transport.
+  httpClient.watchBlockHeaders({ onBlockHeader() {} })
+})
+
+test('preserves chain formatter fields', () => {
+  zksyncClient.watchBlockHeaders({
+    onBlockHeader(blockHeader) {
+      expectTypeOf(blockHeader.l1BatchNumber).toEqualTypeOf<bigint | null>()
+    },
+  })
+})

--- a/src/actions/public/watchBlockHeaders.test.ts
+++ b/src/actions/public/watchBlockHeaders.test.ts
@@ -1,0 +1,45 @@
+import { expect, test, vi } from 'vitest'
+
+import { anvilMainnet } from '~test/anvil.js'
+import { createClient } from '../../clients/createClient.js'
+import { webSocket } from '../../clients/transports/webSocket.js'
+import { wait } from '../../utils/wait.js'
+import { mine } from '../test/mine.js'
+import * as getBlock from './getBlock.js'
+import {
+  type OnBlockHeaderParameter,
+  watchBlockHeaders,
+} from './watchBlockHeaders.js'
+
+const client = anvilMainnet.getClient()
+const webSocketClient = createClient({
+  ...anvilMainnet.clientConfig,
+  transport: webSocket(),
+})
+
+test('watches for new block headers without fetching blocks', async () => {
+  const blockHeaders: OnBlockHeaderParameter[] = []
+  const prevBlockHeaders: OnBlockHeaderParameter[] = []
+  const getBlock_ = vi.spyOn(getBlock, 'getBlock')
+  const unwatch = watchBlockHeaders(webSocketClient, {
+    onBlockHeader(blockHeader, prevBlockHeader) {
+      blockHeaders.push(blockHeader)
+      if (prevBlockHeader) prevBlockHeaders.push(prevBlockHeader)
+    },
+  })
+  await wait(200)
+  await mine(client, { blocks: 1 })
+  await wait(200)
+  await mine(client, { blocks: 1 })
+  await wait(200)
+  unwatch()
+
+  expect(blockHeaders).toHaveLength(2)
+  expect(prevBlockHeaders).toHaveLength(1)
+  expect(typeof blockHeaders[0].number).toBe('bigint')
+  expect(typeof blockHeaders[0].timestamp).toBe('bigint')
+  expect(blockHeaders[0]).not.toHaveProperty('transactions')
+  expect(blockHeaders[0]).not.toHaveProperty('withdrawals')
+  expect(getBlock_).not.toHaveBeenCalled()
+  getBlock_.mockRestore()
+})

--- a/src/actions/public/watchBlockHeaders.ts
+++ b/src/actions/public/watchBlockHeaders.ts
@@ -1,0 +1,128 @@
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { Chain } from '../../types/chain.js'
+import type { HasTransportType } from '../../types/transport.js'
+import { formatBlock } from '../../utils/formatters/block.js'
+import { observe } from '../../utils/observe.js'
+import { type StringifyErrorType, stringify } from '../../utils/stringify.js'
+
+import type { GetBlockReturnType } from './getBlock.js'
+
+const blockFields = [
+  'size',
+  'totalDifficulty',
+  'transactions',
+  'uncles',
+  'withdrawals',
+] as const
+
+export type BlockHeader<chain extends Chain | undefined = Chain> = Omit<
+  GetBlockReturnType<chain, false, 'latest'>,
+  (typeof blockFields)[number]
+>
+
+export type OnBlockHeaderParameter<chain extends Chain | undefined = Chain> =
+  BlockHeader<chain>
+
+export type OnBlockHeader<chain extends Chain | undefined = Chain> = (
+  blockHeader: OnBlockHeaderParameter<chain>,
+  prevBlockHeader: OnBlockHeaderParameter<chain> | undefined,
+) => void
+
+export type WatchBlockHeadersParameters<
+  chain extends Chain | undefined = Chain,
+> = {
+  /** The callback to call when a new block header is received. */
+  onBlockHeader: OnBlockHeader<chain>
+  /** The callback to call when an error occurs while watching block headers. */
+  onError?: ((error: Error) => void) | undefined
+}
+
+export type WatchBlockHeadersReturnType = () => void
+
+export type WatchBlockHeadersErrorType = StringifyErrorType | ErrorType
+
+/**
+ * Watches and returns incoming block headers.
+ *
+ * - Docs: https://viem.sh/docs/actions/public/watchBlockHeaders
+ * - JSON-RPC Methods: Uses a WebSocket or IPC subscription via [`eth_subscribe`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_subscribe) and the `"newHeads"` event.
+ *
+ * @param client - Client to use
+ * @param parameters - {@link WatchBlockHeadersParameters}
+ * @returns A function that can be invoked to stop watching for new block headers. {@link WatchBlockHeadersReturnType}
+ *
+ * @example
+ * import { createPublicClient, watchBlockHeaders, webSocket } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ *
+ * const client = createPublicClient({
+ *   chain: mainnet,
+ *   transport: webSocket(),
+ * })
+ * const unwatch = watchBlockHeaders(client, {
+ *   onBlockHeader: (blockHeader) => console.log(blockHeader),
+ * })
+ */
+export function watchBlockHeaders<
+  transport extends Transport,
+  chain extends Chain | undefined,
+>(
+  client: Client<transport, chain>,
+  {
+    onBlockHeader,
+    onError,
+  }: HasTransportType<transport, 'webSocket' | 'ipc'> extends true
+    ? WatchBlockHeadersParameters<chain>
+    : never,
+): WatchBlockHeadersReturnType {
+  let prevBlockHeader: OnBlockHeaderParameter<chain> | undefined
+
+  const observerId = stringify(['watchBlockHeaders', client.uid])
+
+  return observe(observerId, { onBlockHeader, onError }, (emit) => {
+    let active = true
+    let unsubscribe = () => (active = false)
+    ;(async () => {
+      try {
+        const transport = (() => {
+          if (client.transport.type === 'fallback') {
+            const transport = client.transport.transports.find(
+              (transport: ReturnType<Transport>) =>
+                transport.config.type === 'webSocket' ||
+                transport.config.type === 'ipc',
+            )
+            if (!transport) return client.transport
+            return transport.value
+          }
+          return client.transport
+        })()
+
+        const { unsubscribe: unsubscribe_ } = await transport.subscribe({
+          params: ['newHeads'],
+          onData(data: any) {
+            if (!active) return
+            const blockHeader = (
+              client.chain?.formatters?.block?.format || formatBlock
+            )(data.result, 'watchBlockHeaders')
+            for (const field of blockFields) delete blockHeader[field]
+            emit.onBlockHeader(
+              blockHeader as OnBlockHeaderParameter<chain>,
+              prevBlockHeader,
+            )
+            prevBlockHeader = blockHeader as OnBlockHeaderParameter<chain>
+          },
+          onError(error: Error) {
+            emit.onError?.(error)
+          },
+        })
+        unsubscribe = unsubscribe_
+        if (!active) unsubscribe()
+      } catch (err) {
+        emit.onError?.(err as Error)
+      }
+    })()
+    return () => unsubscribe()
+  })
+}

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -241,6 +241,11 @@ import {
   waitForTransactionReceipt,
 } from '../../actions/public/waitForTransactionReceipt.js'
 import {
+  type WatchBlockHeadersParameters,
+  type WatchBlockHeadersReturnType,
+  watchBlockHeaders,
+} from '../../actions/public/watchBlockHeaders.js'
+import {
   type WatchBlockNumberParameters,
   type WatchBlockNumberReturnType,
   watchBlockNumber,
@@ -305,6 +310,7 @@ import type {
 } from '../../types/contract.js'
 import type { FeeValuesType } from '../../types/fee.js'
 import type { FilterType } from '../../types/filter.js'
+import type { HasTransportType } from '../../types/transport.js'
 import { bindActionDecorators, type Client } from '../createClient.js'
 import type { Transport } from '../transports/createTransport.js'
 
@@ -1989,6 +1995,32 @@ export type PublicActions<
     args: WatchBlockNumberParameters,
   ) => WatchBlockNumberReturnType
   /**
+   * Watches and returns incoming block headers without fetching full blocks.
+   *
+   * - Docs: https://viem.sh/docs/actions/public/watchBlockHeaders
+   * - JSON-RPC Methods: Uses a WebSocket or IPC subscription via [`eth_subscribe`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_subscribe) and the `"newHeads"` event.
+   *
+   * @param args - {@link WatchBlockHeadersParameters}
+   * @returns A function that can be invoked to stop watching for new block headers. {@link WatchBlockHeadersReturnType}
+   *
+   * @example
+   * import { createPublicClient, webSocket } from 'viem'
+   * import { mainnet } from 'viem/chains'
+   *
+   * const client = createPublicClient({
+   *   chain: mainnet,
+   *   transport: webSocket(),
+   * })
+   * const unwatch = client.watchBlockHeaders({
+   *   onBlockHeader: (blockHeader) => console.log(blockHeader),
+   * })
+   */
+  watchBlockHeaders: (
+    args: HasTransportType<transport, 'webSocket' | 'ipc'> extends true
+      ? WatchBlockHeadersParameters<chain>
+      : never,
+  ) => WatchBlockHeadersReturnType
+  /**
    * Watches and returns information for incoming blocks.
    *
    * - Docs: https://viem.sh/docs/actions/public/watchBlocks
@@ -2337,6 +2369,7 @@ export function publicActions<
     uninstallFilter: (args) => uninstallFilter(client, args),
     waitForTransactionReceipt: (args) =>
       waitForTransactionReceipt(client, args),
+    watchBlockHeaders: (args) => watchBlockHeaders(client, args),
     watchBlocks: (args) => watchBlocks(client, args),
     watchBlockNumber: (args) => watchBlockNumber(client, args),
     watchContractEvent: (args) => watchContractEvent(client, args),

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,6 +321,14 @@ export type {
   WaitForTransactionReceiptReturnType,
 } from './actions/public/waitForTransactionReceipt.js'
 export type {
+  BlockHeader,
+  OnBlockHeader,
+  OnBlockHeaderParameter,
+  WatchBlockHeadersErrorType,
+  WatchBlockHeadersParameters,
+  WatchBlockHeadersReturnType,
+} from './actions/public/watchBlockHeaders.js'
+export type {
   OnBlockNumberFn,
   OnBlockNumberParameter,
   WatchBlockNumberErrorType,


### PR DESCRIPTION
Adds `watchBlockHeaders` to emit formatted `newHeads` payloads without an `eth_getBlockByNumber` round trip. Keeps `watchBlocks` unchanged for full blocks.

Fixes https://github.com/wevm/viem/issues/4998