### PR TITLE
chore(deps): bump @arethetypeswrong/cli to 0.18.5

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -267,8 +267,13 @@ jobs:
             tempo-tag: sha256:af7a8955370adc4868a3237352ceded3bd917702a14758796eab86b338b75e49
             zone-tag: sha256:45b4e66b0a7d5f8d9486eeb05e0842c7a223b53e9ef910ef73cd9558f4a79118
           - hardfork: Tnext
-            # Tempo 7331a612. Newer `latest` images (731535b9 onwards) never
-            # complete the Zone gateway Earn deposit, timing out the suite.
+            # Tempo 7331a612 (reports T12) with Zones f953a3c. Newer Tempo
+            # images report T13, which this Zone build cannot parse from
+            # `tempo_forkSchedule`, so its sequencer falls back to the legacy
+            # `submitBatch` selector that the TIP-1096 portal runtime does not
+            # dispatch. Settlement then reverts and withdrawals never complete.
+            # Newer Zone builds moved to the 9-argument `submitBatch`, which the
+            # portal runtime embedded in Tempo main does not dispatch either.
             tempo-tag: sha256:cf1fb16e17a55efcacd0cf119a215cfa894100f5a46a1cbdb06fb151616b4cb1
             zone-tag: sha256:2c6e58767e75f5b9dc012361daa89cb8baaad7d70f8c4151aa8a506b3d92f44b
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "version:update": "bun scripts/updateVersion.ts"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@ark/attest": "^0.56.0",
     "@biomejs/biome": "^2.2.4",
     "@changesets/changelog-github": "^0.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
   .:
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.18.2
-        version: 0.18.2
+        specifier: ^0.18.5
+        version: 0.18.5
       '@ark/attest':
         specifier: ^0.56.0
         version: 0.56.0(typescript@5.9.3)
@@ -716,13 +716,13 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@arethetypeswrong/cli@0.18.2':
-    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.2':
-    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
     engines: {node: '>=20'}
 
   '@ark/attest@0.56.0':
@@ -3677,10 +3677,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -7260,24 +7256,24 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@arethetypeswrong/cli@0.18.2':
+  '@arethetypeswrong/cli@0.18.5':
     dependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.5
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 7.2.1(marked@9.1.6)
-      semver: 7.7.4
+      semver: 7.8.5
 
-  '@arethetypeswrong/core@0.18.2':
+  '@arethetypeswrong/core@0.18.5':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.4
       cjs-module-lexer: 1.4.1
       fflate: 0.8.3
       lru-cache: 11.2.2
-      semver: 7.7.4
+      semver: 7.8.5
       typescript: 5.9.3
       validate-npm-package-name: 5.0.1
 
@@ -10595,8 +10591,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.4.1: {}
-
   chalk@5.6.2: {}
 
   change-case@5.4.4: {}
@@ -12121,7 +12115,7 @@ snapshots:
     dependencies:
       ansi-escapes: 7.0.0
       ansi-regex: 6.1.0
-      chalk: 5.4.1
+      chalk: 5.6.2
       cli-highlight: 2.1.11
       cli-table3: 0.6.5
       marked: 9.1.6


### PR DESCRIPTION
Follow-up to #5086. Once the audit step passed, the Build job ran again on `main` and its publint step crashed:

```
$ publint --strict ./src && attw --pack ./src --ignore-rules false-esm
error while checking file:
Cannot read properties of undefined (reading 'filename')
```

The crash is in `attw`, not publint. `@arethetypeswrong/core` 0.18.2 unpacks its own tarball with fflate's streaming `Gunzip` and indexes the first entry; the fflate 0.8.3 security override from #5086 changed that stream's output so the entry list comes back empty. 0.18.5 depends on `fflate ^0.8.3` and handles it. Reproduced locally before the bump and verified `pnpm test:build` exits 0 after it; `pnpm audit` stays clean.

The second commit only replaces the comment on the Tnext `tempo-tag` pin in `verify.yml` with the actual cause, found by tracing the failing settlement call on `tempo:latest`:

- The pinned Zones build (f953a3c) selects its `submitBatch` ABI from the `active` fork name returned by `tempo_forkSchedule`, parsed with its embedded Tempo crates.
- Tempo images from 731535b9 onwards report `T13`, which that build cannot parse, so `is_hardfork_active(T12)` is false and the sequencer falls back to the legacy 9-argument `submitBatch` selector.
- The TIP-1096 portal runtime embedded in Tempo only dispatches the 10-argument variant, so `submitBatch` reverts with empty data, batches never settle, and the Zone gateway Earn test times out waiting for the callback.
- Newer Zones builds (5dcad06) send the 9-argument `submitBatch` unconditionally and fail the same way against Tempo main, so the pinned pair is currently the only combination that completes the flow. Both points are being raised upstream; the pin can be lifted once Tempo re-embeds the runtimes and the fork-name parsing is made forward-compatible.

No changeset: dev dependency and CI comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MNnMpdcBXcSaA3UK3ACbs

---
_Generated by [Claude Code](https://claude.ai/code/session_012MNnMpdcBXcSaA3UK3ACbs)_