### PR TITLE
feat(chains): add ENS contracts to Robinhood Chain and Robinhood Chain Testnet

### DIFF
--- a/.changeset/robinhood-ens.md
+++ b/.changeset/robinhood-ens.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added ENS contracts (`ensRegistry`, `ensUniversalResolver`) to the Robinhood Chain and Robinhood Chain Testnet chain definitions.

--- a/src/chains/definitions/robinhood.ts
+++ b/src/chains/definitions/robinhood.ts
@@ -18,6 +18,13 @@ export const robinhood = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ensRegistry: {
+      address: '0x29d8cEae06c4F97c784BD016A41eB45c9A2d6aE1',
+    },
+    ensUniversalResolver: {
+      address: '0x1C336914666256e2c5131FB460C598F2EAB0292B',
+      blockCreated: 41235731,
+    },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
     },

--- a/src/chains/definitions/robinhoodTestnet.ts
+++ b/src/chains/definitions/robinhoodTestnet.ts
@@ -17,6 +17,13 @@ export const robinhoodTestnet = /*#__PURE__*/ defineChain({
     },
   },
   contracts: {
+    ensRegistry: {
+      address: '0x8705DEC51223E119C5C9f03121626d086A8eF753',
+    },
+    ensUniversalResolver: {
+      address: '0x7112730612e4253Ba2e418A86580615A2c3CDB1D',
+      blockCreated: 103084077,
+    },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
     },


### PR DESCRIPTION
### Description

Adds `ensRegistry` and `ensUniversalResolver` to the `robinhood` (4663) and `robinhoodTestnet` (46630) chain definitions, so `getEnsName`, `getEnsAddress`, `getEnsText`, `getEnsAvatar` and the wagmi hooks built on them resolve names on Robinhood Chain out of the box.

Robinhood Chain runs an ENS deployment (the `.robin` namespace) built from `ensdomains/ens-contracts` v1.7.0 with the standard registry, ENSIP-10 `UniversalResolver`, `PublicResolver`, `ReverseRegistrar` and `DefaultReverseRegistrar`. The resolver interfaces are unchanged from upstream, which is why stock viem already resolves these names when the contract addresses are passed explicitly (`universalResolverAddress`); this PR removes the need to pass them.

| chain | contract | address | created |
|---|---|---|---|
| robinhood (4663) | ensRegistry | `0x29d8cEae06c4F97c784BD016A41eB45c9A2d6aE1` | 41235728 |
| robinhood (4663) | ensUniversalResolver | `0x1C336914666256e2c5131FB460C598F2EAB0292B` | 41235731 |
| robinhoodTestnet (46630) | ensRegistry | `0x8705DEC51223E119C5C9f03121626d086A8eF753` | 103083724 |
| robinhoodTestnet (46630) | ensUniversalResolver | `0x7112730612e4253Ba2e418A86580615A2c3CDB1D` | 103084077 |

Sources are verified on Blockscout (https://robinhoodchain.blockscout.com/address/0x1C336914666256e2c5131FB460C598F2EAB0292B) and on Sourcify. Source repository: https://github.com/dotrobinxyz/robin (`contracts/deployments/`).

### Verification

```ts
import { createPublicClient, http } from 'viem'
import { robinhood } from 'viem/chains'

const client = createPublicClient({ chain: robinhood, transport: http() })

await client.getEnsAddress({ name: 'goldfinch.robin' })
// 0x18A3675e49ec7F2782aC0A2515451d60A7645301

await client.getEnsName({ address: '0x18A3675e49ec7F2782aC0A2515451d60A7645301' })
// 'goldfinch.robin'