### PR TITLE
fix: throw error when snapshot could not be reverted

### DIFF
--- a/.changeset/revert-error-handling.md
+++ b/.changeset/revert-error-handling.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added error check in `revert` test action when snapshot could not be reverted.

--- a/src/actions/test/revert.test.ts
+++ b/src/actions/test/revert.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { anvilMainnet } from '~test/anvil.js'
 import { accounts } from '~test/constants.js'
+import { BaseError } from '../../errors/base.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { getBalance } from '../public/getBalance.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
@@ -40,3 +41,13 @@ test('reverts', async () => {
     }),
   ).toBe(balance)
 })
+
+test('error: could not revert snapshot', async () => {
+  await expect(
+    revert(client, { id: '0x1' }),
+  ).rejects.toThrowError(
+    new BaseError('Snapshot with id "0x1" could not be reverted.'),
+  )
+})
+
+

--- a/src/actions/test/revert.ts
+++ b/src/actions/test/revert.ts
@@ -3,6 +3,7 @@ import type {
   TestClientMode,
 } from '../../clients/createTestClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
+import { BaseError, type BaseErrorType } from '../../errors/base.js'
 import type { ErrorType } from '../../errors/utils.js'
 import type { Account } from '../../types/account.js'
 import type { Chain } from '../../types/chain.js'
@@ -14,7 +15,7 @@ export type RevertParameters = {
   id: Quantity
 }
 
-export type RevertErrorType = RequestErrorType | ErrorType
+export type RevertErrorType = RequestErrorType | BaseErrorType | ErrorType
 
 /**
  * Revert the state of the blockchain at the current block.
@@ -43,8 +44,10 @@ export async function revert<
   client: TestClient<TestClientMode, Transport, chain, account, false>,
   { id }: RevertParameters,
 ) {
-  await client.request({
+  const success = await client.request({
     method: 'evm_revert',
     params: [id],
   })
+  if (!success)
+    throw new BaseError(`Snapshot with id "${id}" could not be reverted.`)
 }

--- a/src/types/eip1193.test-d.ts
+++ b/src/types/eip1193.test-d.ts
@@ -152,6 +152,12 @@ test('test methods (strict)', async () => {
   }>({ method: 'eth_wagmi' })
   expectTypeOf<typeof x4>().toEqualTypeOf<number>()
 
+  const x5 = await request({
+    method: 'evm_revert',
+    params: ['0x1'],
+  })
+  expectTypeOf<typeof x5>().toEqualTypeOf<boolean>()
+
   // @ts-expect-error
   request({ method: 'anvil_addCompilationResult' })
   // @ts-expect-error

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -1600,7 +1600,7 @@ export type TestRpcSchema<mode extends string> = [
   {
     Method: 'evm_revert'
     Parameters?: [id: Quantity] | undefined
-    ReturnType: void
+    ReturnType: boolean
   },
   /**
    * @description Enables the automatic mining of new blocks with each new transaction submitted to the network.


### PR DESCRIPTION
Checks the boolean response from `evm_revert` in `revert` test action and throws a `BaseError` when false (e.g. invalid, nonexistent, or already consumed snapshot ID). Also updates the EIP1193 RPC schema to reflect that `evm_revert` returns a `boolean`.

Resolves #5064.