### PR TITLE
feat(tempo): add ZonePortal admin operations

### DIFF
--- a/.changeset/tame-portals-rest.md
+++ b/.changeset/tame-portals-rest.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ZonePortal resume, pause guardian, and admin acceptance operations to Tempo exports.

--- a/src/tempo/zones/Abis.test-d.ts
+++ b/src/tempo/zones/Abis.test-d.ts
@@ -79,13 +79,29 @@ test('zonePortal decodes token configuration', () => {
   }>()
 })
 
-test('zonePortal encodes pause operations', () => {
+test('zonePortal encodes administration operations', () => {
   const pause = encodeFunctionData({
     abi: Abis.zonePortal,
     functionName: 'pause',
   })
+  const resume = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'resume',
+  })
+  const setPauseGuardian = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'setPauseGuardian',
+    args: [zeroAddress, true],
+  })
+  const acceptAdmin = encodeFunctionData({
+    abi: Abis.zonePortal,
+    functionName: 'acceptAdmin',
+  })
 
   expectTypeOf(pause).toEqualTypeOf<Hex>()
+  expectTypeOf(resume).toEqualTypeOf<Hex>()
+  expectTypeOf(setPauseGuardian).toEqualTypeOf<Hex>()
+  expectTypeOf(acceptAdmin).toEqualTypeOf<Hex>()
 })
 
 test('zoneOutbox decodes WithdrawalRequested fallback nonces', () => {

--- a/src/tempo/zones/Abis.ts
+++ b/src/tempo/zones/Abis.ts
@@ -252,6 +252,30 @@ export const zonePortal = [
     outputs: [],
   },
   {
+    name: 'resume',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [],
+  },
+  {
+    name: 'setPauseGuardian',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'account', type: 'address' },
+      { name: 'allowed', type: 'bool' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'acceptAdmin',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [],
+  },
+  {
     name: 'sequencerSetVersion',
     type: 'function',
     stateMutability: 'view',


### PR DESCRIPTION
## Summary

- add ZonePortal resume and pause guardian administration functions
- add pending-admin acceptance support
- cover each operation with type-level encoding tests

## Source

The functions match the canonical [tempoxyz/zones IZone interface](https://github.com/tempoxyz/zones/blob/main/crates/contracts/src/runtime/interfaces/IZone.sol).

## Validation

- Biome passes for changed TypeScript files
- TypeScript project build passes

Prompted by: @0xrusowsky