### PR TITLE
feat(tempo): infer multisig request chains

### DIFF
--- a/.changeset/curly-donkeys-route.md
+++ b/.changeset/curly-donkeys-route.md
@@ -2,11 +2,4 @@
 'viem': patch
 ---
 
-Added chain inference to `Multisig.handleRequest` downstream request options.
-
-```ts
-const handle = Multisig.handleRequest(
-  (request, options) => getClient(options?.chainId).request(request),
-  { store },
-)
-```
+`viem/tempo`: Added chain inference to `Multisig.handleRequest` downstream request options.

--- a/.changeset/curly-donkeys-route.md
+++ b/.changeset/curly-donkeys-route.md
@@ -1,0 +1,12 @@
+---
+'viem': patch
+---
+
+Added chain inference to `Multisig.handleRequest` downstream request options.
+
+```ts
+const handle = Multisig.handleRequest(
+  (request, options) => getClient(options?.chainId).request(request),
+  { store },
+)
+```

--- a/site/pages/tempo/utilities/Multisig.handleRequest.mdx
+++ b/site/pages/tempo/utilities/Multisig.handleRequest.mdx
@@ -15,7 +15,7 @@ import { Multisig, Store } from 'viem/tempo'
 
 const store = Store.memory()
 const handleRequest = Multisig.handleRequest(
-  (request) => rpc.request(request),
+  (request, options) => getClient(options?.chainId).request(request),
   { store },
 )
 ```
@@ -24,13 +24,25 @@ Use a shared persistent store in production. The in-memory store is process-loca
 Incomplete operations expire after 30 days without an approval or submission update. Successful
 operations remain available until the store removes them.
 
+The handler resolves the chain from raw transactions, key authorizations, and stored operations.
+It passes the resolved `chainId` to the downstream handler through the request options. Pass an
+explicit `chainId` when the surrounding route selects a chain:
+
+```ts
+await handleRequest(request, { chainId: 4217 })
+```
+
+The handler rejects a request when the explicit chain conflicts with its signed payload or stored
+operation.
+
 ## Parameters
 
 ### next
 
-- **Type:** `(request) => Promise<unknown>`
+- **Type:** `(request, options) => Promise<unknown>`
 
 The downstream RPC request handler used for configuration reads and final transaction submission.
+`options.chainId` contains the selected chain when the request identifies one.
 
 ### store
 

--- a/src/tempo/Multisig.test-d.ts
+++ b/src/tempo/Multisig.test-d.ts
@@ -1,0 +1,13 @@
+import { Multisig, Store } from 'viem/tempo'
+import { expectTypeOf, test } from 'vitest'
+
+test('handleRequest exposes the resolved chain', async () => {
+  const handle = Multisig.handleRequest(
+    async (_request, options) => {
+      expectTypeOf(options?.chainId).toEqualTypeOf<number | undefined>()
+    },
+    { store: Store.memory() },
+  )
+
+  await handle({ method: 'eth_blockNumber' }, { chainId: 4217 })
+})

--- a/src/tempo/Multisig.test.ts
+++ b/src/tempo/Multisig.test.ts
@@ -1,0 +1,192 @@
+import {
+  KeyAuthorization,
+  MultisigConfig,
+  MultisigOperation,
+  SignatureEnvelope,
+} from 'ox/tempo'
+import { Account, Multisig, Store, Transaction } from 'viem/tempo'
+import { expect, test } from 'vitest'
+import * as Operation from './multisig/Operation.js'
+
+const owner = Account.fromSecp256k1(
+  '0x0000000000000000000000000000000000000000000000000000000000000001',
+)
+const config = MultisigConfig.from({
+  owners: [{ owner: owner.address, weight: 1 }],
+  threshold: 1,
+})
+const account = MultisigConfig.getAddress(config)
+const approval = SignatureEnvelope.from({
+  signature: { r: 1n, s: 2n, yParity: 0 },
+  type: 'secp256k1',
+})
+const serializedApproval = SignatureEnvelope.serialize(approval)
+
+test('behavior: resolves the chain from a Tempo transaction', async () => {
+  const handle = Multisig.handleRequest(
+    async (_request, options) => options?.chainId,
+    { store: Store.memory() },
+  )
+  const transaction = await Transaction.serialize({
+    calls: [],
+    chainId: 4217,
+  })
+
+  await expect(
+    handle({
+      method: 'eth_sendRawTransaction',
+      params: [transaction],
+    }),
+  ).resolves.toMatchInlineSnapshot(`4217`)
+})
+
+test('behavior: resolves the chain from a key authorization', async () => {
+  const handle = Multisig.handleRequest(
+    async (request, options) => {
+      throw new Error(`${request.method}:${options?.chainId}`)
+    },
+    { store: Store.memory() },
+  )
+  const keyAuthorization = KeyAuthorization.from(
+    {
+      account,
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: 4217n,
+      isAdmin: false,
+      type: 'secp256k1',
+    },
+    {
+      signature: SignatureEnvelope.from({
+        account,
+        config,
+        signatures: [approval],
+      }),
+    },
+  )
+
+  await expect(
+    handle({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ keyAuthorization: KeyAuthorization.toRpc(keyAuthorization) }],
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [UnknownRpcError: An unknown RPC error occurred.
+
+    Details: eth_blockNumber:4217
+    Version: viem@x.y.z]
+  `)
+})
+
+test('behavior: resolves the chain from a stored transaction operation', async () => {
+  const store = Store.memory()
+  const transaction = await Transaction.serialize({ calls: [], chainId: 4217 })
+  const hash = MultisigOperation.getHash({
+    account,
+    config,
+    transaction,
+    type: 'transaction',
+  })
+  const validApproval = SignatureEnvelope.serialize(
+    SignatureEnvelope.from(await owner.sign({ hash })),
+  )
+  await Operation.update(store, hash, () =>
+    MultisigOperation.from({
+      account,
+      approvals: [validApproval],
+      config,
+      createdAt: 1,
+      hash,
+      signatureCount: 1,
+      status: 'success',
+      threshold: 1,
+      transaction,
+      transactionHash: `0x${'22'.repeat(32)}`,
+      type: 'transaction',
+      updatedAt: 2,
+      weight: 1,
+    }),
+  )
+  const handle = Multisig.handleRequest(
+    async (_request, options) => options?.chainId,
+    { store },
+  )
+
+  await expect(
+    handle({ method: 'eth_getTransactionReceipt', params: [hash] }),
+  ).resolves.toMatchInlineSnapshot(`4217`)
+})
+
+test('behavior: resolves the chain from a stored key authorization operation', async () => {
+  const store = Store.memory()
+  const keyAuthorization = KeyAuthorization.serialize(
+    KeyAuthorization.from({
+      account,
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: 4217n,
+      isAdmin: false,
+      type: 'secp256k1',
+    }),
+  )
+  const hash = MultisigOperation.getHash({
+    account,
+    config,
+    keyAuthorization,
+    type: 'keyAuthorization',
+  })
+  await Operation.update(store, hash, () =>
+    MultisigOperation.from({
+      account,
+      approvals: [],
+      config,
+      createdAt: 1,
+      hash,
+      keyAuthorization,
+      signatureCount: 0,
+      status: 'pending',
+      threshold: 1,
+      type: 'keyAuthorization',
+      updatedAt: 2,
+      weight: 0,
+    }),
+  )
+  const handle = Multisig.handleRequest(
+    async (request, options) => {
+      throw new Error(`${request.method}:${options?.chainId}`)
+    },
+    { store },
+  )
+
+  await expect(
+    handle({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ hash, signature: serializedApproval }],
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [UnknownRpcError: An unknown RPC error occurred.
+
+    Details: eth_blockNumber:4217
+    Version: viem@x.y.z]
+  `)
+})
+
+test('error: rejects conflicting chain ids', async () => {
+  const handle = Multisig.handleRequest(async () => null, {
+    store: Store.memory(),
+  })
+  const transaction = await Transaction.serialize({
+    calls: [],
+    chainId: 4217,
+  })
+
+  await expect(
+    handle(
+      {
+        method: 'eth_sendRawTransaction',
+        params: [transaction],
+      },
+      { chainId: 1 },
+    ),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `[RpcResponse.InvalidParamsError: Conflicting chain ids.]`,
+  )
+})

--- a/src/tempo/Multisig.ts
+++ b/src/tempo/Multisig.ts
@@ -44,14 +44,19 @@ export function handleRequest(
       message:
         'Multisig coordination requires a store with atomic `compareAndSet`.',
     })
-  const client = createClient({
-    transport: custom({
-      request: ({ method, params }, options) =>
-        next({ method, params }, options),
-    }),
-  })
+  return async (request, requestOptions_) => {
+    const requestOptions = await resolveRequestOptions({
+      request,
+      requestOptions: requestOptions_,
+      store: parameters.store,
+    })
+    const client = createClient({
+      transport: custom({
+        request: ({ method, params }, options) =>
+          next({ method, params }, { ...requestOptions, ...options }),
+      }),
+    })
 
-  return async (request, requestOptions) => {
     if (request.method === 'multisig_getConfig') {
       const value = request.params?.[0]
       const address =
@@ -200,7 +205,7 @@ export declare namespace handleRequest {
   /** RPC request handler. */
   export type Handler = (
     request: Request,
-    options?: EIP1193RequestOptions | undefined,
+    options?: RequestOptions | undefined,
   ) => Promise<unknown>
 
   /** RPC request passed to a handler. */
@@ -209,6 +214,12 @@ export declare namespace handleRequest {
     method: string
     /** RPC method parameters. */
     params?: readonly unknown[] | undefined
+  }
+
+  /** Options for one handled request. */
+  export type RequestOptions = EIP1193RequestOptions & {
+    /** Chain selected by the caller or inferred from the multisig request. */
+    chainId?: number | undefined
   }
 
   /** Parameters for {@link handleRequest}. */
@@ -555,7 +566,7 @@ declare namespace submit {
     /** Original RPC request. */
     request: handleRequest.Request
     /** Original request overrides. */
-    requestOptions?: EIP1193RequestOptions | undefined
+    requestOptions?: handleRequest.RequestOptions | undefined
     /** Serialized Tempo transaction. */
     serialized: Hex.Hex
     /** Shared multisig store. */
@@ -1338,6 +1349,136 @@ function getTransactionHash(result: unknown): Hex.Hex {
   )
     return result.transactionHash
   throw new Error('Expected transaction hash in multisig broadcast result.')
+}
+
+/** Resolves and validates the chain used by a handled request. */
+async function resolveRequestOptions(options: {
+  request: handleRequest.Request
+  requestOptions?: handleRequest.RequestOptions | undefined
+  store: Store.Store
+}): Promise<handleRequest.RequestOptions | undefined> {
+  const { request, requestOptions, store } = options
+  const chainId_explicit = requestOptions?.chainId
+  if (
+    chainId_explicit !== undefined &&
+    (!Number.isSafeInteger(chainId_explicit) || chainId_explicit <= 0)
+  )
+    throw new RpcResponse.InvalidParamsError({
+      message: 'Expected a valid chain ID.',
+    })
+  const chainId_request = await resolveRequestChainId(request, store)
+  if (
+    chainId_explicit !== undefined &&
+    chainId_request !== undefined &&
+    chainId_explicit !== chainId_request
+  )
+    throw new RpcResponse.InvalidParamsError({
+      message: 'Conflicting chain ids.',
+    })
+  const chainId = chainId_explicit ?? chainId_request
+  if (chainId === undefined) return requestOptions
+  return { ...requestOptions, chainId }
+}
+
+/** Resolves a chain from request fields, envelopes, or stored operations. */
+async function resolveRequestChainId(
+  request: handleRequest.Request,
+  store: Store.Store,
+) {
+  const value = request.params?.[0]
+  const chainId_body =
+    value && typeof value === 'object' && 'chainId' in value
+      ? parseChainId(value.chainId)
+      : undefined
+  const chainId_multisig = await (async () => {
+    if (
+      request.method === 'eth_sendRawTransaction' ||
+      request.method === 'eth_sendRawTransactionSync' ||
+      request.method === 'multisig_approveRawTransaction' ||
+      request.method === 'multisig_approveRawTransactionSync'
+    ) {
+      if (!isSerializedTempoTransaction(value)) return undefined
+      try {
+        return parseChainId(Transaction.deserialize(value).chainId)
+      } catch {
+        return undefined
+      }
+    }
+
+    if (
+      request.method === 'multisig_approveKeyAuthorization' &&
+      value &&
+      typeof value === 'object' &&
+      'keyAuthorization' in value
+    ) {
+      try {
+        return parseChainId(
+          KeyAuthorization.fromRpc(
+            value.keyAuthorization as KeyAuthorization.Rpc,
+          ).chainId,
+        )
+      } catch {
+        return undefined
+      }
+    }
+
+    const hash = (() => {
+      if (
+        request.method === 'eth_getTransactionByHash' ||
+        request.method === 'eth_getTransactionReceipt'
+      )
+        return value
+      if (
+        request.method === 'multisig_approveKeyAuthorization' &&
+        value &&
+        typeof value === 'object' &&
+        'hash' in value
+      )
+        return value.hash
+      return undefined
+    })()
+    if (typeof hash !== 'string' || !Hash.validate(hash)) return undefined
+    const operation = await OperationStore.read(store, hash)
+    if (!operation) return undefined
+    if (operation.type === 'transaction')
+      return parseChainId(
+        Transaction.deserialize(
+          operation.transaction as Transaction.TransactionSerializedTempo,
+        ).chainId,
+      )
+    return parseChainId(
+      KeyAuthorization.deserialize(operation.keyAuthorization).chainId,
+    )
+  })()
+
+  if (
+    chainId_body !== undefined &&
+    chainId_multisig !== undefined &&
+    chainId_body !== chainId_multisig
+  )
+    throw new RpcResponse.InvalidParamsError({
+      message: 'Conflicting chain ids.',
+    })
+  return chainId_body ?? chainId_multisig
+}
+
+/** Parses a supported chain ID representation. */
+function parseChainId(value: unknown) {
+  const chainId = (() => {
+    if (typeof value === 'number') return value
+    if (typeof value === 'bigint') return Number(value)
+    if (typeof value === 'string' && Hex.validate(value)) {
+      try {
+        return Hex.toNumber(value)
+      } catch {
+        return undefined
+      }
+    }
+    return undefined
+  })()
+  if (chainId === undefined || !Number.isSafeInteger(chainId) || chainId <= 0)
+    return undefined
+  return chainId
 }
 
 /** Checks whether a value is a serialized Tempo transaction. */


### PR DESCRIPTION
Infers the chain from multisig transaction payloads, key authorizations, and stored operations, then passes it to downstream handlers for multi-chain client selection.
