### PR TITLE
feat(tempo): add system contract metadata

### DIFF
--- a/.changeset/fuzzy-zones-share.md
+++ b/.changeset/fuzzy-zones-share.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Zone system contract metadata, deterministic Portal address utilities, current settlement ABIs, and EIP-2935 raw calldata codecs.

--- a/.changeset/fuzzy-zones-share.md
+++ b/.changeset/fuzzy-zones-share.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added Zone system contract metadata, deterministic Portal address utilities, current settlement ABIs, and EIP-2935 raw calldata codecs.
+Added Zone system contract metadata, deterministic Portal address utilities, current settlement and administration ABIs, and EIP-2935 raw calldata codecs.

--- a/src/tempo/Addresses.ts
+++ b/src/tempo/Addresses.ts
@@ -3,6 +3,7 @@ export const accountImplementation =
 export const accountKeychain = '0xaAAAaaAA00000000000000000000000000000000'
 export const accountRegistrar = '0x7702ac0000000000000000000000000000000000'
 export const addressRegistry = '0xfdc0000000000000000000000000000000000000'
+export const blockHashHistory = '0x0000F90827F1C53a10cb7A02335B175320002935'
 export const feeManager = '0xfeec000000000000000000000000000000000000'
 export const nativeMultisig = '0xAACC000000000000000000000000000000000000'
 export const nonceManager = '0x4e4F4E4345000000000000000000000000000000'

--- a/src/tempo/BlockHashHistory.test-d.ts
+++ b/src/tempo/BlockHashHistory.test-d.ts
@@ -1,0 +1,11 @@
+import type { Hex } from 'viem'
+import { type Addresses, BlockHashHistory, SystemContracts } from 'viem/tempo'
+import { expectTypeOf, test } from 'vitest'
+
+test('exposes EIP-2935 and system contract utilities', () => {
+  expectTypeOf<
+    typeof Addresses.blockHashHistory
+  >().toEqualTypeOf<'0x0000F90827F1C53a10cb7A02335B175320002935'>()
+  expectTypeOf(BlockHashHistory.encodeInput(1n)).toEqualTypeOf<Hex>()
+  expectTypeOf(SystemContracts.isSystemContract('0x')).toEqualTypeOf<boolean>()
+})

--- a/src/tempo/BlockHashHistory.test.ts
+++ b/src/tempo/BlockHashHistory.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+import * as BlockHashHistory from './BlockHashHistory.js'
+
+describe('BlockHashHistory', () => {
+  test('encodes and decodes selectorless input', () => {
+    const input = BlockHashHistory.encodeInput(31_772_336n)
+    expect(input).toHaveLength(66)
+    expect(BlockHashHistory.decodeInput(input)).toBe(31_772_336n)
+  })
+
+  test('decodes a bytes32 output', () => {
+    const hash = `0x${'12'.repeat(32)}` as const
+    expect(BlockHashHistory.decodeOutput(hash)).toBe(hash)
+  })
+
+  test('rejects malformed raw data', () => {
+    expect(() => BlockHashHistory.decodeInput('0x01')).toThrow(RangeError)
+    expect(() => BlockHashHistory.decodeOutput('0x01')).toThrow(RangeError)
+  })
+})

--- a/src/tempo/BlockHashHistory.ts
+++ b/src/tempo/BlockHashHistory.ts
@@ -1,0 +1,25 @@
+import * as Hex from 'ox/Hex'
+import { blockHashHistory as address } from './Addresses.js'
+
+export { address }
+
+/** Encodes a block number for the selectorless EIP-2935 history contract. */
+export function encodeInput(blockNumber: bigint | number): Hex.Hex {
+  const value = BigInt(blockNumber)
+  if (value < 0n) throw new RangeError('Block number must be non-negative.')
+  return Hex.fromNumber(value, { size: 32 })
+}
+
+/** Decodes selectorless EIP-2935 calldata into a block number. */
+export function decodeInput(data: Hex.Hex): bigint {
+  if (Hex.size(data) !== 32)
+    throw new RangeError('Block hash history input must be 32 bytes.')
+  return Hex.toBigInt(data)
+}
+
+/** Decodes the EIP-2935 return value into a block hash. */
+export function decodeOutput(data: Hex.Hex): Hex.Hex {
+  if (Hex.size(data) !== 32)
+    throw new RangeError('Block hash history output must be 32 bytes.')
+  return data
+}

--- a/src/tempo/SystemContracts.test.ts
+++ b/src/tempo/SystemContracts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import * as Addresses from './Addresses.js'
+import * as SystemContracts from './SystemContracts.js'
+
+describe('SystemContracts', () => {
+  test('includes fixed Tempo and Zone contracts', () => {
+    expect(SystemContracts.addresses).toContain(Addresses.signatureVerifier)
+    expect(SystemContracts.addresses).toContain(Addresses.blockHashHistory)
+    expect(SystemContracts.addresses).toContain(Addresses.zoneFactory)
+    expect(SystemContracts.addresses).toContain(
+      Addresses.zonePortalImplementation,
+    )
+    expect(SystemContracts.addresses).toContain(Addresses.zoneMessenger)
+  })
+
+  test('recognizes deterministic Zone Portal proxies', () => {
+    expect(
+      SystemContracts.isSystemContract(
+        '0x5Ad0000000000000000000000000000000000003',
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects regular addresses', () => {
+    expect(
+      SystemContracts.isSystemContract(
+        '0x0000000000000000000000000000000000000001',
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/tempo/SystemContracts.ts
+++ b/src/tempo/SystemContracts.ts
@@ -1,0 +1,17 @@
+import type { Address } from 'abitype'
+import { isAddress } from '../utils/address/isAddress.js'
+import * as Addresses from './Addresses.js'
+import { isZonePortalAddress } from './zones/portal.js'
+
+/** Fixed protocol-managed contract addresses exported by Tempo. */
+export const addresses = Object.values(Addresses)
+
+const addressSet = new Set(addresses.map((address) => address.toLowerCase()))
+
+/** Returns whether an address is a fixed or deterministic Tempo system contract. */
+export function isSystemContract(address: string): address is Address {
+  return (
+    isAddress(address) &&
+    (addressSet.has(address.toLowerCase()) || isZonePortalAddress(address))
+  )
+}

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -51,6 +51,7 @@ export * as Abis from './Abis.js'
 export * as Account from './Account.js'
 export * as Addresses from './Addresses.js'
 export * as Actions from './actions/index.js'
+export * as BlockHashHistory from './BlockHashHistory.js'
 export * as Capabilities from './Capabilities.js'
 export * as Chain from './Chain.js'
 export {
@@ -74,6 +75,7 @@ export * as Scopes from './Scopes.js'
 /** @experimental */
 export * as Selectors from './Selectors.js'
 export * as Storage from './Storage.js'
+export * as SystemContracts from './SystemContracts.js'
 export * as TokenIds from './TokenIds.js'
 // Export types required for inference.
 export type {

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -79,13 +79,29 @@ test('zonePortal decodes token configuration', () => {
   }>()
 })
 
-test('zonePortal encodes pause operations', () => {
+test('zonePortal encodes administration operations', () => {
   const pause = encodeFunctionData({
     abi: Abis.zonePortal,
     functionName: 'pause',
   })
+  const resume = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'resume',
+  })
+  const setPauseGuardian = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'setPauseGuardian',
+    args: [zeroAddress, true],
+  })
+  const acceptAdmin = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'acceptAdmin',
+  })
 
   expectTypeOf(pause).toEqualTypeOf<Hex>()
+  expectTypeOf(resume).toEqualTypeOf<Hex>()
+  expectTypeOf(setPauseGuardian).toEqualTypeOf<Hex>()
+  expectTypeOf(acceptAdmin).toEqualTypeOf<Hex>()
 })
 
 test('zonePortal encodes batch submissions', () => {

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -88,6 +88,63 @@ test('zonePortal encodes pause operations', () => {
   expectTypeOf(pause).toEqualTypeOf<Hex>()
 })
 
+test('zonePortal encodes batch submissions', () => {
+  const data = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'submitBatch',
+    args: [
+      1n,
+      1n,
+      { prevBlockHash: zeroHash, nextBlockHash: zeroHash },
+      {
+        prevProcessedHash: zeroHash,
+        nextProcessedHash: zeroHash,
+        prevDepositNumber: 0n,
+        nextDepositNumber: 0n,
+      },
+      zeroHash,
+      '0x',
+      '0x',
+      1n,
+      [],
+    ],
+  })
+
+  expectTypeOf(data).toEqualTypeOf<Hex>()
+})
+
+test('zoneMessenger and zoneVerifier expose callable ABIs', () => {
+  const relay = encodeFunctionData({
+    abi: Abis.zoneMessenger,
+    functionName: 'relayMessage',
+    args: [1, zeroAddress, zeroHash, zeroAddress, 1n, 100_000n, '0x'],
+  })
+  const verify = encodeFunctionData({
+    abi: Abis.zoneVerifier,
+    functionName: 'verify',
+    args: [
+      1,
+      1n,
+      1n,
+      zeroHash,
+      1n,
+      { prevBlockHash: zeroHash, nextBlockHash: zeroHash },
+      {
+        prevProcessedHash: zeroHash,
+        nextProcessedHash: zeroHash,
+        prevDepositNumber: 0n,
+        nextDepositNumber: 0n,
+      },
+      zeroHash,
+      '0x',
+      '0x',
+    ],
+  })
+
+  expectTypeOf(relay).toEqualTypeOf<Hex>()
+  expectTypeOf(verify).toEqualTypeOf<Hex>()
+})
+
 test('zoneOutbox decodes WithdrawalRequested fallback nonces', () => {
   const [event] = parseEventLogs({
     abi: Abis.zoneOutbox,

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -294,6 +294,30 @@ export const zonePortal = [
     outputs: [],
   },
   {
+    name: 'resume',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [],
+  },
+  {
+    name: 'setPauseGuardian',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'account', type: 'address' },
+      { name: 'allowed', type: 'bool' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'acceptAdmin',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [],
+  },
+  {
     name: 'sequencerSetVersion',
     type: 'function',
     stateMutability: 'view',

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -1,3 +1,5 @@
+import { parseAbi } from 'abitype'
+
 export const zoneFactory = [
   {
     type: 'event',
@@ -135,9 +137,49 @@ export const zoneFactory = [
     inputs: [],
     outputs: [{ name: '', type: 'address' }],
   },
+  ...parseAbi([
+    'event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)',
+    'function transferOwnership(address newOwner)',
+    'function isZonePortal(address portal) view returns (bool isPortal)',
+    'error InvalidToken()',
+    'error NotOwner()',
+    'error InvalidAdmin()',
+    'error InvalidSequencerSet()',
+    'error InvalidClosedLoopConfig()',
+    'error DuplicateAllowedAccount()',
+    'error DuplicateZoneGateway()',
+  ]),
 ] as const
 
+const zonePortalCurrent = parseAbi([
+  'event BatchSubmitted(uint64 indexed withdrawalBatchIndex, uint256 indexed withdrawalQueueIndex, bytes32 nextProcessedDepositQueueHash, bytes32 nextBlockHash, bytes32 withdrawalQueueHash, uint64 lastProcessedDepositNumber)',
+  'event WithdrawalBounceBack(bytes32 indexed newCurrentDepositQueueHash, uint64 indexed fallbackNonce, address token, uint128 amount, uint64 depositNumber)',
+  'event AdminTransferStarted(address indexed currentAdmin, address indexed pendingAdmin)',
+  'event AdminTransferred(address indexed previousAdmin, address indexed newAdmin)',
+  'event DepositMade(bytes32 indexed newCurrentDepositQueueHash, address indexed sender, address token, uint128 netAmount, uint128 fee, uint256 keyIndex, bytes32 ephemeralPubkeyX, uint8 ephemeralPubkeyYParity, bytes ciphertext, bytes12 nonce, bytes16 tag, address tempoRefundRecipient, uint64 depositNumber)',
+  'event DepositBounceBack(address indexed tempoRefundRecipient, address token, uint128 amount, uint128 bouncebackFee)',
+  'event DepositBounceBackPending(address indexed tempoRefundRecipient, address token, uint128 amount, uint128 bouncebackFee)',
+  'event RefundClaimed(address indexed recipient, address indexed token, uint128 amount)',
+  'event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, address pubkey, uint256 keyIndex, uint64 activationBlock)',
+  'event ZoneGasRateUpdated(uint128 zoneGasRate)',
+  'event MaxTempoGasRateUpdated(uint128 maxTempoGasRate)',
+  'event BouncebackGasUpdated(uint64 bouncebackGas)',
+  'event TokenEnabled(address indexed token, string name, string symbol, string currency)',
+  'event DepositsPaused(address indexed token)',
+  'event DepositsResumed(address indexed token)',
+  'event PortalPaused(address indexed account)',
+  'event PortalResumed(address indexed account)',
+  'event AbdicationScheduled(uint8 indexed capability, uint64 effectiveAt)',
+  'event RpcUrlUpdated(string rpcUrl)',
+  'event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers)',
+  'event LeaderUpdated(address indexed previousLeader, address indexed newLeader, uint64 indexed epoch, uint64 activationTempoBlock)',
+  'event EnforcementModesUpdated(bool accessMode, bool gatewayMode)',
+  'event RoleUpdated(address indexed account, uint8 prev, uint8 next)',
+  'function submitBatch(uint64 tempoBlockNumber, uint64 recentTempoBlockNumber, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof, uint256 zoneHeight, bytes[] signatures)',
+])
+
 export const zonePortal = [
+  ...zonePortalCurrent,
   {
     name: 'WithdrawalProcessed',
     type: 'event',
@@ -327,6 +369,14 @@ export const zonePortal = [
     outputs: [{ name: '', type: 'uint256' }],
   },
 ] as const
+
+export const zoneMessenger = parseAbi([
+  'function relayMessage(uint32 zoneId, address token, bytes32 senderTag, address target, uint128 amount, uint64 gasLimit, bytes data)',
+])
+
+export const zoneVerifier = parseAbi([
+  'function verify(uint32 zoneId, uint64 tempoBlockNumber, uint64 anchorBlockNumber, bytes32 anchorBlockHash, uint64 expectedWithdrawalBatchIndex, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof) view returns (bool)',
+])
 
 export const zoneOutbox = [
   {

--- a/src/tempo/zones/Contracts.test.ts
+++ b/src/tempo/zones/Contracts.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest'
+import * as Contracts from './Contracts.js'
+
+describe('Zone contracts', () => {
+  test('pairs system addresses with current ABIs', () => {
+    expect(Contracts.systemContracts).toHaveLength(5)
+    expect(
+      Contracts.portalImplementation.abi.some(
+        (item) => item.type === 'function' && item.name === 'submitBatch',
+      ),
+    ).toBe(true)
+    expect(
+      Contracts.messenger.abi.some(
+        (item) => item.type === 'function' && item.name === 'relayMessage',
+      ),
+    ).toBe(true)
+    expect(
+      Contracts.verifier.abi.some(
+        (item) => item.type === 'function' && item.name === 'verify',
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/tempo/zones/Contracts.ts
+++ b/src/tempo/zones/Contracts.ts
@@ -1,0 +1,36 @@
+import * as Addresses from '../Addresses.js'
+import * as Abis from './Abis.js'
+
+export const factory = {
+  address: Addresses.zoneFactory,
+  abi: Abis.zoneFactory,
+} as const
+
+export const messenger = {
+  address: Addresses.zoneMessenger,
+  abi: Abis.zoneMessenger,
+} as const
+
+export const outbox = {
+  address: Addresses.zoneOutbox,
+  abi: Abis.zoneOutbox,
+} as const
+
+export const portalImplementation = {
+  address: Addresses.zonePortalImplementation,
+  abi: Abis.zonePortal,
+} as const
+
+export const verifier = {
+  address: Addresses.zoneVerifier,
+  abi: Abis.zoneVerifier,
+} as const
+
+/** Fixed system contracts used by the Tempo Zone protocol. */
+export const systemContracts = [
+  factory,
+  messenger,
+  outbox,
+  portalImplementation,
+  verifier,
+] as const

--- a/src/tempo/zones/index.ts
+++ b/src/tempo/zones/index.ts
@@ -1,6 +1,12 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint module
 export * as Abis from './Abis.js'
 export * as Addresses from './Addresses.js'
+export * as Contracts from './Contracts.js'
+export {
+  getZonePortalAddress,
+  getZonePortalId,
+  isZonePortalAddress,
+} from './portal.js'
 export { http, type ZoneHttpConfig } from './transport.js'
 export {
   from,

--- a/src/tempo/zones/portal.test.ts
+++ b/src/tempo/zones/portal.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import {
+  getZonePortalAddress,
+  getZonePortalId,
+  isZonePortalAddress,
+} from './portal.js'
+
+describe('Zone Portal addresses', () => {
+  test('derives and parses a portal address', () => {
+    const address = getZonePortalAddress(3)
+    expect(address).toBe('0x5Ad0000000000000000000000000000000000003')
+    expect(isZonePortalAddress(address)).toBe(true)
+    expect(getZonePortalId(address)).toBe(3)
+  })
+
+  test('rejects addresses outside the portal range', () => {
+    const address = '0x5AD1000000000000000000000000000000000000'
+    expect(isZonePortalAddress(address)).toBe(false)
+    expect(getZonePortalId(address)).toBeUndefined()
+    expect(
+      isZonePortalAddress('0x5ad0000000000000000000000000000100000000'),
+    ).toBe(false)
+  })
+
+  test('rejects invalid Zone IDs', () => {
+    expect(() => getZonePortalAddress(-1)).toThrow(RangeError)
+    expect(() => getZonePortalAddress(2n ** 32n)).toThrow(RangeError)
+  })
+})

--- a/src/tempo/zones/portal.ts
+++ b/src/tempo/zones/portal.ts
@@ -1,0 +1,27 @@
+import type { Address } from 'abitype'
+import { getAddress } from '../../utils/address/getAddress.js'
+import { isAddress } from '../../utils/address/isAddress.js'
+
+const prefix = '5ad000000000000000000000'
+const maxZoneId = 2n ** 32n - 1n
+
+/** Returns the deterministic Tempo address for a Zone Portal proxy. */
+export function getZonePortalAddress(zoneId: bigint | number): Address {
+  const value = BigInt(zoneId)
+  if (value < 0n || value > maxZoneId)
+    throw new RangeError('Zone ID must fit in an unsigned 32-bit integer.')
+  return getAddress(`0x${prefix}${value.toString(16).padStart(16, '0')}`)
+}
+
+/** Returns whether an address belongs to the deterministic Zone Portal range. */
+export function isZonePortalAddress(address: string): address is Address {
+  if (!isAddress(address) || !address.toLowerCase().startsWith(`0x${prefix}`))
+    return false
+  return BigInt(`0x${address.slice(2 + prefix.length)}`) <= maxZoneId
+}
+
+/** Extracts the Zone ID from a deterministic Zone Portal address. */
+export function getZonePortalId(address: Address): number | undefined {
+  if (!isZonePortalAddress(address)) return undefined
+  return Number(BigInt(`0x${address.slice(2 + prefix.length)}`))
+}

--- a/src/tempo/zones/zone.test-d.ts
+++ b/src/tempo/zones/zone.test-d.ts
@@ -1,6 +1,13 @@
 import { tempoModerato } from 'viem/chains'
 import type { Addresses as TempoAddresses } from 'viem/tempo'
-import { Addresses, zoneModerato } from 'viem/tempo/zones'
+import {
+  Addresses,
+  Contracts,
+  getZonePortalAddress,
+  getZonePortalId,
+  isZonePortalAddress,
+  zoneModerato,
+} from 'viem/tempo/zones'
 import { expectTypeOf, test } from 'vitest'
 
 test('exposes Zone E contracts', () => {
@@ -30,4 +37,15 @@ test('exposes Zone protocol addresses', () => {
   expectTypeOf<
     typeof TempoAddresses.zoneVerifier
   >().toEqualTypeOf<'0x5a56000000000000000000000000000000000000'>()
+})
+
+test('exposes Zone system contracts and deterministic Portal helpers', () => {
+  expectTypeOf(
+    Contracts.factory.address,
+  ).toEqualTypeOf<'0x5aF2000000000000000000000000000000000000'>()
+  expectTypeOf(getZonePortalAddress(3)).toEqualTypeOf<`0x${string}`>()
+  expectTypeOf(getZonePortalId(getZonePortalAddress(3))).toEqualTypeOf<
+    number | undefined
+  >()
+  expectTypeOf(isZonePortalAddress('0x')).toEqualTypeOf<boolean>()
 })


### PR DESCRIPTION
## Summary

- export EIP-2935 block hash history address and selectorless calldata codecs
- expose fixed and deterministic Tempo system contract detection
- add typed Zone Factory, Portal implementation, Messenger, Outbox, and Verifier contract metadata
- add deterministic Zone Portal address derivation and parsing helpers
- extend Zone ABIs with current settlement events, submitBatch, Messenger relay, Verifier verification, Factory ownership/portal discovery, and Portal administration operations

## Source

The Zone interfaces and address layout match the canonical [tempoxyz/zones interfaces](https://github.com/tempoxyz/zones/blob/main/crates/contracts/src/runtime/interfaces/IZone.sol). EIP-2935 uses selectorless 32-byte calldata, so this exports explicit codecs instead of a misleading conventional ABI.

## Validation

- source TypeScript project passes
- selected public type tests pass
- declaration generation passes
- 10 focused runtime tests pass
- Biome passes for all changed files
- full Tempo fixture tests are unavailable locally because postinstall cannot clone the repository SSH-only submodules in this sandbox

Prompted by: @0xalpharush

Prompted by: @0xrusowsky