### PR TITLE
fix: retry QuickNode -32007 rate limit error in shouldRetry

### DIFF
--- a/.changeset/retry-quicknode-32007.md
+++ b/.changeset/retry-quicknode-32007.md
@@ -1,0 +1,5 @@
+---
+'viem': patch
+---
+
+Fixed `shouldRetry` to retry QuickNode's `-32007` rate limit error.

--- a/src/utils/buildRequest.test.ts
+++ b/src/utils/buildRequest.test.ts
@@ -1194,6 +1194,29 @@ describe('behavior', () => {
       expect(retryCount).toBe(3)
     })
 
+    test('non-deterministic rate limit error (QuickNode -32007)', async () => {
+      let retryCount = -1
+      const server = await createHttpServer((_req, res) => {
+        retryCount++
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+        })
+        res.end(
+          JSON.stringify({
+            error: {
+              code: -32007,
+              message: 'N/second request limit reached',
+            },
+          }),
+        )
+      })
+
+      await expect(() =>
+        buildRequest(request(server.url))({ method: 'eth_blockNumber' }),
+      ).rejects.toThrowError()
+      expect(retryCount).toBe(3)
+    })
+
     test('non-deterministic UnknownRpcError', async () => {
       let retryCount = -1
       await expect(() =>
@@ -1541,6 +1564,14 @@ describe('shouldRetry', () => {
     // JSON-RPC body containing `{ code: 429 }` rather than a real HTTP 429.
     // shouldRetry must return true so that retryCount is honoured.
     const err = Object.assign(new Error('rate limited'), { code: 429 })
+    expect(shouldRetry(err)).toBe(true)
+  })
+
+  test('RPC code -32007 (rate-limit, e.g. QuickNode HTTP 200 + JSON body)', () => {
+    // Some providers (e.g. QuickNode) respond with HTTP 200 and a JSON-RPC
+    // body containing `{ code: -32007 }` when rate limited rather than a real
+    // HTTP 429. shouldRetry must return true so that retryCount is honoured.
+    const err = Object.assign(new Error('rate limited'), { code: -32007 })
     expect(shouldRetry(err)).toBe(true)
   })
 

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -294,6 +294,10 @@ export function shouldRetry(error: Error) {
     if (error.code === -1) return true // Unknown error
     if (error.code === LimitExceededRpcError.code) return true
     if (error.code === InternalRpcError.code) return true
+    // Rate Limited — some providers (e.g. QuickNode) return a JSON-RPC body
+    // of `{ code: -32007 }` instead of an HTTP 429 when rate limited,
+    // so we need to handle this code in addition to the HTTP status check below.
+    if (error.code === -32007) return true
     // Too Many Requests — some providers (e.g. Alchemy in batch mode) return
     // HTTP 200 with a JSON-RPC body of `{ code: 429 }` instead of an HTTP 429,
     // so we need to handle this code in addition to the HTTP status check below.


### PR DESCRIPTION
Fixes #5082

## Summary

`shouldRetry` did not retry QuickNode's non-standard rate-limit error code `-32007`, so `retryCount` on the `http()` transport was silently ignored for QuickNode rate limits and the request failed on the first attempt.

QuickNode signals rate limiting with HTTP 200 and a JSON-RPC body of `{ code: -32007 }` ("N/second request limit reached") instead of an HTTP 429, so the existing HTTP status checks never matched. This adds `-32007` to the retryable JSON-RPC codes, alongside the existing `-32005`, `-32603`, and `429` handling.

## Tests

- Unit test that `shouldRetry` returns `true` for an error carrying code `-32007` (fails before, passes after).
- End-to-end test through `buildRequest` against a real HTTP server responding with HTTP 200 and `{ code: -32007 }`, asserting the request is retried 3 times (fails before, passes after).

Changeset included.
