### PR TITLE
feat(chains): add XGR Testnet

### DIFF
--- a/.changeset/quiet-llamas-build.md
+++ b/.changeset/quiet-llamas-build.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Add XGR Testnet chain.
+Added XGR Testnet chain.

--- a/.changeset/quiet-llamas-build.md
+++ b/.changeset/quiet-llamas-build.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add XGR Testnet chain.

--- a/src/chains/definitions/xgrTestnet.ts
+++ b/src/chains/definitions/xgrTestnet.ts
@@ -1,0 +1,23 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const xgrTestnet = /*#__PURE__*/ defineChain({
+  id: 1879,
+  name: 'XGR Testnet',
+  nativeCurrency: {
+    name: 'XGR',
+    symbol: 'XGR',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc1.testnet.xgr.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'XGR Testnet Explorer',
+      url: 'https://explorer.testnet.xgr.network',
+    },
+  },
+  testnet: true,
+})

--- a/src/chains/definitions/xgrTestnet.ts
+++ b/src/chains/definitions/xgrTestnet.ts
@@ -4,8 +4,8 @@ export const xgrTestnet = /*#__PURE__*/ defineChain({
   id: 1879,
   name: 'XGR Testnet',
   nativeCurrency: {
-    name: 'XGR',
-    symbol: 'XGR',
+    name: 'XGR Testnet',
+    symbol: 'XGRt',
     decimals: 18,
   },
   rpcUrls: {

--- a/src/chains/definitions/xgrTestnet.ts
+++ b/src/chains/definitions/xgrTestnet.ts
@@ -4,8 +4,8 @@ export const xgrTestnet = /*#__PURE__*/ defineChain({
   id: 1879,
   name: 'XGR Testnet',
   nativeCurrency: {
-    name: 'XGR Testnet',
-    symbol: 'XGRt',
+    name: 'XGR',
+    symbol: 'XGR',
     decimals: 18,
   },
   rpcUrls: {

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -714,6 +714,7 @@ export { xaiTestnet } from './definitions/xaiTestnet.js'
 export { xdc } from './definitions/xdc.js'
 export { xdcTestnet } from './definitions/xdcTestnet.js'
 export { xgr } from './definitions/xgr.js'
+export { xgrTestnet } from './definitions/xgrTestnet.js'
 export { xLayer } from './definitions/xLayer.js'
 export {
   /** @deprecated Use `xLayerTestnet` */


### PR DESCRIPTION
Adds the official XGR Testnet chain definition to `viem/chains`.

- Chain ID: `1879`
- RPC: `https://rpc1.testnet.xgr.network`
- Explorer: `https://explorer.testnet.xgr.network`
- Native currency: `XGR` (18 decimals)
- Includes a patch changeset

This supersedes the closed review thread in #4979 after addressing the maintainer's requested changes:

- `xgrTestnet` is exported from `src/chains/index.ts`.
- `nativeCurrency` is reconciled to `XGR`, matching the currently published Ethereum Chains entry for `eip155:1879`.

XGR Mainnet is already available through `xgr`.