### PR TITLE
fix(utils): reject odd-length hex in isHex strict mode

### DIFF
--- a/.changeset/ishex-odd-nibbles-strict.md
+++ b/.changeset/ishex-odd-nibbles-strict.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `isHex` incorrectly returning `true` for odd-length hex strings in strict mode.

--- a/src/utils/data/isHex.test.ts
+++ b/src/utils/data/isHex.test.ts
@@ -4,11 +4,15 @@ import { isHex } from './isHex.js'
 
 test('is hex', () => {
   expect(isHex('0x')).toBeTruthy()
-  expect(isHex('0x0')).toBeTruthy()
+  expect(isHex('0x0')).toBeFalsy()
+  expect(isHex('0x01')).toBeTruthy()
+  expect(isHex('0x123')).toBeFalsy()
   expect(isHex('0x0123456789abcdef')).toBeTruthy()
   expect(isHex('0x0123456789abcdefABCDEF')).toBeTruthy()
   expect(isHex('0x0123456789abcdefg')).toBeFalsy()
   expect(isHex('0x0123456789abcdefg', { strict: false })).toBeTruthy()
+  expect(isHex('0x0', { strict: false })).toBeTruthy()
+  expect(isHex('0x123', { strict: false })).toBeTruthy()
   expect(isHex({ foo: 'bar' })).toBeFalsy()
   expect(isHex(undefined)).toBeFalsy()
 })

--- a/src/utils/data/isHex.ts
+++ b/src/utils/data/isHex.ts
@@ -9,5 +9,7 @@ export function isHex(
 ): value is Hex {
   if (!value) return false
   if (typeof value !== 'string') return false
-  return strict ? /^0x[0-9a-fA-F]*$/.test(value) : value.startsWith('0x')
+  return strict
+    ? /^0x([0-9a-fA-F]{2})*$/.test(value)
+    : value.startsWith('0x')
 }


### PR DESCRIPTION
## Summary

Fixes #5048.

In strict mode, `isHex` currently accepts any `0x` + hex digits string, including odd lengths like `0x0` and `0x123`. Those are not full bytes, so they should fail the strict check.

This updates the strict regex to require pairs of hex digits (`/^0x([0-9a-fA-F]{2})*$/`). Non-strict mode still only checks the `0x` prefix.

Includes unit test updates and a patch changeset.

## Note

Looks like #5050 tried the same fix and was closed without a comment. Happy to rework this if there is a preferred direction (for example keeping `0x0` as a special case). Just want `isHex` to match how hex bytes are usually validated.

## Test plan

- [ ] `isHex('0x')` true
- [ ] `isHex('0x0')` false (strict), true with `{ strict: false }`
- [ ] `isHex('0x01')` true
- [ ] `isHex('0x123')` false (strict)
- [ ] Existing even-length cases still pass