### PR TITLE
docs: clarify multicall address requirements

### DIFF
--- a/site/pages/docs/contract/multicall.md
+++ b/site/pages/docs/contract/multicall.md
@@ -81,6 +81,10 @@ export const publicClient = createPublicClient({
 
 :::
 
+:::warning
+By default, `multicall` uses the `multicall3` address defined on the target chain. If the chain does not define one, provide [`multicallAddress`](#multicalladdress-optional) or set [`deployless`](#deployless-optional) to `true`. When using an address to read a historical block, the Multicall3 contract must have been deployed at that block.
+:::
+
 ## Return Value
 
 `({ data: <inferred>, status: 'success' } | { error: string, status: 'reverted' })[]`


### PR DESCRIPTION
## Summary

- Add a warning about the default Multicall3 address used by `multicall`.
- Clarify that address-based historical calls require Multicall3 to be deployed at the requested block.

## Why

Some chains do not define a Multicall3 address, and the contract may not exist at the block being read. The existing documentation did not clearly explain these requirements.

## Testing

- `git diff --check`
- Verified the warning with the Vocs `:::warning` syntax.