### PR TITLE
Add Zone portal info action

### DIFF
--- a/.changeset/fresh-zones-report.md
+++ b/.changeset/fresh-zones-report.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `Actions.zone.getPortalInfo` for reading the current configuration of a Tempo Zone portal.

--- a/site/pages/tempo/actions/index.mdx
+++ b/site/pages/tempo/actions/index.mdx
@@ -160,6 +160,7 @@
 | [`zone.encryptedDeposit`](/tempo/actions/zone.encryptedDeposit) | Deposits tokens into a zone with encrypted recipient and memo |
 | [`zone.getAuthorizationTokenInfo`](/tempo/actions/zone.getAuthorizationTokenInfo) | Gets the authenticated account and expiry from the current authorization token |
 | [`zone.getEncryptionKey`](/tempo/actions/zone.getEncryptionKey) | Gets the active sequencer encryption key and index |
+| [`zone.getPortalInfo`](/tempo/actions/zone.getPortalInfo) | Gets the current Zone portal configuration |
 | [`zone.getWithdrawalFee`](/tempo/actions/zone.getWithdrawalFee) | Gets the withdrawal fee for a given gas limit |
 | [`zone.getZoneInfo`](/tempo/actions/zone.getZoneInfo) | Gets metadata about the current zone |
 | [`zone.requestVerifiableWithdrawal`](/tempo/actions/zone.requestVerifiableWithdrawal) | Requests a verifiable withdrawal from a zone to the parent Tempo chain |

--- a/site/pages/tempo/actions/zone.getPortalInfo.mdx
+++ b/site/pages/tempo/actions/zone.getPortalInfo.mdx
@@ -1,0 +1,57 @@
+# `zone.getPortalInfo`
+
+Gets the current configuration of a Zone portal from the parent Tempo chain.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client } from './viem.config'
+
+const info = await client.zone.getPortalInfo({
+  portalAddress: '0x5Ad0000000000000000000000000000000000003',
+})
+
+console.log('Admin:', info.admin)
+console.log('Sequencers:', info.sequencers)
+console.log('Tokens:', info.tokens)
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/tempo/viem.config.ts:setup]
+```
+
+:::
+
+The action reads fixed fields, indexed sequencers and tokens, and token configurations in three deployless multicall stages.
+
+## Return Type
+
+```ts
+type ReturnType = {
+  admin: Address
+  messenger: Address
+  paused: boolean
+  pauseExpiry: bigint
+  pendingAdmin: Address
+  portalAddress: Address
+  sequencers: readonly Address[]
+  sequencerSetVersion: bigint
+  sequencerThreshold: number
+  tokens: readonly {
+    address: Address
+    depositsActive: boolean
+    enabled: boolean
+  }[]
+  verifier: Address
+}
+```
+
+## Parameters
+
+### portalAddress
+
+- **Type:** `Address`
+
+Zone portal address on the parent Tempo chain.

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -3290,6 +3290,10 @@ export default defineConfig({
                   link: '/tempo/actions/zone.getEncryptionKey',
                 },
                 {
+                  text: 'getPortalInfo',
+                  link: '/tempo/actions/zone.getPortalInfo',
+                },
+                {
                   text: 'getWithdrawalFee',
                   link: '/tempo/actions/zone.getWithdrawalFee',
                 },

--- a/src/tempo/Decorator.ts
+++ b/src/tempo/Decorator.ts
@@ -5512,6 +5512,31 @@ type DecoratorBase<
       parameters: zoneActions.getEncryptionKey.Parameters,
     ) => Promise<zoneActions.getEncryptionKey.ReturnValue>
     /**
+     * Gets the current configuration of a Zone portal.
+     *
+     * @example
+     * ```ts
+     * import { createClient, http } from 'viem'
+     * import { tempoModerato } from 'viem/chains'
+     * import { tempoActions } from 'viem/tempo'
+     *
+     * const client = createClient({
+     *   chain: tempoModerato,
+     *   transport: http(),
+     * }).extend(tempoActions())
+     *
+     * const info = await client.zone.getPortalInfo({
+     *   portalAddress: '0x5Ad0000000000000000000000000000000000003',
+     * })
+     * ```
+     *
+     * @param parameters - Parameters.
+     * @returns The current Zone portal configuration.
+     */
+    getPortalInfo: (
+      parameters: zoneActions.getPortalInfo.Parameters,
+    ) => Promise<zoneActions.getPortalInfo.ReturnValue>
+    /**
      * Returns the authenticated account address and authorization token expiry.
      *
      * @example
@@ -6144,6 +6169,7 @@ export function decorator() {
         'encryptedDepositSync',
         'getAuthorizationTokenInfo',
         'getEncryptionKey',
+        'getPortalInfo',
         'getWithdrawalFee',
         'getZoneInfo',
         'requestWithdrawal',

--- a/src/tempo/actions/zone.test-d.ts
+++ b/src/tempo/actions/zone.test-d.ts
@@ -24,6 +24,7 @@ const publicClient = createClient({
   chain: tempoModerato,
   transport,
 })
+const decoratedClient = client.extend(decorator())
 const zoneClient = createClient({
   account: '0x0000000000000000000000000000000000000001',
   chain: zoneModerato(7),
@@ -212,6 +213,25 @@ test('getZoneInfo returns sequencers and the imported Tempo block number', async
 
   expectTypeOf(info.sequencers).toEqualTypeOf<readonly Address[]>()
   expectTypeOf(info.tempoBlockNumber).toEqualTypeOf<bigint>()
+})
+
+test('getPortalInfo returns the current portal configuration', async () => {
+  const info = await zoneActions.getPortalInfo(client, {
+    portalAddress: '0x0000000000000000000000000000000000000001',
+  })
+
+  expectTypeOf(info).toEqualTypeOf<zoneActions.getPortalInfo.ReturnValue>()
+  expectTypeOf(info.admin).toEqualTypeOf<Address>()
+  expectTypeOf(info.paused).toEqualTypeOf<boolean>()
+  expectTypeOf(info.sequencers).toEqualTypeOf<readonly Address[]>()
+  expectTypeOf(info.tokens[0]!.depositsActive).toEqualTypeOf<boolean>()
+
+  const decoratedInfo = await decoratedClient.zone.getPortalInfo({
+    portalAddress: '0x0000000000000000000000000000000000000001',
+  })
+  expectTypeOf(
+    decoratedInfo,
+  ).toEqualTypeOf<zoneActions.getPortalInfo.ReturnValue>()
 })
 
 test('waitForTempoBlock returns zone info', async () => {

--- a/src/tempo/actions/zone.test.ts
+++ b/src/tempo/actions/zone.test.ts
@@ -376,6 +376,27 @@ describe('getZoneInfo', () => {
   })
 })
 
+describe('getPortalInfo', () => {
+  test('behavior: returns the current portal configuration', async () => {
+    const info = await zoneActions.getPortalInfo(mainnetClient, {
+      portalAddress,
+    })
+
+    expect(isAddressEqual(info.portalAddress, portalAddress)).toBe(true)
+    expect(isAddressEqual(info.admin, portalAdmin.address)).toBe(true)
+    expect(info.messenger).toBeDefined()
+    expect(info.verifier).toBeDefined()
+    expect(info.paused).toBe(false)
+    expect(info.pauseExpiry).toBe(0n)
+    expect(info.sequencers).toHaveLength(1)
+    expect(info.sequencerThreshold).toBe(1)
+    expect(info.sequencerSetVersion).toBeGreaterThanOrEqual(0n)
+    expect(
+      info.tokens.some(({ address }) => isAddressEqual(address, parentToken)),
+    ).toBe(true)
+  })
+})
+
 describe('getTokenMetadata', () => {
   test('behavior: supports disabled client multicall', async () => {
     const client = getZoneClient({

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -437,6 +437,170 @@ export namespace getEncryptionKey {
 }
 
 /**
+ * Gets the current configuration of a Zone portal.
+ *
+ * @example
+ * ```ts
+ * import { createClient, http } from 'viem'
+ * import { tempoModerato } from 'viem/chains'
+ * import { Actions } from 'viem/tempo'
+ *
+ * const client = createClient({
+ *   chain: tempoModerato,
+ *   transport: http(),
+ * })
+ *
+ * const info = await Actions.zone.getPortalInfo(client, {
+ *   portalAddress: '0x5Ad0000000000000000000000000000000000003',
+ * })
+ * ```
+ *
+ * @param client - Public client connected to the parent Tempo chain.
+ * @param parameters - Zone portal parameters.
+ * @returns The current Zone portal configuration.
+ */
+export async function getPortalInfo<chain extends Chain | undefined>(
+  client: Client<Transport, chain>,
+  parameters: getPortalInfo.Parameters,
+): Promise<getPortalInfo.ReturnValue> {
+  const { account, portalAddress, ...rest } = parameters
+  const options = {
+    ...rest,
+    account: account ? parseAccount(account).address : undefined,
+    allowFailure: false,
+    batchSize: 0,
+    deployless: true,
+  } as const
+  const portal = { address: portalAddress, abi: ZoneAbis.zonePortal } as const
+  const [
+    messenger,
+    verifier,
+    admin,
+    pendingAdmin,
+    paused,
+    pauseExpiry,
+    sequencerSetVersion,
+    sequencerThreshold,
+    sequencerCount,
+    enabledTokenCount,
+  ] = await multicall(client, {
+    ...options,
+    contracts: [
+      defineCall({ ...portal, functionName: 'messenger' }),
+      defineCall({ ...portal, functionName: 'verifier' }),
+      defineCall({ ...portal, functionName: 'admin' }),
+      defineCall({ ...portal, functionName: 'pendingAdmin' }),
+      defineCall({ ...portal, functionName: 'paused' }),
+      defineCall({ ...portal, functionName: 'pauseExpiry' }),
+      defineCall({ ...portal, functionName: 'sequencerSetVersion' }),
+      defineCall({ ...portal, functionName: 'sequencerThreshold' }),
+      defineCall({ ...portal, functionName: 'sequencerCount' }),
+      defineCall({ ...portal, functionName: 'enabledTokenCount' }),
+    ],
+  })
+  const [sequencers, tokenAddresses] = await Promise.all([
+    multicall(client, {
+      ...options,
+      contracts: Array.from({ length: Number(sequencerCount) }, (_, index) =>
+        defineCall({
+          ...portal,
+          functionName: 'sequencerAt',
+          args: [BigInt(index)],
+        }),
+      ),
+    }),
+    multicall(client, {
+      ...options,
+      contracts: Array.from({ length: Number(enabledTokenCount) }, (_, index) =>
+        defineCall({
+          ...portal,
+          functionName: 'enabledTokenAt',
+          args: [BigInt(index)],
+        }),
+      ),
+    }),
+  ])
+  const tokenConfigs = await multicall(client, {
+    ...options,
+    contracts: tokenAddresses.map((token) =>
+      defineCall({
+        ...portal,
+        functionName: 'tokenConfig',
+        args: [token],
+      }),
+    ),
+  })
+
+  return {
+    admin,
+    messenger,
+    paused,
+    pauseExpiry,
+    pendingAdmin,
+    portalAddress,
+    sequencers,
+    sequencerSetVersion,
+    sequencerThreshold,
+    tokens: tokenAddresses.map((address, index) => ({
+      address,
+      ...tokenConfigs[index]!,
+    })),
+    verifier,
+  }
+}
+
+export namespace getPortalInfo {
+  export type Parameters = UnionOmit<
+    MulticallParameters,
+    | 'allowFailure'
+    | 'batchSize'
+    | 'contracts'
+    | 'deployless'
+    | 'multicallAddress'
+  > &
+    Args
+
+  export type Args = {
+    /** Zone portal address on the parent Tempo chain. */
+    portalAddress: Address
+  }
+
+  export type ReturnValue = Compute<{
+    /** Current Zone administrator. */
+    admin: Address
+    /** Zone messenger contract. */
+    messenger: Address
+    /** Whether deposits and withdrawal processing are currently paused. */
+    paused: boolean
+    /** Unix timestamp at which the current pause expires. */
+    pauseExpiry: bigint
+    /** Pending Zone administrator. */
+    pendingAdmin: Address
+    /** Zone portal address on the parent Tempo chain. */
+    portalAddress: Address
+    /** Active sequencer addresses. */
+    sequencers: readonly Address[]
+    /** Current sequencer set version. */
+    sequencerSetVersion: bigint
+    /** Signatures required from the active sequencer set. */
+    sequencerThreshold: number
+    /** Enabled token configurations. */
+    tokens: readonly {
+      /** Whether deposits are active for the token. */
+      depositsActive: boolean
+      /** Whether the token is enabled. */
+      enabled: boolean
+      /** Token address on the parent Tempo chain. */
+      address: Address
+    }[]
+    /** Zone verifier contract. */
+    verifier: Address
+  }>
+
+  export type ErrorType = MulticallErrorType | BaseErrorType
+}
+
+/**
  * Deposits tokens into a zone on the parent Tempo chain with encrypted
  * recipient and memo. Batches approve and depositEncrypted into a single
  * transaction.


### PR DESCRIPTION
## Summary

- add Actions.zone.getPortalInfo and the tempoActions() decorator
- read Portal fields, sequencers, enabled tokens, and token configs with deployless multicalls
- add runtime/type coverage and API docs

## Validation

- Biome passes for changed files
- pnpm check:types
- pnpm build:types
- live Moderato Zone 3 read
- Docker-backed Zone test is included but could not run locally because the sandbox has no Docker socket

Prompted by: @0xrusowsky