### PR TITLE
Fix `isHash` accepting odd-length hex strings

### DIFF
--- a/.changeset/is-hash-odd-length.md
+++ b/.changeset/is-hash-odd-length.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `isHash` returning `true` for odd-length hex strings. `size` rounds odd-length hex up to the next whole byte, so a 63-character hex string reported a size of 32 and passed the check. `isHash` now validates the length directly.

--- a/src/utils/hash/isHash.test.ts
+++ b/src/utils/hash/isHash.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 import { isHash } from './isHash.js'
 
-test('checks if address is valid', () => {
+test('checks if hash is valid', () => {
   expect(isHash('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac')).toBeFalsy()
   expect(isHash('0xa0cf798816d4b9b9866b5330eea46a18382f251e')).toBeFalsy()
   expect(isHash('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678az')).toBeFalsy()
@@ -13,4 +13,21 @@ test('checks if address is valid', () => {
       '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
     ),
   ).toBeTruthy()
+  expect(
+    isHash(
+      '0x60FDD29FF912CE880CD3EDAF9F932DC61D3DAE823EA77E0323F94ADB9F6A72FE',
+    ),
+  ).toBeTruthy()
+})
+
+test('checks length is exactly 32 bytes', () => {
+  expect(isHash('')).toBeFalsy()
+  expect(isHash('0x')).toBeFalsy()
+  // 31.5 bytes: `size` rounds odd-length hex up to 32, so this used to pass.
+  expect(isHash(`0x${'a'.repeat(63)}`)).toBeFalsy()
+  expect(isHash(`0x${'a'.repeat(64)}`)).toBeTruthy()
+  expect(isHash(`0x${'a'.repeat(65)}`)).toBeFalsy()
+  expect(isHash(`0x${'a'.repeat(66)}`)).toBeFalsy()
+  // 66 chars, but not hex.
+  expect(isHash(`0x${'z'.repeat(64)}`)).toBeFalsy()
 })

--- a/src/utils/hash/isHash.ts
+++ b/src/utils/hash/isHash.ts
@@ -1,10 +1,9 @@
 import type { ErrorType } from '../../errors/utils.js'
 import type { Hex } from '../../types/misc.js'
 import { type IsHexErrorType, isHex } from '../data/isHex.js'
-import { type SizeErrorType, size } from '../data/size.js'
 
-export type IsHashErrorType = IsHexErrorType | SizeErrorType | ErrorType
+export type IsHashErrorType = IsHexErrorType | ErrorType
 
 export function isHash(hash: string): hash is Hex {
-  return isHex(hash) && size(hash) === 32
+  return isHex(hash) && hash.length === 66
 }


### PR DESCRIPTION
`isHash` returns `true` for hex strings of 65 characters, one short of a valid
32-byte hash. The most common way to produce one is truncating a real hash by a
single character, so the false positive lands exactly where validation matters.

```ts
isHash('0x' + 'a'.repeat(63)) // true — expected false
```

**Cause**

`isHash` is `isHex(hash) && size(hash) === 32`. `isHex` in strict mode accepts an
odd number of nibbles, and `size` rounds up: `Math.ceil(63 / 2) === 32`. So 63
nibbles report as 32 bytes and pass the check.

**Impact**

Validation passes client-side and the value fails later, further down the stack.
A node rejects it with `-32602 invalid params`, so the error surfaces from inside
a query or a receipt wait rather than at the input boundary. For comparison,
ethers rejects the same string: `isHexString(value, 32)` returns `false` and
`getBytes` throws.

**Note**
The same pattern (`size(value) === N` used as a validator on untrusted input) appears at several other call sites.