### PR TITLE
ci: reduce draft pull request workflows

### DIFF
--- a/.github/workflows/prepublish.yml
+++ b/.github/workflows/prepublish.yml
@@ -1,6 +1,10 @@
 name: Prepublish
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('branch-{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) || format('{0}-{1}-{2}', github.ref_type, github.repository, github.ref_name) }}
@@ -8,6 +12,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,7 @@
 name: Pull request
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ${{ github.workflow }}-branch-${{ github.event.pull_request.head.repo.full_name }}-${{ github.head_ref }}
@@ -10,12 +11,15 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
+    with:
+      full: ${{ !github.event.pull_request.draft }}
     secrets: inherit
     permissions:
       contents: read
 
   publish:
     name: Publish Prerelease
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -38,6 +42,7 @@ jobs:
 
   size:
     name: Size
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,7 +1,17 @@
 name: Verify
 on:
   workflow_call:
+    inputs:
+      full:
+        description: Run the full verification suite
+        type: boolean
+        default: true
   workflow_dispatch:
+    inputs:
+      full:
+        description: Run the full verification suite
+        type: boolean
+        default: true
 
 concurrency:
   group: verify-${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +46,7 @@ jobs:
   build:
     name: Build
     needs: check
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -65,6 +76,7 @@ jobs:
   types:
     name: Types
     needs: check
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,6 +110,7 @@ jobs:
 
   test:
     name: 'Test Local (transport: ${{ matrix.transport-mode }}, multicall: ${{ matrix.multicall }}, ${{ matrix.shard }}/${{ matrix.total-shards }})'
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -145,6 +158,7 @@ jobs:
 
   test-tempo-fuzz:
     name: Test Tempo Fuzz
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -173,6 +187,7 @@ jobs:
 
   test-tempo-deployed:
     name: 'Test Deployed Tempo (env: ${{ matrix.node-env }}, e2e)'
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -202,6 +217,7 @@ jobs:
 
   test-tempo-multisig:
     name: Test Local Tempo Multisig
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -233,6 +249,7 @@ jobs:
 
   test-tempo:
     name: Test Local Tempo (${{ matrix.hardfork }}, ${{ matrix.shard }}/${{ matrix.total-shards }})
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -285,6 +302,7 @@ jobs:
 
   test-envs:
     name: Test Environments
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -349,6 +367,7 @@ jobs:
 
   vectors:
     name: Vectors
+    if: ${{ inputs.full }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Run only repository checks for draft pull requests, then restore full verification, prerelease publishing, and size checks when marked ready. Avoid duplicate branch prepublish runs.