### PR TITLE
fix(linea): send stateOverride to linea_estimateGas

### DIFF
--- a/.changeset/linea-estimate-gas-state-override.md
+++ b/.changeset/linea-estimate-gas-state-override.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `stateOverride` being silently dropped by `estimateGas` in `viem/linea` — it was destructured into an unused rest object and never serialized onto the `linea_estimateGas` request, so overrides never reached the node.

--- a/src/linea/actions/estimateGas.test.ts
+++ b/src/linea/actions/estimateGas.test.ts
@@ -33,5 +33,34 @@ test('error: insufficient balance', async () => {
       to: '0x0000000000000000000000000000000000000000',
       value: parseEther('0.0001'),
     }),
-  ).rejects.toThrowError('exceeds transaction sender account balance')
+  ).rejects.toThrowError(
+    // Linea reports the missing balance as "up-front cost … exceeds …
+    // sender account balance" for zero-value calls, and as a Besu
+    // "Cannot remove … wei from account" internal error once a non-zero
+    // `value` reaches the transfer step.
+    /exceeds transaction sender account balance|Cannot remove/,
+  )
+})
+
+test('args: stateOverride', async () => {
+  // Same unfunded-sender call as the test above — the balance override is
+  // what lets it succeed.
+  const account = Hex.random(20)
+  const { baseFeePerGas, gasLimit, priorityFeePerGas } = await estimateGas(
+    client,
+    {
+      account,
+      to: '0x0000000000000000000000000000000000000000',
+      value: parseEther('0.0001'),
+      stateOverride: [
+        {
+          address: account,
+          balance: parseEther('1'),
+        },
+      ],
+    },
+  )
+  expect(baseFeePerGas).toBeGreaterThan(0n)
+  expect(gasLimit).toBe(21000n)
+  expect(priorityFeePerGas).toBeGreaterThan(0n)
 })

--- a/src/linea/actions/estimateGas.ts
+++ b/src/linea/actions/estimateGas.ts
@@ -13,6 +13,7 @@ import { numberToHex } from '../../utils/encoding/toHex.js'
 import { getCallError } from '../../utils/errors/getCallError.js'
 import { extract } from '../../utils/formatters/extract.js'
 import { formatTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import { serializeStateOverride } from '../../utils/stateOverride.js'
 import {
   type AssertRequestParameters,
   assertRequest,
@@ -75,6 +76,7 @@ export async function estimateGas<
       maxFeePerGas,
       maxPriorityFeePerGas,
       nonce,
+      stateOverride,
       to,
       value,
       ...rest
@@ -107,6 +109,8 @@ export async function estimateGas<
       'estimateGas',
     )
 
+    const rpcStateOverride = serializeStateOverride(stateOverride)
+
     type LineaEstimateGasSchema = Filter<
       LineaRpcSchema,
       { Method: 'linea_estimateGas' }
@@ -114,7 +118,13 @@ export async function estimateGas<
     const { baseFeePerGas, gasLimit, priorityFeePerGas } =
       await client.request<LineaEstimateGasSchema>({
         method: 'linea_estimateGas',
-        params: block ? [request, block] : [request],
+        params: rpcStateOverride
+          ? block
+            ? [request, block, rpcStateOverride]
+            : [request, rpcStateOverride]
+          : block
+            ? [request, block]
+            : [request],
       })
     return {
       baseFeePerGas: BigInt(baseFeePerGas),

--- a/src/linea/types/rpc.ts
+++ b/src/linea/types/rpc.ts
@@ -14,9 +14,10 @@ export type LineaRpcSchema = [
           transaction: RpcTransactionRequest,
           block: Hex | BlockNumber | BlockTag,
         ]
+      | [transaction: RpcTransactionRequest, stateOverride: RpcStateOverride]
       | [
           transaction: RpcTransactionRequest,
-          block: BlockNumber | BlockTag,
+          block: Hex | BlockNumber | BlockTag,
           stateOverride: RpcStateOverride,
         ]
     ReturnType: {


### PR DESCRIPTION
### Problem

`estimateGas` from `viem/linea` accepts `stateOverride` in its parameter type (inherited from the base `EstimateGasParameters`), but the implementation silently drops it: the argument is destructured into a rest object that is never serialized, and `params` is built as `block ? [request, block] : [request]`. Overrides never reach the node.

This matters on Linea specifically because `linea_estimateGas` always validates the sender's **real** balance against `gas * price + value` (unlike `eth_estimateGas`, which skips the balance check when no gas price is supplied). Without a working balance override there is no way to quote gas for an account that isn't funded yet — e.g. previewing a WETH unwrap for a wallet that holds no native ETH, which is exactly when users unwrap. Such calls fail with `transaction up-front cost … exceeds transaction sender account balance` (or a Besu `Cannot remove … wei from account` internal error once a non-zero `value` reaches the transfer step).

### Fix

- Serialize `stateOverride` with the existing internal `serializeStateOverride` and send it on `linea_estimateGas`. When no block is given it rides as the **second** positional param in the eth_call account-map shape — verified accepted by the Linea mainnet public sequencer (`rpc.linea.build`), Linea Sepolia (`rpc.sepolia.linea.build`), and Alchemy's Linea endpoints:

  ```
  // params: [tx, {"0x1111…": {"balance": "0x21e19e0c9bab2400000"}}]
  → {"result":{"gasLimit":"0x5208","baseFeePerGas":"0x7","priorityFeePerGas":"0x24137da"}}
  ```

- Add the missing `[transaction, stateOverride]` variant to `LineaRpcSchema`'s `Parameters` union, and allow `Hex` for the block position of the 3-param variant (the 2-param variant already allowed it; the implementation passes `numberToHex(blockNumber)`).

- New test `args: stateOverride` against Linea Sepolia: the exact unfunded-sender call that the existing `error: insufficient balance` test expects to fail now succeeds with a balance override — it fails without this PR and passes with it.

### Notes for reviewers

- The pre-existing `error: insufficient balance` test currently fails on `main` against Linea Sepolia: the node now reports a non-zero-value transfer from an unfunded sender as a Besu `Cannot remove … wei from account` internal error rather than the up-front-cost message. This PR loosens that assertion to accept either message; happy to split that out if preferred.
- Node behavior observed while testing (not changed by this PR): the Linea sequencer rejects every `linea_estimateGas` call that includes a block param (`[tx, "latest"]`, `[tx, blockNumberHex]`, and the 3-param shape all return `Internal error`), so the block path appears unusable against current nodes. This PR leaves that path as-is and only threads `stateOverride` through.