### PR TITLE
fix: validate array members in validateTypedData

### DIFF
--- a/.changeset/typed-data-array-validation.md
+++ b/.changeset/typed-data-array-validation.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `validateTypedData` skipping array members, so out-of-range integers, invalid addresses, and mismatched `bytes<M>` sizes are now caught inside array-typed fields.

--- a/src/utils/typedData.test.ts
+++ b/src/utils/typedData.test.ts
@@ -356,6 +356,196 @@ describe('validateTypedData', () => {
     `)
   })
 
+  test('array: valid', () => {
+    validateTypedData({
+      types: {
+        EIP712Domain: [],
+        Mail: [
+          { name: 'to', type: 'Person[]' },
+          { name: 'wallets', type: 'address[]' },
+          { name: 'hashes', type: 'bytes32[2]' },
+          { name: 'amounts', type: 'uint8[][]' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallet', type: 'address' },
+        ],
+      },
+      primaryType: 'Mail',
+      message: {
+        to: [
+          { name: 'Bob', wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' },
+        ],
+        wallets: ['0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'],
+        hashes: [
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        ],
+        amounts: [[1, 2], [255]],
+      },
+    })
+  })
+
+  test('array: invalid address', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'wallets', type: 'address[]' }],
+        },
+        primaryType: 'Mail',
+        message: {
+          wallets: [
+            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            '0x000000000000000000000000000000000000z',
+          ],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidAddressError: Address "0x000000000000000000000000000000000000z" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: uint overflow', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'amounts', type: 'uint8[]' }],
+        },
+        primaryType: 'Mail',
+        message: {
+          amounts: [1, 256],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [IntegerOutOfRangeError: Number "256" is not in safe 8-bit unsigned integer range (0 to 255)
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: bytes size mismatch', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'hashes', type: 'bytes32[]' }],
+        },
+        primaryType: 'Mail',
+        message: {
+          hashes: ['0x0000000000000000000000000000000000000000'],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [BytesSizeMismatchError: Expected bytes32, got bytes20.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: nested struct with invalid address', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'to', type: 'Person[]' }],
+          Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' },
+          ],
+        },
+        primaryType: 'Mail',
+        message: {
+          to: [
+            { name: 'Bob', wallet: '0x000000000000000000000000000000000000z' },
+          ],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidAddressError: Address "0x000000000000000000000000000000000000z" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: nested array uint overflow', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'amounts', type: 'uint8[][]' }],
+        },
+        primaryType: 'Mail',
+        message: {
+          amounts: [[1], [2, 256]],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [IntegerOutOfRangeError: Number "256" is not in safe 8-bit unsigned integer range (0 to 255)
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: fixed size with invalid address', () => {
+    expect(() =>
+      validateTypedData({
+        types: {
+          EIP712Domain: [],
+          Mail: [{ name: 'wallets', type: 'address[2]' }],
+        },
+        primaryType: 'Mail',
+        message: {
+          wallets: [
+            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            '0x000000000000000000000000000000000000z',
+          ],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidAddressError: Address "0x000000000000000000000000000000000000z" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
+  test('array: domain', () => {
+    expect(() =>
+      validateTypedData({
+        domain: {
+          name: 'Ether!',
+          wallets: ['0x000000000000000000000000000000000000z'],
+        },
+        primaryType: 'EIP712Domain',
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'wallets', type: 'address[]' },
+          ],
+        },
+      } as any),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidAddressError: Address "0x000000000000000000000000000000000000z" is invalid.
+
+      - Address must be a hex value of 20 bytes (40 hex characters).
+      - Address must match its checksum counterpart.
+
+      Version: viem@x.y.z]
+    `)
+  })
+
   test('domain: invalid chainId', () => {
     expect(() =>
       validateTypedData({

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -14,7 +14,7 @@ import type { TypedDataDefinition } from '../types/typedData.js'
 import { type IsAddressErrorType, isAddress } from './address/isAddress.js'
 import { type SizeErrorType, size } from './data/size.js'
 import { type NumberToHexErrorType, numberToHex } from './encoding/toHex.js'
-import { bytesRegex, integerRegex } from './regex.js'
+import { arrayRegex, bytesRegex, integerRegex } from './regex.js'
 import {
   type HashDomainErrorType,
   hashDomain,
@@ -85,44 +85,54 @@ export function validateTypedData<
   ) => {
     for (const param of struct) {
       const { name, type } = param
-      const value = data[name]
+      validateValue(type, data[name])
+    }
+  }
 
-      const baseType = type.replace(/(\[[0-9]*\])+$/, '')
-      if (baseType === 'int' || baseType === 'uint')
-        throw new InvalidTypedDataTypeError({ type })
+  const validateValue = (type: string, value: unknown) => {
+    const baseType = type.replace(/(\[[0-9]*\])+$/, '')
+    if (baseType === 'int' || baseType === 'uint')
+      throw new InvalidTypedDataTypeError({ type })
 
-      const integerMatch = type.match(integerRegex)
-      if (
-        integerMatch &&
-        (typeof value === 'number' || typeof value === 'bigint')
-      ) {
-        const [_type, base, size_] = integerMatch
-        // If number cannot be cast to a sized hex value, it is out of range
-        // and will throw.
-        numberToHex(value, {
-          signed: base === 'int',
-          size: Number.parseInt(size_, 10) / 8,
+    const arrayMatch = type.match(arrayRegex)
+    if (arrayMatch) {
+      const [_type, elementType] = arrayMatch
+      if (Array.isArray(value))
+        for (const element of value) validateValue(elementType, element)
+      return
+    }
+
+    const integerMatch = type.match(integerRegex)
+    if (
+      integerMatch &&
+      (typeof value === 'number' || typeof value === 'bigint')
+    ) {
+      const [_type, base, size_] = integerMatch
+      // If number cannot be cast to a sized hex value, it is out of range
+      // and will throw.
+      numberToHex(value, {
+        signed: base === 'int',
+        size: Number.parseInt(size_, 10) / 8,
+      })
+    }
+
+    if (type === 'address' && typeof value === 'string' && !isAddress(value))
+      throw new InvalidAddressError({ address: value })
+
+    const bytesMatch = type.match(bytesRegex)
+    if (bytesMatch) {
+      const [_type, size_] = bytesMatch
+      if (size_ && size(value as Hex) !== Number.parseInt(size_, 10))
+        throw new BytesSizeMismatchError({
+          expectedSize: Number.parseInt(size_, 10),
+          givenSize: size(value as Hex),
         })
-      }
+    }
 
-      if (type === 'address' && typeof value === 'string' && !isAddress(value))
-        throw new InvalidAddressError({ address: value })
-
-      const bytesMatch = type.match(bytesRegex)
-      if (bytesMatch) {
-        const [_type, size_] = bytesMatch
-        if (size_ && size(value as Hex) !== Number.parseInt(size_, 10))
-          throw new BytesSizeMismatchError({
-            expectedSize: Number.parseInt(size_, 10),
-            givenSize: size(value as Hex),
-          })
-      }
-
-      const struct = types[type]
-      if (struct) {
-        validateReference(type)
-        validateData(struct, value as Record<string, unknown>)
-      }
+    const struct = types[type]
+    if (struct) {
+      validateReference(type)
+      validateData(struct, value as Record<string, unknown>)
     }
   }
 


### PR DESCRIPTION
`validateTypedData` matches every field against its raw type string. Array types therefore fall through every check:

- `type === 'address'` is false for `address[]`
- `bytesRegex` / `integerRegex` are anchored, so `bytes32[]` and `uint8[]` never match
- `types[type]` is `undefined` for `Person[]`, so struct arrays are never recursed into

The result is that out-of-range integers, invalid addresses and mismatched `bytes<M>` sizes are silently accepted inside any array-typed field, while the identical scalar field is rejected:

```ts
// throws InvalidAddressError
validateTypedData({
  types: { Foo: [{ name: 'a', type: 'address' }] },
  primaryType: 'Foo',
  message: { a: '0xdeadbeef' },
})

// passes validation today
validateTypedData({
  types: { Foo: [{ name: 'a', type: 'address[]' }] },
  primaryType: 'Foo',
  message: { a: ['0xdeadbeef'] },
})
```

This matters beyond the standalone util. `signTypedData` calls `validateTypedData` and then hands the message straight to the wallet via `eth_signTypedData_v4` without encoding it locally, so for JSON-RPC accounts this check is the only guard: malformed array data is currently forwarded to the wallet rather than rejected. `hashTypedData` does eventually throw, but from the ABI encoder (`AbiEncodingBytesSizeMismatchError`) rather than the intended validation error (`BytesSizeMismatchError`).

The array intent is already half-present: #4961 added `baseType` suffix stripping so bare `uint[]` / `int[2]` are rejected, but the remaining checks still use the raw `type`. `encodeField` in `hashTypedData` already walks array types when hashing, so validation was simply lagging behind encoding.

### Change

Extracted the per-field body of `validateData` into `validateValue(type, value)` and added an array branch that recurses into element types using the existing `arrayRegex`. Handles nested (`uint8[][]`) and fixed-size (`address[2]`) arrays. The diff is mostly re-indentation from the extraction; `git diff -w` shows the actual change is the import plus the new array branch.

Non-array values for array-typed fields are still skipped rather than rejected, to keep the change scoped to the missing traversal and avoid rejecting input that is accepted today.

### Alternatives considered

Validating declared length for fixed-size arrays (`address[2]`) was left out deliberately: `encodeField` does not enforce it either, so adding it here would reject payloads viem currently encodes, which is a behaviour change rather than a bug fix.

### Tests

Added seven cases to `src/utils/typedData.test.ts` covering `address[]`, `uint8[]`, `bytes32[]`, nested `Person[]`, nested `uint8[][]`, fixed-size `address[2]`, and an `address[]` in the domain, plus one positive case asserting valid array data still passes.

All seven fail on `main` and pass with this change:

```
# with the fix reverted
 × array: invalid address
 × array: uint overflow
 × array: bytes size mismatch
 × array: nested struct with invalid address
 × array: nested array uint overflow
 × array: fixed size with invalid address
 × array: domain
 Tests  7 failed | 22 passed (29)

# with the fix
 Tests  29 passed (29)
```

`typedData.test.ts` and `hashTypedData.test.ts` pass together (42 tests). I also ran the wider `src/utils` and `src/accounts` suites before and after the change and got an identical set of 26 pre-existing failures, all from tests needing a local Anvil instance.
