### PR TITLE
fix(tempo): export inference types

### DIFF
--- a/.changeset/quiet-chains-infer.md
+++ b/.changeset/quiet-chains-infer.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed declaration emit for inferred Tempo chains.

--- a/.changeset/quiet-chains-infer.md
+++ b/.changeset/quiet-chains-infer.md
@@ -2,4 +2,4 @@
 'viem': patch
 ---
 
-Fixed declaration emit for inferred Tempo chains.
+`viem/tempo`: Fixed declaration emit for inferred Tempo chains.

--- a/src/tempo/index.test-d.ts
+++ b/src/tempo/index.test-d.ts
@@ -1,0 +1,9 @@
+import type { Owner } from 'ox/tempo/MultisigConfig'
+import { expectTypeOf, test } from 'vitest'
+import type { z_MultisigConfigOwner, z_MultisigOwnerState } from './index.js'
+import type { MultisigOwnerState } from './Transaction.js'
+
+test('exports types required for inference', () => {
+  expectTypeOf<z_MultisigConfigOwner>().toEqualTypeOf<Owner>()
+  expectTypeOf<z_MultisigOwnerState>().toEqualTypeOf<MultisigOwnerState>()
+})

--- a/src/tempo/index.test-d.ts
+++ b/src/tempo/index.test-d.ts
@@ -1,9 +1,0 @@
-import type { Owner } from 'ox/tempo/MultisigConfig'
-import { expectTypeOf, test } from 'vitest'
-import type { z_MultisigConfigOwner, z_MultisigOwnerState } from './index.js'
-import type { MultisigOwnerState } from './Transaction.js'
-
-test('exports types required for inference', () => {
-  expectTypeOf<z_MultisigConfigOwner>().toEqualTypeOf<Owner>()
-  expectTypeOf<z_MultisigOwnerState>().toEqualTypeOf<MultisigOwnerState>()
-})

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -23,6 +23,11 @@ export {
   VirtualAddress,
   VirtualMaster,
 } from 'ox/tempo'
+// TODO: remove
+export type {
+  /** @deprecated */
+  Owner as z_MultisigConfigOwner,
+} from 'ox/tempo/MultisigConfig'
 export {
   type CustomTransport,
   type CustomTransportConfig,
@@ -76,6 +81,8 @@ export * as Storage from './Storage.js'
 export * as TokenIds from './TokenIds.js'
 // Export types required for inference.
 export type {
+  /** @deprecated */
+  MultisigOwnerState as z_MultisigOwnerState,
   /** @deprecated */
   Transaction as z_Transaction,
   /** @deprecated */


### PR DESCRIPTION
Exports the new Tempo multisig types through `viem/tempo`, allowing consumers to emit declarations for inferred Tempo chains without explicit annotations.
