### PR TITLE
Fix shouldRetry not retrying QuickNode's -32007 rate-limit code

### DIFF
--- a/.changeset/fix-quicknode-retry.md
+++ b/.changeset/fix-quicknode-retry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `shouldRetry` not retrying QuickNode's `-32007` rate-limit error code, mirroring the existing handling for the `429` (Alchemy) case.

--- a/src/utils/buildRequest.test.ts
+++ b/src/utils/buildRequest.test.ts
@@ -1544,6 +1544,19 @@ describe('shouldRetry', () => {
     expect(shouldRetry(err)).toBe(true)
   })
 
+  test('RPC code -32007 (QuickNode rate limit)', () => {
+    // QuickNode returns its own rate-limit error as `{ code: -32007 }`
+    // rather than the standard `LimitExceededRpcError` code (`-32005`) or
+    // HTTP 429. shouldRetry must return true so that retryCount is honoured.
+    const err = Object.assign(
+      new Error(
+        '15/second request limit reached - reduce calls per second or upgrade your account at quicknode.com',
+      ),
+      { code: -32007 },
+    )
+    expect(shouldRetry(err)).toBe(true)
+  })
+
   test('WalletConnectSessionSettlementError', () => {
     expect(
       shouldRetry(new WalletConnectSessionSettlementError({} as any)),

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -298,6 +298,12 @@ export function shouldRetry(error: Error) {
     // HTTP 200 with a JSON-RPC body of `{ code: 429 }` instead of an HTTP 429,
     // so we need to handle this code in addition to the HTTP status check below.
     if (error.code === 429) return true
+    // Request limit exceeded — QuickNode's own non-standard rate-limit code,
+    // distinct from the standard `LimitExceededRpcError` (`-32005`). Seen in
+    // production as `{ code: -32007, message: "N/second request limit
+    // reached - reduce calls per second or upgrade your account at
+    // quicknode.com" }`.
+    if (error.code === -32007) return true
     return false
   }
   if (error instanceof HttpRequestError && error.status) {


### PR DESCRIPTION
Fixes #5082

## Summary

`shouldRetry` handles the JSON-RPC-level `429` code (Alchemy's rate-limit
signal, added in #4424) but doesn't handle QuickNode's own non-standard
rate-limit code, `-32007` ("N/second request limit reached..."). This
means `retryCount` on the `http()` transport is silently ignored for
QuickNode rate limits specifically — the request fails on the very first
attempt regardless of how high `retryCount` is set.

This isn't hypothetical: it's the exact failure mode that caused a real
production incident for us against a QuickNode Base endpoint.

- Added `error.code === -32007` to the retryable codes in `shouldRetry`,
  mirroring the existing `429` special-case.
- Added a unit test for `shouldRetry` with a `-32007` error code,
  matching the style of the existing `429` test.
- Added a changeset.

## Test plan

- `src/utils/buildRequest.test.ts` — new `shouldRetry > RPC code -32007
  (QuickNode rate limit)` test.
- Could not run the full local suite in this environment (needs a
  Foundry/Anvil toolchain this sandbox doesn't have), so I also verified
  the exact patched branching logic in isolation against six cases
  (the new `-32007` case, the three already-passing retryable codes,
  and two non-retryable codes) before opening this PR.
