### PR TITLE
fix(account-abstraction): handle pending User Operations in getUserOperation

### DIFF
--- a/.changeset/get-user-operation-pending.md
+++ b/.changeset/get-user-operation-pending.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `getUserOperation` throwing `Cannot convert null to a BigInt` for pending User Operations, and made `blockHash`, `blockNumber`, and `transactionHash` nullable on its return value (as well as on `GetUserOperationByHashReturnType`) to reflect what Bundlers return while a User Operation is in the mempool.

--- a/site/pages/account-abstraction/actions/bundler/getUserOperation.md
+++ b/site/pages/account-abstraction/actions/bundler/getUserOperation.md
@@ -41,15 +41,15 @@ The Bundler URL above is a public endpoint. Please do not use it in production a
 
 ```ts
 {
-  blockHash: Hash,
-  blockNumber: bigint,
+  blockHash: Hash | null,
+  blockNumber: bigint | null,
   entryPoint: Address,
-  transactionHash: Hash,
+  transactionHash: Hash | null,
   userOperation: UserOperation
 }
 ```
 
-User Operation information.
+User Operation information. `blockHash`, `blockNumber`, and `transactionHash` are `null` while the User Operation is pending (that is, still in the Bundler's mempool).
 
 ## Parameters
 

--- a/src/account-abstraction/actions/bundler/getUserOperation.test-d.ts
+++ b/src/account-abstraction/actions/bundler/getUserOperation.test-d.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf, test } from 'vitest'
+import { bundlerMainnet } from '~test/bundler.js'
+import type { Hash } from '../../../types/misc.js'
+import { getUserOperation } from './getUserOperation.js'
+
+const bundlerClient = bundlerMainnet.getBundlerClient()
+
+test('default', async () => {
+  const result = await getUserOperation(bundlerClient, { hash: '0x' })
+
+  expectTypeOf(result.blockHash).toEqualTypeOf<Hash | null>()
+  expectTypeOf(result.blockNumber).toEqualTypeOf<bigint | null>()
+  expectTypeOf(result.transactionHash).toEqualTypeOf<Hash | null>()
+})

--- a/src/account-abstraction/actions/bundler/getUserOperation.test.ts
+++ b/src/account-abstraction/actions/bundler/getUserOperation.test.ts
@@ -6,9 +6,12 @@ import {
 } from '~test/account-abstraction.js'
 import { anvilMainnet } from '~test/anvil.js'
 import { bundlerMainnet } from '~test/bundler.js'
+import { createHttpServer } from '~test/utils.js'
 import { signAuthorization } from '../../../actions/index.js'
 import { mine } from '../../../actions/test/mine.js'
+import { http } from '../../../clients/transports/http.js'
 import { parseEther, parseGwei } from '../../../utils/index.js'
+import { createBundlerClient } from '../../clients/createBundlerClient.js'
 import { getUserOperation } from './getUserOperation.js'
 import { sendUserOperation } from './sendUserOperation.js'
 
@@ -23,6 +26,62 @@ const fees = {
 beforeEach(async () => {
   await bundlerMainnet.restart()
 })
+
+test('behavior: pending user operation', async () => {
+  const server = await createHttpServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(
+      JSON.stringify({
+        result: {
+          blockHash: null,
+          blockNumber: null,
+          entryPoint: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+          transactionHash: null,
+          userOperation: {
+            callData: '0xdeadbeef',
+            callGasLimit: '0x1a1c0',
+            maxFeePerGas: '0x1a13b8600',
+            maxPriorityFeePerGas: '0x3b9aca00',
+            nonce: '0x0',
+            preVerificationGas: '0xb1f4',
+            sender: '0x0000000000000000000000000000000000000001',
+            signature: '0xcafebabe',
+            verificationGasLimit: '0x18190',
+          },
+        },
+      }),
+    )
+  })
+
+  const client = createBundlerClient({ transport: http(server.url) })
+
+  const result = await getUserOperation(client, {
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
+  })
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "blockHash": null,
+      "blockNumber": null,
+      "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+      "transactionHash": null,
+      "userOperation": {
+        "callData": "0xdeadbeef",
+        "callGasLimit": 106944n,
+        "maxFeePerGas": 7000000000n,
+        "maxPriorityFeePerGas": 1000000000n,
+        "nonce": 0n,
+        "preVerificationGas": 45556n,
+        "sender": "0x0000000000000000000000000000000000000001",
+        "signature": "0xcafebabe",
+        "verificationGasLimit": 98704n,
+      },
+    }
+  `)
+
+  await server.close()
+})
+
 describe('entryPointVersion: 0.8', async () => {
   const [account] = await getSmartAccounts_08()
 

--- a/src/account-abstraction/actions/bundler/getUserOperation.ts
+++ b/src/account-abstraction/actions/bundler/getUserOperation.ts
@@ -18,14 +18,14 @@ export type GetUserOperationParameters = {
 }
 
 export type GetUserOperationReturnType = Prettify<{
-  /** The block hash the User Operation was included on. */
-  blockHash: Hash
-  /** The block number the User Operation was included on. */
-  blockNumber: bigint
+  /** The block hash the User Operation was included on. `null` if pending. */
+  blockHash: Hash | null
+  /** The block number the User Operation was included on. `null` if pending. */
+  blockNumber: bigint | null
   /** The EntryPoint which handled the User Operation. */
   entryPoint: Address
-  /** The hash of the transaction which included the User Operation. */
-  transactionHash: Hash
+  /** The hash of the transaction which included the User Operation. `null` if pending. */
+  transactionHash: Hash | null
   /** The User Operation. */
   userOperation: UserOperation
 }>
@@ -76,10 +76,10 @@ export async function getUserOperation(
     result
 
   return {
-    blockHash,
-    blockNumber: BigInt(blockNumber),
+    blockHash: blockHash ?? null,
+    blockNumber: blockNumber ? BigInt(blockNumber) : null,
     entryPoint,
-    transactionHash,
+    transactionHash: transactionHash ?? null,
     userOperation: formatUserOperation(userOperation),
   }
 }

--- a/src/account-abstraction/types/userOperation.ts
+++ b/src/account-abstraction/types/userOperation.ts
@@ -53,10 +53,13 @@ export type GetUserOperationByHashReturnType<
   uint256 = bigint,
   uint32 = number,
 > = {
-  blockHash: Hash
-  blockNumber: uint256
+  /** `null` if the User Operation is pending. */
+  blockHash: Hash | null
+  /** `null` if the User Operation is pending. */
+  blockNumber: uint256 | null
   entryPoint: Address
-  transactionHash: Hash
+  /** `null` if the User Operation is pending. */
+  transactionHash: Hash | null
   userOperation: UserOperation<entryPointVersion, uint256, uint32>
 }
 


### PR DESCRIPTION
Bundlers return `null` for `blockHash`, `blockNumber`, and `transactionHash` while a User Operation is still in the mempool. `getUserOperation` passed `blockNumber` to `BigInt`, which throws `Cannot convert null to a BigInt`, so polling a just-submitted UserOp is unusable.

Those three fields are now null-safe at runtime and nullable on `GetUserOperationByHashReturnType` / `GetUserOperationReturnType`.

Closes #5057