### PR TITLE
ci: fix Verify failures on main

### DIFF
--- a/contracts/src/test/EnsAvatarTokenUri.sol
+++ b/contracts/src/test/EnsAvatarTokenUri.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.28;
 
 contract EnsAvatarTokenUri {
+    string internal metadataUri;
+
+    constructor(string memory metadataUri_) {
+        metadataUri = metadataUri_;
+    }
+
     function ownerOf(uint256 tokenId) public view returns (address) {
         return 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045;
     }
@@ -75,6 +81,6 @@ contract EnsAvatarTokenUri {
             return "wat";
         }
 
-        return "https://boredapeyachtclub.com/api/mutants/0x{id}";
+        return string.concat(metadataUri, "0x{id}");
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "version:update": "bun scripts/updateVersion.ts"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@ark/attest": "^0.56.0",
     "@biomejs/biome": "^2.2.4",
     "@changesets/changelog-github": "^0.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
   .:
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.18.2
-        version: 0.18.2
+        specifier: ^0.18.5
+        version: 0.18.5
       '@ark/attest':
         specifier: ^0.56.0
         version: 0.56.0(typescript@5.9.3)
@@ -716,13 +716,13 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@arethetypeswrong/cli@0.18.2':
-    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.2':
-    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
     engines: {node: '>=20'}
 
   '@ark/attest@0.56.0':
@@ -3677,10 +3677,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -7260,24 +7256,24 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@arethetypeswrong/cli@0.18.2':
+  '@arethetypeswrong/cli@0.18.5':
     dependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.5
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 7.2.1(marked@9.1.6)
-      semver: 7.7.4
+      semver: 7.8.5
 
-  '@arethetypeswrong/core@0.18.2':
+  '@arethetypeswrong/core@0.18.5':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.4
       cjs-module-lexer: 1.4.1
       fflate: 0.8.3
       lru-cache: 11.2.2
-      semver: 7.7.4
+      semver: 7.8.5
       typescript: 5.9.3
       validate-npm-package-name: 5.0.1
 
@@ -10595,8 +10591,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.4.1: {}
-
   chalk@5.6.2: {}
 
   change-case@5.4.4: {}
@@ -12121,7 +12115,7 @@ snapshots:
     dependencies:
       ansi-escapes: 7.0.0
       ansi-regex: 6.1.0
-      chalk: 5.4.1
+      chalk: 5.6.2
       cli-highlight: 2.1.11
       cli-table3: 0.6.5
       marked: 9.1.6

--- a/src/actions/ens/getEnsAvatar.test.ts
+++ b/src/actions/ens/getEnsAvatar.test.ts
@@ -21,6 +21,7 @@ const ipfsContentTypes = {
 } as const
 
 let ipfsGateway: Awaited<ReturnType<typeof createHttpServer>>
+let metadataServer: Awaited<ReturnType<typeof createHttpServer>>
 
 beforeAll(async () => {
   ipfsGateway = await createHttpServer((req, res) => {
@@ -32,6 +33,14 @@ beforeAll(async () => {
     })
     res.end()
   })
+  metadataServer = await createHttpServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(
+      JSON.stringify({
+        image: 'ipfs://QmbUCe7JMPsG39FRaLaJ9VwSKrE74PzEb1s4DKuEkARepS',
+      }),
+    )
+  })
 
   await impersonateAccount(client, {
     address: address.vitalik,
@@ -42,7 +51,7 @@ beforeAll(async () => {
   })
 })
 
-afterAll(() => ipfsGateway.close())
+afterAll(() => Promise.all([ipfsGateway.close(), metadataServer.close()]))
 
 test.each([
   {
@@ -171,7 +180,9 @@ describe('eip155:1 string (erc721)', () => {
   ])('$tokenId -> $expected', async ({ tokenId, expected }) => {
     const expected_ =
       expected?.replace('https://ipfs.io', ipfsGateway.url) ?? expected
-    const { contractAddress } = await deployEnsAvatarTokenUri()
+    const { contractAddress } = await deployEnsAvatarTokenUri({
+      metadataUri: `${metadataServer.url}/`,
+    })
     await setEnsAvatar(`eip155:1/erc721:${contractAddress}/${tokenId}`)
     await expect(
       getEnsAvatar(client, {

--- a/src/utils/ens/avatar/parseAvatarRecord.test.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.test.ts
@@ -1,18 +1,31 @@
-import { beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { anvilMainnet } from '~test/anvil.js'
-import { deployEnsAvatarTokenUri } from '~test/utils.js'
+import { createHttpServer, deployEnsAvatarTokenUri } from '~test/utils.js'
 
 import { reset } from '../../../actions/index.js'
 import { parseAvatarRecord } from './parseAvatarRecord.js'
 
 const client = anvilMainnet.getClient()
 
+let metadataServer: Awaited<ReturnType<typeof createHttpServer>>
+
 beforeAll(async () => {
+  metadataServer = await createHttpServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(
+      JSON.stringify({
+        image: 'ipfs://QmbUCe7JMPsG39FRaLaJ9VwSKrE74PzEb1s4DKuEkARepS',
+      }),
+    )
+  })
+
   await reset(client, {
     blockNumber: 23_085_558n,
     jsonRpcUrl: anvilMainnet.forkUrl,
   })
 })
+
+afterAll(() => metadataServer.close())
 
 test('default', async () => {
   expect(
@@ -27,7 +40,9 @@ test('default', async () => {
 
 describe('nft', () => {
   test('default ({id} template)', async () => {
-    const { contractAddress } = await deployEnsAvatarTokenUri()
+    const { contractAddress } = await deployEnsAvatarTokenUri({
+      metadataUri: `${metadataServer.url}/`,
+    })
     expect(
       await parseAvatarRecord(client, {
         record: `eip155:1/erc721:${contractAddress}/69`,
@@ -38,7 +53,9 @@ describe('nft', () => {
   })
 
   test('onchain (encoded json)', async () => {
-    const { contractAddress } = await deployEnsAvatarTokenUri()
+    const { contractAddress } = await deployEnsAvatarTokenUri({
+      metadataUri: `${metadataServer.url}/`,
+    })
     expect(
       await parseAvatarRecord(client, {
         record: `eip155:1/erc721:${contractAddress}/100`,
@@ -49,7 +66,9 @@ describe('nft', () => {
   })
 
   test('onchain (raw json)', async () => {
-    const { contractAddress } = await deployEnsAvatarTokenUri()
+    const { contractAddress } = await deployEnsAvatarTokenUri({
+      metadataUri: `${metadataServer.url}/`,
+    })
     expect(
       await parseAvatarRecord(client, {
         record: `eip155:1/erc721:${contractAddress}/108`,

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -112,10 +112,16 @@ export async function deployErrorExample() {
   })
 }
 
-export async function deployEnsAvatarTokenUri() {
+export async function deployEnsAvatarTokenUri({
+  metadataUri,
+}: {
+  /** Base URI of the token metadata. The token ID is appended as `0x{id}`. */
+  metadataUri: string
+}) {
   return deploy(client, {
     abi: EnsAvatarTokenUri.abi,
     bytecode: EnsAvatarTokenUri.bytecode.object,
+    args: [metadataUri],
   })
 }
 


### PR DESCRIPTION
The Changesets workflow on main fails in two Verify jobs.

Build: `attw --pack` crashes with "Cannot read properties of undefined
(reading 'filename')". #5086 added the `fflate@>=0.8.0 <0.8.3: 0.8.3`
security override. attw 0.18.2 feeds the packed tarball through
fflate's streaming `Gunzip` and keeps only the last emitted chunk; with
fflate 0.8.3 the stream emits several chunks, the last one empty, so
attw untars nothing and `data[0]` is undefined. attw 0.18.3+ collects
every chunk, so bump `@arethetypeswrong/cli` to ^0.18.5.

Test Local: `parseAvatarRecord.test.ts > nft > default ({id} template)`
fetches NFT metadata from boredapeyachtclub.com, which intermittently
rejects GitHub runners (all three retry attempts failed). Give the
`EnsAvatarTokenUri` test contract a constructor-provided metadata base
URI and serve the metadata from a local HTTP server in the two tests
that use it, the same way those tests already stand in for the IPFS
gateway.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FX4wEMZUhRpj7jYnuML2GW