### PR TITLE
Fix isHex to reject odd-length hex strings in strict mode

### DIFF
--- a/.changeset/fix-ishex-odd-nibbles.md
+++ b/.changeset/fix-ishex-odd-nibbles.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `isHex` incorrectly returning `true` for odd-length hex strings in strict mode

--- a/src/utils/data/isHex.test.ts
+++ b/src/utils/data/isHex.test.ts
@@ -4,11 +4,15 @@ import { isHex } from './isHex.js'
 
 test('is hex', () => {
   expect(isHex('0x')).toBeTruthy()
-  expect(isHex('0x0')).toBeTruthy()
+  expect(isHex('0x0')).toBeFalsy()
+  expect(isHex('0x01')).toBeTruthy()
+  expect(isHex('0x123')).toBeFalsy()
   expect(isHex('0x0123456789abcdef')).toBeTruthy()
   expect(isHex('0x0123456789abcdefABCDEF')).toBeTruthy()
   expect(isHex('0x0123456789abcdefg')).toBeFalsy()
   expect(isHex('0x0123456789abcdefg', { strict: false })).toBeTruthy()
+  expect(isHex('0x0', { strict: false })).toBeTruthy()
+  expect(isHex('0x123', { strict: false })).toBeTruthy()
   expect(isHex({ foo: 'bar' })).toBeFalsy()
   expect(isHex(undefined)).toBeFalsy()
 })

--- a/src/utils/data/isHex.ts
+++ b/src/utils/data/isHex.ts
@@ -9,5 +9,5 @@ export function isHex(
 ): value is Hex {
   if (!value) return false
   if (typeof value !== 'string') return false
-  return strict ? /^0x[0-9a-fA-F]*$/.test(value) : value.startsWith('0x')
+  return strict ? /^0x([0-9a-fA-F][0-9a-fA-F])*$/.test(value) : value.startsWith('0x')
 }


### PR DESCRIPTION
Fixes #5048

## Changes
- Updated the regex in `isHex()` from `/^0x[0-9a-fA-F]*$/` to `/^0x([0-9a-fA-F][0-9a-fA-F])*$/` to require pairs of hex digits (full bytes) in strict mode
- Updated existing test that depended on the old behavior (`isHex('0x0')` now returns false instead of true)
- Added new test cases:
  - `isHex('0x01')` returns true (even length)
  - `isHex('0x123')` returns false (odd length)
  - Non-strict mode still allows odd-length hex strings

## Notes
- This is a breaking change: `isHex('0x0')` flips from true to false in strict mode
- Non-strict mode behavior is unchanged
- Empty hex string `'0x'` (zero bytes) remains valid
- Changeset added as patch version bump
