### PR TITLE
Reject malformed EIP-7702 authorization quantities in the formatter

### DIFF
--- a/.changeset/strict-authorization-quantities.md
+++ b/.changeset/strict-authorization-quantities.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Validated EIP-7702 authorization RPC quantities before formatting them.

--- a/src/utils/formatters/transaction.test.ts
+++ b/src/utils/formatters/transaction.test.ts
@@ -769,6 +769,42 @@ test('nullish values', () => {
   `)
 })
 
+const authorization = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: '0x1',
+  nonce: '0x2',
+  r: '0x1',
+  s: '0x1',
+  yParity: '0x0',
+} as const
+
+test('eip7702 authorization list quantities', () => {
+  expect(
+    formatTransaction({ authorizationList: [authorization] })
+      .authorizationList,
+  ).toEqual([
+    {
+      address: authorization.address,
+      chainId: 1,
+      nonce: 2,
+      r: authorization.r,
+      s: authorization.s,
+      yParity: 0,
+    },
+  ])
+})
+
+test.each(['chainId', 'nonce', 'yParity'] as const)(
+  'invalid eip7702 authorization %s throws',
+  (field) => {
+    expect(() =>
+      formatTransaction({
+        authorizationList: [{ ...authorization, [field]: '' }],
+      } as unknown as Parameters<typeof formatTransaction>[0]),
+    ).toThrow(`Invalid authorization list quantity ""`)
+  },
+)
+
 test('contract deployment transaction', () => {
   expect(
     formatTransaction({

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -10,6 +10,7 @@ import type { Hex } from '../../types/misc.js'
 import type { RpcAuthorizationList, RpcTransaction } from '../../types/rpc.js'
 import type { Transaction, TransactionType } from '../../types/transaction.js'
 import type { ExactPartial, UnionLooseOmit } from '../../types/utils.js'
+import { isHex } from '../data/isHex.js'
 import { hexToNumber } from '../encoding/fromHex.js'
 import { type DefineFormatterErrorType, defineFormatter } from './formatter.js'
 
@@ -132,11 +133,17 @@ function formatAuthorizationList(
   authorizationList: RpcAuthorizationList,
 ): SignedAuthorizationList {
   return authorizationList.map((authorization) => ({
-    address: (authorization as any).address,
-    chainId: Number(authorization.chainId),
-    nonce: Number(authorization.nonce),
+    address: authorization.address,
+    chainId: parseAuthorizationQuantity(authorization.chainId),
+    nonce: parseAuthorizationQuantity(authorization.nonce),
     r: authorization.r,
     s: authorization.s,
-    yParity: Number(authorization.yParity),
+    yParity: parseAuthorizationQuantity(authorization.yParity),
   })) as SignedAuthorizationList
+}
+
+function parseAuthorizationQuantity(value: Hex): number {
+  if (!isHex(value))
+    throw new Error(`Invalid authorization list quantity "${value}"`)
+  return hexToNumber(value)
 }


### PR DESCRIPTION
## Problem

`formatAuthorizationList` currently parses `chainId`, `nonce`, and `yParity` with `Number(...)`.

That means malformed values like `""` are silently coerced instead of being rejected, and these fields also skip the safe integer checks already used for surrounding transaction quantities.

## Changes

- route authorization quantities through a small helper that keeps the existing hex guard and uses `hexToNumber`
- add focused coverage for a valid authorization list
- add parameterized malformed-input coverage for `chainId`, `nonce`, and `yParity`
- add the required changeset

## Verification

- `pnpm exec vitest run -c ./test/vitest.config.ts src/utils/formatters/transaction.test.ts`
