### PR TITLE
ci: update Tnext image pair

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -267,7 +267,6 @@ jobs:
             tempo-tag: sha256:af7a8955370adc4868a3237352ceded3bd917702a14758796eab86b338b75e49
             zone-tag: sha256:45b4e66b0a7d5f8d9486eeb05e0842c7a223b53e9ef910ef73cd9558f4a79118
           - hardfork: Tnext
-            # Tempo latest with TIP-1096-compatible Zones f953a3c.
             tempo-tag: latest
             zone-tag: sha256:2c6e58767e75f5b9dc012361daa89cb8baaad7d70f8c4151aa8a506b3d92f44b
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -267,8 +267,9 @@ jobs:
             tempo-tag: sha256:af7a8955370adc4868a3237352ceded3bd917702a14758796eab86b338b75e49
             zone-tag: sha256:45b4e66b0a7d5f8d9486eeb05e0842c7a223b53e9ef910ef73cd9558f4a79118
           - hardfork: Tnext
-            tempo-tag: sha256:8ceb2ffd223869b6f4782a225fa05c1f5dcb49ad037a69be2252521713ad3527
-            zone-tag: sha256:cba4ccc8724ee1b2394b1fbb0fbfc1d645b7791ba26267422b9dd90ef7dabdb7
+            # Tempo latest with TIP-1096-compatible Zones f953a3c.
+            tempo-tag: latest
+            zone-tag: sha256:2c6e58767e75f5b9dc012361daa89cb8baaad7d70f8c4151aa8a506b3d92f44b
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Uses Tempo `latest` for Tnext verification and pins the TIP-1096-compatible Zone image, restoring CI coverage against the current Tempo runtime.
