### PR TITLE
fix(tempo): expose zone return type

### DIFF
--- a/.changeset/calm-zones-emit.md
+++ b/.changeset/calm-zones-emit.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Made Tempo Zone return types portable across declaration-emitting projects.

--- a/environments/tsc/index.ts
+++ b/environments/tsc/index.ts
@@ -1,5 +1,13 @@
 import { createPublicClient, http, webSocket } from 'viem'
 import { mainnet } from 'viem/chains'
+import { Zone } from 'viem/tempo'
+
+export const zone = Zone.from({
+  id: 123,
+  name: 'Custom Zone',
+  sourceId: 1,
+})
+
 ;(async () => {
   const client = createPublicClient({
     chain: mainnet,

--- a/environments/tsc/tsconfig.json
+++ b/environments/tsc/tsconfig.json
@@ -50,7 +50,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                                /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */

--- a/src/tempo/Zone.test-d.ts
+++ b/src/tempo/Zone.test-d.ts
@@ -21,9 +21,14 @@ test('exposes Zone definitions', () => {
   >()
   expectTypeOf(Zone.internalTestnet.sourceId).toEqualTypeOf<42431>()
   expectTypeOf(Addresses.zonePortal(Zone.a.id)).toEqualTypeOf<`0x${string}`>()
-  expectTypeOf(
-    Zone.from({ id: 123, name: 'Custom Zone', sourceId: 1 }),
-  ).toHaveProperty('id')
+  const zone = Zone.from({ id: 123, name: 'Custom Zone', sourceId: 1 })
+  expectTypeOf(zone.id).toEqualTypeOf<123>()
+  expectTypeOf(zone.name).toEqualTypeOf<'Custom Zone'>()
+  expectTypeOf(zone.rpcUrls.default.http).toEqualTypeOf<string[]>()
+  expectTypeOf(zone.sourceId).toEqualTypeOf<1>()
+
+  const annotated: ReturnType<typeof Zone.from> = zone
+  expectTypeOf(annotated.id).toEqualTypeOf<number>()
 })
 
 test('exposes Zone protocol addresses', () => {

--- a/src/tempo/Zone.ts
+++ b/src/tempo/Zone.ts
@@ -1,9 +1,30 @@
-import type { Chain } from '../types/chain.js'
-import { defineChain } from '../utils/chain/defineChain.js'
-import { chainConfig } from './chainConfig.js'
+import type { Chain, ChainFormatters } from '../types/chain.js'
+import type { Assign } from '../types/utils.js'
+import {
+  type DefineChainReturnType,
+  defineChain,
+} from '../utils/chain/defineChain.js'
+import { type ChainConfig, chainConfig } from './chainConfig.js'
+
+type Defaults = {
+  nativeCurrency: {
+    decimals: number
+    name: string
+    symbol: string
+  }
+  rpcUrls: { default: { http: string[] } }
+  supportsTransactionReplacementDetection: boolean
+}
+
+type ZoneChain = Chain<ChainFormatters, ChainConfig['extendSchema']> & {
+  formatters: ChainConfig['formatters']
+}
 
 /** Defines a Tempo Zone chain. */
-export function from<const config extends from.Parameters>(config: config) {
+export function from<const config extends from.Parameters>(
+  config: config,
+): from.ReturnValue<config>
+export function from(config: from.Parameters) {
   const chain = {
     ...chainConfig,
     nativeCurrency: {
@@ -23,6 +44,11 @@ export declare namespace from {
     Partial<Omit<Chain, 'id' | 'name' | 'sourceId'>> & {
       sourceId: number
     }
+
+  type ReturnValue<config extends Parameters = Parameters> = Assign<
+    Assign<DefineChainReturnType<ZoneChain>, Defaults>,
+    config
+  >
 }
 
 export const a = /*#__PURE__*/ from({


### PR DESCRIPTION
Adds a named return type to `Zone.from` while preserving literal chain inference. Declaration-emitting consumers can now export custom Zone definitions without referencing Viem's internal account types.
