### PR TITLE
fix: fail closed on non-HTTP(S) and link-local CCIP Read URLs

### DIFF
--- a/.changeset/ccip-url-fail-closed.md
+++ b/.changeset/ccip-url-fail-closed.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+**ccip:** Fail closed on non-HTTP(S) CCIP Read URLs, link-local or unspecified IP literals, and HTTP redirects.

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -263,19 +263,42 @@ function assertCcipRequestUrl(url: string) {
   }
 }
 
-function isBlockedCcipHostname(hostname: string) {
-  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname)
-  if (ipv4) {
-    const octets = ipv4.slice(1, 5).map(Number)
-    if (octets.some((octet) => octet > 255)) return false
-    const [a, b] = octets
-    // 0.0.0.0/8 unspecified, 169.254.0.0/16 link-local / cloud metadata
-    return a === 0 || (a === 169 && b === 254)
-  }
+function isBlockedIpv4([a, b]: readonly number[]) {
+  // 0.0.0.0/8 unspecified, 169.254.0.0/16 link-local / cloud metadata
+  return a === 0 || (a === 169 && b === 254)
+}
 
-  const normalized = hostname.toLowerCase()
-  if (normalized === '::' || normalized === '0:0:0:0:0:0:0:0') return true
+function parseIpv4Literal(host: string) {
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (!ipv4) return null
+  const octets = ipv4.slice(1, 5).map(Number)
+  if (octets.some((octet) => octet > 255)) return null
+  return octets
+}
+
+/** Node keeps brackets on IPv6 `URL.hostname` and rewrites ::ffff:a.b.c.d to hex. */
+function parseIpv4Mapped(host: string) {
+  const dotted = /:ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(host)
+  if (dotted) return parseIpv4Literal(dotted[1])
+
+  const hex = /:ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host)
+  if (!hex) return null
+  const hi = Number.parseInt(hex[1], 16)
+  const lo = Number.parseInt(hex[2], 16)
+  return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff]
+}
+
+function isBlockedCcipHostname(hostname: string) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+
+  const ipv4 = parseIpv4Literal(host)
+  if (ipv4) return isBlockedIpv4(ipv4)
+
+  const mapped = parseIpv4Mapped(host)
+  if (mapped) return isBlockedIpv4(mapped)
+
+  if (host === '::' || host === '0:0:0:0:0:0:0:0') return true
   // IPv6 link-local
-  if (normalized === 'fe80' || normalized.startsWith('fe80:')) return true
+  if (host === 'fe80' || host.startsWith('fe80:')) return true
   return false
 }

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -159,17 +159,25 @@ export async function ccipRequest({
     const body = method === 'POST' ? { data, sender } : undefined
     const headers: HeadersInit =
       method === 'POST' ? { 'Content-Type': 'application/json' } : {}
+    const requestUrl = url
+      .replace('{sender}', sender.toLowerCase())
+      .replace('{data}', data)
 
     try {
-      const response = await fetch(
-        url.replace('{sender}', sender.toLowerCase()).replace('{data}', data),
-        {
-          body: JSON.stringify(body),
-          headers,
-          method,
-          ...(requestOptions?.signal ? { signal: requestOptions.signal } : {}),
-        },
-      )
+      assertCcipRequestUrl(requestUrl)
+    } catch (err) {
+      error = err as Error
+      continue
+    }
+
+    try {
+      const response = await fetch(requestUrl, {
+        body: JSON.stringify(body),
+        headers,
+        method,
+        redirect: 'manual',
+        ...(requestOptions?.signal ? { signal: requestOptions.signal } : {}),
+      })
 
       let result: any
       if (
@@ -216,4 +224,58 @@ export async function ccipRequest({
   }
 
   throw error
+}
+
+function assertCcipRequestUrl(url: string) {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new HttpRequestError({
+      details: 'CCIP Read URL is invalid.',
+      url,
+    })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new HttpRequestError({
+      details:
+        `CCIP Read request with scheme '${parsed.protocol.slice(0, -1)}' is not allowed. ` +
+        'Only HTTP(S) URLs are permitted.',
+      url,
+    })
+  }
+
+  if (!parsed.hostname) {
+    throw new HttpRequestError({
+      details: 'CCIP Read URL has no hostname.',
+      url,
+    })
+  }
+
+  if (isBlockedCcipHostname(parsed.hostname)) {
+    throw new HttpRequestError({
+      details:
+        `CCIP Read request to '${parsed.hostname}' is not allowed: ` +
+        'host is in a blocked link-local or unspecified range.',
+      url,
+    })
+  }
+}
+
+function isBlockedCcipHostname(hostname: string) {
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname)
+  if (ipv4) {
+    const octets = ipv4.slice(1, 5).map(Number)
+    if (octets.some((octet) => octet > 255)) return false
+    const [a, b] = octets
+    // 0.0.0.0/8 unspecified, 169.254.0.0/16 link-local / cloud metadata
+    return a === 0 || (a === 169 && b === 254)
+  }
+
+  const normalized = hostname.toLowerCase()
+  if (normalized === '::' || normalized === '0:0:0:0:0:0:0:0') return true
+  // IPv6 link-local
+  if (normalized === 'fe80' || normalized.startsWith('fe80:')) return true
+  return false
 }

--- a/src/utils/ccipRequest.url.test.ts
+++ b/src/utils/ccipRequest.url.test.ts
@@ -56,6 +56,46 @@ describe('ccipRequest url checks', () => {
     ).rejects.toThrowError('blocked link-local or unspecified range')
   })
 
+  test('error: bracketed ipv6 unspecified', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://[::]/'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
+  test('error: bracketed ipv6 link-local', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://[fe80::1]/'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
+  test('error: ipv4-mapped link-local (node hex form)', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://[::ffff:169.254.169.254]/latest/meta-data'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
+  test('error: ipv4-mapped unspecified', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://[::ffff:0.0.0.0]/'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
   test('skips blocked url and uses the next gateway', async () => {
     const server = await createJsonServer({ data: '0xcafebabe' })
     const result = await ccipRequest({

--- a/src/utils/ccipRequest.url.test.ts
+++ b/src/utils/ccipRequest.url.test.ts
@@ -1,0 +1,72 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { describe, expect, test } from 'vitest'
+
+import { ccipRequest } from './ccip.js'
+
+const sender = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' as const
+const data = '0xdeadbeef' as const
+
+async function createJsonServer(payload: unknown) {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(payload))
+  })
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const { port } = server.address() as AddressInfo
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+describe('ccipRequest url checks', () => {
+  test('error: non-http scheme', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['file:///etc/passwd'],
+      }),
+    ).rejects.toThrowError("scheme 'file' is not allowed")
+  })
+
+  test('error: link-local metadata address', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://169.254.169.254/latest/meta-data'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
+  test('error: unspecified ipv4', async () => {
+    await expect(() =>
+      ccipRequest({
+        data,
+        sender,
+        urls: ['http://0.0.0.0/'],
+      }),
+    ).rejects.toThrowError('blocked link-local or unspecified range')
+  })
+
+  test('skips blocked url and uses the next gateway', async () => {
+    const server = await createJsonServer({ data: '0xcafebabe' })
+    const result = await ccipRequest({
+      data,
+      sender,
+      urls: [
+        'http://169.254.169.254/{sender}/{data}',
+        `${server.url}/{sender}/{data}`,
+      ],
+    })
+    expect(result).toEqual('0xcafebabe')
+    await server.close()
+  })
+})


### PR DESCRIPTION
`ccipRequest` fetched resolver-supplied gateway URLs with no scheme or host check, and `fetch` followed redirects.

A contract `OffchainLookup` can return `file:///...` or `http://169.254.169.254/...`. On Node that becomes a client-side request to a local file or link-local metadata address. A public URL that 302s to the same place had the same effect.

This is the URL-validation class web3.py already applies in `validate_ccip_url_scheme` / `validate_ccip_url_host`. Loopback HTTP stays allowed so local gateways and the existing test servers keep working. Callers who want a stricter allowlist can still wrap `ccipRead.request`.

## Change

- Reject non-`http(s)` schemes before `fetch`.
- Reject IPv4 `0.0.0.0/8` and `169.254.0.0/16`, plus IPv6 unspecified and `fe80:` link-local literals.
- Set `redirect: 'manual'` so a public gateway cannot bounce the client onto a blocked host.
- If one URL in the list is blocked, try the next.

## Test

`SKIP_GLOBAL_SETUP=true pnpm exec vitest run -c ./test/vitest.config.ts --project core src/utils/ccipRequest.url.test.ts` (4/4). Revert-tested: the three reject assertions fail when the pre-fetch guards are removed.