### PR TITLE
fix(tempo): include Zone encryption key address

### DIFF
--- a/.changeset/wise-zones-encrypt.md
+++ b/.changeset/wise-zones-encrypt.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Added the derived public key address to the `sequencerEncryptionKey` Zone Portal ABI output.

--- a/scripts/generateTempoAbis.ts
+++ b/scripts/generateTempoAbis.ts
@@ -469,7 +469,7 @@ function zonesAdapter(): SourceAdapter {
     ]),
     ZonePortal: Abi.from([
       'function deposit(address _token, address to, uint128 amount, bytes32 memo, address tempoRefundRecipient) returns (bytes32)',
-      'function sequencerEncryptionKey() view returns (bytes32 x, uint8 yParity)',
+      'function sequencerEncryptionKey() view returns (bytes32 x, uint8 yParity, address pubkey)',
     ]),
   }
   const outputs = {

--- a/src/tempo/Abis.test.ts
+++ b/src/tempo/Abis.test.ts
@@ -39,3 +39,17 @@ test('preserves Tempo ABI items when merging Zone ABIs', () => {
     ],
   })
 })
+
+test('includes the sequencer encryption key address', () => {
+  expect(Abis.zonePortal).toContainEqual({
+    name: 'sequencerEncryptionKey',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [
+      { type: 'bytes32', name: 'x' },
+      { type: 'uint8', name: 'yParity' },
+      { type: 'address', name: 'pubkey' },
+    ],
+  })
+})

--- a/src/tempo/Abis.ts
+++ b/src/tempo/Abis.ts
@@ -4016,6 +4016,7 @@ export const zonePortal = [
     outputs: [
       { type: 'bytes32', name: 'x' },
       { type: 'uint8', name: 'yParity' },
+      { type: 'address', name: 'pubkey' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- update the Zone Portal compatibility ABI to include the derived `pubkey` address returned by `sequencerEncryptionKey`
- regenerate the exported Tempo ABI and add regression coverage
- add a patch changeset

## Testing

- `pnpm exec vitest run src/tempo/Abis.test.ts --config vitest.isolated.config.ts`
- `pnpm check:types`
- `pnpm build:types`
- `pnpm gen:tempo-abis`

Spec: https://github.com/tempoxyz/zones/blob/f96c54b5afe63ab01f39f7772933403c24d4707f/specs/spec.md?plain=1#L1892-L1893

Prompted by: @0xalpharush