### PR TITLE
fix(tempo): preserve t10 encryption key reads

### DIFF
--- a/.changeset/wise-zones-encrypt.md
+++ b/.changeset/wise-zones-encrypt.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Added the derived public key address to the `sequencerEncryptionKey` Zone Portal ABI output.
+Added the derived public key address to the `sequencerEncryptionKey` Zone Portal ABI output while preserving T10 encryption key reads.

--- a/src/tempo/actions/zone.ts
+++ b/src/tempo/actions/zone.ts
@@ -71,6 +71,21 @@ import type { TransactionReceipt } from '../Transaction.js'
 
 const defaultWithdrawalGas = 10_000_000n
 
+// TODO: Remove this compatibility ABI when T10 support is retired.
+// Later Zone deployments append the derived address to these two values.
+const sequencerEncryptionKeyAbi = [
+  {
+    name: 'sequencerEncryptionKey',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [
+      { type: 'bytes32', name: 'x' },
+      { type: 'uint8', name: 'yParity' },
+    ],
+  },
+] as const
+
 export type EncryptedPayload = {
   ciphertext: Hex.Hex
   ephemeralPubkeyX: Hex.Hex
@@ -420,7 +435,7 @@ export namespace getEncryptionKey {
       }),
       defineCall({
         address: args.portalAddress,
-        abi: Abis.zonePortal,
+        abi: sequencerEncryptionKeyAbi,
         functionName: 'sequencerEncryptionKey',
       }),
     ] as const


### PR DESCRIPTION
Preserves T10 Zone encryption key reads by decoding the two-output prefix while retaining the current three-output public ABI for newer deployments.
