### PR TITLE
ci: cancel overtaken workflow runs

### DIFF
--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -8,8 +8,8 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: friction-log
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-issue-${{ github.event.issue.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
 jobs:
   issue-labeled:
     if: ${{ github.repository_owner == 'wevm' }}

--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lock-issue:
     if: ${{ github.repository_owner == 'wevm' }}

--- a/.github/workflows/prepublish.yml
+++ b/.github/workflows/prepublish.yml
@@ -2,6 +2,10 @@ name: Prepublish
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('branch-{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) || format('{0}-{1}-{2}', github.ref_type, github.repository, github.ref_name) }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-branch-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: verify-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
Adds branch-scoped concurrency to validation and maintenance workflows so newer runs cancel superseded work. Keeps release publishing non-canceling to avoid interrupting npm and GitHub release side effects.