### PR TITLE
feat(chains): add OP Stack config to Whitechain Sepolia

### DIFF
--- a/.changeset/khaki-pillows-tickle.md
+++ b/.changeset/khaki-pillows-tickle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added OP Stack configuration to the Whitechain Sepolia chain.

--- a/src/chains/definitions/whitechainSepolia.ts
+++ b/src/chains/definitions/whitechainSepolia.ts
@@ -1,7 +1,10 @@
+import { chainConfig } from '../../op-stack/chainConfig.js'
 import { defineChain } from '../../utils/chain/defineChain.js'
 
+const sourceId = 11_155_111 // sepolia
+
 export const whitechainSepolia = /*#__PURE__*/ defineChain({
-  testnet: true,
+  ...chainConfig,
   id: 1874,
   name: 'Whitechain Sepolia',
   nativeCurrency: {
@@ -9,9 +12,11 @@ export const whitechainSepolia = /*#__PURE__*/ defineChain({
     name: 'WBT',
     symbol: 'WBT',
   },
+  blockTime: 1_000,
   rpcUrls: {
     default: {
       http: ['https://rpc.testnet.whitechain.io'],
+      webSocket: ['wss://rpc.testnet.whitechain.io/ws'],
     },
   },
   blockExplorers: {
@@ -21,8 +26,28 @@ export const whitechainSepolia = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: '0xcA11bde05977b3631167028862bE2a173976CA11',
     },
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0xfaa2fAA8912C069c01abc169c33713c79027c833',
+      },
+    },
+    portal: {
+      [sourceId]: {
+        address: '0xFF9b597b0781457ae6aa7256Ca5ed5839bF7D0C3',
+        blockCreated: 11071328,
+      },
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0x0c50bE539AB5D72d226038928F2eB25100899DED',
+        blockCreated: 11071328,
+      },
+    },
   },
+  testnet: true,
+  sourceId,
 })


### PR DESCRIPTION
Whitechain Sepolia (chain ID `1874`) is an OP Stack (Bedrock) L2 that settles on Ethereum Sepolia (`11155111`). It is already in `viem/chains`, but only as a plain chain definition: no `chainConfig` spread, no `sourceId`, and no L1 contracts. As a result the `viem/op-stack` actions cannot resolve the contracts they need: `getWithdrawalStatus`, `proveWithdrawal`, `finalizeWithdrawal`, `depositTransaction`, `getGames` and `getPortalVersion` have no `portal` or `disputeGameFactory` to read, and `estimateL1Fee` throws `ChainDoesNotSupportContract` for `gasPriceOracle` because the predeploys from `chainConfig.contracts` are missing.

This PR spreads `chainConfig`, sets `sourceId`, and adds the L1 contracts.

### L1 addresses

Every address was resolved on-chain rather than copied from a list. The call that produced each one:

| Contract | Address | Resolved by |
| --- | --- | --- |
| `l1StandardBridge` | `0x0c50bE539AB5D72d226038928F2eB25100899DED` | `OTHER_BRIDGE()` on the `L2StandardBridge` predeploy `0x4200000000000000000000000000000000000010` (L2) |
| L1CrossDomainMessengerProxy | `0x547967f45d19Dc4Ca0A056Ba525Afe99BDA18a88` | `OTHER_MESSENGER()` on the `L2CrossDomainMessenger` predeploy `0x4200000000000000000000000000000000000007` (L2) |
| `portal` | `0xFF9b597b0781457ae6aa7256Ca5ed5839bF7D0C3` | `PORTAL()` on the L1CrossDomainMessengerProxy above (Sepolia) |
| `disputeGameFactory` | `0xfaa2fAA8912C069c01abc169c33713c79027c833` | `disputeGameFactory()` on the portal (Sepolia) |

`l2Oracle()` on the portal reverts, so the chain is on fault proofs and `disputeGameFactory` is used rather than `l2OutputOracle`. Portal reports `version()` `5.2.0` and `respectedGameType()` `1`; the DisputeGameFactory reports `1.4.0`.

The pairing was checked in both directions: on Sepolia, `L1StandardBridgeProxy.OTHER_BRIDGE()` returns `0x4200000000000000000000000000000000000010` and `L1StandardBridgeProxy.MESSENGER()` returns the same L1 messenger.

`blockCreated` for the portal and the L1 standard bridge is `11071328`. Both proxies are created internally by the OP deployer, so neither appears as a top-level `contractAddress` in a receipt; the block was established from archive state instead – `eth_getCode` returns `0x` for both at Sepolia block `11071327` and returns code for both at `11071328`.

### Custom gas token

Whitechain Sepolia uses **WBT** as its native gas token, not ETH. `SystemConfig.isCustomGasToken()` returns `true` (`SystemConfig` at `0x9328Ea869949f33c57B7b680B6EdB58769e2181c`, reached via `OptimismPortalProxy.systemConfig()`). The existing `nativeCurrency` is kept as-is.

### Other changes in this file

- Added the WebSocket endpoint `wss://rpc.testnet.whitechain.io/ws` to `rpcUrls.default.webSocket`. It responds to `eth_chainId` with `0x752`, and the chain test suite exercises it.
- Added `blockTime: 1_000` after the `chainConfig` spread. `chainConfig` provides `blockTime: 2_000`, but Whitechain Sepolia produces a block every 1000 ms (measured over 100 consecutive blocks), so without the override this change would silently introduce a wrong block time. `giwaSepolia` overrides it the same way.

`whitechain.ts` (`1875`, an L1) and `whitechainTestnet.ts` (`2625`, the legacy L1 testnet) are separate networks and are untouched.

### Verification

- `pnpm check:types` and Biome are clean.
- `pnpm build` succeeds and `whitechainSepolia` resolves from the build output with its `sourceId`, contracts, formatters and serializers intact.
- `vitest run test/scripts/chains.test.ts -t "Whitechain Sepolia"` passes, including the new WebSocket URL.
- Against live RPCs: `estimateL1Fee` returns a value, `getPortalVersion({ targetChain: whitechainSepolia })` returns `{ major: 5, minor: 2, patch: 0 }`, and `getGames({ targetChain: whitechainSepolia })` returns real games – so the portal and dispute game factory addresses in the definition work end to end.

